### PR TITLE
[WebGPU] Switching pipelines does not zero out dynamic offsets from prior pipeline

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-285828-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-285828-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-285828.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-285828.html
@@ -1,0 +1,15022 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let promise0 = navigator.gpu.requestAdapter();
+let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredLimits: {
+    maxStorageTexturesPerShaderStage: 4,
+    maxTextureDimension1D: 8192,
+    maxUniformBufferBindingSize: 50290837,
+    maxStorageBufferBindingSize: 158197003,
+  },
+});
+let texture0 = device0.createTexture({
+  size: {width: 1},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler0 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.24,
+});
+let commandEncoder0 = device0.createCommandEncoder();
+let texture1 = device0.createTexture({
+  size: {width: 2, height: 1095, depthOrArrayLayers: 171},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let commandEncoder1 = device0.createCommandEncoder();
+let sampler1 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.37,
+  maxAnisotropy: 3,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let img0 = await imageWithData(106, 5, '#10101010', '#20202020');
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({});
+let texture2 = device0.createTexture({
+  size: [4, 1575, 1],
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let textureView0 = texture2.createView({mipLevelCount: 1});
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.label = '\u2bb2\ua96f\u5d32\u0201\ud394\u{1fd68}';
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({
+  label: '\u08a7\u0806\ud61d\u139c\uf4e3\u0b9d\u0e68\uf084\u{1ffb6}\ucf9f\u9649',
+  size: [256, 256, 21],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 119, z: 31},
+  aspect: 'all',
+}, new Uint8Array(46_168).fill(144), /* required buffer size: 46_168 */
+{offset: 184, bytesPerRow: 24, rowsPerImage: 237}, {width: 0, height: 21, depthOrArrayLayers: 9});
+} catch {}
+let textureView1 = texture3.createView({dimension: '2d'});
+let textureView2 = texture3.createView({dimension: 'cube', baseArrayLayer: 4});
+let computePassEncoder2 = commandEncoder3.beginComputePass();
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 174,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer0 = device0.createBuffer({
+  size: 14774,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder3 = commandEncoder4.beginComputePass({});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint'],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle0 = renderBundleEncoder0.finish({});
+await gc();
+let buffer1 = device0.createBuffer({size: 17471, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 1878});
+let texture5 = device0.createTexture({
+  size: [419, 1, 20],
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder4 = commandEncoder2.beginComputePass({});
+try {
+buffer1.unmap();
+} catch {}
+let textureView3 = texture3.createView({dimension: 'cube', baseArrayLayer: 3});
+await gc();
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture6 = device0.createTexture({
+  size: {width: 1, height: 273, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView4 = texture5.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder5 = commandEncoder5.beginComputePass({});
+let sampler2 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+device0.queue.writeBuffer(buffer1, 628, new DataView(new ArrayBuffer(5989)), 123, 2164);
+} catch {}
+let texture7 = device0.createTexture({
+  size: {width: 2, height: 787, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8'],
+});
+let sampler3 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 91.41});
+try {
+buffer0.unmap();
+} catch {}
+document.body.append(img0);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: img0,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 38, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder6 = device0.createCommandEncoder({label: '\u6ee5\u6317\u520a\u608f\u098f'});
+let sampler4 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 80.11,
+});
+let computePassEncoder6 = commandEncoder6.beginComputePass({});
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp1: mat2x4h = mat2x4h();
+
+var<private> vp3 = array(modf(vec4f(0.6308, 0.1957, 0.01289, 0.02196)));
+
+var<workgroup> vw1: mat2x2h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T2 {
+  @size(44) f0: array<u32>,
+}
+
+var<workgroup> vw5: vec4i;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp0: mat2x3h = mat2x3h();
+
+var<workgroup> vw0: atomic<i32>;
+
+var<workgroup> vw2: array<array<vec4<bool>, 1>, 1>;
+
+var<private> vp2: mat2x2f = mat2x2f(0.1132, 0.5810, -0.1639, 0.03978);
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T1 {
+  @size(44) f0: array<array<array<array<atomic<i32>, 1>, 1>, 1>>,
+}
+
+struct T0 {
+  @size(48) f0: array<mat2x3f>,
+}
+
+var<workgroup> vw4: array<atomic<u32>, 46>;
+
+struct T3 {
+  f0: vec2u,
+  f1: vec2u,
+  @align(8) @size(152) f2: array<array<array<array<array<vec2h, 5>, 1>, 1>, 1>, 1>,
+}
+
+var<workgroup> vw3: bool;
+
+/* zero global variables used */
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  let ptr0: ptr<workgroup, array<atomic<u32>, 46>> = &vw4;
+  vp0 = mat2x3h(f16(atomicLoad(&(*ptr0)[45])), f16(atomicLoad(&(*ptr0)[45])), f16(atomicLoad(&(*ptr0)[45])), f16(atomicLoad(&(*ptr0)[45])), f16(atomicLoad(&(*ptr0)[45])), f16(atomicLoad(&(*ptr0)[45])));
+}`,
+});
+let buffer3 = device0.createBuffer({
+  size: 4806,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let commandEncoder7 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 254});
+let texture8 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint'],
+});
+let computePassEncoder7 = commandEncoder7.beginComputePass({});
+let sampler5 = device0.createSampler({addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 84.78});
+let imageData0 = new ImageData(36, 32);
+try {
+device0.queue.label = '\u39de\uec9d\u{1fbe5}';
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 202, resource: textureView0}, {binding: 47, resource: textureView1}],
+});
+let commandEncoder8 = device0.createCommandEncoder({});
+let computePassEncoder8 = commandEncoder8.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(392), 155, 0);
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let textureView5 = texture8.createView({baseMipLevel: 0});
+let sampler6 = device0.createSampler({
+  label: '\ud79f\u0ede\u0d66\ub6cc\u9c99\u2e30\u0563\u{1f87f}\u{1f799}\u89c7\u754f',
+  addressModeU: 'mirror-repeat',
+  lodMaxClamp: 63.16,
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup0);
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView6 = texture0.createView({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 796 */
+  offset: 796,
+  bytesPerRow: 4352,
+  buffer: buffer3,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 171, z: 0},
+  aspect: 'stencil-only',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 5, y: 48, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 36, y: 8, z: 0},
+  aspect: 'all',
+},
+{width: 72, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u993b');
+} catch {}
+let imageData1 = new ImageData(72, 4);
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 202, resource: textureView0}, {binding: 47, resource: textureView1}],
+});
+let texture9 = device0.createTexture({
+  label: '\u012b\ub53a',
+  size: {width: 839, height: 1, depthOrArrayLayers: 51},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16sint'],
+});
+let computePassEncoder9 = commandEncoder9.beginComputePass({});
+let sampler7 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.52,
+  lodMaxClamp: 86.39,
+  compare: 'greater-equal',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(678), 23, 0);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder10 = device0.createCommandEncoder({});
+let texture10 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(1885), 180, 0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule0, constants: {}}});
+let textureView7 = texture5.createView({
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+  arrayLayerCount: 3,
+});
+let computePassEncoder10 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup0, new Uint32Array(5534), 799, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+device0.label = '\u0d02\u4187\u{1faa2}\uaadb\u{1fa4e}\ua5c7\uf3db';
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 202, resource: textureView0}, {binding: 47, resource: textureView1}],
+});
+let buffer4 = device0.createBuffer({size: 15981, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture11 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture12 = device0.createTexture({
+  label: '\u52fc\u{1f8d4}\u39c1\uedd1\uf587\u2e36\u0af8\ubaa3\u00a8',
+  size: {width: 1},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.56,
+});
+let pipeline1 = await device0.createComputePipelineAsync({
+  label: '\u4422\u{1fddd}\u{1f89d}\ubb6f\uef3a\u0614\u89a6\u8a88',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView8 = texture3.createView({dimension: '2d'});
+let texture13 = device0.createTexture({
+  size: {width: 2, height: 1095, depthOrArrayLayers: 42},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+let texture14 = device0.createTexture({
+  size: [839, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView9 = texture10.createView({dimension: '2d-array', aspect: 'stencil-only'});
+let computePassEncoder11 = commandEncoder11.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 47, resource: textureView1}, {binding: 202, resource: textureView0}],
+});
+let textureView10 = texture11.createView({aspect: 'all'});
+let textureView11 = texture14.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler9 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'equal',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup3, new Uint32Array(347), 59, 0);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let buffer5 = device0.createBuffer({size: 731, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({
+  label: '\u98e2\u0635\u{1ff24}\u64fa\u3f95',
+  size: {width: 2, height: 1095, depthOrArrayLayers: 247},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture16 = device0.createTexture({size: [419, 1, 1], format: 'stencil8', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder12 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer1, 3000, new Float32Array(8279), 63, 192);
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture17 = device0.createTexture({
+  size: {width: 4, height: 1575, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let pipeline2 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let texture18 = device0.createTexture({
+  size: [1678, 1, 1],
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture19 = device0.createTexture({
+  size: [2, 787, 1],
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView12 = texture4.createView({});
+try {
+device0.queue.writeBuffer(buffer1, 6640, new BigUint64Array(9338), 2242, 360);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 31, y: 94, z: 5},
+  aspect: 'all',
+}, new Uint8Array(36).fill(145), /* required buffer size: 36 */
+{offset: 36, bytesPerRow: 287, rowsPerImage: 82}, {width: 43, height: 57, depthOrArrayLayers: 0});
+} catch {}
+let promise1 = device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule0}});
+await gc();
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture20 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture21 = device0.createTexture({
+  size: {width: 2, height: 787, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder13 = commandEncoder13.beginComputePass();
+try {
+device0.queue.writeBuffer(buffer1, 1076, new BigUint64Array(13781), 3283, 212);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: imageData1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte432', transfer: 'bt709'} });
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+var<workgroup> vw6: atomic<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp4: VertexOutput0 = VertexOutput0();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput0 {
+  @location(4) @interpolate(flat, center) f0: vec2f,
+  @location(0) f1: vec2i,
+  @location(3) @interpolate(flat) f2: vec4u,
+}
+
+var<private> vp5 = modf(vec3h(8486.0, 19642.6, 12390.4));
+
+@group(0) @binding(174) var<storage, read> buffer6: T0;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @size(44) f0: array<u32>,
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+  @location(7) @interpolate(perspective, centroid) f1: vec2f,
+}
+
+alias vec3b = vec3<bool>;
+
+/* used global variables: buffer6 */
+fn fn0(a0: array<mat2x3f, 1>, a1: array<array<array<array<i32, 1>, 1>, 9>, 1>) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf0: i32 = a1[unconst_u32(236)][8][0][0];
+  while bool(a1[0][8][unconst_u32(122)][0]) {
+  vp4 = VertexOutput0(vec4f(f32(a1[unconst_u32(71)][8][0][0])), vec2f(f32(a1[unconst_u32(71)][8][0][0])));
+  out.f2 |= vec4u(bitcast<u32>(a1[0][unconst_u32(486)][0][0]));
+  vp4 = VertexOutput0(vec4f(bitcast<f32>(a1[0][8][unconst_u32(24)][0])), vec2f(bitcast<f32>(a1[0][8][unconst_u32(24)][0])));
+}
+  var vf1: vec3h = exp(vec3h(unconst_f16(10857.4), unconst_f16(8752.6), unconst_f16(17471.1)));
+  let vf2: array<i32, 1> = a1[unconst_u32(337)][8][0];
+  var vf3: array<i32, 1> = a1[unconst_u32(177)][unconst_u32(168)][unconst_u32(169)];
+  let ptr1: ptr<storage, u32, read> = &buffer6.f0[u32(a1[unconst_u32(282)][8][0][0])];
+  var vf4: f32 = vp4.f1[unconst_u32(93)];
+  vp4 = VertexOutput0(vec4f(f32(a1[unconst_u32(384)][unconst_u32(214)][unconst_u32(33)][unconst_u32(284)])), vec2f(bitcast<f32>(a1[unconst_u32(384)][unconst_u32(214)][unconst_u32(33)][unconst_u32(284)])));
+  return out;
+  _ = buffer6;
+}
+
+/* used global variables: buffer6 */
+@vertex
+fn vertex0(@location(8) a0: vec4h) -> VertexOutput0 {
+  var out: VertexOutput0;
+  if bool(exp(bitcast<vec2h>(vp4.f1[unconst_u32(279)])).y) {
+  fn0(array<mat2x3f, 1>(mat2x3f(f32(buffer6.f0[arrayLength(&buffer6.f0)]), f32(buffer6.f0[arrayLength(&buffer6.f0)]), f32(buffer6.f0[arrayLength(&buffer6.f0)]), f32(buffer6.f0[arrayLength(&buffer6.f0)]), f32(buffer6.f0[arrayLength(&buffer6.f0)]), bitcast<f32>(buffer6.f0[arrayLength(&buffer6.f0)]))), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193))).x)), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193))).z)), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193))).g)), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193)))[3])), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193)))[2])), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193)))[1])), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193))).z)), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193)))[1])), array<array<i32, 1>, 1>(array<i32, 1>((unconst_i32(-377) % vec4i(unconst_i32(-128), unconst_i32(93), unconst_i32(100), unconst_i32(193))).a)))));
+  var vf5: vec2h = refract(bitcast<vec2h>((*&buffer6).f0[unconst_u32(570)]), vec2h(unconst_f16(799.8), unconst_f16(35378.5)), unconst_f16(1265.6));
+  fn0(array<mat2x3f, 1>(mat2x3f(unpack4x8snorm((*&buffer6).f0[unconst_u32(14)]).yzx, unpack4x8snorm((*&buffer6).f0[unconst_u32(14)]).zww)), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))))));
+  var vf6: f16 = a0[unconst_u32(404)];
+  let vf7: bool = (unconst_f32(0.07586) <= unconst_f32(-0.00542));
+  return out;
+  _ = buffer6;
+}
+  var vf8 = fn0(array<mat2x3f, 1>(mat2x3f(vp4.f1.rrr, vp4.f1.xxy)), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(buffer6.f0[unconst_i32(230)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(buffer6.f0[unconst_i32(230)]))))));
+  let ptr2: ptr<storage, array<u32>, read> = &(*&buffer6).f0;
+  var vf9 = fn0(array<mat2x3f, 1>(mat2x3f(vec3f((vec4f(unconst_f32(0.08898), unconst_f32(0.01385), unconst_f32(-0.5640), unconst_f32(0.1732)) != vec4f(unconst_f32(0.00470), unconst_f32(0.09445), unconst_f32(0.3106), unconst_f32(0.06449))).yzz), vec3f((vec4f(unconst_f32(0.08898), unconst_f32(0.01385), unconst_f32(-0.5640), unconst_f32(0.1732)) != vec4f(unconst_f32(0.00470), unconst_f32(0.09445), unconst_f32(0.3106), unconst_f32(0.06449))).ggg))), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[unconst_u32(94)]))))));
+  if bool(vf8.f0[1]) {
+  let ptr3: ptr<storage, array<u32>, read> = &buffer6.f0;
+  _ = buffer6;
+}
+  while bool(vf8.f1[unconst_u32(51)]) {
+  let ptr4: ptr<storage, u32, read> = &buffer6.f0[arrayLength(&buffer6.f0)];
+  out.f0 = vec4f(log2(vec3h(unconst_f16(-24556.7), unconst_f16(3228.8), unconst_f16(3336.2))).ggbg);
+  vp4.f1 = vec2f(f32(arrayLength(&buffer6.f0)));
+  if bool(degrees(vec4f(unconst_f32(0.08147), unconst_f32(0.07067), unconst_f32(0.1506), unconst_f32(0.1256))).g) {
+  fn0(array<mat2x3f, 1>(mat2x3f(bitcast<f32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]), bitcast<f32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]), f32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]), f32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]), f32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]), f32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(vec4i(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5))))[2])), array<array<i32, 1>, 1>(array<i32, 1>(vec4i(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5)))).b)), array<array<i32, 1>, 1>(array<i32, 1>(i32(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5))).g))), array<array<i32, 1>, 1>(array<i32, 1>(vec4i(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5))))[3])), array<array<i32, 1>, 1>(array<i32, 1>(vec4i(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5))))[2])), array<array<i32, 1>, 1>(array<i32, 1>(vec4i(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5))))[0])), array<array<i32, 1>, 1>(array<i32, 1>(vec4i(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5)))).b)), array<array<i32, 1>, 1>(array<i32, 1>(vec4i(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5)))).x)), array<array<i32, 1>, 1>(array<i32, 1>(i32(acosh(vec4h(unconst_f16(1947.1), unconst_f16(6034.9), unconst_f16(1186.5), unconst_f16(14295.5))).w))))));
+  for (var it0=vec3u(cross(vec3f(unconst_f32(0.3885), unconst_f32(0.5456), unconst_f32(0.1485)), vec3f(unconst_f32(-0.02032), unconst_f32(0.1128), unconst_f32(0.1366))))[2]; it0<buffer6.f0[arrayLength(&buffer6.f0)]; it0++) {
+  out.f0 *= unpack4x8snorm((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]);
+  break;
+  _ = buffer6;
+}
+  fn0(array<mat2x3f, 1>(mat2x3f(cos(unconst_f32(0.2421)), cos(unconst_f32(0.2421)), cos(unconst_f32(0.2421)), cos(unconst_f32(0.2421)), cos(unconst_f32(0.2421)), cos(unconst_f32(0.2421)))), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(i32(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(i32(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(i32(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(i32(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(i32(arrayLength(&(*&buffer6).f0)))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>(arrayLength(&(*&buffer6).f0)))))));
+  break;
+  _ = buffer6;
+}
+  fn0(array<mat2x3f, 1>(mat2x3f(f32(dot4I8Packed(pack2x16unorm(vec2f(unconst_f32(0.01436), unconst_f32(0.02815))), unconst_u32(268))), bitcast<f32>(dot4I8Packed(pack2x16unorm(vec2f(unconst_f32(0.01436), unconst_f32(0.02815))), unconst_u32(268))), bitcast<f32>(dot4I8Packed(pack2x16unorm(vec2f(unconst_f32(0.01436), unconst_f32(0.02815))), unconst_u32(268))), f32(dot4I8Packed(pack2x16unorm(vec2f(unconst_f32(0.01436), unconst_f32(0.02815))), unconst_u32(268))), f32(dot4I8Packed(pack2x16unorm(vec2f(unconst_f32(0.01436), unconst_f32(0.02815))), unconst_u32(268))), f32(dot4I8Packed(pack2x16unorm(vec2f(unconst_f32(0.01436), unconst_f32(0.02815))), unconst_u32(268))))), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all(unconst_bool(true))))))));
+  return out;
+  _ = buffer6;
+}
+  vp4 = VertexOutput0(vec4f(f32(atanh(unconst_f16(13111.1)))), vec2f(f32(atanh(unconst_f16(13111.1)))));
+  return out;
+  _ = buffer6;
+}
+
+/* used global variables: buffer6 */
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f1 *= bitcast<vec2i>(cross(vec3f(unconst_f32(0.01026), unconst_f32(0.1000), unconst_f32(0.1707)), cross(vec3f(unconst_f32(0.2053), unconst_f32(0.1013), unconst_f32(0.06794)), vp4.f0.yzx)).yx);
+  out.f0 *= vec2f(f32(buffer6.f0[arrayLength(&buffer6.f0)]));
+  while bool(vp4.f0[unconst_u32(122)]) {
+  for (var it1=(*&buffer6).f0[unconst_i32(410)]; it1<bitcast<vec3u>(sin(vec3f(unconst_f32(0.2366), unconst_f32(0.2420), unconst_f32(0.4868))))[2]; it1++) {
+  out.f2 |= vec4u(arrayLength(&(*&buffer6).f0));
+  out = FragmentOutput0(vec2f(cos(bitcast<vec2h>((*&buffer6).f0[unconst_u32(140)]))), vec2i(cos(bitcast<vec2h>((*&buffer6).f0[unconst_u32(140)]))), vec4u(cos(bitcast<vec2h>((*&buffer6).f0[unconst_u32(140)])).ggrg));
+  vp5 = modf(vec3h(f16(reverseBits(u32(vp4.f0[unconst_u32(184)])))));
+  fn0(array<mat2x3f, 1>(transpose(transpose(mat2x3f()))), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(i32((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))), array<array<i32, 1>, 1>(array<i32, 1>(bitcast<i32>((*&buffer6).f0[arrayLength(&(*&buffer6).f0)]))))));
+  out = FragmentOutput0(vec2f(f32(arrayLength(&(*&buffer6).f0))), vec2i(i32(arrayLength(&(*&buffer6).f0))), unpack4xU8(arrayLength(&(*&buffer6).f0)));
+  _ = buffer6;
+}
+  let vf10: f16 = dot(vec3h(unconst_f16(3831.3), unconst_f16(1846.7), unconst_f16(1418.9)), vec3h(unconst_f16(1020.3), unconst_f16(37395.6), unconst_f16(20692.0)));
+  var vf11: vec3f = sin(vec3f(unconst_f32(0.2462), unconst_f32(0.08568), unconst_f32(0.05655)));
+  var vf12 = fn0(array<mat2x3f, 1>(mat2x3f(vp4.f1[unconst_u32(21)], vp4.f1[unconst_u32(21)], vp4.f1[unconst_u32(21)], vp4.f1[unconst_u32(21)], vp4.f1[unconst_u32(21)], vp4.f1[unconst_u32(21)])), array<array<array<array<i32, 1>, 1>, 9>, 1>(array<array<array<i32, 1>, 1>, 9>(array<array<i32, 1>, 1>(array<i32, 1>(vec2i((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309)))).x)), array<array<i32, 1>, 1>(array<i32, 1>(i32(all((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309))))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(any((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309))))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309))))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(all((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309))))))), array<array<i32, 1>, 1>(array<i32, 1>(vec2i((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309))))[1])), array<array<i32, 1>, 1>(array<i32, 1>(i32(any((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309))))))), array<array<i32, 1>, 1>(array<i32, 1>(i32(any((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309))))))), array<array<i32, 1>, 1>(array<i32, 1>(vec2i((vec2f(unconst_f32(0.00209), unconst_f32(0.09453)) > vec2f(unconst_f32(0.00926), unconst_f32(0.02309)))).g)))));
+  _ = buffer6;
+}
+  let ptr5: ptr<storage, u32, read> = &(*&buffer6).f0[arrayLength(&(*&buffer6).f0)];
+  if bool(buffer6.f0[arrayLength(&buffer6.f0)]) {
+  let vf13: vec4h = radians(vec4h(unconst_f16(12528.8), unconst_f16(2210.2), unconst_f16(16128.8), unconst_f16(6209.8)));
+}
+  let ptr6: ptr<private, vec4f> = &vp4.f0;
+  return out;
+  _ = buffer6;
+}
+
+/* used global variables: buffer6 */
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  let vf14: u32 = arrayLength(&buffer6.f0);
+  return;
+  _ = buffer6;
+}`,
+});
+let texture22 = device0.createTexture({
+  size: [1, 136, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView13 = texture12.createView({});
+let computePassEncoder14 = commandEncoder14.beginComputePass({});
+let sampler10 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+let buffer7 = device0.createBuffer({
+  size: 3830,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let texture23 = device0.createTexture({
+  size: [256, 256, 21],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+let promise2 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x25997163},
+  fragment: {module: shaderModule1, constants: {}, targets: [{format: 'r16sint'}]},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater-equal', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilReadMask: 116557698,
+    stencilWriteMask: 378321618,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 64,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 4, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+let texture24 = device0.createTexture({
+  size: [256, 256, 294],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2888 */
+  offset: 2888,
+  bytesPerRow: 40448,
+  buffer: buffer4,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 0, y: 144, z: 0},
+  aspect: 'stencil-only',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture25 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture26 = device0.createTexture({
+  size: {width: 4, height: 1575, depthOrArrayLayers: 11},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView14 = texture7.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 266 */
+  offset: 266,
+  bytesPerRow: 4096,
+  buffer: buffer4,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer7, offset: 2560, size: 1008}}],
+});
+let commandEncoder16 = device0.createCommandEncoder();
+let texture27 = device0.createTexture({
+  size: [1, 136, 1],
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView15 = texture4.createView({baseMipLevel: 0});
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 690 */
+  offset: 690,
+  buffer: buffer4,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView16 = texture24.createView({});
+let texture28 = device0.createTexture({size: [1, 136, 1], mipLevelCount: 1, format: 'r16sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder15 = commandEncoder15.beginComputePass();
+try {
+computePassEncoder3.setBindGroup(2, bindGroup2, new Uint32Array(610), 6, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3448 */
+  offset: 3448,
+  bytesPerRow: 7168,
+  buffer: buffer4,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let textureView17 = texture11.createView({aspect: 'all'});
+let textureView18 = texture21.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup4, new Uint32Array(683), 6, 1);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let textureView19 = texture18.createView({arrayLayerCount: 1});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup4, [0]);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline2);
+} catch {}
+let videoFrame1 = videoFrame0.clone();
+let recycledExplicitBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let commandEncoder19 = device0.createCommandEncoder();
+let texture29 = device0.createTexture({
+  size: [1678, 1, 21],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture30 = device0.createTexture({
+  size: {width: 2, height: 787, depthOrArrayLayers: 137},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView20 = texture25.createView({
+  label: '\u0408\u056f\u{1fbf8}\u32a9\u092e\ubb8d\u3402\u0a2c\u{1fc9c}\u49e0',
+  dimension: '2d',
+  format: 'depth16unorm',
+});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(6, 31);
+let commandEncoder20 = device0.createCommandEncoder({});
+let texture31 = device0.createTexture({
+  size: [1, 393, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 496 */
+  offset: 496,
+  buffer: buffer4,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(videoFrame0, {timestamp: 0});
+let texture32 = device0.createTexture({
+  size: [839],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder2.insertDebugMarker('\u4bc6');
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture33 = device0.createTexture({
+  size: [2, 787, 1],
+  mipLevelCount: 2,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView21 = texture16.createView({dimension: '2d-array', aspect: 'stencil-only'});
+let computePassEncoder16 = commandEncoder20.beginComputePass({});
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 840});
+let textureView22 = texture15.createView({mipLevelCount: 1});
+let textureView23 = texture9.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 9});
+let computePassEncoder17 = commandEncoder19.beginComputePass({});
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 56, z: 1},
+  aspect: 'all',
+}, new Uint8Array(46).fill(186), /* required buffer size: 46 */
+{offset: 46, bytesPerRow: 151}, {width: 0, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let textureView24 = texture27.createView({mipLevelCount: 1});
+let sampler11 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.95,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup4, new Uint32Array(566), 89, 1);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2116 */
+  offset: 2116,
+  buffer: buffer4,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 1680, new Float32Array(169), 139, 16);
+} catch {}
+try {
+offscreenCanvas0.getContext('bitmaprenderer');
+} catch {}
+let textureView25 = texture23.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 6});
+let texture34 = device0.createTexture({
+  size: {width: 1, height: 273, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView26 = texture24.createView({});
+let computePassEncoder18 = commandEncoder17.beginComputePass({});
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2210 */
+  offset: 2210,
+  bytesPerRow: 18944,
+  buffer: buffer4,
+}, {
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 99, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 47, resource: textureView1}, {binding: 202, resource: textureView0}],
+});
+let texture35 = device0.createTexture({
+  size: [1, 547, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture36 = device0.createTexture({
+  size: {width: 1, height: 547, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder19 = commandEncoder18.beginComputePass({});
+let sampler12 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\ub34a');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 472, new Float32Array(24672), 3025, 8);
+} catch {}
+let texture37 = device0.createTexture({
+  size: [1],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture38 = device0.createTexture({
+  size: [1, 196, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView27 = texture36.createView({mipLevelCount: 1});
+let computePassEncoder20 = commandEncoder21.beginComputePass({});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup4, [0]);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup4, new Uint32Array(1405), 85, 1);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let textureView28 = texture37.createView({});
+let textureView29 = texture18.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder21 = commandEncoder16.beginComputePass({});
+let buffer8 = device0.createBuffer({size: 4907, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView30 = texture35.createView({});
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u5311');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 168, new DataView(new ArrayBuffer(3701)), 436, 24);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 171}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 515, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0}});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup4, new Uint32Array(4502), 493, 1);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+let textureView31 = texture24.createView({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder();
+let texture39 = device0.createTexture({
+  size: {width: 839, height: 1, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture40 = device0.createTexture({
+  size: {width: 2, height: 787, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler13 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+});
+try {
+commandEncoder22.copyBufferToBuffer(buffer4, 124, buffer1, 3084, 1140);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 312 */
+  offset: 312,
+  bytesPerRow: 768,
+  buffer: buffer3,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder22 = commandEncoder22.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(3, bindGroup0, new Uint32Array(1414), 108, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 208, new DataView(new ArrayBuffer(10708)), 1222, 496);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 1, y: 4 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 188, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let commandEncoder23 = device0.createCommandEncoder();
+try {
+computePassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer0, 116, 940);
+} catch {}
+let pipeline4 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule1, constants: {}}});
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 47, resource: textureView8}, {binding: 202, resource: textureView0}],
+});
+let textureView32 = texture7.createView({aspect: 'stencil-only', mipLevelCount: 1});
+let computePassEncoder23 = commandEncoder23.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer5, 244); };
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 152, z: 0},
+  aspect: 'all',
+}, new Uint8Array(320).fill(249), /* required buffer size: 320 */
+{offset: 320, bytesPerRow: 31}, {width: 0, height: 263, depthOrArrayLayers: 0});
+} catch {}
+let textureView33 = texture11.createView({mipLevelCount: 1});
+let sampler14 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 94.62,
+});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 432,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup7 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 174, resource: {buffer: buffer3, offset: 256, size: 584}}],
+});
+let textureView34 = texture27.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let textureView35 = texture5.createView({dimension: '2d', mipLevelCount: 2, baseArrayLayer: 4});
+let sampler15 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.95,
+  compare: 'less-equal',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup2, new Uint32Array(946), 17, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroups(1); };
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer5, 224, buffer8, 160, 100);
+} catch {}
+document.body.append(img0);
+let texture41 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder24 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(img0);
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 360,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 47, resource: textureView8}, {binding: 202, resource: textureView0}],
+});
+let commandEncoder24 = device0.createCommandEncoder({});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'stencil8', sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(0, bindGroup5);
+} catch {}
+let texture42 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder25 = commandEncoder24.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture43 = device0.createTexture({
+  label: '\ubf07\u{1fcdc}\u04a8\ucc8d\u{1f67c}\u{1fb51}\uc7e7\u394f\u4949\ua5e2',
+  size: [1, 547, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let textureView36 = texture18.createView({label: '\u687e\u2588', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+let promise4 = device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0}});
+let renderBundle1 = renderBundleEncoder1.finish({});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup2, new Uint32Array(329), 31, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let buffer9 = device0.createBuffer({size: 35981, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder15.end();
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 174, resource: {buffer: buffer0, offset: 7680, size: 1616}}],
+});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 498});
+let computePassEncoder26 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+let texture44 = device0.createTexture({
+  size: [839, 1, 124],
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({
+  size: [1, 547, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture46 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup5, new Uint32Array(1008), 154, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer5, 384); };
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 56, z: 23},
+  aspect: 'all',
+}, new Uint8Array(16_358).fill(192), /* required buffer size: 16_358 */
+{offset: 58, bytesPerRow: 28, rowsPerImage: 101}, {width: 1, height: 78, depthOrArrayLayers: 6});
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let texture47 = device0.createTexture({
+  size: [1678, 1, 1],
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline2);
+} catch {}
+try {
+adapter0.label = '\u{1fd7d}\u6125';
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture48 = device0.createTexture({size: [2, 1095, 1], format: 'stencil8', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let sampler16 = device0.createSampler({lodMaxClamp: 97.97});
+let texture49 = device0.createTexture({
+  size: {width: 419, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder23.setPipeline(pipeline4);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 0, y: 17, z: 0},
+  aspect: 'all',
+}, new Uint8Array(38).fill(32), /* required buffer size: 38 */
+{offset: 38, bytesPerRow: 226, rowsPerImage: 45}, {width: 0, height: 23, depthOrArrayLayers: 0});
+} catch {}
+let buffer10 = device0.createBuffer({size: 2607, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView37 = texture29.createView({baseMipLevel: 0});
+let texture50 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView38 = texture38.createView({baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder27 = commandEncoder28.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+  await promise3;
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let textureView39 = texture23.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+let textureView40 = texture37.createView({format: 'rgba16sint', arrayLayerCount: 1});
+let computePassEncoder28 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder();
+let computePassEncoder29 = commandEncoder26.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup7, new Uint32Array(204), 8, 1);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u19b5');
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470m', transfer: 'smpteSt4281'} });
+let texture51 = device0.createTexture({
+  size: [419, 1, 1],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder30 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup7, [0]);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0, new Uint32Array(1098), 1, 0);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 0, y: 28, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 360 */
+  offset: 360,
+  bytesPerRow: 17152,
+  buffer: buffer3,
+}, {width: 0, height: 25, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer8, 820, 68);
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer0, offset: 1536, size: 3328}}],
+});
+let buffer11 = device0.createBuffer({
+  size: 7941,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder31 = device0.createCommandEncoder();
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 1571});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup9, [512]);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer11, 4428, buffer0, 4576, 408);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+struct VertexOutput1 {
+  @invariant @builtin(position) f2: vec4f,
+}
+
+struct T3 {
+  @size(44) f0: array<atomic<i32>>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp6 = modf(f16(8602.1));
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* used global variables: buffer12 */
+fn fn0() -> array<mat2x3h, 1> {
+  var out: array<mat2x3h, 1>;
+  out[unconst_u32(109)] = mat2x3h((*&buffer12)[unconst_u32(14)][0].yyy, (*&buffer12)[unconst_u32(14)][0].yyx);
+  var vf15: i32 = dot4I8Packed(unconst_u32(623), unconst_u32(150));
+  let ptr7: ptr<storage, array<vec2h, 1>, read> = &(*&buffer12)[10];
+  let ptr8: ptr<storage, array<vec2h, 1>, read> = &(*ptr7);
+  vp6 = modf(buffer12[10][0].y);
+  vp6 = modf(f16(insertBits(vec3i(unconst_i32(14), unconst_i32(252), unconst_i32(39)), vec3i(unconst_i32(295), unconst_i32(63), unconst_i32(159)), unconst_u32(79), unconst_u32(119)).b));
+  let ptr9: ptr<storage, vec2h, read> = &(*&buffer12)[10][unconst_u32(22)];
+  vp7[37] = f16(sqrt(unconst_f32(0.3741)));
+  let ptr10: ptr<storage, vec2h, read> = &buffer12[unconst_u32(55)][unconst_u32(127)];
+  return out;
+  _ = buffer12;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @size(48) f0: array<mat4x4h>,
+}
+
+struct T0 {
+  @size(44) f0: array<array<atomic<u32>, 5>>,
+}
+
+@group(0) @binding(174) var<storage, read> buffer12: array<array<vec2h, 1>, 11>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp7: array<f16, 38> = array(f16(1480.9), f16(4615.3), f16(-13789.0), f16(1902.2), f16(-6965.3), f16(768.7), f16(3905.2), f16(6269.9), f16(6435.1), f16(-2159.5), f16(1631.4), f16(4007.4), f16(1061.5), f16(706.5), f16(2089.2), f16(-4350.7), f16(2029.0), f16(6323.4), f16(4213.2), f16(9422.2), f16(7554.2), f16(-5140.4), f16(1693.4), f16(5685.4), f16(-44164.4), f16(2674.8), f16(552.5), f16(19114.6), f16(4525.2), f16(3436.3), f16(29507.9), f16(1721.6), f16(26009.8), f16(1789.7), f16(3781.4), f16(4789.7), f16(16462.0), f16(3840.6));
+
+struct T2 {
+  @size(44) f0: f32,
+}
+
+/* used global variables: buffer12 */
+@vertex
+fn vertex1(@location(12) @interpolate(perspective) a0: vec2h, @location(15) @interpolate(perspective, center) a1: vec2f, @location(9) a2: f32, @location(2) @interpolate(flat) a3: u32) -> VertexOutput1 {
+  var out: VertexOutput1;
+  vp7[unconst_u32(79)] -= buffer12[10][0].r;
+  out.f2 *= vec4f((*&buffer12)[unconst_u32(9)][0].xyxy);
+  out = VertexOutput1(vec4f((*&buffer12)[unconst_u32(115)][0].xyyy));
+  let ptr11: ptr<storage, array<vec2h, 1>, read> = &buffer12[10];
+  out.f2 -= vec4f(buffer12[unconst_u32(79)][0].rgrr);
+  vp7[bitcast<u32>(buffer12[unconst_u32(344)][0])] = vec4h(tanh(vec4f(unconst_f32(0.01158), unconst_f32(0.3207), unconst_f32(0.2735), unconst_f32(0.07404)))).g;
+  loop {
+  out.f2 = vec4f(f32((*&buffer12)[10][0][unconst_u32(326)]));
+  var vf16: vec3u = select(vec3u(unconst_u32(223), unconst_u32(87), unconst_u32(26)), vec3u(unconst_u32(167), unconst_u32(34), unconst_u32(29)), unconst_bool(false));
+  fn0();
+  fn0();
+  let ptr12: ptr<private, f16> = &vp6.fract;
+  break;
+  _ = buffer12;
+}
+  var vf17: vec4h = min(vec4h(unconst_f16(9541.8), unconst_f16(965.1), unconst_f16(5545.6), unconst_f16(13610.7)), vec4h(unconst_f16(5765.1), unconst_f16(418.0), unconst_f16(-5796.4), unconst_f16(12453.6)));
+  fn0();
+  return out;
+  _ = buffer12;
+}
+
+/* used global variables: buffer12 */
+@compute @workgroup_size(1, 2, 2)
+fn compute2() {
+  storageBarrier();
+  var vf18: bool = (unconst_bool(true) && unconst_bool(false));
+  let vf19: f16 = buffer12[bitcast<u32>((*&buffer12)[10][unconst_u32(45)])][0][unconst_u32(111)];
+  var vf20: f16 = buffer12[unconst_u32(123)][0][unconst_u32(205)];
+  let vf21: f16 = (*&buffer12)[10][unconst_u32(29)][unconst_u32(15)];
+  let ptr13: ptr<storage, vec2h, read> = &(*&buffer12)[10][unconst_u32(173)];
+  let vf22: vec4i = unpack4xI8(unconst_u32(481));
+  let ptr14: ptr<storage, vec2h, read> = &buffer12[unconst_u32(25)][0];
+  _ = buffer12;
+}`,
+});
+let recycledExplicitBindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+let bindGroup11 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 47, resource: textureView8}, {binding: 202, resource: textureView0}],
+});
+let buffer13 = device0.createBuffer({size: 2922, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture52 = device0.createTexture({
+  size: {width: 419, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture53 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder31 = commandEncoder29.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 171}
+*/
+{
+  source: imageData1,
+  origin: { x: 22, y: 0 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 130, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView41 = texture15.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(1); };
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let commandEncoder32 = device0.createCommandEncoder({});
+let textureView42 = texture17.createView({mipLevelCount: 1});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup0, new Uint32Array(3539), 167, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline3);
+} catch {}
+let texture54 = device0.createTexture({
+  size: {width: 1, height: 547, depthOrArrayLayers: 385},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView43 = texture44.createView({dimension: '2d', aspect: 'all', mipLevelCount: 4, baseArrayLayer: 108});
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer5, 156, buffer1, 1892, 228);
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1096 */
+  offset: 1096,
+  bytesPerRow: 16384,
+  rowsPerImage: 605,
+  buffer: buffer4,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer14 = device0.createBuffer({
+  size: 15546,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let texture55 = device0.createTexture({
+  size: [1678, 1, 40],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder32 = commandEncoder31.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup2, new Uint32Array(828), 74, 0);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer5, 56, buffer10, 44, 4);
+} catch {}
+let pipeline5 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule1}});
+let commandEncoder34 = device0.createCommandEncoder({});
+let textureView44 = texture17.createView({dimension: '2d-array', mipLevelCount: 3, baseArrayLayer: 0});
+let texture56 = device0.createTexture({
+  size: [256, 256, 21],
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder33 = commandEncoder33.beginComputePass();
+try {
+computePassEncoder29.setBindGroup(0, bindGroup4, new Uint32Array(892), 35, 1);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 171}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 290, z: 99},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let buffer15 = device0.createBuffer({
+  size: 5987,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView45 = texture54.createView({mipLevelCount: 1});
+let sampler17 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 93.50,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1, 1, 2); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 844, new DataView(new ArrayBuffer(5761)), 248, 428);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 85, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 47, resource: textureView8}, {binding: 202, resource: textureView42}],
+});
+let buffer16 = device0.createBuffer({
+  size: 2597,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture57 = device0.createTexture({
+  size: [839, 1, 10],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView46 = texture16.createView({dimension: '2d-array', aspect: 'stencil-only', format: 'stencil8', baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder34 = commandEncoder35.beginComputePass();
+try {
+computePassEncoder11.setBindGroup(0, bindGroup9, [512]);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup4, new Uint32Array(404), 72, 1);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 408, new DataView(new ArrayBuffer(307)), 100, 32);
+} catch {}
+let commandBuffer0 = commandEncoder17.finish();
+let textureView47 = texture57.createView({});
+let texture58 = device0.createTexture({size: [256, 256, 21], mipLevelCount: 6, format: 'stencil8', usage: GPUTextureUsage.COPY_DST});
+let textureView48 = texture37.createView({arrayLayerCount: 1});
+try {
+computePassEncoder33.setPipeline(pipeline3);
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt2020', transfer: 'bt709'} });
+let computePassEncoder35 = commandEncoder34.beginComputePass({});
+let sampler18 = device0.createSampler({addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 82.63});
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer13, 212, 872);
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  label: '\uae79\u{1f9cb}\u8a66\u{1fa63}\u{1f634}\u0e1f\u3e0e',
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 432, resource: textureView42}, {binding: 77, resource: textureView1}],
+});
+let texture59 = device0.createTexture({
+  size: [256, 256, 21],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView49 = texture18.createView({label: '\u08ca\u0ec0', aspect: 'all', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder36 = commandEncoder32.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup7, [256]);
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 79, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 72 */
+  offset: 72,
+  bytesPerRow: 6144,
+  buffer: buffer8,
+}, {width: 0, height: 25, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 408, new Float32Array(27176), 2118, 172);
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer14, offset: 2816, size: 2936}}],
+});
+let buffer17 = device0.createBuffer({
+  size: 11387,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup8, new Uint32Array(2273), 325, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 960 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 632 */
+  offset: 632,
+  buffer: buffer16,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 120, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture60 = device0.createTexture({
+  size: [256, 256, 3],
+  mipLevelCount: 6,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder37 = commandEncoder36.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup10, [1792]);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer14, 2356, buffer3, 1776, 488);
+} catch {}
+let texture61 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 62 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 208 */
+  offset: 208,
+  bytesPerRow: 50176,
+  buffer: buffer3,
+}, {
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 28,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 495,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder38 = commandEncoder25.beginComputePass({});
+try {
+computePassEncoder38.setPipeline(pipeline1);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.READ, 0, 3108);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 132, new Int16Array(10134), 1467, 60);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout1]});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 8444, new BigUint64Array(26188), 8679, 552);
+} catch {}
+let buffer18 = device0.createBuffer({size: 16851, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture62 = device0.createTexture({size: [2, 1095, 1], mipLevelCount: 5, format: 'rgba8snorm', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(3, bindGroup6, new Uint32Array(1670), 128, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer19 = device0.createBuffer({
+  size: 6705,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder37 = device0.createCommandEncoder({label: '\u0291\u53c9\uc432\u0e3e\u{1f646}\u7a4b\u0139\u{1ff67}\u9064'});
+let texture63 = device0.createTexture({
+  size: [2, 1095, 7],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder39 = commandEncoder37.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup1, new Uint32Array(1906), 373, 0);
+} catch {}
+let arrayBuffer0 = buffer1.getMappedRange(1456, 680);
+let pipeline6 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0}});
+document.body.append(img0);
+let texture64 = device0.createTexture({
+  label: '\u6e39\ub3ba',
+  size: [1, 547, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler19 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.40,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup14, [0]);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let buffer20 = device0.createBuffer({
+  size: 177,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture65 = device0.createTexture({size: [2, 787, 1], mipLevelCount: 3, format: 'stencil8', usage: GPUTextureUsage.COPY_SRC});
+let textureView50 = texture31.createView({baseArrayLayer: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 209, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let commandEncoder38 = device0.createCommandEncoder();
+let texture66 = device0.createTexture({
+  size: {width: 839, height: 1, depthOrArrayLayers: 14},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 248 widthInBlocks: 124 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 236 */
+  offset: 236,
+  buffer: buffer4,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 124, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 171}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 245, z: 55},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView51 = texture66.createView({dimension: '2d', format: 'rgba16float', baseArrayLayer: 11});
+let computePassEncoder40 = commandEncoder38.beginComputePass();
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 102 */
+  offset: 102,
+  buffer: buffer5,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.resolveQuerySet(querySet3, 52, 56, buffer19, 1280);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 264, new Float32Array(1844), 199, 136);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\u1954\ud897\u065d\ufd00\u{1f844}\u0d3f\u0add\u436f',
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer11, offset: 768, size: 344}}],
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup4, new Uint32Array(10000), 1_150, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(2); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(102).fill(244), /* required buffer size: 102 */
+{offset: 102}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 174, resource: {buffer: buffer11, offset: 768, size: 1620}}],
+});
+let sampler20 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.15,
+});
+try {
+commandEncoder14.copyBufferToBuffer(buffer16, 192, buffer1, 2948, 240);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 1832 widthInBlocks: 229 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2184 */
+  offset: 2184,
+  bytesPerRow: 39680,
+  buffer: buffer3,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 229, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer3, 2200, 964);
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 77, resource: textureView27}, {binding: 432, resource: textureView42}],
+});
+let textureView52 = texture17.createView({dimension: '2d-array', format: 'rgba8snorm', mipLevelCount: 1, baseArrayLayer: 0});
+let textureView53 = texture23.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder41 = commandEncoder14.beginComputePass({});
+let sampler21 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline3);
+} catch {}
+let buffer21 = device0.createBuffer({
+  size: 19208,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder39 = device0.createCommandEncoder({});
+let texture67 = device0.createTexture({
+  size: {width: 839, height: 1, depthOrArrayLayers: 26},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler22 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.90,
+  lodMaxClamp: 97.98,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({});
+let textureView54 = texture61.createView({mipLevelCount: 1});
+let sampler23 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 96.18,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 171}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 81, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u100e\u38bb\ub61b\u05d4\u6d2b';
+} catch {}
+let texture68 = device0.createTexture({
+  size: {width: 839, height: 1, depthOrArrayLayers: 80},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder42 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder8.setBindGroup(3, bindGroup11, new Uint32Array(1343), 1, 0);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer14, 732, buffer9, 8388, 372);
+} catch {}
+let buffer22 = device0.createBuffer({
+  size: 5964,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let computePassEncoder43 = commandEncoder41.beginComputePass();
+try {
+computePassEncoder42.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 128, new Int16Array(2156), 74, 1544);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder42 = device0.createCommandEncoder({});
+let textureView55 = texture15.createView({dimension: '3d', mipLevelCount: 1});
+let sampler24 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 60.66});
+let arrayBuffer1 = buffer1.getMappedRange(2136, 360);
+try {
+device0.queue.writeBuffer(buffer11, 1392, new Int16Array(5460), 3567, 456);
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpteRp431', transfer: 'iec61966-2-1'} });
+try {
+computePassEncoder5.setBindGroup(1, bindGroup8);
+} catch {}
+document.body.append(img0);
+let bindGroup18 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer15, offset: 0, size: 1608}}],
+});
+let computePassEncoder44 = commandEncoder40.beginComputePass();
+try {
+computePassEncoder35.setBindGroup(2, bindGroup12, new Uint32Array(284), 25, 0);
+} catch {}
+let imageData2 = new ImageData(132, 20);
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let texture69 = device0.createTexture({
+  size: {width: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder45 = commandEncoder42.beginComputePass();
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 96.49,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup16, [0]);
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer3, offset: 512, size: 1156}}],
+});
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture70 = device0.createTexture({
+  size: [839],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler26 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat'});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup5, new Uint32Array(82), 17, 0);
+} catch {}
+try {
+textureView55.label = '\u{1fd70}\uc4f2\u0e66\u08c5\u8d49';
+} catch {}
+let buffer23 = device0.createBuffer({size: 18432, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let texture71 = device0.createTexture({
+  size: [3357, 1, 1],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'stencil8', sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup16, new Uint32Array(4228), 360, 1);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 400 */
+  offset: 400,
+  bytesPerRow: 13824,
+  buffer: buffer23,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 273, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder31.insertDebugMarker('\u{1fcc0}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1564, new Float32Array(7288), 1235, 20);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(188).fill(255), /* required buffer size: 188 */
+{offset: 188, rowsPerImage: 104}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup20 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 174, resource: {buffer: buffer11, offset: 1536, size: 1696}}],
+});
+let commandEncoder44 = device0.createCommandEncoder({});
+let commandEncoder45 = device0.createCommandEncoder();
+let texture72 = device0.createTexture({
+  size: {width: 2, height: 1095, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder46 = commandEncoder44.beginComputePass({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'stencil8', sampleCount: 4, stencilReadOnly: false});
+let renderBundle2 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup18, [768]);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup11, new Uint32Array(576), 28, 0);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 92, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1310 */
+  offset: 1310,
+  buffer: buffer18,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 1600, new Float32Array(576), 19, 64);
+} catch {}
+let imageData3 = new ImageData(20, 4);
+let buffer24 = device0.createBuffer({size: 1355, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let commandEncoder46 = device0.createCommandEncoder({});
+let renderBundle3 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder3.end();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let commandEncoder47 = device0.createCommandEncoder();
+let texture73 = device0.createTexture({
+  size: {width: 3357, height: 1, depthOrArrayLayers: 1},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder47 = commandEncoder43.beginComputePass({});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.98,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup12, new Uint32Array(4783), 2_314, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroups(1); };
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(querySet2, 19, 375, buffer19, 256);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 119, z: 3},
+  aspect: 'stencil-only',
+}, new Uint8Array(6).fill(230), /* required buffer size: 6 */
+{offset: 6}, {width: 256, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer1 = commandEncoder4.finish();
+let textureView56 = texture66.createView({baseArrayLayer: 3, arrayLayerCount: 2});
+let texture74 = device0.createTexture({
+  size: {width: 839},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView57 = texture69.createView({});
+try {
+commandEncoder47.copyBufferToBuffer(buffer16, 440, buffer9, 2416, 120);
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let textureView58 = texture73.createView({aspect: 'all', baseMipLevel: 0});
+let computePassEncoder48 = commandEncoder2.beginComputePass({});
+let sampler28 = device0.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 77.43});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder47.setPipeline(pipeline6);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 199, z: 22},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let buffer25 = device0.createBuffer({
+  size: 5382,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let textureView59 = texture23.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup17, []);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder47.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 51, y: 43, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 10, y: 32, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 32, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+document.body.append(img0);
+let computePassEncoder49 = commandEncoder46.beginComputePass({label: '\u0d88\ua9ea\ub741\u94ab\u0c3c\u0754'});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup18, new Uint32Array(1526), 103, 1);
+} catch {}
+try {
+adapter0.label = '\u8fe6\u{1f7e2}\u877b\ue884\u6e6c\u5f90\ue407\u0dca\u6a35\u98ae';
+} catch {}
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 59,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let buffer26 = device0.createBuffer({
+  size: 4065,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture75 = device0.createTexture({
+  size: {width: 1, height: 273, depthOrArrayLayers: 27},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView60 = texture2.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder50 = commandEncoder20.beginComputePass({});
+try {
+computePassEncoder50.setPipeline(pipeline6);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder22.insertDebugMarker('\u0989');
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'stencil8', sampleCount: 4});
+let renderBundle4 = renderBundleEncoder4.finish();
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 84.66,
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup4, new Uint32Array(3308), 334, 1);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup10, new Uint32Array(660), 74, 1);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(0, bindGroup20, [3072]);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline3);
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+  await buffer9.mapAsync(GPUMapMode.READ, 0, 5144);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet0, 99, 372, buffer17, 768);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder();
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'stencil8', sampleCount: 4});
+let sampler30 = device0.createSampler({addressModeV: 'repeat', magFilter: 'linear', lodMaxClamp: 85.54});
+try {
+computePassEncoder46.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup3, []);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: imageData2,
+  origin: { x: 8, y: 3 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 71, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt709', transfer: 'gamma22curve'} });
+let bindGroup21 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer0, offset: 2048, size: 2324}}],
+});
+let buffer27 = device0.createBuffer({
+  size: 3449,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler31 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 88.83,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer3, 'uint16', 226, 60);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 208 */
+  offset: 208,
+  bytesPerRow: 54272,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 48, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 245, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet3, 17, 26, buffer15, 768);
+} catch {}
+try {
+adapter0.label = '\udca4\u6820\u{1fc1f}\u{1f87c}\u1e30\u{1f6dc}\u5b3d\u{1f729}\u0b0c\u01ad\u022c';
+} catch {}
+let sampler32 = device0.createSampler({addressModeW: 'repeat', lodMaxClamp: 91.31});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(5, buffer17);
+} catch {}
+let pipeline7 = await promise2;
+let commandBuffer2 = commandEncoder24.finish({});
+let computePassEncoder51 = commandEncoder47.beginComputePass();
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint'],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle5 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup16, new Uint32Array(537), 16, 1);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer14, 'uint32', 156, 448);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let computePassEncoder52 = commandEncoder50.beginComputePass({});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthStencilFormat: 'stencil8', sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder52.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer22, 'uint32', 960, 768);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(0, buffer21, 0, 22);
+} catch {}
+let recycledExplicitBindGroupLayout3 = pipeline1.getBindGroupLayout(0);
+let computePassEncoder53 = commandEncoder48.beginComputePass({});
+try {
+computePassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1692 */
+  offset: 1692,
+  bytesPerRow: 52480,
+  buffer: buffer4,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 29, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder54 = commandEncoder52.beginComputePass({});
+try {
+computePassEncoder51.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup2, new Uint32Array(153), 10, 0);
+} catch {}
+try {
+device0.queue.label = '\u36a8\u0f4e\u{1fd49}\u143f\u0691\u58a2\u43d9';
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer27, offset: 0, size: 2040}}],
+});
+let texture76 = device0.createTexture({
+  size: [4, 1575, 1],
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder55 = commandEncoder49.beginComputePass({});
+try {
+computePassEncoder53.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 209, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 8, y: 12 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+let textureView61 = texture69.createView({});
+let sampler33 = device0.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 92.51});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup12, new Uint32Array(2342), 137, 0);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 716 */
+  offset: 716,
+  bytesPerRow: 2048,
+  rowsPerImage: 796,
+  buffer: buffer4,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'stencil-only',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer28 = device0.createBuffer({
+  label: '\ue5c4\u77fc\u2714\ue70b\u0051\u0520\u2bbd\u{1fe30}\uf2c4\ub2fd',
+  size: 23331,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture77 = device0.createTexture({
+  size: [3357, 1, 1],
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView62 = texture50.createView({
+  label: '\u{1fffe}\uab6b\ua06a\u221d\u{1fb72}\u{1f926}\uc3bd\u9b88\u{1f83e}',
+  dimension: 'cube-array',
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let renderBundle6 = renderBundleEncoder5.finish({});
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.47,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup1, new Uint32Array(1993), 97, 0);
+} catch {}
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup11, []);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer22, 'uint32', 480, 2_200);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+adapter0.label = '\u0fbd\u{1ffe4}';
+} catch {}
+let computePassEncoder56 = commandEncoder53.beginComputePass({});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup18, new Uint32Array(196), 56, 1);
+} catch {}
+try {
+computePassEncoder43.insertDebugMarker('\u4ae0');
+} catch {}
+let recycledExplicitBindGroupLayout4 = pipeline3.getBindGroupLayout(0);
+try {
+computePassEncoder56.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer19, 'uint32', 832, 17);
+} catch {}
+let buffer29 = device0.createBuffer({
+  size: 3839,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture78 = device0.createTexture({
+  size: [4, 1575, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup9, new Uint32Array(1208), 171, 1);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer5, 'uint16', 202, 36);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(7, buffer7, 0);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6190 */
+  offset: 6190,
+  bytesPerRow: 17408,
+  buffer: buffer23,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline1.getBindGroupLayout(0);
+let commandEncoder54 = device0.createCommandEncoder({});
+let computePassEncoder57 = commandEncoder45.beginComputePass();
+let sampler35 = device0.createSampler({addressModeW: 'repeat', minFilter: 'linear', compare: 'always'});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup13, new Uint32Array(466), 175, 0);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let commandBuffer3 = commandEncoder9.finish();
+let sampler36 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'linear', lodMaxClamp: 79.84});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup22, [512]);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer27, 'uint16', 528, 108);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 495, resource: {buffer: buffer17, offset: 256, size: 1964}},
+    {binding: 34, resource: textureView47},
+    {binding: 28, resource: textureView42},
+    {binding: 14, resource: sampler32},
+  ],
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+let textureView63 = texture47.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(2); };
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 1222, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 58, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T1 {
+  @size(44) f0: array<u32>,
+}
+
+/* used global variables: buffer30 */
+fn fn0() -> VertexOutput2 {
+  var out: VertexOutput2;
+  let vf23: vec3<bool> = (vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true)) != vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false)));
+  loop {
+  var vf24: vec4f = unpack4x8unorm(unconst_u32(7));
+  let ptr15: ptr<storage, array<u32>, read> = &(*&buffer30).f0;
+  {
+  out.f3 = unpack4x8unorm((*&buffer30).f0[arrayLength(&(*&buffer30).f0)]);
+  break;
+  _ = buffer30;
+}
+  var vf25: f16 = exp(f16(buffer30.f0[unconst_i32(-7)]));
+  var vf26: i32 = (unconst_i32(-19) - unconst_i32(306));
+  vf26 *= vec4i(max(vec4f(unconst_f32(0.2014), unconst_f32(0.08161), unconst_f32(0.00686), unconst_f32(0.03156)), vec4f(unconst_f32(0.03737), unconst_f32(0.6352), unconst_f32(0.2518), unconst_f32(0.04265))))[2];
+  break;
+  _ = buffer30;
+}
+  let ptr16: ptr<storage, array<u32>, read> = &buffer30.f0;
+  var vf27: vec4h = exp2(vec4h(unconst_f16(8007.3), unconst_f16(1318.6), unconst_f16(16412.7), unconst_f16(29181.2)));
+  vf27 = vec4h(f16(select(bool(buffer30.f0[arrayLength(&buffer30.f0) - 1]), bool((*&buffer30).f0[arrayLength(&(*&buffer30).f0) - 1]), unconst_bool(false))));
+  let vf28: u32 = arrayLength(&buffer30.f0);
+  vf27 = ceil(vec3h(unconst_f16(7016.4), unconst_f16(2899.2), unconst_f16(11145.3))).bbbr;
+  out = VertexOutput2(tan(vec3f(unconst_f32(-0.1362), unconst_f32(0.08804), unconst_f32(0.2267))).xyyy);
+  let vf29: i32 = firstTrailingBit(bitcast<i32>((*ptr16)[arrayLength(&(*ptr16))]));
+  vf27 = vec4h(f16(buffer30.f0[arrayLength(&buffer30.f0)]));
+  let vf30: f16 = step(unconst_f16(1169.2), unconst_f16(-2628.1));
+  return out;
+  _ = buffer30;
+}
+
+struct T0 {
+  @align(4) @size(44) f0: array<f16, 11>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* used global variables: buffer30 */
+fn fn1() -> bool {
+  var out: bool;
+  let ptr17: ptr<storage, u32, read> = &buffer30.f0[unconst_u32(24)];
+  fn0();
+  fn0();
+  let ptr18: ptr<storage, T1, read> = &buffer30;
+  fn0();
+  out = bool((*ptr18).f0[arrayLength(&(*ptr18).f0)]);
+  if bool(countTrailingZeros(unconst_i32(4))) {
+  out = bool(extractBits(vec3i(unconst_i32(115), unconst_i32(-46), unconst_i32(821)), unconst_u32(20), unconst_u32(352))[2]);
+  let vf31: vec2f = unpack2x16float(unconst_u32(23));
+  fn0();
+  var vf32 = fn0();
+  var vf33 = fn0();
+  _ = buffer30;
+}
+  {
+  fn0();
+  out = bool(pow(vec4h(unconst_f16(20360.1), unconst_f16(2051.7), unconst_f16(11131.1), unconst_f16(3388.3)), vec4h(unconst_f16(10101.2), unconst_f16(-14034.2), unconst_f16(1008.9), unconst_f16(2177.5)))[1]);
+  while bool(arrayLength(&(*&buffer30).f0)) {
+  var vf34 = fn0();
+  if bool(step(vec2f(unconst_f32(0.1301), unconst_f32(0.2189)), vec2f(unconst_f32(0.1092), unconst_f32(0.1368)))[0]) {
+  var vf35: bool = any(vec2<bool>(unconst_bool(false), unconst_bool(false)));
+  let ptr19: ptr<storage, u32, read> = &(*&buffer30).f0[unconst_u32(1)];
+  _ = buffer30;
+}
+  return out;
+  _ = buffer30;
+}
+  _ = buffer30;
+}
+  var vf36 = fn0();
+  let ptr20: ptr<function, vec4f> = &vf36.f3;
+  var vf37 = fn0();
+  var vf38 = fn0();
+  return out;
+  _ = buffer30;
+}
+
+@group(0) @binding(174) var<storage, read> buffer30: T1;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+struct VertexOutput2 {
+  @invariant @builtin(position) f3: vec4f,
+}
+
+/* used global variables: buffer30 */
+@vertex
+fn vertex2() -> VertexOutput2 {
+  var out: VertexOutput2;
+  out = VertexOutput2(vec4f(bitcast<f32>(buffer30.f0[arrayLength(&buffer30.f0) - 1])));
+  while bool(normalize(vec3h(unconst_f16(7113.0), unconst_f16(4260.1), unconst_f16(20666.3)))[1]) {
+  out.f3 = unpack4x8unorm((*&buffer30).f0[arrayLength(&(*&buffer30).f0)]);
+  break;
+  _ = buffer30;
+}
+  out.f3 = unpack4x8snorm((*&buffer30).f0[arrayLength(&(*&buffer30).f0)]);
+  var vf39: f16 = sqrt(unconst_f16(-34025.2));
+  return out;
+  _ = buffer30;
+}
+
+/* used global variables: buffer30 */
+@fragment
+fn fragment1() -> @location(200) @interpolate(flat) vec4u {
+  var out: vec4u;
+  out = vec4u(buffer30.f0[arrayLength(&buffer30.f0)]);
+  let vf40: vec2<bool> = (vec2h(unconst_f16(7315.4), unconst_f16(41030.9)) < vec2h(unconst_f16(3198.9), unconst_f16(1956.0)));
+  var vf41: u32 = pack4x8unorm(vec4f(unconst_f32(-0.5165), unconst_f32(0.07544), unconst_f32(0.01253), unconst_f32(0.2863)));
+  vf41 -= (*&buffer30).f0[(*&buffer30).f0[arrayLength(&(*&buffer30).f0)]];
+  var vf42: i32 = dot4I8Packed(unconst_u32(27), unconst_u32(71));
+  var vf43: vec2f = unpack2x16snorm(u32(all((vec4u(unconst_u32(60), unconst_u32(7), unconst_u32(328), unconst_u32(58)) <= vec4u(unconst_u32(300), unconst_u32(190), unconst_u32(384), unconst_u32(736))))));
+  vf42 |= i32((*&buffer30).f0[arrayLength(&(*&buffer30).f0)]);
+  out = vec4u((vec2f(unconst_f32(-0.09618), unconst_f32(0.04256)) <= vec2f(unconst_f32(0.2185), unconst_f32(0.1012))).grgg);
+  return out;
+  _ = buffer30;
+}
+
+/* used global variables: buffer30 */
+@compute @workgroup_size(1, 1, 1)
+fn compute3() {
+  let vf44: u32 = arrayLength(&(*&buffer30).f0);
+  _ = buffer30;
+}`,
+});
+let buffer31 = device0.createBuffer({
+  size: 1458,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder56 = device0.createCommandEncoder({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+let sampler37 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', addressModeW: 'repeat'});
+try {
+computePassEncoder57.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 2784 widthInBlocks: 1392 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1890 */
+  offset: 1890,
+  bytesPerRow: 14592,
+  buffer: buffer21,
+}, {
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1392, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder58 = commandEncoder39.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(buffer19, 1360, buffer17, 468, 960);
+} catch {}
+let bindGroup24 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 59, resource: textureView20}]});
+let commandBuffer4 = commandEncoder2.finish({});
+let computePassEncoder59 = commandEncoder55.beginComputePass({});
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup22, new Uint32Array(2449), 1_799, 1);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer3, 120, buffer1, 6496, 556);
+} catch {}
+document.body.prepend(img0);
+let bindGroup25 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 34, resource: textureView47},
+    {binding: 28, resource: textureView42},
+    {binding: 495, resource: {buffer: buffer31, offset: 0, size: 760}},
+    {binding: 14, resource: sampler16},
+  ],
+});
+let buffer32 = device0.createBuffer({size: 8178, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u4a3e\uc83b\u01bb\u{1fc6d}\u{1f97d}\uc1fd\u7540\u5921'});
+let texture79 = device0.createTexture({size: [1, 273, 1], format: 'stencil8', usage: GPUTextureUsage.COPY_DST, viewFormats: ['stencil8']});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup7, [256]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer11, 600); };
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline1);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let promise7 = shaderModule3.getCompilationInfo();
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer2 = buffer9.getMappedRange(0, 1644);
+try {
+computePassEncoder57.insertDebugMarker('\u06cb');
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let videoFrame7 = new VideoFrame(videoFrame3, {timestamp: 0});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout4]});
+let textureView64 = texture12.createView({aspect: 'all'});
+let computePassEncoder60 = commandEncoder57.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline6);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: pipelineLayout4, compute: {module: shaderModule1, constants: {}}});
+let commandEncoder58 = device0.createCommandEncoder({});
+let sampler39 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 34.59,
+  lodMaxClamp: 96.26,
+  maxAnisotropy: 6,
+});
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 266, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 728 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3120 */
+  offset: 3120,
+  buffer: buffer8,
+}, {width: 91, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame3);
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture80 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder61 = commandEncoder58.beginComputePass({});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 195, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 91, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup26 = device0.createBindGroup({
+  label: '\u{1f7d6}\u0ea9\u{1f916}\u{1fb52}\u0abb\u0c4e\u{1f74a}\u{1fd38}\u4071\u08be',
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 70, resource: {buffer: buffer29, offset: 256, size: 973}},
+    {binding: 116, resource: {buffer: buffer0, offset: 1536, size: 5420}},
+  ],
+});
+let buffer33 = device0.createBuffer({size: 21714, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder60 = device0.createCommandEncoder();
+try {
+computePassEncoder26.setBindGroup(0, bindGroup4, new Uint32Array(936), 278, 1);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1968 */
+  offset: 1968,
+  bytesPerRow: 13568,
+  rowsPerImage: 770,
+  buffer: buffer16,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 177, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 215, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({});
+let computePassEncoder62 = commandEncoder61.beginComputePass();
+let sampler40 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest'});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup7, new Uint32Array(4094), 52, 1);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 0, y: 48, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 436 */
+  offset: 436,
+  bytesPerRow: 5120,
+  buffer: buffer21,
+}, {width: 0, height: 197, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 2},
+  aspect: 'stencil-only',
+}, new Uint8Array(37).fill(182), /* required buffer size: 37 */
+{offset: 37}, {width: 256, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [{binding: 174, resource: {buffer: buffer31, offset: 0, size: 208}}],
+});
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView65 = texture8.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let sampler41 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder32); computePassEncoder32.dispatchWorkgroupsIndirect(buffer21, 3_000); };
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer3, 568, buffer25, 640, 332);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(226).fill(244), /* required buffer size: 226 */
+{offset: 226}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x21fc3b4},
+  fragment: {
+  module: shaderModule3,
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [{arrayStride: 124, attributes: [{format: 'float32x4', offset: 0, shaderLocation: 8}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: false},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 116, resource: {buffer: buffer28, offset: 8192, size: 5412}},
+    {binding: 70, resource: {buffer: buffer28, offset: 2048, size: 5041}},
+  ],
+});
+let textureView66 = texture12.createView({format: 'r16sint'});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup10, [1792]);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup14, new Uint32Array(834), 353, 1);
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder62.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 30, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4700 */
+  offset: 4700,
+  bytesPerRow: 28160,
+  buffer: buffer3,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame8 = new VideoFrame(videoFrame3, {timestamp: 0});
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture81 = device0.createTexture({
+  size: {width: 2, height: 787, depthOrArrayLayers: 67},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder63 = commandEncoder54.beginComputePass({});
+let sampler42 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.33,
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+commandEncoder60.copyBufferToTexture({
+  /* bytesInLastRow: 204 widthInBlocks: 102 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 188 */
+  offset: 188,
+  buffer: buffer14,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 135, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 102, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [{binding: 174, resource: {buffer: buffer3, offset: 0, size: 572}}],
+});
+let textureView67 = texture81.createView({});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup15, [1024]);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 0, y: 36, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup30 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 28, resource: textureView42},
+    {binding: 34, resource: textureView47},
+    {binding: 14, resource: sampler39},
+    {binding: 495, resource: {buffer: buffer0, offset: 256, size: 1292}},
+  ],
+});
+let buffer34 = device0.createBuffer({
+  size: 16002,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let textureView68 = texture66.createView({dimension: '2d', baseArrayLayer: 1});
+let texture82 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 118 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5018 */
+  offset: 5018,
+  bytesPerRow: 4096,
+  buffer: buffer34,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 121, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 1044, new Float32Array(6672), 4159, 96);
+} catch {}
+document.body.prepend(img0);
+let texture83 = device0.createTexture({
+  size: [3357],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup21, new Uint32Array(132), 27, 1);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1388 */
+  offset: 1388,
+  buffer: buffer4,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder1.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 13 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1949 */
+  offset: 1936,
+  buffer: buffer21,
+}, {width: 13, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer0, 2620, 4516);
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer35 = device0.createBuffer({
+  size: 25919,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandBuffer5 = commandEncoder1.finish();
+let texture84 = device0.createTexture({
+  size: [839],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder64 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup4, new Uint32Array(88), 12, 1);
+} catch {}
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder12.pushDebugGroup('\uabf6');
+} catch {}
+try {
+computePassEncoder12.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 419, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 5, y: 1 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup31 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer17, offset: 256, size: 240}}],
+});
+let commandEncoder65 = device0.createCommandEncoder();
+let texture85 = device0.createTexture({
+  size: [1, 136, 1],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture86 = device0.createTexture({
+  size: [256, 256, 21],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView69 = texture3.createView({format: 'r32sint', arrayLayerCount: 1});
+let computePassEncoder65 = commandEncoder63.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup24, new Uint32Array(3683), 148, 0);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline5);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer25, 120, 124);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 419, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 12, y: 4 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 70, resource: {buffer: buffer11, offset: 768, size: 923}},
+    {binding: 116, resource: {buffer: buffer25, offset: 0, size: 4232}},
+  ],
+});
+let buffer36 = device0.createBuffer({size: 4499, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder66 = device0.createCommandEncoder({});
+let textureView70 = texture83.createView({baseMipLevel: 0});
+let computePassEncoder66 = commandEncoder62.beginComputePass({});
+let sampler43 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 66.01, compare: 'always'});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup10, [1280]);
+} catch {}
+try {
+commandEncoder64.copyBufferToBuffer(buffer21, 5916, buffer24, 232, 220);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 419, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x4edf9309},
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 493572131,
+    stencilWriteMask: 355281851,
+    depthBias: -936575024,
+    depthBiasClamp: 117.35366950391324,
+  },
+  vertex: {module: shaderModule3, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'none'},
+});
+let imageData4 = new ImageData(256, 28);
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt470m', transfer: 'gamma22curve'} });
+let commandEncoder67 = device0.createCommandEncoder({});
+let computePassEncoder67 = commandEncoder60.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup21, [5888]);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+document.body.append(img0);
+let bindGroup33 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer25, offset: 2304, size: 528}}],
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: {width: 1678, height: 1, depthOrArrayLayers: 235},
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler44 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 80.77,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup29, new Uint32Array(2470), 21, 1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 173, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 270});
+let texture88 = device0.createTexture({
+  size: {width: 1678, height: 1, depthOrArrayLayers: 13},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder68 = commandEncoder69.beginComputePass({});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let arrayBuffer3 = buffer9.getMappedRange(1648, 464);
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 192 widthInBlocks: 96 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5682 */
+  offset: 5682,
+  buffer: buffer14,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 96, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup34 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 360, resource: textureView21}]});
+let texture89 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler45 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 97.50});
+let commandEncoder70 = device0.createCommandEncoder();
+try {
+computePassEncoder53.setBindGroup(2, bindGroup8, new Uint32Array(2236), 392, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder64); computePassEncoder64.dispatchWorkgroupsIndirect(buffer22, 440); };
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+let pipeline11 = await promise4;
+let textureView71 = texture17.createView({mipLevelCount: 1});
+let texture90 = device0.createTexture({
+  size: [256, 256, 21],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup31, new Uint32Array(1857), 861, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder52); computePassEncoder52.dispatchWorkgroupsIndirect(buffer4, 1_072); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 264, new Int16Array(6189), 1087, 736);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 347, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(73).fill(141), /* required buffer size: 73 */
+{offset: 73, bytesPerRow: 1579}, {width: 766, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout0]});
+let texture91 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView72 = texture20.createView({});
+let computePassEncoder69 = commandEncoder70.beginComputePass({});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(73_918).fill(132), /* required buffer size: 73_918 */
+{offset: 13, bytesPerRow: 379, rowsPerImage: 39}, {width: 172, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let buffer37 = device0.createBuffer({size: 14279, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let texture92 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView73 = texture66.createView({format: 'rgba16float', mipLevelCount: 1, arrayLayerCount: 4});
+let computePassEncoder70 = commandEncoder64.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroupsIndirect(buffer22, 240); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 32, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(273).fill(12), /* required buffer size: 273 */
+{offset: 273}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder({});
+let textureView74 = texture41.createView({format: 'r16sint'});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup20, new Uint32Array(1027), 151, 1);
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 912 */
+  offset: 912,
+  bytesPerRow: 4352,
+  rowsPerImage: 568,
+  buffer: buffer35,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 40, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 160, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 828, new BigUint64Array(49068), 1848, 372);
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout6 = pipeline8.getBindGroupLayout(0);
+let computePassEncoder71 = commandEncoder65.beginComputePass();
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 56.86,
+  maxAnisotropy: 2,
+});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup25, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer11, 8); };
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({});
+let textureView75 = texture83.createView({dimension: '1d', format: 'rgba32float'});
+let computePassEncoder72 = commandEncoder56.beginComputePass();
+try {
+computePassEncoder67.setBindGroup(0, bindGroup2, new Uint32Array(4114), 771, 0);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 436 widthInBlocks: 109 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 928 */
+  offset: 928,
+  buffer: buffer23,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 132, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 109, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule1}});
+let buffer38 = device0.createBuffer({size: 5664, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture93 = device0.createTexture({
+  size: {width: 1, height: 547, depthOrArrayLayers: 304},
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder73 = commandEncoder71.beginComputePass({});
+let sampler47 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 92.03});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(1, bindGroup33, new Uint32Array(347), 13, 1);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer5, 196, buffer33, 608, 136);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1512 */
+  offset: 1512,
+  buffer: buffer23,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer39 = device0.createBuffer({
+  size: 4651,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture94 = device0.createTexture({
+  size: [1, 547, 1],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder74 = commandEncoder31.beginComputePass({});
+let sampler48 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', mipmapFilter: 'linear'});
+try {
+computePassEncoder71.setPipeline(pipeline3);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData5 = new ImageData(20, 44);
+let commandEncoder73 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 65});
+let computePassEncoder75 = commandEncoder51.beginComputePass({});
+let sampler49 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'linear'});
+try {
+computePassEncoder72.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 470 */
+  offset: 470,
+  bytesPerRow: 19968,
+  rowsPerImage: 251,
+  buffer: buffer16,
+}, {
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(528).fill(39), /* required buffer size: 528 */
+{offset: 528, bytesPerRow: 32}, {width: 1, height: 273, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 202, resource: textureView71}, {binding: 47, resource: textureView8}],
+});
+let texture95 = device0.createTexture({size: [1678, 1, 15], mipLevelCount: 5, format: 'rg11b10ufloat', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup32, [768]);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 86 */
+  offset: 86,
+  buffer: buffer14,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet0, 383, 36, buffer22, 1280);
+} catch {}
+let textureView76 = texture84.createView({});
+let sampler50 = device0.createSampler({addressModeU: 'repeat', magFilter: 'linear', minFilter: 'linear'});
+try {
+computePassEncoder65.setPipeline(pipeline5);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder();
+let computePassEncoder76 = commandEncoder68.beginComputePass();
+let sampler51 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup31, new Uint32Array(1780), 1_446, 1);
+} catch {}
+try {
+computePassEncoder45.end();
+} catch {}
+let imageData6 = new ImageData(88, 20);
+let bindGroup36 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer14, offset: 1792, size: 120}}],
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup31, new Uint32Array(1812), 11, 1);
+} catch {}
+try {
+computePassEncoder46.end();
+} catch {}
+let arrayBuffer4 = buffer1.getMappedRange(408, 124);
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder0.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 44 */
+  offset: 44,
+  bytesPerRow: 56064,
+  buffer: buffer18,
+}, {width: 0, height: 225, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let commandEncoder75 = device0.createCommandEncoder();
+let commandBuffer6 = commandEncoder42.finish();
+let textureView77 = texture3.createView({dimension: '2d', baseArrayLayer: 13});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2336 */
+  offset: 2336,
+  bytesPerRow: 4352,
+  buffer: buffer16,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 147, depthOrArrayLayers: 0});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+adapter0.label = '\u89bb\u590f\u0516\u0b5f\ueebe\u1583\ucffd\u1ad9\u0f8f\u4d8f\uddd8';
+} catch {}
+let buffer40 = device0.createBuffer({
+  size: 4910,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder76 = device0.createCommandEncoder();
+let computePassEncoder77 = commandEncoder0.beginComputePass();
+try {
+computePassEncoder74.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 128 */
+  offset: 128,
+  buffer: buffer40,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 0, y: 18, z: 0},
+  aspect: 'all',
+}, new Uint8Array(152).fill(220), /* required buffer size: 152 */
+{offset: 152, bytesPerRow: 40}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 171}
+*/
+{
+  source: imageData3,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 45, z: 30},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture96 = device0.createTexture({
+  size: {width: 4, height: 1575, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler52 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder76.setPipeline(pipeline5);
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {
+      compare: 'greater',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilWriteMask: 184769459,
+  },
+  vertex: {
+    module: shaderModule2,
+    buffers: [
+      {
+        arrayStride: 1764,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 302, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 192, shaderLocation: 12},
+          {format: 'uint32x2', offset: 216, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 724, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: false},
+});
+let recycledExplicitBindGroupLayout7 = pipeline13.getBindGroupLayout(0);
+let commandBuffer7 = commandEncoder44.finish();
+let textureView78 = texture56.createView({dimension: 'cube-array', format: 'stencil8', baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup21, new Uint32Array(1342), 48, 1);
+} catch {}
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1192 */
+  offset: 1192,
+  bytesPerRow: 22784,
+  buffer: buffer14,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder74.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 84, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1060 */
+  offset: 1060,
+  bytesPerRow: 12288,
+  buffer: buffer17,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder64.pushDebugGroup('\uf5ce');
+} catch {}
+try {
+computePassEncoder64.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise10;
+} catch {}
+offscreenCanvas0.width = 1971;
+let buffer41 = device0.createBuffer({size: 8684, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder77 = device0.createCommandEncoder({});
+let texture97 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder78 = commandEncoder74.beginComputePass({});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup21, [2304]);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(3, bindGroup7, new Uint32Array(556), 169, 1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+adapter0.label = '\u0df1\u{1fe95}\ud010\u140b\u0c98\u6885\u{1fca9}';
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  mipLevelCount: 6,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler53 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 74.08,
+  compare: 'greater',
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup8, new Uint32Array(761), 261, 0);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1232 */
+  offset: 1232,
+  bytesPerRow: 6144,
+  buffer: buffer22,
+}, {
+  texture: texture75,
+  mipLevel: 2,
+  origin: {x: 0, y: 5, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 912, new Int16Array(12660), 3952, 1292);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 4,
+  origin: {x: 0, y: 8, z: 3},
+  aspect: 'stencil-only',
+}, new Uint8Array(3).fill(48), /* required buffer size: 3 */
+{offset: 3}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+commandEncoder78.resolveQuerySet(querySet3, 120, 63, buffer14, 256);
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({});
+try {
+computePassEncoder78.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1978 */
+  offset: 1978,
+  buffer: buffer29,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder79 = commandEncoder77.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup19, [1024]);
+} catch {}
+let promise12 = shaderModule2.getCompilationInfo();
+try {
+buffer18.unmap();
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 772 */
+  offset: 772,
+  bytesPerRow: 5632,
+  rowsPerImage: 1143,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 273, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 209, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 8, y: 7 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let texture99 = device0.createTexture({
+  size: [1, 196, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder80 = commandEncoder79.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup28, new Uint32Array(726), 192, 1);
+} catch {}
+let arrayBuffer5 = buffer1.getMappedRange(600, 80);
+let bindGroup37 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 432, resource: textureView42}, {binding: 77, resource: textureView58}],
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 303});
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 710 */
+  offset: 710,
+  bytesPerRow: 17152,
+  buffer: buffer23,
+}, {
+  texture: texture49,
+  mipLevel: 2,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(48).fill(17), /* required buffer size: 48 */
+{offset: 48, rowsPerImage: 30}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer42 = device0.createBuffer({
+  size: 17912,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 953});
+let textureView79 = texture81.createView({mipLevelCount: 1});
+let computePassEncoder81 = commandEncoder11.beginComputePass();
+try {
+computePassEncoder38.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline8);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture100 = device0.createTexture({size: [839, 1, 54], format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let textureView80 = texture88.createView({baseArrayLayer: 3, arrayLayerCount: 3});
+try {
+computePassEncoder79.setPipeline(pipeline11);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+  await promise12;
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  label: '\u4572\u09d4\u5fbf\u{1f742}\u{1ff12}',
+  layout: veryExplicitBindGroupLayout10,
+  entries: [{binding: 87, resource: {buffer: buffer11, offset: 0, size: 1480}}],
+});
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture101 = device0.createTexture({
+  size: {width: 4},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView81 = texture35.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder82 = commandEncoder67.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder64.end();
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1384 */
+  offset: 1384,
+  rowsPerImage: 426,
+  buffer: buffer40,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 38, z: 0},
+  aspect: 'stencil-only',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView82 = texture48.createView({label: '\u0081\u{1fc2e}\u89c7\u7d17', aspect: 'stencil-only', baseArrayLayer: 0});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup23, new Uint32Array(1350), 396, 0);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer34, 568, buffer16, 272, 20);
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer33, 1456, 6064);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+enable f16;
+
+var<private> vp9: array<FragmentOutput1, 1> = array(FragmentOutput1());
+
+/* used global variables: buffer43 */
+fn fn1(a0: ptr<storage, array<u32>, read_write>) {
+  for (var it2=u32(buffer43[u32((*&buffer43)[arrayLength(&(*&buffer43))][10])][vp9[0].f2]); it2<u32(vp9[0].f1[unconst_u32(90)]); it2++) {
+  let vf46: f32 = override2;
+  var vf47: i32 = vp9[unconst_u32(271)].f0[unconst_u32(22)];
+  _ = override2;
+}
+  let ptr26: ptr<storage, array<i32, 11>, read> = &(*&buffer43)[unconst_i32(21)];
+  vp9[(*a0)[arrayLength(&(*a0))]].f2 = bitcast<vec4u>(vp9[0].f0)[2];
+  vp8 = VertexOutput3(vp8.f4, vec2h(vp8.f4.gr), bitcast<vec4f>(vp8.f4));
+  switch bitcast<vec4i>(vp9[0].f1)[2] { 
+  default {
+  vp9[unconst_u32(14)] = FragmentOutput1(unpack4xI8(u32(insertBits(vec3i(unconst_i32(34), unconst_i32(17), unconst_i32(61)), vec3i(unconst_i32(475), unconst_i32(0), unconst_i32(221)), unconst_u32(193), unconst_u32(282)).g)), bitcast<vec4f>(unpack4xI8(u32(insertBits(vec3i(unconst_i32(34), unconst_i32(17), unconst_i32(61)), vec3i(unconst_i32(475), unconst_i32(0), unconst_i32(221)), unconst_u32(193), unconst_u32(282)).g))), pack4xI8Clamp(unpack4xI8(u32(insertBits(vec3i(unconst_i32(34), unconst_i32(17), unconst_i32(61)), vec3i(unconst_i32(475), unconst_i32(0), unconst_i32(221)), unconst_u32(193), unconst_u32(282)).g))));
+  (*a0)[unconst_u32(71)] -= bitcast<u32>((*&buffer43)[unconst_u32(212)][10]);
+  return;
+  _ = buffer43;
+}
+  }
+  _ = override2;
+  _ = buffer43;
+}
+
+@group(0) @binding(174) var<storage, read> buffer43: array<array<i32, 11>>;
+
+struct VertexOutput3 {
+  @location(2) f4: vec4u,
+  @location(8) f5: vec2h,
+  @builtin(position) f6: vec4f,
+}
+
+@id(29444) override override4: f16;
+
+@id(29957) override override3: f16;
+
+struct FragmentOutput1 {
+  @location(2) f0: vec4i,
+  @location(0) f1: vec4f,
+  @builtin(sample_mask) f2: u32,
+}
+
+struct S0 {
+  @location(10) @interpolate(flat) f0: vec2u,
+  @builtin(instance_index) f1: u32,
+}
+
+@id(54727) override override0: u32 = 135;
+
+struct T0 {
+  @size(76) f0: array<array<u32, 1>, 1>,
+}
+
+@id(35987) override override2 = 0.00472;
+
+override override5: f32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp8: VertexOutput3 = VertexOutput3();
+
+@id(34762) override override1: u32;
+
+/* used global variables: buffer43 */
+fn fn0(a0: ptr<storage, array<u32>, read_write>, a1: VertexOutput3, a2: ptr<storage, array<u32>, read_write>, a3: ptr<function, FragmentOutput1>) -> array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1> {
+  var out: array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 1>;
+  while bool(a1.f6.y) {
+  out[unconst_u32(640)][unconst_u32(23)][unconst_u32(70)][unconst_u32(786)][unconst_u32(336)] -= f16(arrayLength(&(*a0)));
+  var vf45: vec2h = a1.f5;
+  let ptr21: ptr<storage, array<i32, 11>, read> = &(*&buffer43)[u32((*&buffer43)[arrayLength(&(*&buffer43))][10])];
+  break;
+  _ = buffer43;
+}
+  let ptr22: ptr<private, vec2h> = &vp8.f5;
+  let ptr23: ptr<private, vec4i> = &vp9[0].f0;
+  let ptr24: ptr<storage, i32, read> = &buffer43[arrayLength(&buffer43)][unconst_u32(41)];
+  let ptr25: ptr<storage, array<i32, 11>, read> = &buffer43[unconst_u32(179)];
+  return out;
+  _ = buffer43;
+}
+
+var<workgroup> vw7: vec4h;
+
+struct VertexOutput4 {
+  @builtin(position) f7: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp10: mat4x3h = mat4x3h(7458.6, 6555.6, -24913.0, 9472.4, 675.0, 5812.3, 3911.0, -4190.4, 6157.4, 8217.6, -227.7, 2623.8);
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex3(@location(3) a0: vec4h, @location(1) a1: vec2h, a2: S0) -> VertexOutput3 {
+  var out: VertexOutput3;
+  return out;
+}
+
+/* used global variables: buffer43 */
+@vertex
+fn vertex4() -> VertexOutput4 {
+  var out: VertexOutput4;
+  let ptr27: ptr<storage, i32, read> = &buffer43[unconst_u32(84)][10];
+  let ptr28: ptr<private, vec4u> = &vp8.f4;
+  while bool((*&buffer43)[arrayLength(&(*&buffer43))][pack4x8snorm(vp9[0].f1)]) {
+}
+  out.f7 += vec4f(unpack4xU8(unconst_u32(868)));
+  out.f7 -= (vec4f(f32(buffer43[arrayLength(&buffer43)][unconst_u32(187)])) - vec4f(f32(atan2(unconst_f16(5794.3), unconst_f16(11159.8)))));
+  var vf48: u32 = override0;
+  while bool((*ptr28).w) {
+  switch bitcast<vec3i>(step(vec3f(unconst_f32(0.03976), unconst_f32(0.01375), unconst_f32(0.02441)), vec3f(unconst_f32(0.1538), unconst_f32(0.1482), unconst_f32(0.05061)))).x { 
+  default {
+  vp9[unconst_u32(176)] = FragmentOutput1(vec4i(buffer43[unconst_u32(396)][10]), vec4f(f32(buffer43[unconst_u32(396)][10])), bitcast<u32>(buffer43[unconst_u32(396)][10]));
+  out = VertexOutput4(vec4f(bitcast<f32>((*&buffer43)[unconst_u32(65)][10])));
+  return out;
+  _ = buffer43;
+}
+  }
+  var vf49: vec4i = countLeadingZeros(vec4i(unconst_i32(39), unconst_i32(-86), unconst_i32(296), unconst_i32(167)));
+  let vf50: u32 = dot4U8Packed(unconst_u32(169), unconst_u32(345));
+  let ptr29: ptr<private, vec4i> = &vp9[unconst_u32(332)].f0;
+  let ptr30: ptr<storage, array<i32, 11>, read> = &buffer43[arrayLength(&buffer43) - 1];
+  var vf51: u32 = pack4x8unorm(vec4f(unconst_f32(0.4609), unconst_f32(0.06373), unconst_f32(0.08707), unconst_f32(0.2759)));
+  out.f7 *= vp9[unconst_u32(43)].f1;
+  break;
+  _ = buffer43;
+}
+  return out;
+  _ = override0;
+  _ = buffer43;
+}
+
+/* used global variables: buffer43 */
+@fragment
+fn fragment2() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  vp9[unconst_u32(75)].f1 += vec4f(radians(unconst_f32(0.3626)));
+  out.f2 = pack4x8snorm(unpack4x8unorm(unconst_u32(122)));
+  let vf52: u32 = pack4x8unorm(vec4f(unconst_f32(0.05390), unconst_f32(0.3858), unconst_f32(0.03348), unconst_f32(0.1370)));
+  while bool(extractBits(bitcast<vec3u>(sinh(vec2f(unconst_f32(-0.06815), unconst_f32(0.1094))).ggr), unconst_u32(217), unconst_u32(136)).b) {
+  break;
+}
+  let ptr31: ptr<storage, i32, read> = &(*&buffer43)[unconst_u32(39)][unconst_u32(219)];
+  var vf53: vec3u = extractBits(vec3u(u32(sign(unconst_f16(-19737.6)))), unconst_u32(88), unconst_u32(384));
+  let ptr32: ptr<private, vec4i> = &vp9[0].f0;
+  let ptr33: ptr<private, vec4i> = &vp9[0].f0;
+  let ptr34: ptr<private, vec4i> = &(*ptr32);
+  return out;
+  _ = buffer43;
+}
+
+/* used global variables: buffer43 */
+@fragment
+fn fragment3() -> @location(200) vec4f {
+  var out: vec4f;
+  vp9[unconst_u32(60)] = FragmentOutput1(vec4i(refract(vec4h(unconst_f16(471.6), unconst_f16(-8812.2), unconst_f16(2945.5), unconst_f16(11743.3)), vec4h(unconst_f16(1256.0), unconst_f16(2257.9), unconst_f16(15183.0), unconst_f16(1240.8)), unconst_f16(10464.2))), vec4f(refract(vec4h(unconst_f16(471.6), unconst_f16(-8812.2), unconst_f16(2945.5), unconst_f16(11743.3)), vec4h(unconst_f16(1256.0), unconst_f16(2257.9), unconst_f16(15183.0), unconst_f16(1240.8)), unconst_f16(10464.2))), vec4u(refract(vec4h(unconst_f16(471.6), unconst_f16(-8812.2), unconst_f16(2945.5), unconst_f16(11743.3)), vec4h(unconst_f16(1256.0), unconst_f16(2257.9), unconst_f16(15183.0), unconst_f16(1240.8)), unconst_f16(10464.2)))[3]);
+  var vf54: u32 = arrayLength(&buffer43);
+  vp10 = mat4x3h(f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]), f16(buffer43[unconst_i32(-203)][10]));
+  vp10 = mat4x3h(vec3h(unpack4x8snorm(unconst_u32(326)).aar), vec3h(unpack4x8snorm(unconst_u32(326)).yxy), vec3h(unpack4x8snorm(unconst_u32(326)).aar), vec3h(unpack4x8snorm(unconst_u32(326)).zxz));
+  switch vec4i(step(vec4h(unconst_f16(419.9), unconst_f16(23063.8), unconst_f16(2669.9), unconst_f16(7006.2)), vec4h(unconst_f16(-2566.8), unconst_f16(43420.6), unconst_f16(4848.2), unconst_f16(16676.4))))[1] { 
+  default {
+  vp8 = VertexOutput3(vec4u(bitcast<u32>((*&buffer43)[unconst_u32(154)][10])), bitcast<vec2h>((*&buffer43)[unconst_u32(154)][10]), vec4f(bitcast<f32>((*&buffer43)[unconst_u32(154)][10])));
+  vp10 = mat4x3h(f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]), f16((*&buffer43)[arrayLength(&(*&buffer43))][10]));
+  _ = buffer43;
+}
+  }
+  for (var it3=bitcast<u32>(determinant(mat2x2f(unconst_f32(0.00743), unconst_f32(0.09783), unconst_f32(0.1182), unconst_f32(0.1661)))); it3<u32(dot(vec2i(unconst_i32(103), unconst_i32(131)), vec2i(unconst_i32(-7), unconst_i32(133)))); it3++) {
+  vp9[unconst_u32(273)] = FragmentOutput1(vec4i(vp8.f6), vp8.f6, pack4x8unorm(vp8.f6));
+  discard;
+  {
+  out = vec4f(vp9[0].f0);
+  break;
+}
+  out *= vec4f(bitcast<f32>((*&buffer43)[arrayLength(&(*&buffer43)) - 1][10]));
+  _ = buffer43;
+}
+  {
+  vp8.f5 = bitcast<vec2h>((*&buffer43)[arrayLength(&(*&buffer43))][10]);
+  let ptr35: ptr<storage, array<i32, 11>, read> = &buffer43[unconst_i32(-56)];
+  while bool(buffer43[arrayLength(&buffer43)][10]) {
+  let vf55: u32 = (unconst_u32(214) >> unconst_u32(27));
+  return out;
+}
+  out += vec4f(bitcast<f32>(buffer43[bitcast<u32>(vp8.f5)][10]));
+  _ = buffer43;
+}
+  let vf56: vec2h = ceil(vec2h(unconst_f16(2471.9), unconst_f16(31164.7)));
+  loop {
+  vp8.f6 *= vec4f(bitcast<f32>((*&buffer43)[unconst_u32(69)][10]));
+  break;
+  _ = buffer43;
+}
+  vf54 >>= pack4x8snorm(vp9[unconst_u32(247)].f1);
+  switch vp9[unconst_u32(186)].f0[3] { 
+  default {
+  let ptr36: ptr<private, vec4f> = &vp9[0].f1;
+  var vf57: vec2f = degrees(vec2f(unconst_f32(0.00747), unconst_f32(-0.6569)));
+  vf57 -= vec2f(vp8.f5);
+  out *= vec4f(f32(buffer43[unconst_u32(314)][10]));
+  return out;
+  _ = buffer43;
+}
+  }
+  return out;
+  _ = buffer43;
+}`,
+});
+let buffer44 = device0.createBuffer({
+  size: 20498,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup31, [2816]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 1292, new Int16Array(5613), 1050, 288);
+} catch {}
+document.body.append(img0);
+let buffer45 = device0.createBuffer({size: 1459, usage: GPUBufferUsage.COPY_DST});
+let texture102 = device0.createTexture({
+  size: [1, 196, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture103 = device0.createTexture({
+  size: {width: 419, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder83 = commandEncoder75.beginComputePass({});
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater-equal',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup16, [0]);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(0, bindGroup24, new Uint32Array(37), 0, 0);
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2800 */
+  offset: 2800,
+  bytesPerRow: 17920,
+  buffer: buffer23,
+}, {
+  texture: texture75,
+  mipLevel: 2,
+  origin: {x: 0, y: 26, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let textureView83 = texture102.createView({dimension: '2d-array', baseMipLevel: 0});
+let computePassEncoder84 = commandEncoder80.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16sint'],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler55 = device0.createSampler({addressModeV: 'clamp-to-edge', lodMaxClamp: 87.76});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup21, new Uint32Array(1510), 652, 1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0xa321720},
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'keep', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 8921187,
+    stencilWriteMask: 1325500624,
+    depthBiasSlopeScale: -78.7629908253929,
+  },
+  vertex: {module: shaderModule3, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let textureView84 = texture23.createView({
+  dimension: 'cube-array',
+  format: 'rg16float',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 6,
+});
+let texture104 = device0.createTexture({
+  size: {width: 1, height: 136, depthOrArrayLayers: 20},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder85 = commandEncoder50.beginComputePass({});
+try {
+computePassEncoder69.setBindGroup(1, bindGroup38, [256]);
+} catch {}
+try {
+computePassEncoder74.setBindGroup(0, bindGroup14, new Uint32Array(1159), 204, 1);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer7, 'uint32', 464, 338);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(99).fill(107), /* required buffer size: 99 */
+{offset: 99, bytesPerRow: 531}, {width: 126, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise11;
+} catch {}
+document.body.prepend(img0);
+let commandEncoder83 = device0.createCommandEncoder({});
+let textureView85 = texture15.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder86 = commandEncoder66.beginComputePass();
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+device0.queue.writeBuffer(buffer13, 272, new BigUint64Array(3923), 5, 84);
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 174, resource: {buffer: buffer3, offset: 0, size: 2276}}],
+});
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let commandEncoder84 = device0.createCommandEncoder({label: '\u89d0\uc7fc\udf26\u{1fa2a}\u0737\u5960\udfe8'});
+let texture105 = device0.createTexture({
+  size: [839, 1, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler56 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.88,
+  maxAnisotropy: 6,
+});
+let recycledExplicitBindGroupLayout8 = pipeline3.getBindGroupLayout(0);
+let commandEncoder85 = device0.createCommandEncoder({});
+let computePassEncoder87 = commandEncoder82.beginComputePass({});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup4, [0]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 704 */
+  offset: 704,
+  buffer: buffer14,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let commandBuffer8 = commandEncoder73.finish({});
+let textureView86 = texture57.createView({baseMipLevel: 0});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup27, [0]);
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder81.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4840 */
+  offset: 4840,
+  buffer: buffer38,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 209, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView87 = texture3.createView({aspect: 'all', baseArrayLayer: 8, arrayLayerCount: 2});
+try {
+computePassEncoder85.setBindGroup(2, bindGroup24, new Uint32Array(508), 2, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 2176, new BigUint64Array(7631), 1587, 12);
+} catch {}
+let textureView88 = texture97.createView({dimension: '2d-array', aspect: 'stencil-only'});
+let computePassEncoder88 = commandEncoder86.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup17, []);
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [{binding: 174, resource: {buffer: buffer15, offset: 2048, size: 1236}}],
+});
+let computePassEncoder89 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline6);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+let computePassEncoder90 = commandEncoder8.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer42, 11640, new BigUint64Array(5010), 186, 40);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let imageData7 = new ImageData(16, 208);
+let bindGroup41 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [{binding: 174, resource: {buffer: buffer40, offset: 512, size: 792}}],
+});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup27, new Uint32Array(2726), 285, 1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 1260, new Float32Array(2702), 414, 108);
+} catch {}
+let buffer46 = device0.createBuffer({size: 6240, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture106 = device0.createTexture({size: [419, 1, 1], format: 'stencil8', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let computePassEncoder91 = commandEncoder72.beginComputePass({});
+let sampler57 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.27,
+  maxAnisotropy: 5,
+});
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 146 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1818 */
+  offset: 1818,
+  buffer: buffer41,
+}, {
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 903, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 73, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let buffer47 = device0.createBuffer({
+  size: 13872,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 13});
+let texture107 = device0.createTexture({
+  size: {width: 1, height: 273, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView89 = texture15.createView({mipLevelCount: 1});
+let computePassEncoder92 = commandEncoder36.beginComputePass({});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup27, [768]);
+} catch {}
+try {
+computePassEncoder90.setBindGroup(3, bindGroup29, new Uint32Array(3273), 772, 1);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 452 */
+  offset: 452,
+  buffer: buffer8,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder();
+let commandBuffer9 = commandEncoder84.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroupsIndirect(buffer22, 236); };
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline12);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 0, y: 90, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(964).fill(251), /* required buffer size: 964 */
+{offset: 964}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let buffer48 = device0.createBuffer({size: 24534, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView90 = texture98.createView({
+  dimension: 'cube-array',
+  format: 'rg16uint',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 4,
+  arrayLayerCount: 6,
+});
+let texture108 = device0.createTexture({
+  size: {width: 1, height: 273, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler58 = device0.createSampler({addressModeW: 'repeat', lodMaxClamp: 86.94});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup28, [11264]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer14, 1_496); };
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline11);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 44, new DataView(new ArrayBuffer(1190)), 121, 196);
+} catch {}
+let textureView91 = texture105.createView({aspect: 'all'});
+let computePassEncoder93 = commandEncoder83.beginComputePass({});
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet4, 37, 89, buffer39, 0);
+} catch {}
+document.body.prepend(img0);
+let imageData8 = new ImageData(16, 84);
+let bindGroup42 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer42, offset: 1280}}],
+});
+let commandEncoder90 = device0.createCommandEncoder({});
+let textureView92 = texture73.createView({});
+let texture109 = device0.createTexture({
+  size: {width: 4, height: 1575, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer14, 1_536); };
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder78.resolveQuerySet(querySet2, 3, 45, buffer42, 1280);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder84.setBindGroup(0, bindGroup19, [256]);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline8);
+} catch {}
+document.body.prepend(img0);
+let textureView93 = texture61.createView({});
+let imageBitmap1 = await createImageBitmap(imageData8);
+let bindGroup43 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 59, resource: textureView20}]});
+let sampler59 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 98.80});
+try {
+computePassEncoder89.setPipeline(pipeline8);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [{binding: 174, resource: {buffer: buffer28, offset: 4608, size: 2120}}],
+});
+let buffer49 = device0.createBuffer({
+  size: 8272,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture110 = device0.createTexture({size: [1, 273, 1], format: 'r16sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+try {
+computePassEncoder91.setPipeline(pipeline6);
+} catch {}
+let buffer50 = device0.createBuffer({size: 13845, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let computePassEncoder94 = commandEncoder81.beginComputePass({});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup21, [0]);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 20, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct S3 {
+  @location(10) f0: i32,
+}
+
+var<workgroup> vw10: bool;
+
+var<workgroup> vw9: array<atomic<i32>, 28>;
+
+override override11: i32 = 354;
+
+struct S2 {
+  @location(1) @interpolate(linear, either) f0: f32,
+}
+
+override override9: i32;
+
+var<workgroup> vw8: S2;
+
+struct T0 {
+  @size(76) f0: array<u32>,
+}
+
+struct S1 {
+  @location(6) @interpolate(flat, either) f0: vec2f,
+  @location(14) @interpolate(flat, first) f1: vec2h,
+}
+
+override override8: f32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw11: FragmentOutput2;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput2 {
+  @location(0) @interpolate(flat, center) f0: vec2f,
+  @location(3) f1: vec2i,
+}
+
+struct T1 {
+  @size(44) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw12: VertexOutput5;
+
+struct VertexOutput5 {
+  @invariant @builtin(position) f8: vec4f,
+}
+
+@group(0) @binding(174) var<storage, read> buffer51: array<S3, 11>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(5332) override override7 = 0.06215;
+
+var<workgroup> vw13: atomic<u32>;
+
+@id(19533) override override6 = -0.1803;
+
+var<private> vp11 = modf(f32(0.4078));
+
+@id(12974) override override10 = true;
+
+/* used global variables: buffer51 */
+@vertex
+fn vertex5(@location(7) a0: u32, @location(12) a1: vec2h, a2: S1, a3: S2, @location(2) a4: vec2f, @location(4) a5: i32, @location(11) a6: vec4h, a7: S3, @location(15) a8: u32, @location(9) @interpolate(flat) a9: vec4u, @location(3) @interpolate(perspective) a10: vec2f, @location(13) @interpolate(flat, first) a11: f16, @location(8) @interpolate(flat) a12: f32) -> VertexOutput5 {
+  var out: VertexOutput5;
+  out.f8 = vec4f(a3.f0);
+  out.f8 += vec4f(f32(buffer51[bitcast<vec2u>(a10)[1]].f0));
+  vp11 = modf(bitcast<f32>((*&buffer51)[bitcast<u32>(unpack2x16float(unconst_u32(227)).g)].f0));
+  out.f8 -= vec4f(a3.f0);
+  var vf58: vec2f = a4;
+  for (var it4=bitcast<u32>(normalize(vec2h(unconst_f16(8412.4), unconst_f16(19342.3)))); it4<bitcast<u32>(buffer51[unconst_u32(236)].f0); it4++) {
+  let vf59: bool = (i32(a6.b) >= unconst_i32(117));
+}
+  var vf60: vec4u = a9;
+  var vf61: f32 = override7;
+  vp11.fract -= tan(vec2f(unconst_f32(0.01108), unconst_f32(0.1584)))[1];
+  vf60 = vec4u(bitcast<u32>(a7.f0));
+  vf61 = f32(a2.f1[unconst_u32(15)]);
+  vf58 -= vec2f(bitcast<f32>(vf60[unconst_u32(9)]));
+  var vf62: u32 = a8;
+  out.f8 -= vec4f(f32((*&buffer51)[unconst_u32(278)].f0));
+  var vf63: vec2h = pow(vec2h(unconst_f16(4570.5), unconst_f16(3165.1)), vec2h(unconst_f16(-8914.6), unconst_f16(4325.8)));
+  return out;
+  _ = override7;
+  _ = buffer51;
+}
+
+/* used global variables: buffer51 */
+@fragment
+fn fragment4() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  out.f1 ^= vec2i(i32(inverseSqrt(sin(vec3h(unconst_f16(8683.8), unconst_f16(1729.8), unconst_f16(13272.7)))[0])));
+  var vf64: vec4i = unpack4xI8(unconst_u32(46));
+  let ptr37: ptr<storage, S3, read> = &buffer51[unconst_u32(388)];
+  var vf65: f32 = override8;
+  var vf66: vec3f = atanh(vec3f(unconst_f32(-0.07615), unconst_f32(0.1456), unconst_f32(0.1021)));
+  let ptr38: ptr<storage, S3, read> = &(*&buffer51)[unconst_u32(8)];
+  var vf67: mat3x4f = (mat3x4f() - mat3x4f(vec4f(unpack4xI8(bitcast<u32>((*ptr37).f0))), vec4f(unpack4xI8(bitcast<u32>((*ptr37).f0))), vec4f(unpack4xI8(bitcast<u32>((*ptr37).f0)))));
+  vf66 = vec3f(f32(buffer51[unconst_u32(36)].f0));
+  return out;
+  _ = override8;
+  _ = buffer51;
+}
+
+/* used global variables: buffer51 */
+@compute @workgroup_size(1, 1, 1)
+fn compute4(@builtin(num_workgroups) a0: vec3u) {
+  var vf68: u32 = extractBits(unconst_u32(162), unconst_u32(42), u32(cos(vec3f(unconst_f32(0.1209), unconst_f32(0.1330), unconst_f32(0.04080)))[1]));
+  switch atomicLoad(&(*&vw9)[27]) { 
+  default {
+  while bool(insertBits(vec2i(unconst_i32(101), unconst_i32(502)), vec2i(unconst_i32(474), unconst_i32(60)), atomicLoad(&(*&vw13)), unconst_u32(66)).r) {
+  vw12.f8 = vw12.f8;
+  let ptr39: ptr<workgroup, vec2i> = &(*&vw11).f1;
+  let vf69: u32 = atomicExchange(&(*&vw13), unconst_u32(464));
+  let ptr40: ptr<workgroup, vec2f> = &vw11.f0;
+  let vf70: vec3<bool> = (vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false)) != vec3<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true)));
+}
+  let ptr41: ptr<workgroup, FragmentOutput2> = &vw11;
+  vw11 = FragmentOutput2(bitcast<vec2f>(firstTrailingBit(vec3i(unconst_i32(196), unconst_i32(224), unconst_i32(-268))).rg), firstTrailingBit(vec3i(unconst_i32(196), unconst_i32(224), unconst_i32(-268))).xz);
+  vw8.f0 *= f32(smoothstep(unconst_f16(34193.3), unconst_f16(7747.7), unconst_f16(13163.6)));
+  vw11.f1 += vec2i(i32(override7));
+  let vf71: mat3x2f = (mat3x2f(unconst_f32(0.3833), unconst_f32(0.2176), unconst_f32(0.07781), unconst_f32(0.00883), unconst_f32(0.1272), unconst_f32(0.05348)) * mat3x3f(unconst_f32(0.02804), unconst_f32(0.01872), unconst_f32(0.1030), unconst_f32(0.1285), unconst_f32(0.2216), unconst_f32(0.01547), unconst_f32(0.00068), unconst_f32(0.3099), unconst_f32(0.1784)));
+  let ptr42: ptr<workgroup, FragmentOutput2> = &vw11;
+  break;
+  _ = override7;
+}
+  }
+  {
+  let ptr43: ptr<workgroup, vec2f> = &vw11.f0;
+  let ptr44: ptr<workgroup, array<atomic<i32>, 28>> = &vw9;
+  let vf72: f32 = vw11.f0[unconst_u32(89)];
+  var vf73: vec2h = mix(vec2h(unconst_f16(13350.3), unconst_f16(9770.1)), bitcast<vec2h>(pack2x16float(vec2f(unconst_f32(0.1782), unconst_f32(0.7445)))), vec2h(unconst_f16(17743.2), unconst_f16(10591.8)));
+}
+  vw12 = VertexOutput5(vec4f(f32(buffer51[unconst_u32(322)].f0)));
+  var vf74: vec3h = refract(vec3h(unconst_f16(23040.3), unconst_f16(-2468.1), unconst_f16(11893.2)), vec3h(unconst_f16(760.8), unconst_f16(4659.0), unconst_f16(-3503.5)), unconst_f16(57.04));
+  let ptr45: ptr<storage, S3, read> = &buffer51[10];
+  let vf75: mat3x2h = transpose(mat2x3h());
+  let ptr46: ptr<workgroup, bool> = &(*&vw10);
+  let ptr47: ptr<workgroup, bool> = &(*ptr46);
+  let ptr48: ptr<storage, S3, read> = &(*ptr45);
+  atomicAdd(&vw13, unconst_u32(643));
+  var vf76: f32 = override6;
+  while bool((*&vw11).f0.x) {
+  atomicStore(&vw9[unconst_u32(370)], i32(atomicLoad(&vw13)));
+}
+  let ptr49: ptr<workgroup, vec4f> = &vw12.f8;
+  _ = override6;
+  _ = override7;
+  _ = buffer51;
+}`,
+});
+let commandEncoder91 = device0.createCommandEncoder({label: '\u0918\ud0e8\u0613\u{1fe28}\u{1f77b}\u{1fc15}\ufbe4\u046f\u2b86'});
+try {
+computePassEncoder93.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1756 */
+  offset: 1756,
+  buffer: buffer4,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 1292});
+let texture111 = device0.createTexture({
+  size: {width: 419, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup25, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 212, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout9 = pipeline11.getBindGroupLayout(0);
+let bindGroup45 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer42, offset: 512}}],
+});
+let computePassEncoder95 = commandEncoder76.beginComputePass();
+try {
+commandEncoder90.copyTextureToBuffer({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 540 widthInBlocks: 135 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2628 */
+  offset: 2628,
+  bytesPerRow: 54016,
+  buffer: buffer44,
+}, {width: 135, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer16, 392, 128);
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 116, resource: {buffer: buffer28, offset: 1024, size: 5784}},
+    {binding: 70, resource: {buffer: buffer47, offset: 256}},
+  ],
+});
+let buffer52 = device0.createBuffer({
+  size: 3080,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture112 = device0.createTexture({
+  size: {width: 2, height: 1095, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder96 = commandEncoder87.beginComputePass({});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer49, 556, buffer9, 6444, 2296);
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4200 */
+  offset: 4200,
+  bytesPerRow: 41728,
+  buffer: buffer44,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 84, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 99, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder90.clearBuffer(buffer9, 1244, 4532);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 85}
+*/
+{
+  source: imageData2,
+  origin: { x: 25, y: 2 },
+  flipY: false,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 0, y: 99, z: 28},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let buffer53 = device0.createBuffer({size: 16626, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 987});
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 64 */
+  offset: 64,
+  bytesPerRow: 26624,
+  buffer: buffer29,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 15, z: 0},
+  aspect: 'stencil-only',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder67.insertDebugMarker('\u{1fc0b}');
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt709', transfer: 'hlg'} });
+let bindGroup47 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [{binding: 174, resource: {buffer: buffer35, offset: 2048, size: 4128}}],
+});
+let buffer54 = device0.createBuffer({size: 19431, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+try {
+commandEncoder90.copyBufferToBuffer(buffer41, 572, buffer45, 152, 4);
+} catch {}
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3952 */
+  offset: 3952,
+  bytesPerRow: 19456,
+  buffer: buffer38,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 378, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 641, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer19, 624, 384);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet6, 4, 3, buffer16, 256);
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {
+  fullRange: true,
+  matrix: 'unspecified',
+  primaries: 'jedecP22Phosphors',
+  transfer: 'bt1361ExtendedColourGamut',
+} });
+let bindGroup48 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 174, resource: {buffer: buffer52, offset: 0, size: 400}}],
+});
+let texture113 = device0.createTexture({
+  size: {width: 839, height: 1, depthOrArrayLayers: 28},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView94 = texture31.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder97 = commandEncoder90.beginComputePass({});
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 0, y: 341, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 3,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder92 = device0.createCommandEncoder({});
+let textureView95 = texture5.createView({
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder98 = commandEncoder78.beginComputePass({});
+let sampler60 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', compare: 'greater-equal'});
+try {
+computePassEncoder97.setPipeline(pipeline1);
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 210 widthInBlocks: 105 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1012 */
+  offset: 1012,
+  bytesPerRow: 80128,
+  rowsPerImage: 249,
+  buffer: buffer47,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 105, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 565});
+let textureView96 = texture35.createView({dimension: '2d-array'});
+let computePassEncoder99 = commandEncoder88.beginComputePass();
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup3, new Uint32Array(4416), 1_900, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer26, 1_868); };
+} catch {}
+let arrayBuffer6 = buffer1.getMappedRange(0, 40);
+let promise14 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 209,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+try {
+computePassEncoder98.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup28, new Uint32Array(443), 7, 1);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer31, 'uint32', 200, 176);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder92.copyTextureToTexture({
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 207, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 3});
+let computePassEncoder100 = commandEncoder91.beginComputePass();
+let renderBundle9 = renderBundleEncoder9.finish({});
+let sampler61 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 57.80,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder99.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 1667, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 1,
+  origin: {x: 0, y: 31, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 77, resource: textureView30}, {binding: 432, resource: textureView42}],
+});
+let buffer55 = device0.createBuffer({size: 9645, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let computePassEncoder101 = commandEncoder92.beginComputePass({});
+let sampler62 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.46,
+});
+try {
+computePassEncoder100.setPipeline(pipeline11);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder89.copyTextureToBuffer({
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 126 widthInBlocks: 63 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1238 */
+  offset: 1238,
+  rowsPerImage: 281,
+  buffer: buffer33,
+}, {width: 63, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 180, new Int16Array(7174), 1233, 128);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 0, y: 28, z: 0},
+  aspect: 'all',
+}, new Uint8Array(516).fill(106), /* required buffer size: 516 */
+{offset: 516, bytesPerRow: 24}, {width: 0, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u6811\u{1f981}\udd1a\ud720\u047d\u0933\uadc8',
+  entries: [
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let texture114 = device0.createTexture({
+  size: [1, 196, 997],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView97 = texture5.createView({aspect: 'stencil-only', format: 'stencil8', mipLevelCount: 2, arrayLayerCount: 5});
+let sampler63 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', lodMinClamp: 68.36, lodMaxClamp: 68.69});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup13, new Uint32Array(7044), 279, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroups(1); };
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 372 widthInBlocks: 186 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1594 */
+  offset: 1594,
+  bytesPerRow: 15104,
+  rowsPerImage: 712,
+  buffer: buffer29,
+}, {
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 186, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({});
+let texture115 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  mipLevelCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView98 = texture21.createView({dimension: '2d-array', format: 'stencil8', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder92.setBindGroup(1, bindGroup32, new Uint32Array(1057), 105, 1);
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline12);
+} catch {}
+let arrayBuffer7 = buffer1.getMappedRange(40, 48);
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 419 widthInBlocks: 419 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2152 */
+  offset: 2152,
+  bytesPerRow: 21504,
+  buffer: buffer35,
+}, {
+  texture: texture106,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 419, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 11720, new BigUint64Array(25474), 422, 216);
+} catch {}
+let texture116 = device0.createTexture({
+  size: [1, 547, 1],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView99 = texture93.createView({baseMipLevel: 0});
+let computePassEncoder102 = commandEncoder93.beginComputePass({});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline12);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(69, 46);
+let bindGroup50 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout9,
+  entries: [{binding: 174, resource: {buffer: buffer25, offset: 1536, size: 92}}],
+});
+let textureView100 = texture106.createView({dimension: '2d'});
+let computePassEncoder103 = commandEncoder85.beginComputePass();
+try {
+commandEncoder89.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 247, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 860 */
+  offset: 860,
+  bytesPerRow: 27136,
+  buffer: buffer21,
+}, {width: 0, height: 148, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer9, 28572, 924);
+} catch {}
+document.body.append(img0);
+let texture117 = device0.createTexture({
+  size: [4, 1575, 1],
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup8, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer4, 6_820); };
+} catch {}
+let texture118 = device0.createTexture({
+  size: {width: 2, height: 1095, depthOrArrayLayers: 1},
+  mipLevelCount: 11,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder104 = commandEncoder89.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroupsIndirect(buffer35, 4_756); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 2676, new Int16Array(95), 18, 52);
+} catch {}
+let imageData9 = new ImageData(16, 32);
+let commandEncoder95 = device0.createCommandEncoder({label: '\uf6e4\u2da0\u06ed\ufc9b\u6762\ub276\u4c14\u0740'});
+let sampler64 = device0.createSampler({
+  label: '\u0424\u3fb6\uac0d\u{1f7c2}\u{1fc95}\u028e\u{1fc01}\u{1fdc3}\u0ddc\u01cc',
+  addressModeU: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.44,
+});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 972, new Float32Array(5299), 206, 1108);
+} catch {}
+let recycledExplicitBindGroupLayout10 = pipeline6.getBindGroupLayout(0);
+let commandEncoder96 = device0.createCommandEncoder({});
+let textureView101 = texture34.createView({dimension: '2d', aspect: 'stencil-only'});
+try {
+computePassEncoder95.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 393, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 2,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule1, constants: {}}});
+let bindGroup51 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 116, resource: {buffer: buffer35, offset: 14592, size: 6008}},
+    {binding: 70, resource: {buffer: buffer52, offset: 0, size: 1172}},
+  ],
+});
+let buffer56 = device0.createBuffer({
+  size: 20612,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture119 = device0.createTexture({
+  size: [4, 1575, 1],
+  mipLevelCount: 2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder105 = commandEncoder96.beginComputePass({});
+let sampler65 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.47,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder104.setPipeline(pipeline2);
+} catch {}
+let arrayBuffer8 = buffer1.getMappedRange(552, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 1175, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(389).fill(141), /* required buffer size: 389 */
+{offset: 389}, {width: 913, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 393, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 6, y: 2 },
+  flipY: true,
+}, {
+  texture: texture96,
+  mipLevel: 2,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 17, depthOrArrayLayers: 0});
+} catch {}
+let buffer57 = device0.createBuffer({
+  size: 52304,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder97 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 1185});
+let commandEncoder98 = device0.createCommandEncoder();
+let textureView102 = texture81.createView({});
+let sampler66 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 55.06});
+try {
+{ clearResourceUsages(device0, computePassEncoder56); computePassEncoder56.dispatchWorkgroupsIndirect(buffer25, 92); };
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline15);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt709', transfer: 'smpte240m'} });
+let buffer58 = device0.createBuffer({size: 15566, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder99 = device0.createCommandEncoder({});
+let texture120 = device0.createTexture({
+  size: [419, 1, 2048],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView103 = texture71.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder106 = commandEncoder97.beginComputePass({});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup33, [512]);
+} catch {}
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 304, new Float32Array(206), 49, 48);
+} catch {}
+let commandBuffer10 = commandEncoder56.finish();
+let texture121 = device0.createTexture({
+  size: {width: 419, height: 1, depthOrArrayLayers: 48},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder107 = commandEncoder94.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder2.pushDebugGroup('\u9904');
+} catch {}
+document.body.prepend(img0);
+let recycledExplicitBindGroupLayout11 = pipeline5.getBindGroupLayout(0);
+let bindGroup52 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [{binding: 174, resource: {buffer: buffer3, offset: 0, size: 544}}],
+});
+let computePassEncoder108 = commandEncoder98.beginComputePass();
+let sampler67 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'clamp-to-edge', minFilter: 'nearest'});
+try {
+computePassEncoder38.setPipeline(pipeline15);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({
+  size: [3357, 1, 1],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder109 = commandEncoder100.beginComputePass({});
+try {
+computePassEncoder108.setPipeline(pipeline6);
+} catch {}
+await gc();
+let imageBitmap2 = await createImageBitmap(videoFrame3);
+let bindGroup53 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer25, offset: 1536, size: 532}}],
+});
+let buffer59 = device0.createBuffer({size: 44896, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder101 = device0.createCommandEncoder({});
+let texture123 = device0.createTexture({
+  size: {width: 419, height: 1, depthOrArrayLayers: 371},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView104 = texture109.createView({});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup16, new Uint32Array(1236), 120, 1);
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline3);
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let buffer60 = device0.createBuffer({
+  size: 22733,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView105 = texture88.createView({dimension: '2d-array', format: 'rg16uint', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+let shaderModule6 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput3 {
+  @location(1) @interpolate(flat) f0: vec4u,
+  @location(0) f1: vec2i,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@id(35410) override override12: i32;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @size(44) f0: array<atomic<u32>, 1>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput6 {
+  @builtin(position) f9: vec4f,
+  @location(12) f10: vec2h,
+  @location(13) @interpolate(linear, first) f11: vec2h,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex6() -> VertexOutput6 {
+  var out: VertexOutput6;
+  while bool(max(vec2i(unconst_i32(318), unconst_i32(-88)), vec2i(unconst_i32(313), unconst_i32(171))).y) {
+  var vf77: vec4h = sinh(vec4h(unconst_f16(43246.7), unconst_f16(18020.5), unconst_f16(3079.7), unconst_f16(-1784.9)));
+  var vf78: vec4i = (vec4i(i32(all(unconst_bool(true)))) ^ vec4i(unconst_i32(149), unconst_i32(390), unconst_i32(-27), unconst_i32(337)));
+  loop {
+  while bool(pack4x8unorm(vec4f(unconst_f32(0.1790), unconst_f32(0.5858), unconst_f32(0.1902), unconst_f32(0.08638)))) {
+  let vf79: u32 = countTrailingZeros(unconst_u32(210));
+  out.f9 = unpack4x8snorm(pack4xI8Clamp(vec4i(unconst_i32(184), unconst_i32(-59), unconst_i32(454), unconst_i32(49))));
+  let vf80: vec4f = smoothstep(vec4f(unconst_f32(0.4528), unconst_f32(0.3306), unconst_f32(-0.01555), unconst_f32(0.06310)), vec4f(unconst_f32(0.05649), unconst_f32(0.1847), unconst_f32(0.2116), unconst_f32(0.04102)), vec4f(unconst_f32(0.06518), unconst_f32(0.2630), unconst_f32(0.00002), unconst_f32(-0.00680)));
+  return out;
+}
+  break;
+}
+  var vf81: vec4f = atan(unpack4x8snorm(unconst_u32(125)));
+  loop {
+  var vf82: vec3i = sign(vec3i(unconst_i32(-10), unconst_i32(187), unconst_i32(218)));
+  out.f9 = vec4f(transpose(mat2x3h(unconst_f16(18314.3), unconst_f16(698.4), unconst_f16(2185.4), unconst_f16(14003.5), unconst_f16(15466.1), unconst_f16(16925.3)))[unconst_i32(2)].yxyy);
+  let vf83: f16 = inverseSqrt(unconst_f16(-3107.7));
+  var vf84: vec3i = sign(vec3i(unconst_i32(24), unconst_i32(162), unconst_i32(18)));
+  break;
+}
+  let vf85: vec4u = (vec4u(unconst_u32(128), unconst_u32(255), unconst_u32(324), unconst_u32(121)) >> vec4u(unconst_u32(236), unconst_u32(160), unconst_u32(185), unconst_u32(264)));
+  while bool(exp(vec2f(unconst_f32(0.3289), unconst_f32(0.1912))).y) {
+  var vf86: vec2h = (vec2h((vec4f(unconst_f32(0.4148), unconst_f32(0.03704), unconst_f32(0.03616), unconst_f32(0.1497)) == vec4f(unconst_f32(0.05229), unconst_f32(0.2899), unconst_f32(-0.00409), unconst_f32(0.05226))).ag) / unconst_f16(4689.6));
+  let vf87: u32 = countOneBits(unconst_u32(90));
+  var vf88: vec3h = ceil(vec3h(vf86[unconst_u32(19)]));
+  return out;
+}
+  break;
+}
+  var vf89: vec4i = (vec4i(unconst_i32(3), unconst_i32(26), unconst_i32(148), unconst_i32(444)) & vec4i(i32((unconst_bool(true) && unconst_bool(true)))));
+  let ptr50: ptr<function, vec4i> = &vf89;
+  var vf90: i32 = (*ptr50)[unconst_u32(208)];
+  vf89 &= (vec4i(unconst_i32(-40), unconst_i32(161), unconst_i32(304), unconst_i32(197)) & vec4i(unconst_i32(220), unconst_i32(104), unconst_i32(213), unconst_i32(82)));
+  var vf91: vec2i = max(vec2i(unconst_i32(1), unconst_i32(-14)), vec2i(unconst_i32(2), unconst_i32(-168)));
+  let vf92: vec2h = reflect(vec2h(unconst_f16(40170.5), unconst_f16(7552.4)), vec2h(unconst_f16(5908.4), unconst_f16(3318.3)));
+  let vf93: f16 = determinant(mat3x3h(unconst_f16(1853.9), unconst_f16(4865.6), unconst_f16(2199.5), unconst_f16(4271.4), unconst_f16(-1142.2), unconst_f16(16570.0), unconst_f16(8944.1), unconst_f16(25580.9), unconst_f16(25095.7)));
+  var vf94: f16 = determinant(mat3x3h(unconst_f16(394.6), unconst_f16(6170.4), unconst_f16(2844.4), unconst_f16(13115.7), unconst_f16(5617.0), unconst_f16(10742.0), unconst_f16(10866.1), unconst_f16(23950.5), unconst_f16(3016.5)));
+  out.f11 = min(vec3h(unconst_f16(9176.3), unconst_f16(5341.1), unconst_f16(16215.1)), vec3h(unconst_f16(-14106.2), unconst_f16(2634.6), unconst_f16(1297.3))).rg;
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment5() -> @location(200) vec4u {
+  var out: vec4u;
+  out = vec4u(bitcast<u32>(override12));
+  out = vec4u((vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)) & vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true))).ggbr);
+  out = unpack4xU8(bitcast<u32>(inverseSqrt(unconst_f32(0.1221))));
+  out -= vec4u((vec3h(round(unconst_f16(1898.5))) < vec3h(unconst_f16(2826.5), unconst_f16(23283.0), unconst_f16(15188.4))).zyxz);
+  var vf95: f32 = trunc(unconst_f32(0.06536));
+  let vf96: bool = (unconst_u32(172) < unconst_u32(92));
+  out -= bitcast<vec4u>((vec2i(unconst_i32(227), unconst_i32(173)) << vec2u(unconst_u32(15), unconst_u32(61))).rrrg);
+  var vf97: f32 = (unconst_f32(0.2713) % unconst_f32(0.05609));
+  let vf98: bool = all(vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(false), unconst_bool(true)));
+  while bool(floor(unconst_f32(0.01390))) {
+  var vf99: vec3h = asinh(vec3h(unconst_f16(28944.2), unconst_f16(7321.0), unconst_f16(8553.3)));
+  let ptr51: ptr<function, vec3h> = &vf99;
+  let vf100: vec3h = asinh(vec3h(unconst_f16(2396.7), unconst_f16(23710.7), unconst_f16(13404.9)));
+  break;
+}
+  vf97 = inverseSqrt(unconst_f32(0.3026));
+  var vf101: vec2h = floor(min(vec2h(unconst_f16(15923.9), unconst_f16(15105.6)), vec2h(unconst_f16(19298.8), unconst_f16(7651.6))));
+  vf97 = floor(unconst_f32(1.000));
+  return out;
+  _ = override12;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment6(@location(8) a0: vec2h) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  var vf102: vec2i = reverseBits(vec2i(unconst_i32(-1), unconst_i32(272)));
+  out.f1 = vec2i(vf102[bitcast<vec2u>(asinh(vec2f(unconst_f32(0.5596), unconst_f32(-0.2441))))[0]]);
+  discard;
+  let vf103: bool = any(vec2<bool>(unconst_bool(true), unconst_bool(true)));
+  out.f1 = bitcast<vec2i>(unpack4xU8(unconst_u32(180)).yx);
+  while (unconst_f16(10442.2) < unconst_f16(944.8)) {
+  let vf104: u32 = pack4x8unorm(vec4f(unconst_f32(0.1996), unconst_f32(0.1796), unconst_f32(0.08893), unconst_f32(0.1801)));
+  for (var it5=bitcast<u32>(faceForward(vec2h(unconst_f16(8997.5), unconst_f16(8980.4)), vec2h(unconst_f16(25703.5), unconst_f16(16.23)), vec2h(unconst_f16(3892.1), unconst_f16(-15879.8)))); it5<bitcast<u32>(firstLeadingBit(vec4i(unconst_i32(-213), unconst_i32(423), unconst_i32(-52), unconst_i32(18))).y); it5++) {
+  out.f0 |= vec4u(mix(vec4h(unconst_f16(5124.6), unconst_f16(53102.2), unconst_f16(10054.8), unconst_f16(7827.8)), vec4h(unconst_f16(26320.3), unconst_f16(7030.3), unconst_f16(568.1), unconst_f16(1449.2)), unconst_f16(40031.3)));
+  let vf105: bool = (unconst_bool(true) | unconst_bool(false));
+  var vf106: vec2f = degrees(vec2f(unconst_f32(0.3181), unconst_f32(0.01835)));
+  let vf107: vec4f = fma(vec4f(unconst_f32(0.2699), unconst_f32(0.03386), unconst_f32(0.1671), unconst_f32(0.02054)), vec4f(unconst_f32(0.00980), unconst_f32(0.09005), unconst_f32(0.1805), unconst_f32(0.1055)), vec4f(unconst_f32(0.02417), unconst_f32(0.1395), unconst_f32(0.2114), unconst_f32(0.08025)));
+  let vf108: vec4f = unpack4x8unorm(unconst_u32(430));
+}
+  out.f0 = vec4u(pack4xI8Clamp(vec4i(unconst_i32(130), unconst_i32(122), unconst_i32(31), unconst_i32(60))));
+  var vf109: vec3h = min(vec3h(unconst_f16(8831.7), unconst_f16(2573.2), unconst_f16(11356.5)), vec3h(unconst_f16(31190.3), unconst_f16(2276.6), unconst_f16(12915.6)));
+  var vf110: vec3f = mix(vec3f(firstLeadingBit(vec4i(unconst_i32(159), unconst_i32(24), unconst_i32(-54), unconst_i32(178))).rga), vec3f(bitcast<f32>(dot4I8Packed(unconst_u32(24), unconst_u32(121)))), vec3f(unconst_f32(0.03999), unconst_f32(0.1194), unconst_f32(-0.2379)));
+  out.f1 &= vec2i(min(vec3h(unconst_f16(8529.3), unconst_f16(-3420.6), unconst_f16(25784.3)), vec3h(unconst_f16(2745.5), unconst_f16(8397.2), unconst_f16(917.8))).bg);
+  out.f1 *= vec2i(bitcast<i32>(vf110[unconst_u32(22)]));
+  break;
+}
+  out.f1 += vec2i(i32(pack4x8unorm(vec4f(unconst_f32(0.01809), unconst_f32(0.07307), unconst_f32(0.1509), unconst_f32(0.5169)))));
+  let ptr52: ptr<function, vec2i> = &vf102;
+  let vf111: f16 = a0[unconst_u32(4)];
+  vf102 += (*ptr52);
+  let vf112: vec4h = asinh(vec4h((unconst_f32(0.1204) - vec3f(unconst_f32(0.09700), unconst_f32(-0.03144), unconst_f32(0.06000))).gbbg));
+  let vf113: vec4h = normalize(vec4h(unconst_f16(9627.4), unconst_f16(-19593.9), unconst_f16(49507.3), unconst_f16(3071.9)));
+  let ptr53: ptr<function, vec2i> = &vf102;
+  return out;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(2, 1, 2)
+fn compute5(@builtin(global_invocation_id) a0: vec3u, @builtin(workgroup_id) a1: vec3u, @builtin(num_workgroups) a2: vec3u) {
+  var vf114: u32 = pack4xU8Clamp(vec4u(unconst_u32(55), unconst_u32(150), unconst_u32(367), unconst_u32(69)));
+  let vf115: vec3u = a2;
+  vf114 ^= u32((unconst_bool(false) && unconst_bool(true)));
+  vf114 += vf115.x;
+}`,
+});
+let commandBuffer11 = commandEncoder19.finish();
+let texture124 = device0.createTexture({
+  size: {width: 839, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder110 = commandEncoder101.beginComputePass();
+try {
+computePassEncoder110.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder99.insertDebugMarker('\u0e27');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 209, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+textureView98.label = '\u9a1e\u7bb5\u0e7e\u0109\u0047\u9da6\u0c74\ud31d\uf35d';
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({});
+let textureView106 = texture114.createView({});
+let texture125 = device0.createTexture({
+  size: [1678, 1, 58],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder111 = commandEncoder99.beginComputePass();
+try {
+computePassEncoder93.setBindGroup(0, bindGroup4, new Uint32Array(1795), 598, 1);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 816, new DataView(new ArrayBuffer(27423)), 272, 4);
+} catch {}
+let buffer62 = device0.createBuffer({
+  size: 5182,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView107 = texture77.createView({dimension: '2d-array'});
+let computePassEncoder112 = commandEncoder95.beginComputePass({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup10, [1280]);
+} catch {}
+try {
+computePassEncoder103.insertDebugMarker('\ua320');
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 787, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 3, y: 1 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 0, y: 261, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let textureView108 = texture117.createView({
+  label: '\u1649\u{1fedb}\u65d5\uc5d8\u{1f983}\ue602\u{1fba5}\u0be0\udf5a\u0e57',
+  dimension: '2d-array',
+});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup27, [0]);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline12);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let textureView109 = texture9.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 5});
+let computePassEncoder113 = commandEncoder102.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder94); computePassEncoder94.dispatchWorkgroupsIndirect(buffer19, 1_840); };
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer35, 1464, buffer54, 3812, 1920);
+} catch {}
+try {
+commandEncoder28.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 884 */
+  offset: 884,
+  rowsPerImage: 1193,
+  buffer: buffer44,
+}, {
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer18, 600, 116);
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer25, offset: 0, size: 1332}}],
+});
+let textureView110 = texture76.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder114 = commandEncoder28.beginComputePass({});
+try {
+computePassEncoder94.setBindGroup(2, bindGroup12, new Uint32Array(79), 3, 0);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline4);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas1.getContext('webgpu');
+let buffer63 = device0.createBuffer({size: 8518, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture126 = device0.createTexture({
+  size: [1, 273, 1],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true});
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup22, new Uint32Array(1102), 84, 1);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(1, buffer48, 0);
+} catch {}
+let arrayBuffer9 = buffer1.getMappedRange(2584, 8);
+let promise15 = device0.queue.onSubmittedWorkDone();
+try {
+texture45.label = '\u09fd\u0188\u{1fd50}';
+} catch {}
+let renderBundle11 = renderBundleEncoder11.finish();
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.37,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup54, new Uint32Array(3457), 796, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer34, 3_352); };
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let imageData10 = new ImageData(56, 216);
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1, 3, 1); };
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline3);
+} catch {}
+let pipeline16 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule4, entryPoint: 'fragment3', constants: {}, targets: [{format: 'bgra8unorm'}]},
+  vertex: {
+    module: shaderModule5,
+    constants: {5_332: 1},
+    buffers: [
+      {
+        arrayStride: 152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 64, shaderLocation: 12},
+          {format: 'sint8x2', offset: 22, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 3},
+          {format: 'float16x4', offset: 4, shaderLocation: 13},
+          {format: 'uint32x4', offset: 24, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 14},
+          {format: 'uint32x3', offset: 40, shaderLocation: 7},
+          {format: 'uint8x2', offset: 14, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 11},
+          {format: 'float32x3', offset: 0, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 12, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 24, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 172,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 0, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+let buffer64 = device0.createBuffer({size: 5339, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let buffer65 = device0.createBuffer({
+  size: 991,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 733});
+let textureView111 = texture45.createView({dimension: '2d'});
+try {
+computePassEncoder114.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView112 = texture95.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 8});
+let sampler69 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 76.75,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  label: '\u{1ff69}\u5ea7\u03f5\u00b9\u7599\u0e95\u021a\u1c3b\u882d',
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 174, resource: {buffer: buffer57, offset: 46080}}],
+});
+let buffer66 = device0.createBuffer({
+  size: 17704,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup26, [256]);
+} catch {}
+try {
+computePassEncoder62.insertDebugMarker('\u{1f8b3}');
+} catch {}
+let recycledExplicitBindGroupLayout12 = pipeline5.getBindGroupLayout(0);
+let texture127 = device0.createTexture({
+  size: [839],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler70 = device0.createSampler({
+  label: '\u26e6\ucf2c\ub622\u0169\u26b1\u0ca6\u8e60',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.38,
+});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let imageData11 = new ImageData(12, 28);
+let commandEncoder103 = device0.createCommandEncoder({});
+let textureView113 = texture52.createView({
+  label: '\u7669\u0bf4\u02ad\u878a\u0b2a\u0e47\u08dd\u067a\u6fb3\uc5d9\u0be8',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+});
+let computePassEncoder115 = commandEncoder103.beginComputePass({label: '\u3cc7\u8137\uee2b\u0ca3'});
+let sampler71 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 94.92,
+});
+try {
+computePassEncoder102.setBindGroup(3, bindGroup54, new Uint32Array(3208), 275, 1);
+} catch {}
+try {
+adapter0.label = '\u5ee8\u0beb';
+} catch {}
+try {
+externalTexture3.label = '\u{1fe05}\u{1f9bf}\ub342\ue5dd';
+} catch {}
+let buffer67 = device0.createBuffer({
+  size: 2404,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture128 = device0.createTexture({
+  size: {width: 2, height: 1095, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView114 = texture123.createView({dimension: '3d'});
+let sampler72 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.02,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup47, [4352]);
+} catch {}
+try {
+computePassEncoder103.setBindGroup(0, bindGroup18, new Uint32Array(2685), 779, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 9156, new DataView(new ArrayBuffer(5241)), 381, 668);
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let recycledExplicitBindGroupLayout13 = pipeline6.getBindGroupLayout(0);
+let commandEncoder104 = device0.createCommandEncoder({});
+let textureView115 = texture69.createView({});
+let computePassEncoder116 = commandEncoder104.beginComputePass({});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup16, [0]);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let texture129 = device0.createTexture({
+  size: {width: 2, height: 1095, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup5, new Uint32Array(195), 59, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 787, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 0, y: 33, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 209,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup56 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [{binding: 174, resource: {buffer: buffer3, offset: 0, size: 120}}],
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: false});
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer11, 1_172); };
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup52, new Uint32Array(475), 194, 1);
+} catch {}
+let arrayBuffer10 = buffer1.getMappedRange(120, 20);
+let buffer68 = device0.createBuffer({
+  size: 4292,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder105 = device0.createCommandEncoder({});
+let texture130 = device0.createTexture({
+  size: {width: 1678, height: 1, depthOrArrayLayers: 44},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder117 = commandEncoder105.beginComputePass({});
+let sampler73 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 69.74, compare: 'always'});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup33, [0]);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(0, bindGroup29, new Uint32Array(284), 102, 1);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData12 = new ImageData(64, 24);
+try {
+adapter0.label = '\udb85\u434f';
+} catch {}
+let buffer69 = device0.createBuffer({
+  size: 20208,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder106 = device0.createCommandEncoder({});
+let textureView116 = texture65.createView({dimension: '2d', aspect: 'stencil-only', mipLevelCount: 1});
+let computePassEncoder118 = commandEncoder106.beginComputePass({});
+try {
+computePassEncoder114.setBindGroup(0, bindGroup31, new Uint32Array(934), 32, 1);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer47, 1_416);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 209, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [{binding: 174, resource: {buffer: buffer11, offset: 1024, size: 1180}}],
+});
+let buffer70 = device0.createBuffer({size: 4820, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let textureView117 = texture126.createView({dimension: '2d-array', format: 'rgba8snorm'});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup49, new Uint32Array(19), 0, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6, buffer47, 1_168, 2_727);
+} catch {}
+document.body.prepend(img0);
+let imageData13 = new ImageData(4, 64);
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'gamma22curve'} });
+let commandEncoder107 = device0.createCommandEncoder({});
+let texture131 = device0.createTexture({
+  size: {width: 1, height: 136, depthOrArrayLayers: 20},
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder119 = commandEncoder107.beginComputePass();
+let sampler74 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.78,
+  compare: 'never',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder104.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer19, 'uint16', 542, 600);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4, buffer22, 0, 831);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(150).fill(2), /* required buffer size: 150 */
+{offset: 150}, {width: 839, height: 1, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let textureView118 = texture36.createView({mipLevelCount: 1});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup29, [768]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder114); computePassEncoder114.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup40, [0]);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+  await buffer46.mapAsync(GPUMapMode.WRITE, 1064, 764);
+} catch {}
+try {
+computePassEncoder87.pushDebugGroup('\u0d01');
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({});
+let texture132 = device0.createTexture({size: {width: 419}, dimension: '1d', format: 'rg16uint', usage: GPUTextureUsage.COPY_SRC});
+let renderBundle12 = renderBundleEncoder12.finish({label: '\u8d7b\uf304\u74be\u{1f9fd}\u0e63'});
+try {
+computePassEncoder119.setPipeline(pipeline0);
+} catch {}
+let pipeline17 = device0.createComputePipeline({layout: pipelineLayout8, compute: {module: shaderModule2, constants: {}}});
+offscreenCanvas0.height = 2003;
+let computePassEncoder120 = commandEncoder108.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup15, [512]);
+} catch {}
+try {
+computePassEncoder100.setBindGroup(3, bindGroup13, new Uint32Array(17), 1, 0);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 419, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture133 = device0.createTexture({
+  size: {width: 3357, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder120.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer32.mapAsync(GPUMapMode.WRITE, 0, 5692);
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout13]});
+let commandEncoder109 = device0.createCommandEncoder({});
+let computePassEncoder121 = commandEncoder109.beginComputePass({});
+try {
+computePassEncoder121.setPipeline(pipeline5);
+} catch {}
+document.body.prepend(img0);
+let bindGroup58 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [{binding: 79, resource: textureView73}, {binding: 209, resource: textureView58}],
+});
+try {
+computePassEncoder90.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder87.popDebugGroup();
+} catch {}
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let buffer71 = device0.createBuffer({
+  size: 1841,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder110 = device0.createCommandEncoder({});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup43, new Uint32Array(60), 23, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroupsIndirect(buffer64, 552); };
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let texture134 = gpuCanvasContext0.getCurrentTexture();
+let textureView119 = texture34.createView({aspect: 'stencil-only'});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup14, [1792]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroupsIndirect(buffer47, 3_404); };
+} catch {}
+try {
+computePassEncoder94.end();
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline3);
+} catch {}
+document.body.prepend(img0);
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 360,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup59 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 202, resource: textureView0}, {binding: 47, resource: textureView77}],
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], stencilReadOnly: true});
+let renderBundle13 = renderBundleEncoder13.finish();
+try {
+  await buffer10.mapAsync(GPUMapMode.READ, 0, 664);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer62, 1264, buffer35, 2060, 88);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise16;
+} catch {}
+try {
+adapter0.label = '\u6af8\u4f0d\u1dc8\uf1db\u06b8\u{1f613}\u2e5a\u1a48\u48c6\u54a5\u8001';
+} catch {}
+let commandBuffer12 = commandEncoder81.finish();
+let computePassEncoder122 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup48, new Uint32Array(1008), 32, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 130 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1906 */
+  offset: 1906,
+  bytesPerRow: 4096,
+  buffer: buffer23,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 74, y: 10, z: 10},
+  aspect: 'all',
+}, {width: 65, height: 17, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline1);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(33, 56);
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture135 = device0.createTexture({
+  size: {width: 1, height: 136, depthOrArrayLayers: 1},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder123 = commandEncoder110.beginComputePass({});
+let sampler75 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMinClamp: 80.95, lodMaxClamp: 81.18});
+try {
+computePassEncoder107.end();
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder112.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 800 */
+  offset: 800,
+  bytesPerRow: 30976,
+  buffer: buffer19,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 98, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 120, depthOrArrayLayers: 0});
+} catch {}
+let pipeline18 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment2',
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 148,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 8, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let imageData14 = new ImageData(88, 20);
+try {
+offscreenCanvas2.getContext('webgpu');
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({});
+let computePassEncoder124 = commandEncoder94.beginComputePass({});
+try {
+computePassEncoder98.setBindGroup(2, bindGroup32, [256]);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(0, bindGroup10, new Uint32Array(996), 640, 1);
+} catch {}
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 100, new BigUint64Array(12707), 806, 124);
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout9,
+  entries: [{binding: 174, resource: {buffer: buffer17, offset: 0, size: 3328}}],
+});
+let textureView120 = texture60.createView({format: 'r16sint', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup16, [256]);
+} catch {}
+try {
+computePassEncoder123.setBindGroup(0, bindGroup16, new Uint32Array(951), 136, 1);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline1);
+} catch {}
+let adapter1 = await promise0;
+try {
+computePassEncoder86.setBindGroup(0, bindGroup44, new Uint32Array(1379), 102, 1);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame16 = new VideoFrame(videoFrame7, {timestamp: 0});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 888});
+let textureView121 = texture116.createView({dimension: '2d-array'});
+let sampler76 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 52.64});
+let textureView122 = texture58.createView({dimension: '2d', format: 'stencil8', baseMipLevel: 3, mipLevelCount: 2});
+let computePassEncoder125 = commandEncoder112.beginComputePass({});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup44, new Uint32Array(1687), 77, 1);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 787, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 8, y: 1 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 1,
+  origin: {x: 0, y: 206, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas0 = document.createElement('canvas');
+let bindGroup61 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer53, offset: 6656, size: 2572}}],
+});
+let buffer72 = device0.createBuffer({
+  size: 11424,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture136 = device0.createTexture({
+  size: {width: 1, height: 136, depthOrArrayLayers: 1},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder126 = commandEncoder21.beginComputePass();
+let sampler77 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.55,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup4, [0]);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(2, bindGroup37, new Uint32Array(567), 122, 0);
+} catch {}
+try {
+computePassEncoder75.end();
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer13, 148, 36);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder({});
+let textureView123 = texture136.createView({baseMipLevel: 0});
+let texture137 = device0.createTexture({
+  size: {width: 1, height: 136, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let arrayBuffer11 = buffer1.getMappedRange(536, 0);
+try {
+device0.queue.writeBuffer(buffer45, 296, new BigUint64Array(1191), 67, 0);
+} catch {}
+let texture138 = device0.createTexture({
+  size: {width: 3357},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView124 = texture129.createView({dimension: '2d-array', format: 'bgra8unorm', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder127 = commandEncoder51.beginComputePass({});
+try {
+commandEncoder114.copyBufferToTexture({
+  /* bytesInLastRow: 2200 widthInBlocks: 275 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 480 */
+  offset: 480,
+  buffer: buffer52,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 574, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 275, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer23, 18432);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({});
+let textureView125 = texture138.createView({});
+let textureView126 = texture17.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder128 = commandEncoder114.beginComputePass({});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup44, new Uint32Array(876), 58, 1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline19 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment5',
+  constants: {35_410: 1},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule6, constants: {}, buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder37.beginComputePass();
+let sampler78 = device0.createSampler({addressModeU: 'mirror-repeat'});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup54, [0]);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 108 */
+  offset: 108,
+  buffer: buffer14,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 33, y: 13, z: 3},
+  aspect: 'all',
+}, new Uint8Array(338).fill(170), /* required buffer size: 338 */
+{offset: 332}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'linear'} });
+let commandEncoder117 = device0.createCommandEncoder({label: '\ua37f\u39ac'});
+let texture139 = device0.createTexture({
+  size: [1, 136, 41],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView127 = texture133.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder0 = commandEncoder117.beginRenderPass({
+  colorAttachments: [{
+  view: textureView124,
+  clearValue: { r: -438.8, g: 544.6, b: -29.13, a: 909.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder96.setBindGroup(0, bindGroup44, [512]);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer42, 'uint16', 5_680, 397);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer16, 0, 468);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 1,
+  origin: {x: 0, y: 104, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 3,
+  origin: {x: 0, y: 18, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 31, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1575, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 0, y: 506, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer73 = device0.createBuffer({
+  size: 65536,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder130 = commandEncoder115.beginComputePass();
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer67, 216, 168);
+} catch {}
+document.body.append(img0);
+let buffer74 = device0.createBuffer({
+  size: 2947,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 955});
+let textureView128 = texture136.createView({});
+let computePassEncoder131 = commandEncoder116.beginComputePass({});
+try {
+renderPassEncoder0.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer40, 904);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 48, new DataView(new ArrayBuffer(4244)), 2041, 464);
+} catch {}
+await gc();
+let bindGroup62 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout11,
+  entries: [{binding: 174, resource: {buffer: buffer56, offset: 1536}}],
+});
+let textureView129 = texture60.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer25, 64); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer28, 0);
+} catch {}
+try {
+canvas0.getContext('bitmaprenderer');
+} catch {}
+let buffer75 = device0.createBuffer({size: 17473, usage: GPUBufferUsage.MAP_WRITE});
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 616});
+try {
+computePassEncoder109.setBindGroup(3, bindGroup27, [512]);
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer7, 2464, 640);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture140 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView130 = texture96.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder110.setBindGroup(0, bindGroup25, new Uint32Array(1995), 249, 0);
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup39, new Uint32Array(94), 7, 1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer40, 'uint32', 4_668, 57);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer40, 64);
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 794});
+let textureView131 = texture138.createView({format: 'rg32float'});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup9, new Uint32Array(4335), 60, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder62); computePassEncoder62.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroupsIndirect(buffer55, 3_124); };
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2288 */
+  offset: 2288,
+  bytesPerRow: 39680,
+  rowsPerImage: 177,
+  buffer: buffer50,
+}, {
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer10, 196, 20);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 4800, new BigUint64Array(34351), 2414, 12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26).fill(116), /* required buffer size: 26 */
+{offset: 26, bytesPerRow: 97, rowsPerImage: 560}, {width: 1, height: 547, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder({});
+let textureView132 = texture3.createView({dimension: 'cube-array', aspect: 'all', baseArrayLayer: 3, arrayLayerCount: 6});
+let computePassEncoder132 = commandEncoder113.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup52, [1024]);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup15, new Uint32Array(2453), 558, 1);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer66, 2_220);
+} catch {}
+try {
+commandEncoder119.copyBufferToBuffer(buffer52, 504, buffer58, 4708, 380);
+} catch {}
+let bindGroup63 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 34, resource: textureView86},
+    {binding: 14, resource: sampler69},
+    {binding: 28, resource: textureView42},
+    {binding: 495, resource: {buffer: buffer17, offset: 4352, size: 1356}},
+  ],
+});
+let commandEncoder120 = device0.createCommandEncoder();
+let computePassEncoder133 = commandEncoder120.beginComputePass({});
+let sampler79 = device0.createSampler({addressModeW: 'mirror-repeat'});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder95.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 814.2, g: -673.4, b: 888.5, a: -840.3, });
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\ufbe8');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let pipeline20 = await promise1;
+let promise17 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment5',
+  constants: {35_410: 1},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule3, buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder121 = device0.createCommandEncoder({});
+let computePassEncoder134 = commandEncoder118.beginComputePass();
+try {
+computePassEncoder67.setBindGroup(0, bindGroup33, new Uint32Array(992), 42, 1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup31, new Uint32Array(2054), 463, 1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer14, 'uint16', 6_478, 1_693);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer21);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let device1 = await adapter1.requestDevice({
+  defaultQueue: {},
+  requiredLimits: {
+    minUniformBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 74444816,
+    maxStorageBufferBindingSize: 158637421,
+  },
+});
+try {
+adapter1.label = '\u5c19\ue282';
+} catch {}
+let texture141 = device0.createTexture({
+  size: [256, 256, 21],
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+buffer49.unmap();
+} catch {}
+try {
+commandEncoder121.copyBufferToBuffer(buffer69, 1636, buffer42, 6944, 664);
+} catch {}
+try {
+commandEncoder121.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1560 */
+  offset: 1560,
+  bytesPerRow: 49408,
+  buffer: buffer44,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline21 = await promise17;
+let bindGroup64 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 174, resource: {buffer: buffer25, offset: 512, size: 748}}],
+});
+let texture142 = device0.createTexture({
+  size: [419, 1, 7],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder135 = commandEncoder119.beginComputePass({label: '\u0e90\ub7f9\u0be8\uae4d\uc180\u09c5\ub6b4'});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup8, new Uint32Array(3105), 172, 0);
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer27, 'uint16', 2_406, 29);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder121.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 598 */
+  offset: 598,
+  bytesPerRow: 20736,
+  buffer: buffer56,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 1, y: 139, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 351, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder121.insertDebugMarker('\u52c0');
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\u{1f672}');
+} catch {}
+let pipeline22 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule3, constants: {}}});
+let imageData15 = new ImageData(172, 68);
+let bindGroup65 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 47, resource: textureView8}, {binding: 202, resource: textureView59}],
+});
+let texture143 = gpuCanvasContext0.getCurrentTexture();
+let textureView133 = texture40.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder136 = commandEncoder121.beginComputePass({});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup50, [256]);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup54, new Uint32Array(976), 248, 1);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 424 */
+  offset: 424,
+  bytesPerRow: 14080,
+  rowsPerImage: 338,
+  buffer: buffer17,
+}, {width: 1, height: 273, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let buffer76 = device1.createBuffer({size: 1168, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder122 = device1.createCommandEncoder({});
+let computePassEncoder137 = commandEncoder122.beginComputePass({});
+document.body.append(canvas0);
+let computePassEncoder138 = commandEncoder30.beginComputePass({});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup33, new Uint32Array(884), 55, 1);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder117.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2888 */
+  offset: 2888,
+  bytesPerRow: 24320,
+  buffer: buffer35,
+}, {
+  texture: texture96,
+  mipLevel: 2,
+  origin: {x: 0, y: 147, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler80 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 93.89,
+  compare: 'greater-equal',
+});
+let sampler81 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.98,
+  maxAnisotropy: 1,
+});
+let sampler82 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 68.37,
+  maxAnisotropy: 10,
+});
+try {
+buffer76.unmap();
+} catch {}
+let veryExplicitBindGroupLayout17 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 454,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer77 = device1.createBuffer({
+  size: 20385,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder123 = device1.createCommandEncoder({});
+let texture144 = device1.createTexture({
+  size: {width: 2240, height: 40, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder139 = commandEncoder123.beginComputePass({});
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+let buffer78 = device1.createBuffer({size: 1547, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView134 = texture144.createView({});
+let commandEncoder124 = device0.createCommandEncoder();
+let texture145 = device0.createTexture({
+  size: [839],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup50, new Uint32Array(358), 37, 1);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline15);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let commandEncoder125 = device0.createCommandEncoder({});
+let texture146 = device0.createTexture({
+  size: {width: 1678, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView135 = texture46.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 4});
+let computePassEncoder140 = commandEncoder124.beginComputePass({});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup7, [0]);
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline3);
+} catch {}
+let promise19 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment3',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {module: shaderModule4, entryPoint: 'vertex4', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front'},
+});
+await gc();
+let textureView136 = texture144.createView({baseMipLevel: 0});
+try {
+device1.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 130, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(172).fill(233), /* required buffer size: 172 */
+{offset: 172, bytesPerRow: 721}, {width: 172, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout18 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 454,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder137.pushDebugGroup('\u0341');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer78, 196, new Int16Array(35441), 2394, 160);
+} catch {}
+let texture147 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder141 = commandEncoder117.beginComputePass({});
+let sampler83 = device0.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 81.52, compare: 'never'});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder125.copyBufferToBuffer(buffer50, 980, buffer35, 9804, 3952);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(468_606).fill(51), /* required buffer size: 468_606 */
+{offset: 89, bytesPerRow: 423, rowsPerImage: 284}, {width: 256, height: 256, depthOrArrayLayers: 4});
+} catch {}
+let pipelineLayout12 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout17]});
+let buffer79 = device1.createBuffer({size: 10208, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder126 = device1.createCommandEncoder({});
+let computePassEncoder142 = commandEncoder126.beginComputePass({});
+try {
+computePassEncoder137.popDebugGroup();
+} catch {}
+let promise20 = device1.queue.onSubmittedWorkDone();
+let offscreenCanvas3 = new OffscreenCanvas(221, 102);
+let bindGroup66 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 87, resource: {buffer: buffer25, offset: 512, size: 1948}}],
+});
+let textureView137 = texture96.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2});
+try {
+computePassEncoder136.setPipeline(pipeline0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 419, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 7, y: 2 },
+  flipY: false,
+}, {
+  texture: texture146,
+  mipLevel: 2,
+  origin: {x: 64, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let pipelineLayout13 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout18]});
+let querySet20 = device1.createQuerySet({type: 'occlusion', count: 728});
+let sampler84 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 99.71, compare: 'less'});
+let gpuCanvasContext1 = offscreenCanvas3.getContext('webgpu');
+try {
+  await promise18;
+} catch {}
+let veryExplicitBindGroupLayout19 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 454,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer80 = device0.createBuffer({
+  label: '\u564c\ud9d3\ud7ab\ud1e1\u00eb\u64db\u047d\u{1fa8b}\u1b57\u0ad2\u7484',
+  size: 9762,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder127 = device0.createCommandEncoder({});
+let computePassEncoder143 = commandEncoder125.beginComputePass({});
+try {
+computePassEncoder143.setBindGroup(1, bindGroup60, [1024]);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 30, y: 10, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({});
+let texture148 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder144 = commandEncoder128.beginComputePass({});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup13, new Uint32Array(2380), 135, 0);
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture95,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 231, z: 86},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+document.body.append(img0);
+let buffer81 = device0.createBuffer({size: 1243, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder129 = device0.createCommandEncoder();
+let texture149 = device0.createTexture({
+  size: [419, 1, 52],
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder145 = commandEncoder129.beginComputePass({});
+let renderPassEncoder1 = commandEncoder127.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  clearValue: { r: -727.3, g: -334.5, b: 850.6, a: 221.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder1.setIndexBuffer(buffer27, 'uint32', 40, 1_078);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 4, new Float32Array(36885), 17189, 192);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 291, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(96).fill(144), /* required buffer size: 96 */
+{offset: 96}, {width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView138 = texture3.createView({dimension: 'cube-array', aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 6});
+try {
+computePassEncoder129.setPipeline(pipeline22);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+let textureView139 = texture90.createView({baseArrayLayer: 4, arrayLayerCount: 1});
+try {
+computePassEncoder114.end();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint32', 264, 117);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer67, 88, 438);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+document.body.prepend(canvas0);
+let imageData16 = new ImageData(56, 4);
+let buffer82 = device1.createBuffer({size: 11168, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder130 = device1.createCommandEncoder({});
+let textureView140 = texture144.createView({dimension: '2d-array', format: 'r32sint', baseArrayLayer: 0});
+let sampler85 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 60.55,
+});
+await gc();
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpte170m', transfer: 'bt709'} });
+let commandBuffer13 = commandEncoder28.finish();
+let texture150 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let bindGroup67 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 70, resource: {buffer: buffer14, offset: 1792, size: 1187}},
+    {binding: 116, resource: {buffer: buffer72, offset: 256}},
+  ],
+});
+let commandEncoder131 = device0.createCommandEncoder();
+let computePassEncoder146 = commandEncoder131.beginComputePass({});
+try {
+computePassEncoder134.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup63, new Uint32Array(1279), 213, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(1, 129, 0, 892);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+let pipeline23 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment3',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule5,
+    buffers: [
+      {
+        arrayStride: 140,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 0, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 28, shaderLocation: 14},
+          {format: 'float32x2', offset: 4, shaderLocation: 8},
+          {format: 'float16x4', offset: 20, shaderLocation: 3},
+          {format: 'uint32x3', offset: 12, shaderLocation: 15},
+          {format: 'sint8x2', offset: 52, shaderLocation: 4},
+          {format: 'float32x2', offset: 56, shaderLocation: 6},
+          {format: 'sint8x4', offset: 12, shaderLocation: 10},
+          {format: 'uint16x4', offset: 68, shaderLocation: 7},
+          {format: 'float32x3', offset: 16, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 14, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 348,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 44, shaderLocation: 11},
+          {format: 'uint16x2', offset: 44, shaderLocation: 9},
+          {format: 'float32x2', offset: 184, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let commandEncoder132 = device1.createCommandEncoder({});
+let texture151 = device1.createTexture({
+  size: [1810, 1, 439],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView141 = texture144.createView({});
+document.body.append(img0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture152 = gpuCanvasContext0.getCurrentTexture();
+let textureView142 = texture144.createView({dimension: '2d-array'});
+let computePassEncoder147 = commandEncoder130.beginComputePass({});
+let sampler86 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.43,
+  maxAnisotropy: 15,
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise20;
+} catch {}
+let pipelineLayout14 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout17]});
+let sampler87 = device1.createSampler({lodMaxClamp: 97.50, compare: 'greater-equal'});
+let sampler88 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 16,
+});
+try {
+device1.queue.writeBuffer(buffer77, 2280, new BigUint64Array(3988), 167, 1216);
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder({});
+let texture153 = device0.createTexture({size: {width: 1}, dimension: '1d', format: 'rg16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView143 = texture43.createView({aspect: 'stencil-only', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder148 = commandEncoder133.beginComputePass();
+try {
+computePassEncoder24.setBindGroup(2, bindGroup26, [256]);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(2, bindGroup23, new Uint32Array(3677), 301, 0);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer57, 'uint16', 31_310, 2_467);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer66, 0);
+} catch {}
+let pipeline24 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule2, constants: {}}});
+let offscreenCanvas4 = new OffscreenCanvas(83, 23);
+let commandEncoder134 = device1.createCommandEncoder();
+let computePassEncoder149 = commandEncoder134.beginComputePass({});
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({colorFormats: ['rg32uint']});
+try {
+commandEncoder132.copyTextureToBuffer({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 429, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 432 widthInBlocks: 108 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 388 */
+  offset: 388,
+  bytesPerRow: 14592,
+  buffer: buffer77,
+}, {width: 108, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder14.insertDebugMarker('\ubc41');
+} catch {}
+await gc();
+let commandEncoder135 = device0.createCommandEncoder({});
+let computePassEncoder150 = commandEncoder135.beginComputePass({});
+try {
+computePassEncoder119.setBindGroup(0, bindGroup36, [1792]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer55, 'uint16', 6_360, 247);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 419, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 26, y: 2 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let buffer83 = device1.createBuffer({
+  size: 1585,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture154 = device1.createTexture({
+  size: {width: 8},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView144 = texture144.createView({dimension: '2d-array'});
+let computePassEncoder151 = commandEncoder132.beginComputePass({});
+let renderBundle14 = renderBundleEncoder14.finish({});
+let gpuCanvasContext2 = offscreenCanvas4.getContext('webgpu');
+try {
+device1.label = '\u0460\ue32a';
+} catch {}
+let commandEncoder136 = device1.createCommandEncoder({});
+let textureView145 = texture154.createView({});
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 216 */
+  offset: 216,
+  bytesPerRow: 35072,
+  buffer: buffer83,
+}, {
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout20 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 106,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 162,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 454,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder137 = device1.createCommandEncoder();
+let computePassEncoder152 = commandEncoder137.beginComputePass({});
+document.body.prepend(img0);
+let querySet21 = device1.createQuerySet({type: 'occlusion', count: 382});
+let texture155 = gpuCanvasContext1.getCurrentTexture();
+let textureView146 = texture154.createView({arrayLayerCount: 1});
+let computePassEncoder153 = commandEncoder136.beginComputePass();
+try {
+buffer82.unmap();
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [{binding: 87, resource: {buffer: buffer27, offset: 0, size: 1340}}],
+});
+let buffer84 = device0.createBuffer({
+  size: 31378,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView147 = texture42.createView({aspect: 'all'});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup21, new Uint32Array(619), 62, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder93); computePassEncoder93.dispatchWorkgroupsIndirect(buffer26, 548); };
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 680, new Float32Array(4261), 591, 412);
+} catch {}
+document.body.append(img0);
+let bindGroup69 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 34, resource: textureView99},
+    {binding: 495, resource: {buffer: buffer17, offset: 0, size: 2420}},
+    {binding: 28, resource: textureView126},
+    {binding: 14, resource: sampler29},
+  ],
+});
+let buffer85 = device0.createBuffer({size: 1034, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture156 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler89 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 94.70});
+try {
+computePassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup18, [512]);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u12cd');
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [{binding: 174, resource: {buffer: buffer67, offset: 0, size: 528}}],
+});
+let commandEncoder138 = device0.createCommandEncoder({});
+let texture157 = device0.createTexture({
+  size: {width: 839},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder2 = commandEncoder138.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  clearValue: { r: 758.5, g: 37.77, b: 495.6, a: 267.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler90 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 98.51,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup64, [0]);
+} catch {}
+try {
+computePassEncoder56.end();
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup51, [512]);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let commandEncoder139 = device0.createCommandEncoder({});
+let texture158 = device0.createTexture({
+  size: {width: 1, height: 136, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView148 = texture10.createView({dimension: '2d'});
+let computePassEncoder154 = commandEncoder53.beginComputePass();
+try {
+computePassEncoder120.setBindGroup(0, bindGroup21, new Uint32Array(472), 129, 1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup18, [0]);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+try {
+  await buffer18.mapAsync(GPUMapMode.READ, 1360, 196);
+} catch {}
+try {
+commandEncoder139.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 1,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 55, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture159 = device1.createTexture({
+  size: [1120],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture160 = device1.createTexture({
+  size: {width: 528, height: 40, depthOrArrayLayers: 4},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let promise22 = device1.queue.onSubmittedWorkDone();
+let buffer86 = device1.createBuffer({
+  size: 7045,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture161 = device1.createTexture({
+  size: {width: 528, height: 40, depthOrArrayLayers: 98},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint'],
+});
+let textureView149 = texture154.createView({});
+let textureView150 = texture129.createView({dimension: '2d-array', format: 'bgra8unorm', mipLevelCount: 1});
+let computePassEncoder155 = commandEncoder139.beginComputePass({});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(0, bindGroup52, new Uint32Array(117), 46, 1);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup10, [2048]);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup44, new Uint32Array(881), 166, 1);
+} catch {}
+let arrayBuffer12 = buffer32.getMappedRange(80, 732);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img0);
+let pipelineLayout15 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout19]});
+let texture162 = device1.createTexture({
+  size: {width: 1120, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+gpuCanvasContext1.configure({device: device1, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture151,
+  mipLevel: 1,
+  origin: {x: 33, y: 0, z: 18},
+  aspect: 'all',
+}, new Uint8Array(77_179).fill(183), /* required buffer size: 77_179 */
+{offset: 256, bytesPerRow: 189, rowsPerImage: 37}, {width: 33, height: 0, depthOrArrayLayers: 12});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(123, 110);
+let commandEncoder140 = device0.createCommandEncoder();
+try {
+computePassEncoder115.setBindGroup(2, bindGroup43, new Uint32Array(3067), 134, 0);
+} catch {}
+let pipelineLayout16 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout18]});
+let buffer87 = device1.createBuffer({size: 8654, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let buffer88 = device1.createBuffer({size: 1623, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+try {
+  await promise22;
+} catch {}
+await gc();
+let bindGroup71 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 116, resource: {buffer: buffer64, offset: 0, size: 4224}},
+    {binding: 70, resource: {buffer: buffer25, offset: 512, size: 1096}},
+  ],
+});
+let texture163 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 103},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer84, 140); };
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup17, new Uint32Array(676), 82, 0);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9, renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, undefined, 205_365_235);
+} catch {}
+try {
+commandEncoder127.copyBufferToBuffer(buffer19, 1520, buffer44, 1208, 760);
+} catch {}
+try {
+commandEncoder127.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2054 */
+  offset: 2054,
+  bytesPerRow: 23040,
+  buffer: buffer62,
+}, {
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 39, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(52).fill(123), /* required buffer size: 52 */
+{offset: 52}, {width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise21;
+} catch {}
+document.body.prepend(img0);
+let bindGroup72 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout17,
+  entries: [
+    {binding: 106, resource: {buffer: buffer86, offset: 768, size: 2116}},
+    {binding: 162, resource: {buffer: buffer86, offset: 2816, size: 1024}},
+    {binding: 21, resource: textureView134},
+    {binding: 454, resource: {buffer: buffer86, offset: 256, size: 832}},
+  ],
+});
+let commandEncoder141 = device1.createCommandEncoder();
+let texture164 = device1.createTexture({
+  size: [2, 160, 34],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder149.setBindGroup(1, bindGroup72, [0]);
+} catch {}
+try {
+commandEncoder141.copyTextureToTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 188, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let canvas1 = document.createElement('canvas');
+let textureView151 = texture10.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder155.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup7, [1024]);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline16);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let arrayBuffer13 = buffer46.getMappedRange(1064, 8);
+try {
+adapter1.label = '\u9100\u0795\u0dd6\u{1f605}\ufbe3\u{1fd89}';
+} catch {}
+let commandEncoder142 = device1.createCommandEncoder({});
+try {
+computePassEncoder153.setBindGroup(0, bindGroup72, [1792]);
+} catch {}
+try {
+commandEncoder141.clearBuffer(buffer82);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer89 = device0.createBuffer({
+  size: 14427,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder143 = device0.createCommandEncoder({});
+let texture165 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  mipLevelCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView152 = texture88.createView({arrayLayerCount: 5});
+try {
+renderPassEncoder2.setIndexBuffer(buffer14, 'uint32', 2_972, 12);
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer21, offset: 0, size: 9188}}],
+});
+let commandEncoder144 = device0.createCommandEncoder({});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 152});
+let commandBuffer14 = commandEncoder127.finish();
+let computePassEncoder156 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder120.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder145.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9, renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer26, 'uint16', 276, 1_093);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer80);
+} catch {}
+try {
+commandEncoder144.copyBufferToBuffer(buffer49, 3064, buffer45, 292, 16);
+} catch {}
+try {
+commandEncoder144.copyTextureToBuffer({
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3416 widthInBlocks: 427 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8 */
+  offset: 8,
+  buffer: buffer58,
+}, {width: 427, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder144.resolveQuerySet(querySet13, 0, 1, buffer42, 3584);
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [{binding: 174, resource: {buffer: buffer68, offset: 256}}],
+});
+let computePassEncoder157 = commandEncoder144.beginComputePass({});
+let sampler91 = device0.createSampler({addressModeV: 'mirror-repeat'});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup61, [256]);
+} catch {}
+let arrayBuffer14 = buffer32.getMappedRange(816, 1152);
+try {
+device0.queue.writeBuffer(buffer80, 108, new Float32Array(51347), 5120, 288);
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder();
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 998});
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 1,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 9, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 83, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(canvas1);
+let computePassEncoder158 = commandEncoder141.beginComputePass({});
+let sampler92 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.12,
+});
+try {
+commandEncoder142.copyBufferToTexture({
+  /* bytesInLastRow: 1360 widthInBlocks: 340 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 428 */
+  offset: 428,
+  bytesPerRow: 14592,
+  buffer: buffer83,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 977, y: 12, z: 0},
+  aspect: 'all',
+}, {width: 340, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+externalTexture1.label = '\uca9f\u{1fde9}\u0ce9\u{1fefb}\u9615\u0621';
+} catch {}
+let commandEncoder146 = device0.createCommandEncoder({});
+let textureView153 = texture53.createView({arrayLayerCount: 1});
+try {
+computePassEncoder154.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer22, 'uint32', 400, 562);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 1, y: 10 },
+  flipY: false,
+}, {
+  texture: texture129,
+  mipLevel: 1,
+  origin: {x: 0, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let computePassEncoder159 = commandEncoder142.beginComputePass({});
+let sampler93 = device1.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 73.91,
+  compare: 'never',
+  maxAnisotropy: 13,
+});
+let commandEncoder147 = device1.createCommandEncoder({});
+let querySet24 = device1.createQuerySet({type: 'occlusion', count: 1624});
+let commandBuffer15 = commandEncoder147.finish();
+try {
+computePassEncoder142.setBindGroup(1, bindGroup72, [0]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer15]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+canvas0.height = 2093;
+let commandEncoder148 = device1.createCommandEncoder({});
+let computePassEncoder160 = commandEncoder148.beginComputePass({});
+try {
+device1.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(76).fill(160), /* required buffer size: 76 */
+{offset: 76, bytesPerRow: 31}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder({});
+let computePassEncoder161 = commandEncoder145.beginComputePass({});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup36, new Uint32Array(622), 63, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder93.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup33, [768]);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9]);
+} catch {}
+try {
+commandEncoder149.copyBufferToBuffer(buffer72, 4104, buffer17, 2608, 524);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let bindGroup75 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 21, resource: textureView136},
+    {binding: 454, resource: {buffer: buffer86, offset: 0, size: 1670}},
+    {binding: 162, resource: {buffer: buffer86, offset: 768, size: 1432}},
+    {binding: 106, resource: {buffer: buffer86, offset: 768, size: 1936}},
+  ],
+});
+let commandEncoder150 = device1.createCommandEncoder();
+let computePassEncoder162 = commandEncoder150.beginComputePass({});
+try {
+  await promise23;
+} catch {}
+let textureView154 = texture144.createView({});
+try {
+computePassEncoder142.setBindGroup(3, bindGroup72, new Uint32Array(2007), 67, 1);
+} catch {}
+try {
+buffer77.unmap();
+} catch {}
+let texture166 = device0.createTexture({size: [1678], sampleCount: 1, dimension: '1d', format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder163 = commandEncoder146.beginComputePass({});
+let renderPassEncoder3 = commandEncoder83.beginRenderPass({
+  colorAttachments: [{
+  view: textureView150,
+  clearValue: { r: -763.8, g: 584.1, b: 21.38, a: -124.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle9, renderBundle9]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let texture167 = device1.createTexture({
+  size: {width: 132, height: 10, depthOrArrayLayers: 4},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView155 = texture154.createView({format: 'rg32uint'});
+try {
+computePassEncoder139.setBindGroup(1, bindGroup72, [0]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture151,
+  mipLevel: 2,
+  origin: {x: 15, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(204_750).fill(158), /* required buffer size: 204_750 */
+{offset: 405, bytesPerRow: 239, rowsPerImage: 15}, {width: 28, height: 0, depthOrArrayLayers: 58});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let buffer90 = device0.createBuffer({
+  size: 10067,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder151 = device0.createCommandEncoder();
+let commandBuffer16 = commandEncoder35.finish({});
+try {
+computePassEncoder106.setBindGroup(0, bindGroup48, [512]);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(0, bindGroup56, new Uint32Array(222), 19, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroupsIndirect(buffer64, 1_060); };
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer31, 'uint32', 740, 36);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer42, 0, 1_618);
+} catch {}
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2944 */
+  offset: 2944,
+  buffer: buffer60,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 52, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.label = '\u{1fa4b}\u0b7e\ud91a\u154c\u254d\u1e39\u072d\ue093\uc3d5\u03c5';
+} catch {}
+let commandEncoder152 = device1.createCommandEncoder({});
+let sampler94 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.32,
+});
+try {
+computePassEncoder158.setBindGroup(0, bindGroup75, [1280]);
+} catch {}
+try {
+commandEncoder152.copyTextureToTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder153.pushDebugGroup('\u{1fbaf}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 16},
+  aspect: 'all',
+}, new Uint8Array(344).fill(98), /* required buffer size: 344 */
+{offset: 344}, {width: 113, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture168 = device0.createTexture({
+  size: [419, 1, 26],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder164 = commandEncoder151.beginComputePass({});
+let renderPassEncoder4 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{
+  view: textureView139,
+  clearValue: { r: 469.6, g: 218.0, b: 629.1, a: -867.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup54, [768]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder68); computePassEncoder68.dispatchWorkgroupsIndirect(buffer42, 4_696); };
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer20, 12);
+} catch {}
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3602 */
+  offset: 3602,
+  bytesPerRow: 4864,
+  rowsPerImage: 162,
+  buffer: buffer73,
+}, {
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 0, y: 7, z: 1},
+  aspect: 'all',
+}, {width: 19, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder({});
+let computePassEncoder165 = commandEncoder143.beginComputePass({});
+let renderPassEncoder5 = commandEncoder153.beginRenderPass({
+  colorAttachments: [{
+  view: textureView124,
+  clearValue: { r: 636.6, g: 963.9, b: -960.4, a: -95.14, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer49, 2_148, 1_029);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2304 */
+  offset: 2304,
+  bytesPerRow: 3840,
+  buffer: buffer41,
+}, {
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter1.label = '\u7967\u0c3b\u6efc\u6403\u36ea\ud679\u{1f893}\u89b7\u6c6a\ub811';
+} catch {}
+let computePassEncoder166 = commandEncoder16.beginComputePass({});
+let sampler95 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest'});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder125.setBindGroup(0, bindGroup8, new Uint32Array(353), 76, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder156.setPipeline(pipeline3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img0);
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte170m', transfer: 'logSqrt'} });
+let bindGroup76 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 21, resource: textureView134},
+    {binding: 106, resource: {buffer: buffer86, offset: 256, size: 1860}},
+    {binding: 162, resource: {buffer: buffer86, offset: 512, size: 604}},
+    {binding: 454, resource: {buffer: buffer83, offset: 256, size: 470}},
+  ],
+});
+let computePassEncoder167 = commandEncoder152.beginComputePass({});
+let sampler96 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', mipmapFilter: 'nearest', lodMinClamp: 11.87});
+try {
+computePassEncoder159.setBindGroup(2, bindGroup75, [0]);
+} catch {}
+try {
+computePassEncoder159.setBindGroup(0, bindGroup76, new Uint32Array(3033), 894, 1);
+} catch {}
+try {
+buffer87.unmap();
+} catch {}
+let texture169 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup29, [1280]);
+} catch {}
+try {
+computePassEncoder110.setBindGroup(0, bindGroup73, new Uint32Array(338), 27, 1);
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup68, new Uint32Array(2371), 21, 1);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer11, 'uint32', 2_608, 93);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+try {
+device1.queue.label = '\u374b\u9591\uad62\u07b2\u0e44';
+} catch {}
+let buffer91 = device1.createBuffer({
+  size: 11027,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder154 = device1.createCommandEncoder({});
+let sampler97 = device1.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 96.08});
+let texture170 = gpuCanvasContext2.getCurrentTexture();
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(241).fill(51), /* required buffer size: 241 */
+{offset: 241, rowsPerImage: 41}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext3 = canvas1.getContext('webgpu');
+let buffer92 = device1.createBuffer({
+  label: '\u5c9f\u{1fb0c}\u{1fddf}\u77de\u012b\u973a\u1f72',
+  size: 4640,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder155 = device1.createCommandEncoder({});
+let texture171 = device1.createTexture({
+  size: [1, 80, 4],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView156 = texture144.createView({baseArrayLayer: 0});
+let computePassEncoder168 = commandEncoder154.beginComputePass({});
+try {
+computePassEncoder137.setBindGroup(2, bindGroup75, new Uint32Array(4063), 1_287, 1);
+} catch {}
+try {
+commandEncoder155.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3568 */
+  offset: 3568,
+  bytesPerRow: 25344,
+  rowsPerImage: 607,
+  buffer: buffer91,
+}, {
+  texture: texture171,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 33, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture171,
+  mipLevel: 1,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26).fill(137), /* required buffer size: 26 */
+{offset: 26, bytesPerRow: 12}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+await gc();
+let commandEncoder156 = device1.createCommandEncoder({});
+let texture172 = device1.createTexture({
+  size: [66],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView157 = texture144.createView({dimension: '2d-array', format: 'r32sint', baseMipLevel: 0});
+let bindGroup77 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer34, offset: 2048, size: 444}}],
+});
+let textureView158 = texture82.createView({});
+try {
+computePassEncoder76.setBindGroup(2, bindGroup8, new Uint32Array(3375), 44, 0);
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(559);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer17);
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment2',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule6, buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+document.body.prepend(img0);
+let buffer93 = device1.createBuffer({
+  label: '\uda27\u0104\u07e4\u3930\u{1f66f}\u96dd\u0d2f\u{1fd89}\u636d\ua1a9',
+  size: 5955,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let querySet25 = device1.createQuerySet({type: 'occlusion', count: 325});
+let computePassEncoder169 = commandEncoder156.beginComputePass({});
+try {
+computePassEncoder158.setBindGroup(1, bindGroup76, [2304]);
+} catch {}
+try {
+commandEncoder155.copyBufferToTexture({
+  /* bytesInLastRow: 752 widthInBlocks: 94 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 568 */
+  offset: 568,
+  buffer: buffer92,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 94, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture151,
+  mipLevel: 1,
+  origin: {x: 33, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(214_263).fill(251), /* required buffer size: 214_263 */
+{offset: 119, bytesPerRow: 956, rowsPerImage: 14}, {width: 238, height: 0, depthOrArrayLayers: 17});
+} catch {}
+let texture173 = device0.createTexture({
+  size: [3357, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup19, new Uint32Array(1018), 59, 1);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(0, 466, 0, 84);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer3, 'uint16', 374, 602);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline23);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture96,
+  mipLevel: 4,
+  origin: {x: 0, y: 30, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 0, y: 27, z: 46},
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+await gc();
+let buffer94 = device1.createBuffer({
+  size: 985,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler98 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'linear'});
+try {
+computePassEncoder152.setBindGroup(1, bindGroup72, [512]);
+} catch {}
+try {
+buffer91.unmap();
+} catch {}
+let querySet26 = device1.createQuerySet({type: 'occlusion', count: 714});
+let texture174 = device1.createTexture({
+  size: {width: 226, height: 1, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder170 = commandEncoder155.beginComputePass({});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder171 = commandEncoder61.beginComputePass();
+try {
+computePassEncoder164.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer73, 'uint32', 7_960, 31_044);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline18);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer16]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture139,
+  mipLevel: 0,
+  origin: {x: 0, y: 15, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(38), /* required buffer size: 22 */
+{offset: 22, bytesPerRow: 14}, {width: 0, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let buffer95 = device1.createBuffer({
+  size: 21132,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder169.setBindGroup(0, bindGroup75, new Uint32Array(375), 108, 1);
+} catch {}
+let commandEncoder157 = device0.createCommandEncoder();
+let textureView159 = texture94.createView({mipLevelCount: 1});
+let computePassEncoder172 = commandEncoder157.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder96); computePassEncoder96.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup13, new Uint32Array(505), 39, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -297.7, g: -737.8, b: -272.1, a: -881.9, });
+} catch {}
+try {
+buffer64.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 21}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 27, y: 12, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture175 = device1.createTexture({size: [1, 80, 1], dimension: '2d', format: 'rgba32uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let sampler99 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat'});
+try {
+device0.queue.label = '\u01e9\u9d81\u063f\u0045';
+} catch {}
+let commandEncoder158 = device0.createCommandEncoder();
+let textureView160 = texture39.createView({mipLevelCount: 1, arrayLayerCount: 5});
+let computePassEncoder173 = commandEncoder158.beginComputePass({});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], depthReadOnly: true});
+let renderBundle15 = renderBundleEncoder15.finish({label: '\u{1fcfa}\uce61'});
+try {
+computePassEncoder113.setBindGroup(2, bindGroup65, new Uint32Array(1145), 248, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer73, 3_144, 11_372);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 196, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 13, y: 0 },
+  flipY: true,
+}, {
+  texture: texture96,
+  mipLevel: 3,
+  origin: {x: 0, y: 23, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let texture176 = device1.createTexture({
+  size: {width: 528},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let textureView161 = texture172.createView({mipLevelCount: 1});
+try {
+computePassEncoder153.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+await gc();
+let bindGroup78 = device1.createBindGroup({
+  label: '\u94da\ud17f\u0331\u0bdf\ucdbb\u0f78\u93a8',
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 162, resource: {buffer: buffer92, offset: 0, size: 956}},
+    {binding: 21, resource: textureView154},
+    {binding: 454, resource: {buffer: buffer93, offset: 512, size: 922}},
+    {binding: 106, resource: {buffer: buffer92, offset: 0}},
+  ],
+});
+let texture177 = device1.createTexture({
+  size: {width: 264, height: 20, depthOrArrayLayers: 7},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView162 = texture171.createView({mipLevelCount: 1});
+try {
+computePassEncoder158.setBindGroup(2, bindGroup76, [512]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(193).fill(233), /* required buffer size: 193 */
+{offset: 193, rowsPerImage: 61}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise24 = device1.queue.onSubmittedWorkDone();
+let gpuCanvasContext4 = offscreenCanvas5.getContext('webgpu');
+try {
+  await promise24;
+} catch {}
+let texture178 = device0.createTexture({
+  size: [1, 547, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder109); computePassEncoder109.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup71, [0]);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup25, new Uint32Array(1405), 47, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let texture179 = device0.createTexture({
+  size: {width: 3357},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView163 = texture0.createView({});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup73, [7168]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder106); computePassEncoder106.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup37, new Uint32Array(1335), 130, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 388, new DataView(new ArrayBuffer(43316)), 4015, 108);
+} catch {}
+let texture180 = device0.createTexture({
+  size: {width: 1, height: 393, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler100 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+});
+try {
+computePassEncoder96.setBindGroup(0, bindGroup10, [768]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder100); computePassEncoder100.dispatchWorkgroupsIndirect(buffer84, 12_924); };
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer20, 'uint16', 6, 40);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline25);
+} catch {}
+let externalTexture10 = device1.importExternalTexture({source: videoFrame14, colorSpace: 'srgb'});
+try {
+computePassEncoder162.setBindGroup(1, bindGroup76, [256]);
+} catch {}
+try {
+computePassEncoder151.setBindGroup(2, bindGroup72, new Uint32Array(2217), 182, 1);
+} catch {}
+try {
+device1.lost.then(r => { console.log('device1 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let bindGroup79 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 162, resource: {buffer: buffer95, offset: 1536, size: 668}},
+    {binding: 454, resource: {buffer: buffer77, offset: 512, size: 3898}},
+    {binding: 21, resource: textureView154},
+    {binding: 106, resource: {buffer: buffer86, offset: 0, size: 2552}},
+  ],
+});
+let buffer96 = device1.createBuffer({size: 1878, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder159 = device1.createCommandEncoder({label: '\u8120\u05eb\u3a78\u7e5b\u{1f838}\u727f\ucdc6\u{1f85d}'});
+let sampler101 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 71.44,
+  lodMaxClamp: 93.52,
+});
+try {
+computePassEncoder152.setBindGroup(3, bindGroup79, [0]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 324, y: 34, z: 0},
+  aspect: 'all',
+}, new Uint8Array(231).fill(213), /* required buffer size: 231 */
+{offset: 231}, {width: 543, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let buffer97 = device0.createBuffer({
+  size: 6711,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup61, [512]);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline2);
+} catch {}
+let commandEncoder160 = device0.createCommandEncoder({});
+try {
+computePassEncoder173.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle15, renderBundle9, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 300, new DataView(new ArrayBuffer(4648)), 825, 252);
+} catch {}
+document.body.append(canvas1);
+let bindGroup80 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 106, resource: {buffer: buffer95, offset: 0}},
+    {binding: 454, resource: {buffer: buffer86, offset: 1536, size: 105}},
+    {binding: 21, resource: textureView141},
+    {binding: 162, resource: {buffer: buffer92, offset: 512}},
+  ],
+});
+let commandEncoder161 = device1.createCommandEncoder({});
+let texture181 = device1.createTexture({
+  size: {width: 1810, height: 1, depthOrArrayLayers: 85},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder174 = commandEncoder159.beginComputePass({});
+let sampler102 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder159.setBindGroup(2, bindGroup79, new Uint32Array(2080), 298, 1);
+} catch {}
+try {
+commandEncoder161.copyBufferToTexture({
+  /* bytesInLastRow: 1904 widthInBlocks: 476 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48 */
+  offset: 48,
+  bytesPerRow: 13312,
+  rowsPerImage: 672,
+  buffer: buffer92,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 476, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup81 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 59, resource: textureView20}]});
+let commandEncoder162 = device0.createCommandEncoder({});
+let texture182 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder175 = commandEncoder160.beginComputePass({});
+let sampler103 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.26,
+  compare: 'greater',
+});
+try {
+computePassEncoder165.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup20, new Uint32Array(2568), 50, 1);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle9, renderBundle15, renderBundle15, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer97);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder162.copyBufferToBuffer(buffer19, 116, buffer17, 716, 3804);
+} catch {}
+try {
+commandEncoder162.copyTextureToBuffer({
+  texture: texture179,
+  mipLevel: 0,
+  origin: {x: 192, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 656 */
+  offset: 656,
+  rowsPerImage: 41,
+  buffer: buffer33,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder162.clearBuffer(buffer67);
+} catch {}
+let canvas2 = document.createElement('canvas');
+try {
+computePassEncoder158.setBindGroup(3, bindGroup72, [0]);
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture177,
+  mipLevel: 0,
+  origin: {x: 11, y: 6, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 258, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer94, 60, new BigUint64Array(11041), 7, 8);
+} catch {}
+let buffer98 = device0.createBuffer({size: 8619, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame12});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup20, new Uint32Array(2114), 83, 1);
+} catch {}
+let bindGroup82 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 162, resource: {buffer: buffer92, offset: 1280}},
+    {binding: 106, resource: {buffer: buffer92, offset: 0}},
+    {binding: 21, resource: textureView156},
+    {binding: 454, resource: {buffer: buffer76, offset: 0}},
+  ],
+});
+let buffer99 = device1.createBuffer({
+  size: 14485,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder163 = device1.createCommandEncoder({});
+let texture183 = device1.createTexture({
+  size: [66],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView164 = texture181.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 54});
+try {
+commandEncoder163.clearBuffer(buffer83, 20, 32);
+} catch {}
+let promise25 = device1.queue.onSubmittedWorkDone();
+let commandEncoder164 = device1.createCommandEncoder({});
+let texture184 = device1.createTexture({
+  size: {width: 280, height: 5, depthOrArrayLayers: 24},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder176 = commandEncoder161.beginComputePass({});
+try {
+computePassEncoder149.setBindGroup(0, bindGroup76, [0]);
+} catch {}
+try {
+computePassEncoder142.setBindGroup(0, bindGroup76, new Uint32Array(5062), 580, 1);
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 616 */
+  offset: 616,
+  buffer: buffer95,
+}, {
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture185 = device1.createTexture({
+  size: {width: 4, height: 320, depthOrArrayLayers: 60},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder177 = commandEncoder164.beginComputePass();
+try {
+computePassEncoder169.setBindGroup(2, bindGroup79, new Uint32Array(1273), 68, 1);
+} catch {}
+let buffer100 = device1.createBuffer({size: 15595, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder165 = device1.createCommandEncoder({});
+let textureView165 = texture185.createView({mipLevelCount: 1});
+let texture186 = device1.createTexture({
+  size: {width: 2, height: 160, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView166 = texture183.createView({label: '\ue30b\u{1f6d3}\u076c', baseArrayLayer: 0});
+let computePassEncoder178 = commandEncoder163.beginComputePass({});
+try {
+computePassEncoder152.setBindGroup(3, bindGroup72, [1024]);
+} catch {}
+try {
+commandEncoder165.copyBufferToTexture({
+  /* bytesInLastRow: 1188 widthInBlocks: 297 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 100 */
+  offset: 100,
+  bytesPerRow: 21760,
+  buffer: buffer87,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 172, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 297, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder165.resolveQuerySet(querySet26, 164, 129, buffer91, 256);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let veryExplicitBindGroupLayout21 = device1.createBindGroupLayout({
+  entries: [
+    {binding: 42, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 55,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView167 = texture159.createView({});
+let texture187 = device1.createTexture({
+  size: [66, 5, 4],
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler104 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.29,
+});
+offscreenCanvas3.height = 30;
+let texture188 = device0.createTexture({size: [1], dimension: '1d', format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup27, new Uint32Array(950), 444, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder71); computePassEncoder71.dispatchWorkgroupsIndirect(buffer47, 1_016); };
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup48, new Uint32Array(5116), 2_166, 1);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline9);
+} catch {}
+try {
+texture5.destroy();
+} catch {}
+try {
+commandEncoder162.clearBuffer(buffer1, 1236, 2492);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(img0);
+let buffer101 = device0.createBuffer({
+  size: 13993,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder166 = device0.createCommandEncoder({});
+let textureView168 = texture118.createView({aspect: 'stencil-only', format: 'stencil8', baseMipLevel: 3, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder179 = commandEncoder162.beginComputePass({});
+try {
+computePassEncoder112.setBindGroup(0, bindGroup54, new Uint32Array(902), 125, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder117); computePassEncoder117.dispatchWorkgroupsIndirect(buffer11, 68); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup14, [768]);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup23, new Uint32Array(976), 41, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer44, 4_552);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas1);
+let canvas3 = document.createElement('canvas');
+let computePassEncoder180 = commandEncoder166.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer27, 340, new DataView(new ArrayBuffer(7139)), 361, 228);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(66_427).fill(125), /* required buffer size: 66_427 */
+{offset: 126, bytesPerRow: 259}, {width: 256, height: 256, depthOrArrayLayers: 1});
+} catch {}
+document.body.append(img0);
+let recycledExplicitBindGroupLayout14 = pipeline3.getBindGroupLayout(0);
+let sampler105 = device0.createSampler({minFilter: 'linear', lodMinClamp: 5.607});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup4, new Uint32Array(420), 16, 1);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 7420, new BigUint64Array(3445), 123, 84);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(286).fill(168), /* required buffer size: 286 */
+{offset: 286, bytesPerRow: 24, rowsPerImage: 9}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup83 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 454, resource: {buffer: buffer99, offset: 1536, size: 5551}},
+    {binding: 162, resource: {buffer: buffer92, offset: 1792}},
+    {binding: 106, resource: {buffer: buffer86, offset: 512, size: 2380}},
+    {binding: 21, resource: textureView156},
+  ],
+});
+let buffer102 = device1.createBuffer({size: 1224, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder159.setBindGroup(3, bindGroup78, [0]);
+} catch {}
+try {
+commandEncoder165.copyTextureToBuffer({
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2640 */
+  offset: 2640,
+  buffer: buffer82,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture189 = device0.createTexture({
+  size: {width: 1678, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView169 = texture48.createView({dimension: '2d-array'});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup4, [0]);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup33, [0]);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline25);
+} catch {}
+let imageData17 = new ImageData(12, 80);
+let shaderModule7 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(44) f0: array<u32>,
+}
+
+var<workgroup> vw18: atomic<u32>;
+
+var<workgroup> vw19: array<array<array<bool, 1>, 1>, 13>;
+
+var<workgroup> vw26: array<array<array<f16, 1>, 17>, 1>;
+
+var<workgroup> vw15: atomic<u32>;
+
+var<workgroup> vw25: FragmentOutput4;
+
+var<workgroup> vw22: atomic<i32>;
+
+var<workgroup> vw20: FragmentOutput4;
+
+struct T1 {
+  @size(44) f0: array<u32>,
+}
+
+@group(0) @binding(174) var<storage, read> buffer103: array<array<array<array<array<array<array<array<array<f16, 1>, 1>, 2>, 1>, 11>, 1>, 1>, 1>>;
+
+var<workgroup> vw14: vec2<bool>;
+
+var<workgroup> vw16: FragmentOutput4;
+
+var<workgroup> vw24: array<array<FragmentOutput4, 5>, 1>;
+
+var<workgroup> vw23: mat2x4h;
+
+struct FragmentOutput4 {
+  @location(4) f0: vec2i,
+  @location(0) f1: vec2f,
+}
+
+var<workgroup> vw21: array<array<atomic<u32>, 1>, 3>;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T2 {
+  @size(8) f0: array<u32>,
+}
+
+var<private> vp12 = modf(vec4f(0.04557, 0.03826, 0.2556, 0.3773));
+
+var<workgroup> vw17: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T3 {
+  @size(44) f0: T2,
+}
+
+/* used global variables: buffer103 */
+@fragment
+fn fragment7(@builtin(front_facing) a0: bool) -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  let ptr54: ptr<storage, f16, read> = &buffer103[arrayLength(&buffer103)][0][0][0][10][unconst_u32(113)][1][unconst_u32(23)][0];
+  out.f0 -= vec2i(i32((*&buffer103)[arrayLength(&(*&buffer103))][unconst_u32(310)][0][0][unconst_u32(395)][unconst_u32(164)][unconst_u32(83)][0][0]));
+  let ptr55: ptr<storage, array<f16, 1>, read> = &(*&buffer103)[unconst_u32(410)][0][0][0][unconst_u32(413)][0][1][0];
+  let ptr56: ptr<storage, array<f16, 1>, read> = &buffer103[arrayLength(&buffer103)][unconst_u32(9)][0][0][10][0][1][unconst_u32(9)];
+  switch i32(buffer103[arrayLength(&buffer103)][0][unconst_u32(62)][0][10][unconst_u32(36)][unconst_u32(229)][unconst_u32(18)][0]) { 
+  default {
+  out = FragmentOutput4(vec2i(i32(buffer103[unconst_u32(225)][0][unconst_u32(169)][0][unconst_u32(849)][0][1][0][0])), vec2f(f32(buffer103[unconst_u32(225)][0][unconst_u32(169)][0][unconst_u32(849)][0][1][0][0])));
+  let ptr57: ptr<storage, f16, read> = &buffer103[unconst_u32(617)][0][0][0][unconst_u32(468)][unconst_u32(169)][u32((*&buffer103)[u32(buffer103[unconst_u32(59)][0][0][unconst_u32(117)][10][0][1][0][0])][unconst_u32(243)][unconst_u32(65)][unconst_u32(3)][10][0][1][0][0])][unconst_u32(39)][unconst_u32(33)];
+  break;
+  _ = buffer103;
+}
+  }
+  return out;
+  _ = buffer103;
+}`,
+});
+let recycledExplicitBindGroupLayout15 = pipeline9.getBindGroupLayout(0);
+let bindGroup84 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [{binding: 174, resource: {buffer: buffer74, offset: 512, size: 296}}],
+});
+let texture190 = device0.createTexture({
+  size: {width: 1, height: 196, depthOrArrayLayers: 39},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder108.setBindGroup(0, bindGroup40, [0]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder117.end();
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer89, 'uint16', 3_432, 9_156);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder105.copyTextureToTexture({
+  texture: texture188,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture129,
+  mipLevel: 1,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer8, 16, 884);
+} catch {}
+document.body.append(img0);
+let bindGroup85 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout9,
+  entries: [{binding: 174, resource: {buffer: buffer31, offset: 0, size: 44}}],
+});
+let commandEncoder167 = device0.createCommandEncoder();
+let sampler106 = device0.createSampler({
+  label: '\u6990\u1a6b\u{1fbea}\u0683\uf585\u97c2',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder104); computePassEncoder104.dispatchWorkgroupsIndirect(buffer5, 16); };
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup18, new Uint32Array(1362), 168, 1);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -865.4, g: 555.0, b: -265.5, a: 657.3, });
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer25, 1_932, 365);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(277).fill(221), /* required buffer size: 277 */
+{offset: 277}, {width: 59, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 432, resource: textureView59}, {binding: 77, resource: textureView63}],
+});
+let computePassEncoder181 = commandEncoder105.beginComputePass({});
+let renderPassEncoder6 = commandEncoder167.beginRenderPass({
+  colorAttachments: [{
+  view: textureView139,
+  clearValue: { r: -914.7, g: -517.9, b: -752.4, a: -113.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet19,
+});
+let sampler107 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 97.55});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup20, new Uint32Array(4077), 932, 1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 419, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture146,
+  mipLevel: 2,
+  origin: {x: 53, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture191 = device0.createTexture({
+  size: {width: 1},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder172.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer26, 'uint32', 68, 1_659);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer31, 684);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 280, new Float32Array(11401), 941, 128);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline26 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule3, constants: {}}});
+let veryExplicitBindGroupLayout22 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 177,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 251,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup87 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [
+    {binding: 177, resource: {buffer: buffer86, offset: 1280, size: 1084}},
+    {binding: 251, resource: {buffer: buffer95, offset: 1792}},
+  ],
+});
+let texture192 = device1.createTexture({
+  size: [528, 40, 4],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder159.setBindGroup(3, bindGroup75, [1024]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer77, 5936, new DataView(new ArrayBuffer(5472)), 330, 2124);
+} catch {}
+document.body.prepend(img0);
+let buffer104 = device0.createBuffer({
+  size: 7160,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder168 = device0.createCommandEncoder();
+let renderPassEncoder7 = commandEncoder168.beginRenderPass({
+  label: '\uce8b\u0204\u07f3\u{1fcea}\u{1fbe9}\u8261\u7ea9\u{1fee4}\uce84',
+  colorAttachments: [{
+  view: textureView139,
+  clearValue: { r: 880.1, g: 512.1, b: -253.9, a: -610.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet5,
+});
+let sampler108 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.51,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(0, bindGroup84, new Uint32Array(1618), 236, 1);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer22, 'uint32', 1_092, 377);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 787, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData16,
+  origin: { x: 3, y: 1 },
+  flipY: false,
+}, {
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 0, y: 308, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder169 = device1.createCommandEncoder({});
+let textureView170 = texture162.createView({mipLevelCount: 1});
+let texture193 = device1.createTexture({
+  size: {width: 905, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder153.setBindGroup(0, bindGroup75, new Uint32Array(1221), 259, 1);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(60).fill(71), /* required buffer size: 60 */
+{offset: 60}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder170 = device1.createCommandEncoder({});
+let veryExplicitBindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder171 = device0.createCommandEncoder();
+let texture194 = device0.createTexture({
+  size: {width: 1, height: 547, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let computePassEncoder182 = commandEncoder171.beginComputePass({});
+try {
+renderPassEncoder4.setIndexBuffer(buffer19, 'uint32', 524, 57);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer52);
+} catch {}
+let gpuCanvasContext5 = canvas3.getContext('webgpu');
+await gc();
+try {
+globalThis.someLabel = sampler92.label;
+} catch {}
+let texture195 = device1.createTexture({size: [2], mipLevelCount: 1, dimension: '1d', format: 'rgba32uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder183 = commandEncoder165.beginComputePass({});
+let commandEncoder172 = device1.createCommandEncoder({});
+let computePassEncoder184 = commandEncoder170.beginComputePass();
+let sampler109 = device1.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'linear', mipmapFilter: 'linear'});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let texture196 = device1.createTexture({
+  size: {width: 1, height: 80, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView171 = texture151.createView({format: 'rgba8snorm', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let bindGroup88 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 106, resource: {buffer: buffer95, offset: 2048}},
+    {binding: 454, resource: {buffer: buffer77, offset: 256, size: 2902}},
+    {binding: 21, resource: textureView154},
+    {binding: 162, resource: {buffer: buffer92, offset: 256}},
+  ],
+});
+let commandEncoder173 = device1.createCommandEncoder({});
+try {
+device1.queue.writeTexture({
+  texture: texture196,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(387).fill(0), /* required buffer size: 387 */
+{offset: 387, bytesPerRow: 45}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let sampler110 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 99.64});
+try {
+computePassEncoder181.setBindGroup(1, bindGroup6, new Uint32Array(2578), 146, 0);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline16);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 25, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer105 = device0.createBuffer({size: 4575, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture197 = device0.createTexture({
+  size: {width: 839, height: 1, depthOrArrayLayers: 125},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView172 = texture52.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: false, stencilReadOnly: true});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup69);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup29, new Uint32Array(1410), 457, 1);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle9]);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+canvas0.height = 432;
+let recycledExplicitBindGroupLayout16 = pipeline3.getBindGroupLayout(0);
+let commandEncoder174 = device0.createCommandEncoder();
+let renderPassEncoder8 = commandEncoder7.beginRenderPass({colorAttachments: [{view: textureView150, loadOp: 'load', storeOp: 'store'}]});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup6, new Uint32Array(436), 3, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer7, 0, 1_026);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let texture198 = device0.createTexture({
+  size: [2, 1095, 1],
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView173 = texture140.createView({baseMipLevel: 0});
+try {
+computePassEncoder136.setBindGroup(3, bindGroup1, new Uint32Array(2394), 5, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer84, 312); };
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup44, new Uint32Array(1333), 74, 1);
+} catch {}
+try {
+renderPassEncoder4.draw(2, 271, 662_215_689, 58_054_634);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(2, 285, 2, -1_650_851_557, 490_786_899);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer47, 1_084);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer73, 'uint32', 9_184, 3_293);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer71, 108);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer63, 'uint32', 2_832, 480);
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [{binding: 174, resource: {buffer: buffer80, offset: 3584, size: 72}}],
+});
+let commandEncoder175 = device0.createCommandEncoder({});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder141.setBindGroup(2, bindGroup12, new Uint32Array(716), 76, 0);
+} catch {}
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup11, new Uint32Array(1148), 147, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder4.draw(93, 254, 1_762_166_040, 2_833_891_814);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer69, 1_816);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer41, 'uint16', 1_626, 1_035);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer69, 56, 637);
+} catch {}
+try {
+renderBundleEncoder16.insertDebugMarker('\u{1fd64}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 716, new Float32Array(16813), 1882, 28);
+} catch {}
+let promise26 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {module: shaderModule5, constants: {override8: 1}, targets: [{format: 'rg8unorm'}]},
+  vertex: {module: shaderModule4, entryPoint: 'vertex4', buffers: []},
+});
+document.body.append(img0);
+let buffer106 = device0.createBuffer({
+  size: 810,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder185 = commandEncoder174.beginComputePass({});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup63);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer21, 4_228);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer54, 2_400);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer11, 0, 2_397);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer52, 0, 25);
+} catch {}
+try {
+querySet4.destroy();
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext6 = canvas2.getContext('webgpu');
+try {
+  await promise27;
+} catch {}
+let buffer107 = device0.createBuffer({size: 1433, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView174 = texture132.createView({format: 'rg16uint'});
+let renderPassEncoder9 = commandEncoder14.beginRenderPass({colorAttachments: [{view: textureView139, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler111 = device0.createSampler({addressModeV: 'mirror-repeat', lodMinClamp: 69.98, lodMaxClamp: 72.87, compare: 'greater'});
+try {
+{ clearResourceUsages(device0, computePassEncoder123); computePassEncoder123.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(3, 76, 0, 11_950_677, 711_577_710);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer71, 12);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer69, 1_152);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer72, 'uint16', 6_248, 4_956);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup34, new Uint32Array(202), 100, 0);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer97, 552);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer89, 'uint32', 2_116, 4_771);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer67, 76, buffer10, 140, 28);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1095, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 271, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let textureView175 = texture144.createView({format: 'r32sint'});
+try {
+commandEncoder172.copyTextureToBuffer({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 19, y: 8, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 232 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 136 */
+  offset: 136,
+  bytesPerRow: 34304,
+  buffer: buffer91,
+}, {width: 29, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup90 = device0.createBindGroup({layout: veryExplicitBindGroupLayout15, entries: [{binding: 360, resource: textureView105}]});
+let buffer108 = device0.createBuffer({
+  size: 18432,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder176 = device0.createCommandEncoder({});
+let textureView176 = texture119.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder186 = commandEncoder29.beginComputePass({});
+let renderPassEncoder10 = commandEncoder176.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  clearValue: { r: 516.2, g: -617.7, b: 932.8, a: 341.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 63771878,
+});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup52, new Uint32Array(1032), 30, 1);
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(0, 186, 2, 1_516_131_855, 1_691_726_415);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer97, 3_252);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer42, 'uint32', 352, 2_401);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer16, 772);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup51, new Uint32Array(4820), 578, 1);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer104, 224);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder175.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 476 */
+  offset: 412,
+  buffer: buffer11,
+}, {
+  texture: texture58,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'stencil-only',
+}, {width: 64, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet15, 121, 20, buffer65, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(95).fill(115), /* required buffer size: 95 */
+{offset: 95}, {width: 68, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let imageData18 = new ImageData(60, 12);
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte170m', transfer: 'linear'} });
+let texture199 = device0.createTexture({size: [3357, 1, 59], format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let textureView177 = texture80.createView({dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder11 = commandEncoder175.beginRenderPass({colorAttachments: [{view: textureView176, loadOp: 'load', storeOp: 'store'}], maxDrawCount: 68359566});
+let sampler112 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.98,
+});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup63, new Uint32Array(251), 9, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup58, new Uint32Array(2908), 34, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(286, 314, 418_341_167, 738_454_911);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer34, 816);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer19, 232, 127);
+} catch {}
+try {
+renderBundleEncoder16.draw(284, 48, 554_400_512, 1_207_510_891);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(290, 136, 25, 792_868_267, 397_604_901);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer84, 3_184);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer73, 'uint32', 6_968, 11_384);
+} catch {}
+try {
+commandEncoder31.insertDebugMarker('\u{1f8bd}');
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [{binding: 174, resource: {buffer: buffer106, offset: 0, size: 224}}],
+});
+let texture200 = device0.createTexture({
+  size: [1678, 1, 1],
+  mipLevelCount: 3,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView178 = texture70.createView({aspect: 'all', baseMipLevel: 0, baseArrayLayer: 0});
+let sampler113 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle9, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(0.07127025404227583, 587.2737173010242, 2.684269016344676, 833.216048278188, 0.40771849822582196, 0.6215727445416475);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer42, 1_656);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer19, 'uint16', 570, 545);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder16.draw(228, 138, 102_954_116, 443_156_888);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(310, 12, 285, 568_148_945, 275_322_652);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer60, 4_604);
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let textureView179 = texture151.createView({mipLevelCount: 1});
+try {
+commandEncoder173.copyTextureToBuffer({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 14, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 744 */
+  offset: 744,
+  bytesPerRow: 512,
+  rowsPerImage: 819,
+  buffer: buffer91,
+}, {width: 9, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder172.copyTextureToTexture({
+  texture: texture162,
+  mipLevel: 1,
+  origin: {x: 297, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({});
+let computePassEncoder187 = commandEncoder31.beginComputePass({});
+try {
+computePassEncoder187.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.draw(66, 793, 380_974_773, 720_769_723);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer34, 9_132);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer48);
+} catch {}
+try {
+renderBundleEncoder16.drawIndirect(buffer47, 3_684);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 432 */
+  offset: 432,
+  bytesPerRow: 3840,
+  buffer: buffer16,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 0},
+  aspect: 'stencil-only',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder177.copyTextureToBuffer({
+  texture: texture133,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 839 widthInBlocks: 839 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1864 */
+  offset: 1864,
+  buffer: buffer19,
+}, {width: 839, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer9, 5096, 5052);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 108, new Float32Array(2559), 210, 600);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let renderPassEncoder12 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{
+  view: textureView176,
+  clearValue: { r: 412.3, g: -693.8, b: 863.0, a: -854.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler114 = device0.createSampler({addressModeU: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 96.91});
+try {
+renderPassEncoder4.draw(3, 208, 47_017_395, 1_144_850_799);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(35, 117, 1_395, 359_896_253, 1_039_762_093);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer55, 1_212);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexed(609, 63, 302, 30_560_776, 1_154_233_265);
+} catch {}
+try {
+renderBundleEncoder16.drawIndexedIndirect(buffer84, 3_848);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer25, 124, 330);
+} catch {}
+try {
+commandEncoder177.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 126 */
+  offset: 126,
+  bytesPerRow: 13312,
+  buffer: buffer59,
+}, {
+  texture: texture120,
+  mipLevel: 2,
+  origin: {x: 45, y: 0, z: 14},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder177.resolveQuerySet(querySet16, 694, 58, buffer28, 1792);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u04ed');
+} catch {}
+let commandEncoder178 = device1.createCommandEncoder();
+let computePassEncoder188 = commandEncoder169.beginComputePass({});
+let sampler115 = device1.createSampler({addressModeW: 'mirror-repeat', minFilter: 'nearest', mipmapFilter: 'linear', lodMaxClamp: 70.32});
+try {
+device1.queue.writeTexture({
+  texture: texture172,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(69).fill(29), /* required buffer size: 69 */
+{offset: 69, rowsPerImage: 0}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let img1 = await imageWithData(5, 60, '#10101010', '#20202020');
+let commandEncoder179 = device1.createCommandEncoder({});
+let texture201 = device1.createTexture({
+  size: [4, 320, 1],
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView180 = texture144.createView({dimension: '2d-array'});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({colorFormats: ['rg32uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup79, new Uint32Array(5036), 3_006, 1);
+} catch {}
+try {
+commandEncoder172.copyBufferToBuffer(buffer95, 760, buffer77, 7792, 2924);
+} catch {}
+try {
+commandEncoder178.copyTextureToTexture({
+  texture: texture192,
+  mipLevel: 0,
+  origin: {x: 187, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder183.setBindGroup(3, bindGroup75, [256]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup79, [0]);
+} catch {}
+try {
+commandEncoder179.copyBufferToTexture({
+  /* bytesInLastRow: 688 widthInBlocks: 172 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 464 */
+  offset: 464,
+  bytesPerRow: 4352,
+  buffer: buffer87,
+}, {
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 172, height: 18, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder179.copyTextureToBuffer({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 38, y: 6, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 272 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 480 */
+  offset: 480,
+  bytesPerRow: 1280,
+  buffer: buffer77,
+}, {width: 34, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup92 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout16,
+  entries: [{binding: 174, resource: {buffer: buffer28, offset: 5376, size: 488}}],
+});
+let buffer109 = device0.createBuffer({
+  size: 37116,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer17 = commandEncoder177.finish({});
+let renderBundle16 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup37, new Uint32Array(3816), 78, 0);
+} catch {}
+try {
+renderPassEncoder6.draw(89, 18, 2_743_104_549, 210_641_009);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(1, 84, 0, -2_134_991_633, 2_068_789_045);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer34);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 42, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(105_953).fill(179), /* required buffer size: 105_953 */
+{offset: 97, bytesPerRow: 112, rowsPerImage: 119}, {width: 4, height: 113, depthOrArrayLayers: 8});
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let pipeline27 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0}});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let buffer110 = device0.createBuffer({
+  size: 3752,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture202 = gpuCanvasContext4.getCurrentTexture();
+let textureView181 = texture82.createView({});
+try {
+computePassEncoder164.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+computePassEncoder143.setBindGroup(2, bindGroup5, new Uint32Array(933), 16, 0);
+} catch {}
+try {
+renderPassEncoder6.draw(139, 499, 699_998_550, 1_025_263_537);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer66, 2_136);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 547, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 34, y: 0 },
+  flipY: false,
+}, {
+  texture: texture129,
+  mipLevel: 1,
+  origin: {x: 0, y: 27, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder180 = device1.createCommandEncoder({});
+try {
+computePassEncoder149.setBindGroup(2, bindGroup78, new Uint32Array(341), 2, 1);
+} catch {}
+try {
+commandEncoder178.resolveQuerySet(querySet21, 269, 9, buffer99, 256);
+} catch {}
+let sampler116 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat'});
+let commandEncoder181 = device1.createCommandEncoder({});
+let texture203 = device1.createTexture({
+  size: {width: 1, height: 80, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder178.setBindGroup(3, bindGroup72, [256]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup79, [1536]);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer102);
+} catch {}
+let bindGroup93 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 162, resource: {buffer: buffer92, offset: 0}},
+    {binding: 106, resource: {buffer: buffer86, offset: 512, size: 2884}},
+    {binding: 21, resource: textureView175},
+    {binding: 454, resource: {buffer: buffer99, offset: 3072, size: 982}},
+  ],
+});
+let buffer111 = device1.createBuffer({size: 8931, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let computePassEncoder189 = commandEncoder179.beginComputePass({});
+let externalTexture13 = device1.importExternalTexture({source: videoFrame18});
+try {
+renderBundleEncoder17.setIndexBuffer(buffer93, 'uint16', 1_430, 1_487);
+} catch {}
+let imageData19 = new ImageData(160, 100);
+let bindGroup94 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 21, resource: textureView156},
+    {binding: 162, resource: {buffer: buffer86, offset: 2048, size: 800}},
+    {binding: 106, resource: {buffer: buffer86, offset: 1024, size: 1780}},
+    {binding: 454, resource: {buffer: buffer99, offset: 2816, size: 1272}},
+  ],
+});
+let buffer112 = device1.createBuffer({size: 5017, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let commandEncoder182 = device1.createCommandEncoder({});
+let textureView182 = texture161.createView({});
+let sampler117 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'linear'});
+try {
+computePassEncoder167.setBindGroup(0, bindGroup78, [0]);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup79, new Uint32Array(733), 82, 1);
+} catch {}
+try {
+buffer93.unmap();
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 544 */
+  offset: 544,
+  bytesPerRow: 7168,
+  buffer: buffer111,
+}, {
+  texture: texture196,
+  mipLevel: 0,
+  origin: {x: 0, y: 25, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 28, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer92, 184, new Int16Array(5883), 2238, 348);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup1, new Uint32Array(627), 22, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer54, 3_208);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer72, 1_024);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 136, depthOrArrayLayers: 20}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 174, resource: {buffer: buffer35, offset: 512, size: 1856}}],
+});
+let commandEncoder183 = device0.createCommandEncoder({});
+let computePassEncoder190 = commandEncoder183.beginComputePass({});
+try {
+computePassEncoder190.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer25, 460);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(20).fill(99), /* required buffer size: 20 */
+{offset: 20, rowsPerImage: 102}, {width: 80, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let recycledExplicitBindGroupLayout17 = pipeline3.getBindGroupLayout(0);
+let commandEncoder184 = device0.createCommandEncoder({});
+let computePassEncoder191 = commandEncoder184.beginComputePass({});
+let sampler118 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 95.62});
+try {
+computePassEncoder191.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup57, [0]);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup8, new Uint32Array(615), 48, 0);
+} catch {}
+try {
+renderPassEncoder6.draw(35, 19, 72_296_060, 1_350_041_538);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.append(img1);
+let texture204 = device1.createTexture({
+  size: {width: 264},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView183 = texture151.createView({mipLevelCount: 1});
+let renderPassEncoder13 = commandEncoder181.beginRenderPass({
+  colorAttachments: [{
+  view: textureView182,
+  depthSlice: 1,
+  clearValue: { r: -311.4, g: -887.2, b: -173.3, a: 428.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+});
+let renderBundle17 = renderBundleEncoder17.finish({});
+try {
+renderPassEncoder13.setVertexBuffer(7, undefined, 1_473_687_847);
+} catch {}
+try {
+computePassEncoder170.pushDebugGroup('\ua71e');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture196,
+  mipLevel: 0,
+  origin: {x: 0, y: 22, z: 0},
+  aspect: 'all',
+}, new Uint8Array(192).fill(8), /* required buffer size: 192 */
+{offset: 192, bytesPerRow: 6}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup96 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 116, resource: {buffer: buffer34, offset: 6656, size: 4260}},
+    {binding: 70, resource: {buffer: buffer26, offset: 512, size: 1138}},
+  ],
+});
+let buffer113 = device0.createBuffer({
+  size: 589,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView184 = texture127.createView({dimension: '1d', mipLevelCount: 1});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame17});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup48, [256]);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer48, 4_588);
+} catch {}
+try {
+commandEncoder167.resolveQuerySet(querySet1, 9, 0, buffer35, 768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 1724, new Int16Array(1724), 83, 632);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1575, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 0, y: 458, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+try {
+  await promise28;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder185 = device0.createCommandEncoder({});
+let commandBuffer18 = commandEncoder167.finish();
+let textureView185 = texture47.createView({mipLevelCount: 2});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup12, new Uint32Array(450), 17, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(23);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline23);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2588 */
+  offset: 2588,
+  buffer: buffer55,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder185.copyTextureToBuffer({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 72, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 960 */
+  offset: 960,
+  bytesPerRow: 26880,
+  buffer: buffer35,
+}, {width: 0, height: 113, depthOrArrayLayers: 0});
+} catch {}
+let pipeline28 = await promise19;
+let imageData20 = new ImageData(100, 16);
+let commandEncoder186 = device1.createCommandEncoder({});
+let textureView186 = texture175.createView({dimension: '2d-array'});
+let computePassEncoder192 = commandEncoder172.beginComputePass({});
+try {
+computePassEncoder152.setBindGroup(2, bindGroup78, [0]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer93, 'uint16', 434, 2_143);
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 202, resource: textureView0}, {binding: 47, resource: textureView1}],
+});
+let sampler119 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.49,
+  compare: 'not-equal',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup91, new Uint32Array(905), 148, 1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle16, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer42, 2_744);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer66, 'uint32', 1_440, 50);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline28);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 384 */
+  offset: 384,
+  bytesPerRow: 9472,
+  buffer: buffer89,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder185.clearBuffer(buffer27, 404, 652);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+let commandEncoder187 = device1.createCommandEncoder({label: '\u0820\u0a7c\u{1fd58}\ua569\u0964\ucd2e\u8d70\u0d7b\u0d41\u{1f710}'});
+let querySet27 = device1.createQuerySet({type: 'occlusion', count: 499});
+let renderPassEncoder14 = commandEncoder187.beginRenderPass({
+  colorAttachments: [{
+  view: textureView186,
+  clearValue: { r: -840.5, g: 295.1, b: 147.1, a: 230.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder13.setIndexBuffer(buffer111, 'uint16', 3_138, 722);
+} catch {}
+let bindGroup98 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout21,
+  entries: [
+    {binding: 55, resource: {buffer: buffer77, offset: 5120, size: 6413}},
+    {binding: 70, resource: {buffer: buffer100, offset: 6912, size: 4667}},
+    {binding: 42, resource: {buffer: buffer93, offset: 1024, size: 915}},
+  ],
+});
+let buffer114 = device1.createBuffer({size: 10474, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let querySet28 = device1.createQuerySet({type: 'occlusion', count: 264});
+try {
+computePassEncoder139.setBindGroup(3, bindGroup72, [2048]);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup98);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup79, new Uint32Array(508), 186, 1);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(165).fill(5), /* required buffer size: 165 */
+{offset: 165, bytesPerRow: 228}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(110, 91);
+let commandEncoder188 = device1.createCommandEncoder({});
+let texture205 = device1.createTexture({
+  size: [4, 4, 18],
+  dimension: '2d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView187 = texture196.createView({dimension: '2d-array'});
+try {
+renderPassEncoder13.beginOcclusionQuery(150);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder180.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1104 */
+  offset: 1104,
+  bytesPerRow: 7424,
+  buffer: buffer96,
+}, {
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup99 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 454, resource: {buffer: buffer100, offset: 2304, size: 3683}},
+    {binding: 106, resource: {buffer: buffer95, offset: 256}},
+    {binding: 162, resource: {buffer: buffer92, offset: 768}},
+    {binding: 21, resource: textureView136},
+  ],
+});
+let texture206 = device1.createTexture({
+  size: [280, 5, 42],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView188 = texture186.createView({mipLevelCount: 1});
+let renderPassEncoder15 = commandEncoder188.beginRenderPass({
+  colorAttachments: [{
+  view: textureView186,
+  clearValue: { r: 661.7, g: -193.5, b: -65.73, a: -212.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder153.setBindGroup(0, bindGroup79, new Uint32Array(3443), 1_043, 1);
+} catch {}
+try {
+renderPassEncoder15.setViewport(0.9710071688809843, 37.32916818875295, 0.010235532062389934, 37.23868788164302, 0.19398307019083105, 0.42275135319659923);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas6.getContext('webgpu');
+let bindGroup100 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [
+    {binding: 251, resource: {buffer: buffer86, offset: 0, size: 5440}},
+    {binding: 177, resource: {buffer: buffer86, offset: 2816, size: 1164}},
+  ],
+});
+let texture207 = device1.createTexture({
+  label: '\u8e15\u938c\u{1feb7}\ueae8',
+  size: {width: 4, height: 320, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder193 = commandEncoder173.beginComputePass();
+let sampler120 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 89.14});
+try {
+computePassEncoder188.setBindGroup(1, bindGroup75, new Uint32Array(2649), 221, 1);
+} catch {}
+try {
+commandEncoder178.copyBufferToBuffer(buffer95, 1164, buffer99, 2788, 948);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let buffer115 = device1.createBuffer({
+  size: 22333,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture208 = device1.createTexture({
+  size: [4, 320, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView189 = texture181.createView({label: '\u0abf\u061d\u0b76\u5121\ufbf3\u063e', arrayLayerCount: 5});
+let computePassEncoder194 = commandEncoder178.beginComputePass({});
+let sampler121 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.85,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder170.setBindGroup(3, bindGroup79, [1280]);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup98, new Uint32Array(2700), 1_126, 0);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(0, 1, 0, 3);
+} catch {}
+try {
+renderPassEncoder15.setViewport(0.17609350020148062, 16.06198019914924, 0.3855186026478021, 21.721764970065987, 0.535051820044888, 0.8953923029870379);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer76, 'uint16', 242, 103);
+} catch {}
+try {
+commandEncoder186.copyBufferToBuffer(buffer111, 200, buffer78, 312, 40);
+} catch {}
+try {
+commandEncoder182.copyTextureToTexture({
+  texture: texture193,
+  mipLevel: 0,
+  origin: {x: 454, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let commandEncoder189 = device1.createCommandEncoder();
+let texture209 = device1.createTexture({
+  label: '\ub88b\u0686\u{1ff42}',
+  size: {width: 4, height: 4, depthOrArrayLayers: 18},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup98, new Uint32Array(2790), 1_609, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer77, 'uint16', 1_118, 5_323);
+} catch {}
+let bindGroup101 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 106, resource: {buffer: buffer86, offset: 256, size: 1824}},
+    {binding: 162, resource: {buffer: buffer92, offset: 1280, size: 1792}},
+    {binding: 454, resource: {buffer: buffer114, offset: 256, size: 1354}},
+    {binding: 21, resource: textureView156},
+  ],
+});
+let textureView190 = texture209.createView({dimension: 'cube', aspect: 'all', baseArrayLayer: 1});
+let textureView191 = texture183.createView({});
+let computePassEncoder195 = commandEncoder182.beginComputePass({});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({colorFormats: ['rg32uint'], sampleCount: 1});
+try {
+computePassEncoder149.setBindGroup(2, bindGroup72, [0]);
+} catch {}
+try {
+computePassEncoder170.setBindGroup(0, bindGroup75, new Uint32Array(274), 44, 1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup79, new Uint32Array(1376), 8, 1);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+document.body.append(canvas2);
+let querySet29 = device1.createQuerySet({type: 'occlusion', count: 366});
+let textureView192 = texture208.createView({});
+let textureView193 = texture164.createView({aspect: 'all'});
+let computePassEncoder196 = commandEncoder189.beginComputePass({});
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup98);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer95, 664, 592);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder197 = commandEncoder186.beginComputePass();
+let sampler122 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', compare: 'less'});
+let externalTexture15 = device1.importExternalTexture({source: videoFrame14, colorSpace: 'display-p3'});
+try {
+computePassEncoder193.setBindGroup(1, bindGroup101, [1280]);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, undefined, 0, 307_785_885);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture201,
+  mipLevel: 1,
+  origin: {x: 0, y: 51, z: 0},
+  aspect: 'all',
+}, new Uint8Array(676).fill(252), /* required buffer size: 676 */
+{offset: 676, bytesPerRow: 149, rowsPerImage: 64}, {width: 0, height: 29, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup102 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 162, resource: {buffer: buffer92, offset: 0}},
+    {binding: 21, resource: textureView136},
+    {binding: 454, resource: {buffer: buffer93, offset: 0, size: 252}},
+    {binding: 106, resource: {buffer: buffer95, offset: 1024}},
+  ],
+});
+let commandEncoder190 = device1.createCommandEncoder({});
+let texture210 = device1.createTexture({
+  size: {width: 4, height: 320, depthOrArrayLayers: 207},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup72, new Uint32Array(440), 40, 1);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup101, new Uint32Array(746), 197, 1);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer83);
+} catch {}
+try {
+commandEncoder190.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1912 */
+  offset: 1912,
+  buffer: buffer91,
+}, {
+  texture: texture187,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder180.copyTextureToBuffer({
+  texture: texture195,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 912 */
+  offset: 912,
+  buffer: buffer77,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder170.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.append(canvas3);
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture211 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler123 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 81.82,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder133.setBindGroup(0, bindGroup7, new Uint32Array(1878), 376, 1);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.draw(33, 0, 2_072_439_338, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer42, 940);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline25);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder185.copyBufferToBuffer(buffer16, 24, buffer17, 3472, 368);
+} catch {}
+try {
+buffer53.label = '\u1cf5\ua0d6\u{1fd81}\u{1fc36}\u00bc';
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({});
+let texture212 = device0.createTexture({
+  size: {width: 3357},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let sampler124 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', magFilter: 'linear', compare: 'never'});
+try {
+computePassEncoder109.end();
+} catch {}
+try {
+renderPassEncoder3.draw(124, 0, 578_172_680);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer105, 'uint16', 486, 125);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder193 = device1.createCommandEncoder({});
+let computePassEncoder198 = commandEncoder190.beginComputePass({});
+let renderPassEncoder16 = commandEncoder193.beginRenderPass({
+  colorAttachments: [{
+  view: textureView186,
+  clearValue: { r: 66.97, g: -696.3, b: 404.2, a: -374.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 86602831,
+});
+try {
+computePassEncoder197.setBindGroup(0, bindGroup94, [768]);
+} catch {}
+try {
+computePassEncoder147.insertDebugMarker('\ue782');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageBitmap3 = await createImageBitmap(imageData3);
+let bindGroup103 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [{binding: 174, resource: {buffer: buffer26, offset: 768, size: 2276}}],
+});
+let commandBuffer19 = commandEncoder149.finish();
+let computePassEncoder199 = commandEncoder192.beginComputePass({});
+try {
+computePassEncoder199.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup16, new Uint32Array(2403), 879, 1);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle15, renderBundle15, renderBundle15, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer22, 1_628);
+} catch {}
+try {
+device0.queue.submit([commandBuffer18]);
+} catch {}
+try {
+  await promise29;
+} catch {}
+let buffer116 = device0.createBuffer({size: 4205, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandBuffer20 = commandEncoder100.finish();
+let texture213 = device0.createTexture({
+  size: [1, 393, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder200 = commandEncoder191.beginComputePass({});
+try {
+computePassEncoder200.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup81);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -76.75, g: 295.4, b: -452.8, a: -302.0, });
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer47, 520);
+} catch {}
+try {
+device0.queue.submit([commandBuffer19, commandBuffer20]);
+} catch {}
+let imageData21 = new ImageData(12, 8);
+let bindGroup104 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 162, resource: {buffer: buffer86, offset: 0, size: 1244}},
+    {binding: 21, resource: textureView156},
+    {binding: 454, resource: {buffer: buffer100, offset: 768, size: 5932}},
+    {binding: 106, resource: {buffer: buffer95, offset: 5120, size: 9720}},
+  ],
+});
+let buffer117 = device1.createBuffer({
+  size: 12583,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView194 = texture144.createView({dimension: '2d-array'});
+let computePassEncoder201 = commandEncoder180.beginComputePass({});
+try {
+computePassEncoder160.setBindGroup(0, bindGroup72, [256]);
+} catch {}
+let textureView195 = texture83.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder104); computePassEncoder104.dispatchWorkgroups(4, 1); };
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer106, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 21}
+*/
+{
+  source: imageData3,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 47, y: 46, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup105 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [
+    {binding: 177, resource: {buffer: buffer117, offset: 512, size: 3744}},
+    {binding: 251, resource: {buffer: buffer115, offset: 0, size: 12368}},
+  ],
+});
+let commandEncoder194 = device1.createCommandEncoder({});
+let computePassEncoder202 = commandEncoder194.beginComputePass();
+let sampler125 = device1.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 87.25, compare: 'less'});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup105);
+} catch {}
+let buffer118 = device1.createBuffer({
+  size: 4516,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder195 = device1.createCommandEncoder();
+let computePassEncoder203 = commandEncoder195.beginComputePass({});
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup101, new Uint32Array(3), 0, 1);
+} catch {}
+try {
+buffer86.unmap();
+} catch {}
+document.body.prepend(canvas3);
+try {
+commandEncoder80.label = '\u{1fce9}\ubdf2';
+} catch {}
+let commandEncoder196 = device0.createCommandEncoder({});
+let textureView196 = texture0.createView({});
+let renderPassEncoder17 = commandEncoder196.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  clearValue: { r: -274.2, g: -253.9, b: 395.0, a: -666.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder11.setViewport(1.6824527286332422, 798.879080059006, 1.5276738040561508, 330.9328760539084, 0.5638062345446748, 0.7439704575041617);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer113, 'uint32', 0, 189);
+} catch {}
+let promise30 = shaderModule2.getCompilationInfo();
+let arrayBuffer15 = buffer32.getMappedRange(0, 4);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1575, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData17,
+  origin: { x: 0, y: 14 },
+  flipY: true,
+}, {
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 0, y: 887, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView197 = texture86.createView({aspect: 'stencil-only', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 11});
+let computePassEncoder204 = commandEncoder185.beginComputePass({});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup8, new Uint32Array(81), 8, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer44, 0);
+} catch {}
+let bindGroup106 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout17,
+  entries: [{binding: 174, resource: {buffer: buffer40, offset: 0, size: 348}}],
+});
+let commandEncoder197 = device0.createCommandEncoder({});
+let texture214 = device0.createTexture({
+  size: {width: 1, height: 393, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder205 = commandEncoder197.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroups(1, 3); };
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle15, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder3.draw(15, 0, 454_724_464);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(28, 0, 0, 458_431_463);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline23);
+} catch {}
+let pipeline29 = device0.createComputePipeline({layout: pipelineLayout8, compute: {module: shaderModule1}});
+let textureView198 = texture89.createView({dimension: 'cube', aspect: 'stencil-only', baseArrayLayer: 1});
+try {
+computePassEncoder71.setBindGroup(0, bindGroup61, [1280]);
+} catch {}
+try {
+computePassEncoder205.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup4, [0]);
+} catch {}
+try {
+renderPassEncoder12.draw(65, 100, 2_166_720_532, 147_453_799);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer67, 624);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline28);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let promise31 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment3',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex5',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 272,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 4, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 124, shaderLocation: 6},
+          {format: 'float16x4', offset: 16, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 36, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 24, shaderLocation: 1},
+          {format: 'sint32x2', offset: 24, shaderLocation: 10},
+          {format: 'float16x4', offset: 24, shaderLocation: 12},
+          {format: 'uint8x4', offset: 112, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 12, shaderLocation: 8},
+          {format: 'float32x3', offset: 32, shaderLocation: 11},
+          {format: 'float32', offset: 12, shaderLocation: 2},
+          {format: 'float32', offset: 32, shaderLocation: 13},
+          {format: 'uint16x2', offset: 12, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 32, attributes: [{format: 'sint32', offset: 4, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+let buffer119 = device0.createBuffer({size: 8938, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let texture215 = device0.createTexture({
+  size: [2, 787, 1],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView199 = texture95.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder204.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup84, [512]);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup15, new Uint32Array(468), 133, 1);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer70, 748, 2_204);
+} catch {}
+let arrayBuffer16 = buffer32.getMappedRange(1968, 820);
+let shaderModule8 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+/* used global variables: buffer120 */
+fn fn0() -> array<array<FragmentOutput6, 1>, 1> {
+  var out: array<array<FragmentOutput6, 1>, 1>;
+  var vf116: f16 = determinant(mat3x3h(unconst_f16(54.69), unconst_f16(-3555.2), unconst_f16(4096.0), unconst_f16(11924.0), unconst_f16(1867.2), unconst_f16(1328.5), unconst_f16(3888.9), unconst_f16(13883.7), unconst_f16(18555.8)));
+  atomicAnd(&vw29[30][unconst_u32(470)], unconst_i32(19));
+  let ptr58: ptr<workgroup, u32> = &(*&vw30).f14;
+  vw27.f12 = vec4h((*&vw30).f13);
+  workgroupBarrier();
+  let ptr59: ptr<storage, f16, read> = &(*&buffer120)[1][unconst_u32(18)][unconst_u32(91)];
+  vw30 = VertexOutput7(vec4h(buffer120[unconst_u32(157)][0][10]), vec4f(f32(buffer120[unconst_u32(157)][0][10])), u32(buffer120[unconst_u32(157)][0][10]));
+  let ptr60: ptr<storage, array<array<f16, 11>, 1>, read> = &buffer120[unconst_u32(129)];
+  return out;
+  _ = buffer120;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw27: VertexOutput7;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw31: vec2u;
+
+struct FragmentOutput5 {
+  @location(5) f0: vec2i,
+  @location(0) f1: vec4f,
+}
+
+/* used global variables: buffer120 */
+fn fn2() -> VertexOutput7 {
+  var out: VertexOutput7;
+  out.f13 += vec4f(f32(buffer120[unconst_u32(71)][unconst_u32(439)][10]));
+  var vf118: vec3h = sinh(vec3h(unconst_f16(10124.3), unconst_f16(6579.9), unconst_f16(-4326.2)));
+  let ptr73: ptr<function, vec3h> = &vf118;
+  let ptr74: ptr<storage, array<f16, 11>, read> = &buffer120[1][0];
+  var vf119: mat4x2h = (mat4x2h(unconst_f16(10003.1), unconst_f16(7216.2), unconst_f16(38781.4), unconst_f16(5449.3), unconst_f16(23140.9), unconst_f16(615.0), unconst_f16(14639.5), unconst_f16(2995.3)) + mat4x2h((*&buffer120)[1][0][10], (*&buffer120)[1][0][10], (*&buffer120)[1][0][10], (*&buffer120)[1][0][10], (*&buffer120)[1][0][10], (*&buffer120)[1][0][10], (*&buffer120)[1][0][10], (*&buffer120)[1][0][10]));
+  out.f12 *= bitcast<vec4h>(sinh(vec2f(unconst_f32(0.03626), unconst_f32(0.3168))));
+  let vf120: f16 = mix(unconst_f16(3896.3), unconst_f16(987.1), unconst_f16(4601.9));
+  let ptr75: ptr<storage, f16, read> = &(*&buffer120)[unconst_u32(110)][0][unconst_u32(200)];
+  loop {
+  while bool((*&buffer120)[1][0][10]) {
+  let ptr76: ptr<storage, array<array<array<f16, 11>, 1>, 2>, read> = &(*&buffer120);
+  let ptr77: ptr<storage, f16, read> = &(*ptr76)[unconst_u32(960)][u32((*ptr76)[unconst_u32(80)][0][10])][10];
+  out.f13 += vec4f((vec3u(unconst_u32(295), unconst_u32(22), unconst_u32(42)) + vec3u(unconst_u32(70), unconst_u32(252), unconst_u32(151))).bggg);
+  let ptr78: ptr<storage, f16, read> = &(*&buffer120)[1][0][unconst_u32(309)];
+  out.f13 = tan(vec2f(unconst_f32(0.1307), unconst_f32(-0.06744))).xxxy;
+  break;
+  _ = buffer120;
+}
+  out.f13 = vec4f(f32((*&buffer120)[unconst_u32(120)][0][10]));
+  let ptr79: ptr<storage, f16, read> = &buffer120[unconst_u32(54)][unconst_u32(71)][10];
+  break;
+  _ = buffer120;
+}
+  let ptr80: ptr<storage, array<f16, 11>, read> = &buffer120[1][0];
+  vp14 -= buffer120[unconst_u32(364)][0][unconst_u32(168)];
+  return out;
+  _ = buffer120;
+}
+
+struct VertexOutput7 {
+  @location(6) f12: vec4h,
+  @builtin(position) f13: vec4f,
+  @location(13) @interpolate(flat, center) f14: u32,
+}
+
+var<private> vp14: f16 = f16(8085.2);
+
+var<private> vp13 = modf(vec2f(0.2888, 0.1115));
+
+@group(0) @binding(174) var<storage, read> buffer120: array<array<array<f16, 11>, 1>, 2>;
+
+/* used global variables: buffer120 */
+fn fn1() -> vec2f {
+  var out: vec2f;
+  let ptr61: ptr<private, vec2f> = &vp13.whole;
+  for (var it6=u32(buffer120[1][0][10]); it6<u32(buffer120[unconst_u32(34)][0][10]); it6++) {
+  let ptr62: ptr<storage, f16, read> = &(*&buffer120)[unconst_u32(183)][unconst_u32(367)][unconst_u32(43)];
+  let ptr63: ptr<storage, f16, read> = &(*&buffer120)[1][u32((*&buffer120)[1][unconst_u32(216)][10])][10];
+  vp14 = buffer120[unconst_u32(48)][0][10];
+  out = vec2f(f32((*&buffer120)[1][0][10]));
+  let ptr64: ptr<storage, f16, read> = &(*&buffer120)[u32((*&buffer120)[1][0][10])][0][10];
+  break;
+  _ = buffer120;
+}
+  let ptr65: ptr<storage, array<f16, 11>, read> = &(*&buffer120)[unconst_u32(290)][unconst_u32(23)];
+  let ptr66: ptr<storage, array<array<f16, 11>, 1>, read> = &buffer120[unconst_u32(116)];
+  let ptr67: ptr<storage, f16, read> = &(*&buffer120)[u32((*ptr66)[unconst_u32(49)][10])][unconst_u32(265)][unconst_u32(214)];
+  let ptr68: ptr<storage, array<array<array<f16, 11>, 1>, 2>, read> = &buffer120;
+  out = vec2f(f32((*ptr68)[unconst_u32(404)][0][10]));
+  let ptr69: ptr<private, vec2f> = &vp13.whole;
+  let ptr70: ptr<storage, array<f16, 11>, read> = &(*ptr68)[1][unconst_u32(393)];
+  vp14 = vec2h((*ptr69))[0];
+  let ptr71: ptr<storage, array<f16, 11>, read> = &buffer120[1][unconst_u32(336)];
+  let vf117: bool = (bool(pack4xI8(vec4i(unconst_i32(47), unconst_i32(219), unconst_i32(-132), unconst_i32(33)))) && unconst_bool(true));
+  let ptr72: ptr<storage, f16, read> = &buffer120[unconst_u32(103)][u32((*&buffer120)[unconst_u32(143)][0][10])][10];
+  vp13 = modf(unpack2x16unorm(pack4x8snorm(vec4f(unconst_f32(0.2874), unconst_f32(0.08369), unconst_f32(0.02630), unconst_f32(0.00398)))));
+  vp14 = buffer120[unconst_u32(77)][unconst_u32(24)][10];
+  return out;
+  _ = buffer120;
+}
+
+var<workgroup> vw28: atomic<u32>;
+
+var<workgroup> vw29: array<array<atomic<i32>, 2>, 31>;
+
+struct FragmentOutput6 {
+  @location(0) @interpolate(flat) f0: vec4i,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw30: VertexOutput7;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(48) f0: array<vec2i>,
+}
+
+/* used global variables: buffer120 */
+@vertex
+fn vertex7(@location(1) @interpolate(flat, sample) a0: vec2i) -> VertexOutput7 {
+  var out: VertexOutput7;
+  let ptr81: ptr<storage, array<array<f16, 11>, 1>, read> = &(*&buffer120)[1];
+  vp13.fract *= vec2f(f32((*&buffer120)[1][0][10]));
+  vp14 -= buffer120[1][0][10];
+  fn2();
+  out.f12 += vec4h((*&buffer120)[1][unconst_u32(139)][10]);
+  let ptr82: ptr<storage, array<array<f16, 11>, 1>, read> = &buffer120[1];
+  out.f12 -= vec4h((*&buffer120)[unconst_u32(201)][unconst_u32(80)][10]);
+  var vf121: vec4h = cos(vec4h(unconst_f16(4833.2), unconst_f16(-8472.5), unconst_f16(2426.1), unconst_f16(16082.4)));
+  let ptr83: ptr<storage, f16, read> = &(*ptr81)[0][unconst_u32(59)];
+  var vf122 = fn2();
+  fn2();
+  let ptr84: ptr<storage, array<array<f16, 11>, 1>, read> = &(*&buffer120)[1];
+  return out;
+  _ = buffer120;
+}
+
+/* used global variables: buffer120 */
+@fragment
+fn fragment8(@location(7) a0: vec2f) -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  fn1();
+  out.f0 -= vec2i(refract(vec3f(unconst_f32(0.01249), unconst_f32(0.5625), unconst_f32(0.08390)), vec3f(unconst_f32(0.1028), unconst_f32(-0.09129), unconst_f32(0.01979)), unconst_f32(0.00955)).yz);
+  let ptr85: ptr<storage, f16, read> = &buffer120[unconst_u32(47)][unconst_u32(83)][10];
+  var vf123 = fn1();
+  vp14 = f16(vf123[unconst_u32(254)]);
+  return out;
+  _ = buffer120;
+}
+
+/* used global variables: buffer120 */
+@fragment
+fn fragment9(@builtin(front_facing) a0: bool) -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  if bool(pack4xU8Clamp( ~vec4u(u32(buffer120[unconst_u32(83)][0][unconst_u32(125)])))) {
+  let ptr86: ptr<storage, f16, read> = &buffer120[1][0][unconst_u32(85)];
+  vp13 = modf(unpack2x16float(u32(buffer120[unconst_u32(20)][0][10])));
+  _ = buffer120;
+}
+  let ptr87: ptr<storage, f16, read> = &buffer120[1][0][unconst_u32(69)];
+  out.f0 = vec4i(i32(buffer120[1][unconst_u32(90)][unconst_u32(203)]));
+  let ptr88: ptr<storage, array<array<array<f16, 11>, 1>, 2>, read> = &(*&buffer120);
+  fn1();
+  switch i32((*ptr87)) { 
+  default {
+  let ptr89: ptr<storage, array<f16, 11>, read> = &(*&buffer120)[1][0];
+  var vf124 = fn1();
+  while bool(countOneBits(unconst_u32(272))) {
+  let ptr90: ptr<storage, f16, read> = &buffer120[unconst_u32(157)][0][unconst_u32(395)];
+  fn1();
+  break;
+  _ = buffer120;
+}
+  out.f0 = vec4i(atan(vec3h(buffer120[u32(transpose(mat4x3f(f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)]), f32(buffer120[1][0][unconst_u32(93)])))[unconst_i32(2)].w)][0][10])).xxyx);
+  _ = buffer120;
+}
+  }
+  let ptr91: ptr<storage, array<array<array<f16, 11>, 1>, 2>, read> = &buffer120;
+  var vf125 = fn1();
+  var vf126 = fn1();
+  out.f0 *= vec4i(i32((*ptr88)[1][0][10]));
+  fn1();
+  let vf127: vec3i = (vec3i(unconst_i32(121), unconst_i32(223), unconst_i32(54)) >> vec3u(unconst_u32(14), unconst_u32(133), unconst_u32(254)));
+  var vf128 = fn1();
+  var vf129: vec3i = (vec3i(select(vec4u(u32(buffer120[unconst_u32(2)][0][10])), unpack4xU8(u32((*&buffer120)[unconst_u32(285)][unconst_u32(1)][unconst_u32(123)])), unconst_bool(true)).baa) >> vec3u(unconst_u32(123), unconst_u32(22), unconst_u32(31)));
+  return out;
+  _ = buffer120;
+}
+
+/* used global variables: buffer120 */
+@compute @workgroup_size(1, 1, 1)
+fn compute6() {
+  var vf130 = fn0();
+  var vf131 = fn2();
+  var vf132 = fn2();
+  atomicStore(&vw29[unconst_u32(145)][unconst_u32(132)], unconst_i32(22));
+  fn0();
+  fn0();
+  var vf133 = fn0();
+  vw30 = VertexOutput7(vec4h(buffer120[unconst_u32(99)][0][unconst_u32(468)]), vec4f(f32(buffer120[unconst_u32(99)][0][unconst_u32(468)])), u32(buffer120[unconst_u32(99)][0][unconst_u32(468)]));
+  fn0();
+  fn0();
+  let ptr92: ptr<function, vec4i> = &vf133[unconst_u32(67)][0].f0;
+  _ = buffer120;
+}`,
+});
+let textureView200 = texture41.createView({format: 'r16sint', mipLevelCount: 1});
+let sampler126 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderPassEncoder8.setViewport(1.8285745795133959, 439.27078502680985, 0.09161390613022988, 356.2805215745462, 0.3519418615437552, 0.7536146762468909);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer60, 5_168);
+} catch {}
+let buffer121 = device0.createBuffer({
+  size: 2066,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture216 = device0.createTexture({
+  size: {width: 419, height: 1, depthOrArrayLayers: 25},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder156.setBindGroup(0, bindGroup63);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup64, [512]);
+} catch {}
+try {
+renderPassEncoder9.draw(275, 15, 804_408_116, 365_566_343);
+} catch {}
+try {
+computePassEncoder172.pushDebugGroup('\u{1fd03}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 21}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 9, y: 8 },
+  flipY: true,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 37, y: 27, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470bg', transfer: 'iec6196624'} });
+let commandEncoder198 = device1.createCommandEncoder({});
+let texture217 = device1.createTexture({
+  size: [8, 640, 1],
+  sampleCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView201 = texture206.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder203.setBindGroup(1, bindGroup105, new Uint32Array(1126), 72, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup79, new Uint32Array(1377), 20, 1);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle14]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer100, 0);
+} catch {}
+try {
+commandEncoder198.copyBufferToTexture({
+  /* bytesInLastRow: 864 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2544 */
+  offset: 2544,
+  buffer: buffer112,
+}, {
+  texture: texture181,
+  mipLevel: 0,
+  origin: {x: 633, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 54, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let shaderModule9 = device1.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+struct T1 {
+  @align(128) @size(4992) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw32: mat2x3f;
+
+struct VertexOutput8 {
+  @location(6) @interpolate(flat, either) f15: vec4u,
+  @location(4) @interpolate(flat) f16: vec2i,
+  @location(9) f17: vec4f,
+  @builtin(position) f18: vec4f,
+}
+
+struct T0 {
+  @align(16) @size(80) f0: array<u32>,
+}
+
+@id(6875) override override13: f32;
+
+override override14: u32 = 25;
+
+/* zero global variables used */
+@vertex
+fn vertex8(@location(11) a0: vec4f, @location(6) a1: i32, @location(2) @interpolate(linear) a2: vec2h, @location(15) a3: i32, @location(7) @interpolate(linear) a4: vec2h, @location(9) a5: f32, @location(5) a6: vec4u, @location(12) a7: vec4h, @location(13) @interpolate(flat) a8: vec2u) -> VertexOutput8 {
+  var out: VertexOutput8;
+  var vf134: f16 = a2[unconst_u32(7)];
+  var vf135: vec2u = a8;
+  vf134 -= f16( ~unconst_i32(-33));
+  var vf136: vec3f = cross(vec3f(unconst_f32(-0.1866), unconst_f32(0.1797), unconst_f32(-0.03992)), vec3f(unconst_f32(-0.07958), unconst_f32(0.04214), unconst_f32(0.5497)));
+  vf134 = f16(vf136[unconst_u32(46)]);
+  let vf137: f16 = a4[unconst_u32(366)];
+  out.f17 -= vec4f(bitcast<f32>(a1));
+  if bool(a5) {
+  let vf138: f16 = a4[unconst_u32(314)];
+  var vf139: vec3f = cross(vec3f(unconst_f32(0.04941), unconst_f32(0.02930), unconst_f32(0.7701)), vec3f(bitcast<f32>(countTrailingZeros(unconst_u32(378)))));
+  var vf140: u32 = pack2x16snorm(vec2f(unconst_f32(0.3310), unconst_f32(0.3633)));
+}
+  let vf141: f32 = vf136[unconst_u32(119)];
+  let vf142: vec4u = unpack4xU8(unconst_u32(83));
+  return out;
+}`,
+});
+let computePassEncoder206 = commandEncoder198.beginComputePass({});
+try {
+computePassEncoder153.end();
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(0, 12, 0, 32);
+} catch {}
+try {
+commandEncoder136.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 144 */
+  offset: 144,
+  bytesPerRow: 15616,
+  buffer: buffer91,
+}, {
+  texture: texture171,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let textureView202 = texture172.createView({arrayLayerCount: 1});
+let sampler127 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 5,
+});
+let buffer124 = device1.createBuffer({size: 314, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture218 = device1.createTexture({
+  size: {width: 528, height: 40, depthOrArrayLayers: 4},
+  mipLevelCount: 4,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let computePassEncoder207 = commandEncoder136.beginComputePass({});
+try {
+computePassEncoder193.setBindGroup(3, bindGroup104, new Uint32Array(385), 39, 1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup98, new Uint32Array(388), 21, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer95, 'uint32', 916, 6_147);
+} catch {}
+let textureView203 = texture30.createView({label: '\ubf3d\u{1f6c6}\u0ba2\u708c\ue20f\u83d0\u{1ff1a}', format: 'r16sint'});
+let sampler128 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 64.44,
+  compare: 'less',
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup8, new Uint32Array(1133), 364, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle15]);
+} catch {}
+try {
+renderPassEncoder12.draw(56, 243, 1_837_023_873, 146_916_677);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline25);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+document.body.prepend(canvas2);
+let bindGroup107 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 59, resource: textureView111}]});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(7, 51, 13, 1_267_600_217, 3_209_776_663);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise30;
+} catch {}
+let videoFrame22 = new VideoFrame(canvas3, {timestamp: 0});
+try {
+computePassEncoder203.setBindGroup(2, bindGroup75, new Uint32Array(837), 196, 1);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer118);
+} catch {}
+let commandEncoder199 = device0.createCommandEncoder({});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup90);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(193, 66, 33, 92_518_891, 34_016_484);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer16, 28);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer89, 6_736);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer113, 'uint32', 40, 20);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer69, 0, 9_263);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+commandEncoder199.copyBufferToBuffer(buffer46, 5136, buffer42, 2540, 16);
+} catch {}
+try {
+commandEncoder199.resolveQuerySet(querySet3, 80, 95, buffer108, 4608);
+} catch {}
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 209,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let computePassEncoder208 = commandEncoder199.beginComputePass({});
+let sampler129 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', addressModeW: 'mirror-repeat', maxAnisotropy: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroupsIndirect(buffer71, 748); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+renderPassEncoder3.draw(85, 72, 199_279_722, 1_602_554_203);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(71, 92, 23, 83_068_577, 1_803_341_348);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer84, 1_388);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer49, 420, 424);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u434c');
+} catch {}
+document.body.append(img0);
+let buffer125 = device0.createBuffer({
+  size: 2118,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView204 = texture131.createView({});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup60, new Uint32Array(1354), 34, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder80); computePassEncoder80.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer42, 8_088);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer31, 'uint32', 32, 319);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer28, 0, 4_059);
+} catch {}
+try {
+computePassEncoder196.setBindGroup(1, bindGroup105, new Uint32Array(1542), 112, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup79, [768]);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup93, new Uint32Array(1250), 64, 1);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle14, renderBundle18, renderBundle17]);
+} catch {}
+let promise32 = device1.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({});
+let computePassEncoder209 = commandEncoder200.beginComputePass({});
+try {
+computePassEncoder80.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup89, new Uint32Array(1151), 40, 1);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer113, 144);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer72, 1_488);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer42, 'uint32', 4_672, 6_259);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u42b7');
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [{binding: 174, resource: {buffer: buffer71, offset: 256, size: 396}}],
+});
+let buffer126 = device0.createBuffer({size: 7664, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder201 = device0.createCommandEncoder({});
+let sampler130 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.73,
+  compare: 'not-equal',
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder9.draw(33, 18, 1_752_993_649, 391_220_613);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer26, 108);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer42, 1_896);
+} catch {}
+try {
+commandEncoder201.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 374 */
+  offset: 374,
+  buffer: buffer125,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder202 = device1.createCommandEncoder({});
+let texture219 = device1.createTexture({
+  size: [280],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder202.copyBufferToBuffer(buffer91, 816, buffer78, 96, 76);
+} catch {}
+try {
+commandEncoder202.copyTextureToBuffer({
+  texture: texture217,
+  mipLevel: 0,
+  origin: {x: 0, y: 126, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 6368 */
+  offset: 6368,
+  bytesPerRow: 1792,
+  buffer: buffer82,
+}, {width: 0, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder167.insertDebugMarker('\u{1fd3f}');
+} catch {}
+let bindGroup109 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 162, resource: {buffer: buffer92, offset: 512}},
+    {binding: 21, resource: textureView141},
+    {binding: 106, resource: {buffer: buffer86, offset: 768, size: 1756}},
+    {binding: 454, resource: {buffer: buffer83, offset: 0, size: 91}},
+  ],
+});
+try {
+computePassEncoder188.setBindGroup(2, bindGroup93, new Uint32Array(3739), 649, 1);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer83);
+} catch {}
+try {
+commandEncoder202.copyBufferToBuffer(buffer87, 2852, buffer118, 448, 352);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 70,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView205 = texture98.createView({dimension: 'cube', mipLevelCount: 1});
+let textureView206 = texture42.createView({});
+let computePassEncoder210 = commandEncoder79.beginComputePass({});
+try {
+computePassEncoder96.setBindGroup(0, bindGroup31, new Uint32Array(172), 44, 1);
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder9.draw(142, 19, 1_423_392_689, 311_798_531);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(272, 52, 0, -1_884_297_047, 1_048_897_513);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1128, new DataView(new ArrayBuffer(10681)), 961, 1604);
+} catch {}
+try {
+renderPassEncoder15.setViewport(0.7161090058163561, 15.38097428534444, 0.21426616053877823, 60.902008160815015, 0.7014723024100024, 0.7838329285240132);
+} catch {}
+try {
+buffer99.unmap();
+} catch {}
+try {
+commandEncoder202.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 5440 */
+  offset: 5440,
+  bytesPerRow: 55296,
+  rowsPerImage: 46,
+  buffer: buffer95,
+}, {
+  texture: texture172,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer127 = device1.createBuffer({
+  size: 8289,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder203 = device1.createCommandEncoder({});
+let texture220 = device1.createTexture({
+  size: [528, 40, 246],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder211 = commandEncoder203.beginComputePass();
+let renderPassEncoder18 = commandEncoder202.beginRenderPass({
+  colorAttachments: [{
+  view: textureView182,
+  depthSlice: 10,
+  clearValue: { r: -35.28, g: -393.3, b: -437.2, a: -201.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 144254806,
+});
+let sampler131 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder192.setBindGroup(0, bindGroup100, new Uint32Array(709), 137, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer95, 'uint16', 1_974, 880);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer117);
+} catch {}
+try {
+buffer112.unmap();
+} catch {}
+let bindGroup110 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout21,
+  entries: [
+    {binding: 42, resource: {buffer: buffer76, offset: 0}},
+    {binding: 55, resource: {buffer: buffer77, offset: 1792, size: 6585}},
+    {binding: 70, resource: {buffer: buffer114, offset: 1792, size: 1050}},
+  ],
+});
+let textureView207 = texture196.createView({dimension: '2d-array', arrayLayerCount: 1});
+let externalTexture16 = device1.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder177.setBindGroup(1, bindGroup93, [256]);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(216);
+} catch {}
+let imageData22 = new ImageData(28, 120);
+let texture221 = device1.createTexture({size: [4, 4, 18], format: 'rgba8unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup93, [512]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture207,
+  mipLevel: 1,
+  origin: {x: 0, y: 54, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1).fill(109), /* required buffer size: 1 */
+{offset: 1, bytesPerRow: 58}, {width: 0, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup111 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 34, resource: textureView86},
+    {binding: 28, resource: textureView71},
+    {binding: 14, resource: sampler55},
+    {binding: 495, resource: {buffer: buffer72, offset: 5120, size: 1100}},
+  ],
+});
+let buffer128 = device0.createBuffer({
+  size: 6615,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let computePassEncoder212 = commandEncoder201.beginComputePass({});
+let renderPassEncoder19 = commandEncoder204.beginRenderPass({
+  colorAttachments: [{
+  view: textureView204,
+  depthSlice: 2,
+  clearValue: { r: -264.8, g: 300.8, b: -297.5, a: 927.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 2967769,
+});
+try {
+renderPassEncoder5.executeBundles([renderBundle9, renderBundle9, renderBundle15, renderBundle15, renderBundle9, renderBundle15, renderBundle15, renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder2.draw(19, 263, 1_162_063_234, 98_028_909);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(27, 61, 49, -1_878_851_309, 441_846_080);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer89, 3_100);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer11, 172);
+} catch {}
+let pipeline30 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule6, entryPoint: 'compute5'}});
+let bindGroup112 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout17,
+  entries: [
+    {binding: 454, resource: {buffer: buffer77, offset: 4096, size: 5267}},
+    {binding: 21, resource: textureView154},
+    {binding: 162, resource: {buffer: buffer86, offset: 256, size: 1052}},
+    {binding: 106, resource: {buffer: buffer115, offset: 19200, size: 1944}},
+  ],
+});
+let buffer129 = device1.createBuffer({
+  size: 33730,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder205 = device1.createCommandEncoder({});
+let textureView208 = texture221.createView({dimension: '2d', aspect: 'all', format: 'rgba8unorm-srgb'});
+let computePassEncoder213 = commandEncoder205.beginComputePass();
+try {
+computePassEncoder147.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup101, new Uint32Array(2000), 210, 1);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer94, 'uint32', 36, 154);
+} catch {}
+try {
+gpuCanvasContext6.configure({device: device1, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup113 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout26,
+  entries: [
+    {binding: 6, resource: textureView143},
+    {binding: 15, resource: {buffer: buffer17, offset: 768, size: 6832}},
+  ],
+});
+try {
+renderPassEncoder17.setPipeline(pipeline23);
+} catch {}
+document.body.prepend(canvas3);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView209 = texture128.createView({dimension: '2d-array'});
+let texture222 = device0.createTexture({
+  size: {width: 1, height: 547, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder104.end();
+} catch {}
+try {
+computePassEncoder209.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(0, 183, 0, 42);
+} catch {}
+try {
+renderPassEncoder2.draw(158, 210, 272_849_795, 284_970_289);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer113, 84);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise32;
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageBitmap1);
+let veryExplicitBindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 5, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 6, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 8,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 11, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 12,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 13, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 18, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 24, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 25, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 26, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 27,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 28, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 29,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 32, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 33, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 34, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 36,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 37,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 41, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 46,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+    {binding: 47, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 49, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 51, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 54, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 56, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 58, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 63, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {binding: 64, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 68, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 69, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 71,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 74, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {binding: 75, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 78, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 79,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 82, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 85, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {
+      binding: 86,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 87,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 92,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 94, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 98, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 100,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 103, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }},
+    {binding: 107, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 108, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 110, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 117, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 119, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 125, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {binding: 134, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 135, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 137, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 138,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 150, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 153, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 157,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'write-only', viewDimension: '1d' },
+    },
+    {binding: 158, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 161, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 163,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 164, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 166,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 167,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 175,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 176,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 181,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 183,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 194,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 196, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 197, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 199,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 204, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 205, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {binding: 206, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 208, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 213, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 221, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 226,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 231,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 232,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 233, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 238, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 242, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 243, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 252,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 253, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 257, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 261, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 265,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 267, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 268, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 279,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 293, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 308,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 317, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 326,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 346,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 79, hasDynamicOffset: true },
+    },
+    {binding: 350, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 352, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 353,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 359, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }},
+    {
+      binding: 360,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 374, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 380,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 398,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 410,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+    {binding: 432, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }},
+    {binding: 454, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 488, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 489, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 520, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 655, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 659,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 669,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let bindGroup114 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [{binding: 174, resource: {buffer: buffer25, offset: 512, size: 1968}}],
+});
+let commandEncoder206 = device0.createCommandEncoder();
+let texture223 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 21},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup16, [0]);
+} catch {}
+try {
+computePassEncoder212.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle9, renderBundle15, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder17.setViewport(2.841695551377674, 1500.3041199305112, 1.1486339347716115, 33.48099874439807, 0.6742400234431164, 0.9962318296530792);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(128, 137, 73, -2_147_052_702, 508_534_201);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer113, 100);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline23);
+} catch {}
+try {
+commandEncoder89.insertDebugMarker('\u3dfd');
+} catch {}
+let buffer130 = device1.createBuffer({
+  size: 702,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder207 = device1.createCommandEncoder();
+let textureView210 = texture209.createView({dimension: 'cube', baseArrayLayer: 1});
+let computePassEncoder214 = commandEncoder207.beginComputePass({});
+let renderBundleEncoder19 = device1.createRenderBundleEncoder({
+  label: '\u2f6c\u6e6c\ue14b\u{1ff96}',
+  colorFormats: ['rg32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+let veryExplicitBindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 7, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 18,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 111,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 224,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 291,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 313,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder208 = device0.createCommandEncoder({});
+let commandBuffer21 = commandEncoder89.finish();
+try {
+computePassEncoder13.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder12.draw(0, 8, 199_116_378, 295_590_532);
+} catch {}
+let querySet30 = device1.createQuerySet({type: 'occlusion', count: 61});
+let textureView211 = texture221.createView({dimension: '2d', baseArrayLayer: 4});
+let textureView212 = texture144.createView({baseMipLevel: 0});
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer129, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer92, 40, new DataView(new ArrayBuffer(8375)), 834, 1920);
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [{binding: 174, resource: {buffer: buffer34, offset: 6912, size: 228}}],
+});
+let commandEncoder209 = device0.createCommandEncoder({});
+let computePassEncoder215 = commandEncoder209.beginComputePass({});
+let renderPassEncoder20 = commandEncoder208.beginRenderPass({
+  colorAttachments: [{
+  view: textureView150,
+  clearValue: { r: 550.3, g: -134.2, b: 173.7, a: -562.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder8.setViewport(1.6711211049127752, 348.12930004971713, 0.19746309502134474, 499.71618698435833, 0.44857995892063074, 0.9175439117178059);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(41, 38, 34, 813_689_218, 203_907_808);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline18);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder206.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 680 */
+  offset: 680,
+  bytesPerRow: 5632,
+  buffer: buffer21,
+}, {
+  texture: texture182,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule10 = device1.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput7 {
+  @location(0) @interpolate(flat) f0: vec4u,
+  @location(7) f1: vec4i,
+}
+
+var<private> vp17 = modf(vec3h(1188.7, 7486.6, 30851.2));
+
+var<private> vp16: bool = bool(false);
+
+var<workgroup> vw34: vec2<bool>;
+
+var<workgroup> vw35: atomic<i32>;
+
+@group(0) @binding(177) var<storage, read_write> buffer131: T2;
+
+struct T1 {
+  @align(16) @size(240) f0: array<u32>,
+}
+
+var<workgroup> vw33: mat3x3h;
+
+struct T2 {
+  @align(16) @size(240) f0: array<atomic<i32>>,
+}
+
+var<private> vp18: f32 = f32(0.2188);
+
+var<workgroup> vw37: atomic<i32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput9 {
+  @builtin(position) f19: vec4f,
+}
+
+struct T4 {
+  @align(16) @size(240) f0: array<i32>,
+}
+
+var<private> vp19: vec4h = vec4h(9994.5, 9824.0, 25315.5, 7674.2);
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp20 = modf(vec2f(0.04567, 0.04646));
+
+var<workgroup> vw36: atomic<i32>;
+
+var<private> vp15 = modf(vec4f(0.6631, 0.07320, 0.1166, 0.05934));
+
+struct T0 {
+  f0: array<vec2h, 1>,
+  @size(64) f1: array<array<array<f32, 1>, 1>, 4>,
+}
+
+/* zero global variables used */
+fn fn0(a0: array<f16, 1>) -> VertexOutput9 {
+  var out: VertexOutput9;
+  var vf143: vec2h = log(vec2h(vp15.whole.br));
+  let vf144: f16 = vp19[u32(vp17.whole.g)];
+  var vf145: mat4x4f = (mat2x4f(unconst_f32(0.01120), unconst_f32(0.1329), unconst_f32(0.2637), unconst_f32(0.3498), unconst_f32(0.07828), unconst_f32(0.7408), unconst_f32(0.00368), unconst_f32(-0.1511)) * mat4x2f(unconst_f32(0.04141), unconst_f32(0.04092), unconst_f32(0.3621), unconst_f32(0.02429), unconst_f32(0.02086), unconst_f32(0.1503), unconst_f32(0.1071), unconst_f32(0.09822)));
+  {
+  let ptr93: ptr<private, vec4f> = &vp15.whole;
+  out = VertexOutput9(vec4f(abs(vec3i(unconst_i32(499), unconst_i32(105), unconst_i32(202))).zxxx));
+  let vf146: vec4i = unpack4xI8(unconst_u32(1));
+  let ptr94: ptr<private, vec4f> = &vp15.whole;
+  vp20.fract -= vec2f(f32(any(bool(refract(vec3h(unconst_f16(2467.6), unconst_f16(-27865.3), unconst_f16(4058.8)), vec3h(unconst_f16(595.6), unconst_f16(6669.0), unconst_f16(-3017.4)), unconst_f16(-3841.1))[2]))));
+}
+  let ptr95: ptr<private, vec4f> = &vp15.fract;
+  let vf147: f16 = a0[0];
+  var vf148: vec3h = reflect(vec3h(unconst_f16(14387.7), unconst_f16(15564.8), unconst_f16(11845.6)), vec3h(unconst_f16(38246.3), unconst_f16(7716.6), unconst_f16(5406.2)));
+  let vf149: f32 = log(unconst_f32(0.1501));
+  let vf150: f16 = vf148[unconst_u32(460)];
+  let vf151: f16 = a0[0];
+  var vf152: f16 = a0[u32(vf143[unconst_u32(17)])];
+  let ptr96 = &vp20;
+  vf152 = vf151;
+  let vf153: f16 = a0[unconst_u32(142)];
+  let ptr97: ptr<private, vec2f> = &(*ptr96).fract;
+  return out;
+}
+
+@group(0) @binding(251) var<storage, read> buffer132: array<array<array<array<array<f16, 6>, 1>, 16>, 26>>;
+
+struct T5 {
+  f0: array<atomic<i32>, 28>,
+  @align(16) @size(128) f1: array<u32>,
+}
+
+struct T3 {
+  @align(16) @size(4992) f0: array<T0>,
+}
+
+struct T6 {
+  @align(32) @size(4992) f0: array<atomic<i32>>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex9() -> VertexOutput9 {
+  var out: VertexOutput9;
+  let vf154: vec2f = acosh(vec2f(ldexp(vec2h(unconst_f16(16477.6), unconst_f16(7260.9)), vec2i(unconst_i32(132), unconst_i32(57)))));
+  switch vec4i(vp19).g { 
+  default {
+  var vf155 = fn0(array<f16, 1>(vp17.whole[1]));
+  if bool(max(vec4h(unconst_f16(1154.1), unconst_f16(3430.5), unconst_f16(21520.5), unconst_f16(25113.2)), vec4h(unconst_f16(11986.8), unconst_f16(2941.3), unconst_f16(5789.5), unconst_f16(3799.8))).w) {
+  vp17 = modf(vec3h(vp20.fract.yxy));
+  break;
+}
+  fn0(array<f16, 1>(f16((vec2i(unconst_i32(496), unconst_i32(111)) << vec2u(unconst_u32(43), unconst_u32(187)))[0])));
+  var vf156 = fn0(array<f16, 1>(vp17.fract.r));
+  return out;
+}
+  }
+  while any(unconst_bool(false)) {
+  let ptr98: ptr<private, vec4f> = &vp15.fract;
+  loop {
+  fn0(array<f16, 1>(f16(pack2x16float(vec2f(unconst_f32(0.07150), unconst_f32(0.2524))))));
+  fn0(array<f16, 1>(f16(round(vec4f(unconst_f32(0.1531), unconst_f32(0.2288), unconst_f32(0.02356), unconst_f32(0.2668)))[2])));
+  out.f19 = sign(vec4f(unconst_f32(0.1448), unconst_f32(0.1373), unconst_f32(0.1768), unconst_f32(-0.03307)));
+  break;
+}
+  vp19 += vec4h(f16((*ptr98)[unconst_u32(40)]));
+  return out;
+}
+  vp17.fract = (mat2x4h(unconst_f16(17075.6), unconst_f16(43823.9), unconst_f16(16040.1), unconst_f16(1182.3), unconst_f16(9265.7), unconst_f16(3308.6), unconst_f16(16854.8), unconst_f16(16917.1)) * mat2x2h(ldexp(vec2h(unconst_f16(881.6), unconst_f16(1621.1)), vec2i(unconst_i32(29), unconst_i32(79))), ldexp(vec2h(unconst_f16(881.6), unconst_f16(1621.1)), vec2i(unconst_i32(29), unconst_i32(79)))))[unconst_i32(0)].bgb;
+  out.f19 += vec4f(step(vec3h(unconst_f16(26547.1), unconst_f16(2235.2), unconst_f16(848.3)), vec3h(unconst_f16(1964.1), unconst_f16(7345.2), unconst_f16(5317.4))).rrbb);
+  var vf157 = fn0(array<f16, 1>(fma(vec4h(unconst_f16(3501.7), unconst_f16(8175.3), unconst_f16(1532.0), unconst_f16(3967.5)), vec4h(f16(any(unconst_bool(true)))), vec4h(f16(vf154[unconst_u32(28)])))[3]));
+  out.f19 *= vp15.fract;
+  var vf158: f32 = exp(unconst_f32(0.2043));
+  var vf159 = fn0(array<f16, 1>(f16(vf158)));
+  var vf160: f32 = fma(unconst_f32(0.2283), unconst_f32(0.1861), unconst_f32(0.02126));
+  return out;
+}
+
+/* used global variables: buffer132 */
+@fragment
+fn fragment10() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  discard;
+  fn0(array<f16, 1>(buffer132[arrayLength(&buffer132)][unconst_u32(512)][15][0][unconst_u32(506)]));
+  let ptr99: ptr<storage, f16, read> = &buffer132[unconst_u32(150)][25][15][0][5];
+  vp20.whole = vec2f(f32((*&buffer132)[unconst_u32(8)][unconst_u32(313)][15][unconst_u32(356)][5]));
+  let ptr100: ptr<storage, f16, read> = &(*&buffer132)[unconst_u32(296)][25][15][unconst_u32(40)][unconst_u32(88)];
+  fn0(array<f16, 1>(buffer132[unconst_u32(298)][25][15][unconst_u32(56)][5]));
+  vp19 = vec4h((*&buffer132)[u32(buffer132[arrayLength(&buffer132)][25][15][0][5])][unconst_u32(170)][15][unconst_u32(6)][5]);
+  vp20 = modf(vec2f(f32((*&buffer132)[unconst_u32(66)][25][15][0][unconst_u32(347)])));
+  return out;
+  _ = buffer132;
+}
+
+/* used global variables: buffer131 */
+@compute @workgroup_size(2, 1, 1)
+fn compute7() {
+  var vf161: vec3f = quantizeToF16(vec3f(unconst_f32(0.07264), unconst_f32(0.2039), unconst_f32(0.2562)));
+  let ptr101: ptr<private, vec4h> = &vp19;
+  let ptr102: ptr<private, vec3h> = &vp17.fract;
+  let ptr103: ptr<storage, atomic<i32>, read_write> = &(*&buffer131).f0[unconst_u32(99)];
+  var vf162: f16 = (*ptr102)[unconst_u32(98)];
+  let vf163: vec2f = refract(vec2f(unconst_f32(0.00614), unconst_f32(0.03646)), vec2f(unconst_f32(0.09023), unconst_f32(0.03355)), unconst_f32(0.1913));
+  vf162 = vw33[unconst_u32(41)][u32(atomicLoad(&(*ptr103)))];
+  let ptr104: ptr<workgroup, mat3x3h> = &(*&vw33);
+  atomicMin(&vw35, unconst_i32(212));
+  let ptr105: ptr<workgroup, mat3x3h> = &(*ptr104);
+  _ = buffer131;
+}
+
+/* used global variables: buffer131 */
+@compute @workgroup_size(3, 1, 1)
+fn compute8(@builtin(local_invocation_id) a0: vec3u) {
+  var vf164: vec3u = (vec3u(unconst_u32(399), unconst_u32(88), unconst_u32(144)) >> vec3u(unconst_u32(31), unconst_u32(74), unconst_u32(172)));
+  var vf165: u32 = pack4x8unorm(vec4f(unconst_f32(0.7443), unconst_f32(0.06586), unconst_f32(0.1281), unconst_f32(0.1164)));
+  for (var it7=reverseBits(vec4u(unconst_u32(339), unconst_u32(58), unconst_u32(327), unconst_u32(67))).r; it7<u32(vw33[unconst_i32(2)][0]); it7++) {
+  vp19 += vec4h(vw33[unconst_u32(282)][unconst_u32(73)]);
+  vp17 = modf(vec3h(pow(vec3f(unconst_f32(0.00993), unconst_f32(0.2691), unconst_f32(-0.03373)), vec3f(unconst_f32(0.2376), unconst_f32(0.08088), unconst_f32(0.1755)))));
+  atomicMax(&vw35, unconst_i32(-870));
+  vp18 = bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.07509), unconst_f32(0.06800))));
+  let ptr106: ptr<workgroup, atomic<i32>> = &(*&vw37);
+  let ptr107: ptr<storage, array<atomic<i32>>, read_write> = &buffer131.f0;
+  break;
+  _ = buffer131;
+}
+  for (var it8=u32(atomicLoad(&(*&vw37))); it8<bitcast<u32>(saturate(vec3f(unconst_f32(0.04516), unconst_f32(0.01825), unconst_f32(0.04176)))[1]); it8++) {
+  let ptr108 = &vp15;
+  vw33 = mat3x3h(f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))), f16(atomicExchange(&(*&buffer131).f0[unconst_u32(257)], unconst_i32(155))));
+  let ptr109: ptr<workgroup, atomic<i32>> = &(*&vw36);
+  let ptr110: ptr<workgroup, atomic<i32>> = &(*ptr109);
+  let ptr111: ptr<storage, atomic<i32>, read_write> = &(*&buffer131).f0[unconst_i32(-108)];
+  loop {
+  vp16 = bool(vw33[unconst_u32(149)][2]);
+  break;
+}
+  _ = buffer131;
+}
+  let ptr112: ptr<private, bool> = &vp16;
+  _ = buffer131;
+}`,
+});
+let veryExplicitBindGroupLayout29 = device1.createBindGroupLayout({
+  entries: [
+    {binding: 1, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {binding: 5, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let buffer133 = device1.createBuffer({size: 190, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture224 = device1.createTexture({
+  size: [1, 80, 1],
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder137.setBindGroup(2, bindGroup112, [256]);
+} catch {}
+try {
+computePassEncoder202.setBindGroup(2, bindGroup98, new Uint32Array(1933), 1_065, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer111, 'uint16', 108, 149);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer115, 3044, new Int16Array(4521), 70, 252);
+} catch {}
+let textureView213 = texture148.createView({dimension: '2d-array'});
+let computePassEncoder216 = commandEncoder206.beginComputePass({});
+try {
+computePassEncoder190.setBindGroup(0, bindGroup53, [0]);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup108, [0]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(0, 43, 0, 114);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer31);
+} catch {}
+let pipeline31 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  multisample: {mask: 0xb6ff622},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment5',
+  constants: {35_410: 1},
+  targets: [{format: 'rg16uint'}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 588,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 164, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout7]});
+let sampler132 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.10,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder3.drawIndexed(8, 1, 2, -1_256_606_487, 5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 140, new DataView(new ArrayBuffer(3761)), 1192, 416);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 21}
+*/
+{
+  source: imageData20,
+  origin: { x: 16, y: 1 },
+  flipY: true,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 5, y: 18, z: 12},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [{binding: 174, resource: {buffer: buffer71, offset: 512, size: 128}}],
+});
+let buffer134 = device0.createBuffer({size: 15202, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder132.setBindGroup(0, bindGroup7, [768]);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.draw(17, 0, 537_290_437);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer62, 900);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer128, 'uint32', 760, 37);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(9_168).fill(160), /* required buffer size: 9_168 */
+{offset: 38, bytesPerRow: 166, rowsPerImage: 11}, {width: 41, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer135 = device0.createBuffer({
+  size: 5224,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder9.draw(111, 91, 50_697_982, 289_763_447);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer14, 1_708);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer106, 'uint32', 32, 23);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer35, 552, 3_215);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer41, 2336, buffer121, 72, 44);
+} catch {}
+let bindGroup117 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 495, resource: {buffer: buffer68, offset: 768}},
+    {binding: 28, resource: textureView42},
+    {binding: 34, resource: textureView99},
+    {binding: 14, resource: sampler47},
+  ],
+});
+let buffer136 = device0.createBuffer({
+  size: 3985,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView214 = texture98.createView({dimension: 'cube', mipLevelCount: 2, baseArrayLayer: 2});
+let computePassEncoder217 = commandEncoder138.beginComputePass({});
+try {
+computePassEncoder96.setBindGroup(1, bindGroup40, [1024]);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup70, new Uint32Array(3057), 419, 1);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder3.draw(172, 2, 2_746_432_684);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(3, 2, 36, -1_740_870_207, 1);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer47, 5_464);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline16);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder210 = device0.createCommandEncoder({});
+let computePassEncoder218 = commandEncoder210.beginComputePass({});
+let renderPassEncoder21 = commandEncoder14.beginRenderPass({
+  colorAttachments: [{
+  view: textureView139,
+  clearValue: { r: -246.3, g: -96.73, b: -945.0, a: -462.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(1, 0, 3, 348_214_028, 2);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer25, 1_028);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer89, 0, 601);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer21]);
+} catch {}
+let veryExplicitBindGroupLayout30 = device1.createBindGroupLayout({entries: [{binding: 284, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }}]});
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({colorFormats: ['rg32uint']});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+computePassEncoder170.setBindGroup(0, bindGroup98, new Uint32Array(182), 8, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer115, 'uint32', 2_212, 1_770);
+} catch {}
+let promise33 = device1.queue.onSubmittedWorkDone();
+let commandEncoder211 = device0.createCommandEncoder({});
+let renderPassEncoder22 = commandEncoder211.beginRenderPass({colorAttachments: [{view: textureView130, loadOp: 'clear', storeOp: 'store'}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder215.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup23, new Uint32Array(3578), 3, 0);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder3.draw(209, 0, 2_026_937_334, 1);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(10, 6, 7, 378_577_079);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer5, 124);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer80, 472);
+} catch {}
+let arrayBuffer17 = buffer1.getMappedRange(2496, 0);
+try {
+commandEncoder168.copyBufferToTexture({
+  /* bytesInLastRow: 388 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 424 */
+  offset: 424,
+  rowsPerImage: 307,
+  buffer: buffer29,
+}, {
+  texture: texture146,
+  mipLevel: 1,
+  origin: {x: 164, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 97, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+await gc();
+let bindGroup118 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [{binding: 209, resource: textureView58}, {binding: 79, resource: textureView56}],
+});
+let commandEncoder212 = device0.createCommandEncoder({});
+let sampler133 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 50.54, compare: 'less'});
+try {
+{ clearResourceUsages(device0, computePassEncoder120); computePassEncoder120.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup118, new Uint32Array(1540), 237, 0);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer22, 888);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer35, 2_844);
+} catch {}
+try {
+commandEncoder212.copyTextureToBuffer({
+  texture: texture190,
+  mipLevel: 1,
+  origin: {x: 0, y: 17, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1904 */
+  offset: 1904,
+  bytesPerRow: 3584,
+  buffer: buffer73,
+}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise33;
+} catch {}
+let renderPassEncoder23 = commandEncoder212.beginRenderPass({
+  colorAttachments: [{
+  view: textureView139,
+  clearValue: { r: 49.10, g: 125.3, b: -385.6, a: -358.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler134 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 87.46});
+try {
+computePassEncoder85.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+computePassEncoder216.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer72, 232);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(0, buffer34, 200);
+} catch {}
+try {
+commandEncoder168.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 68 */
+  offset: 68,
+  bytesPerRow: 8704,
+  buffer: buffer84,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 192, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 165, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer126, 964);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer80, 36, new Float32Array(2827), 1240, 92);
+} catch {}
+let commandEncoder213 = device1.createCommandEncoder({});
+let computePassEncoder219 = commandEncoder213.beginComputePass({});
+try {
+  await buffer96.mapAsync(GPUMapMode.WRITE, 0, 300);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture208,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(24).fill(188), /* required buffer size: 24 */
+{offset: 24, bytesPerRow: 75}, {width: 4, height: 320, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout18 = pipeline6.getBindGroupLayout(0);
+let texture225 = device0.createTexture({size: [2, 1095, 1], format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC});
+let textureView215 = texture97.createView({aspect: 'stencil-only'});
+let computePassEncoder220 = commandEncoder168.beginComputePass({});
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(3.0003451632123803, 1098.9345917450783, 0.7317160481558183, 471.1832746227924, 0.09376546005682618, 0.36759323055172943);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer44, 'uint32', 1_464, 6_681);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer41, 2104, buffer18, 3768, 120);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 260 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 224 */
+  offset: 224,
+  buffer: buffer59,
+}, {
+  texture: texture124,
+  mipLevel: 1,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 130, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 77, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 950 */
+  offset: 950,
+  bytesPerRow: 12032,
+  rowsPerImage: 100,
+  buffer: buffer54,
+}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer33, 2624, 4276);
+} catch {}
+try {
+computePassEncoder172.popDebugGroup();
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder({});
+let computePassEncoder221 = commandEncoder83.beginComputePass({});
+let arrayBuffer18 = buffer32.getMappedRange(24, 4);
+try {
+commandEncoder69.copyBufferToBuffer(buffer67, 1052, buffer9, 1696, 104);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 274 */
+  offset: 274,
+  bytesPerRow: 5120,
+  buffer: buffer121,
+}, {
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 0, y: 158, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 134, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder36.insertDebugMarker('\u0818');
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule2, entryPoint: 'compute2', constants: {}}});
+let imageData23 = new ImageData(12, 60);
+let commandBuffer22 = commandEncoder69.finish({});
+let texture226 = device0.createTexture({size: {width: 1}, dimension: '1d', format: 'rg16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let texture227 = gpuCanvasContext2.getCurrentTexture();
+let textureView216 = texture42.createView({});
+let sampler135 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup52, new Uint32Array(1195), 428, 1);
+} catch {}
+try {
+renderPassEncoder11.draw(60, 120, 52_763_773, 337_141_140);
+} catch {}
+try {
+renderPassEncoder11.drawIndexed(49, 34, 191, 139_844_984, 608_547_705);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer49, 'uint16', 2_030, 480);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer66, 88, 9_838);
+} catch {}
+try {
+commandEncoder214.copyBufferToBuffer(buffer38, 220, buffer17, 836, 136);
+} catch {}
+let commandEncoder215 = device0.createCommandEncoder({});
+let texture228 = device0.createTexture({
+  size: [1, 136, 1],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup91, [0]);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -246,8 +246,6 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
     }
 
     [computeCommandEncoder() setBytes:&m_computeDynamicOffsets[0] length:m_computeDynamicOffsets.size() * sizeof(m_computeDynamicOffsets[0]) atIndex:m_device->maxBuffersForComputeStage()];
-
-    m_bindGroupDynamicOffsets.clear();
 }
 
 void ComputePassEncoder::dispatch(uint32_t x, uint32_t y, uint32_t z)
@@ -483,6 +481,7 @@ void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
 
     m_pipeline = &pipeline;
     m_computeDynamicOffsets.resize(m_pipeline->protectedPipelineLayout()->sizeOfComputeDynamicOffsets());
+    m_computeDynamicOffsets.fill(0);
 
     ASSERT(pipeline.computePipelineState());
     m_threadsPerThreadgroup = pipeline.threadsPerThreadgroup();

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -610,7 +610,6 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
     ASSERT(m_fragmentDynamicOffsets.size());
     [commandEncoder setFragmentBytes:&m_fragmentDynamicOffsets[0] length:m_fragmentDynamicOffsets.size() * sizeof(m_fragmentDynamicOffsets[0]) atIndex:m_device->maxBuffersForFragmentStage()];
 
-    m_bindGroupDynamicOffsets.clear();
     incrementDrawCount();
 
     return true;
@@ -1361,7 +1360,9 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
     m_pipeline = &pipeline;
 
     m_vertexDynamicOffsets.resize(pipeline.protectedPipelineLayout()->sizeOfVertexDynamicOffsets());
+    m_vertexDynamicOffsets.fill(0);
     m_fragmentDynamicOffsets.resize(pipeline.protectedPipelineLayout()->sizeOfFragmentDynamicOffsets() + RenderBundleEncoder::startIndexForFragmentDynamicOffsets);
+    m_fragmentDynamicOffsets.fill(0);
 
     if (m_fragmentDynamicOffsets.size() < RenderBundleEncoder::startIndexForFragmentDynamicOffsets)
         m_fragmentDynamicOffsets.grow(RenderBundleEncoder::startIndexForFragmentDynamicOffsets);


### PR DESCRIPTION
#### 479f27f56399082fb3c4dac5807743a66cd7c599
<pre>
[WebGPU] Switching pipelines does not zero out dynamic offsets from prior pipeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=285828">https://bugs.webkit.org/show_bug.cgi?id=285828</a>
<a href="https://rdar.apple.com/142761614">rdar://142761614</a>

Reviewed by Cameron McCormack.

(Reland with clearing of dynamic offsets container fixed)

When calling resize() on a Vector, dynamic offsets from a previous draw
call could remain in the dynamic offsets Vector. Ensure they are zero&apos;ed instead
by using Vector&apos;s ctor instead.

No change needed for RenderBundles since render bundles save all the dynamic
offsets across all draw calls into a single buffer.

* LayoutTests/fast/webgpu/nocrash/fuzz-285828-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-285828.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setPipeline):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setPipeline):
Ensure stale dynamic offsets do not persist.

Canonical link: <a href="https://commits.webkit.org/289069@main">https://commits.webkit.org/289069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/491fc4cb727db204438317c801cf0de748c6d65c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66252 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24067 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77398 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31659 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35323 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91761 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12562 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9149 "Found 2 new test failures: http/tests/navigation/page-cache-requestAnimationFrame.html http/tests/security/contentSecurityPolicy/connect-src-websocket-allowed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74769 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73888 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4549 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17958 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->