### PR TITLE
Add a quirk to zomato.com, to prevent hiding the caret in login-by-email

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -598,6 +598,16 @@ bool Quirks::needsWeChatScrollingQuirk() const
 #endif
 }
 
+// zomato.com <rdar://problem/128962778>
+bool Quirks::needsZomatoEmailLoginLabelQuirk() const
+{
+#if PLATFORM(MAC)
+    return needsQuirks() && m_quirksData.needsZomatoEmailLoginLabelQuirk;
+#else
+    return false;
+#endif
+}
+
 // maps.google.com rdar://67358928
 bool Quirks::needsGoogleMapsScrollingQuirk() const
 {
@@ -2650,6 +2660,18 @@ static void handleZillowQuirks(QuirksData& quirksData, const URL& quirksURL, con
 #endif
 }
 
+#if PLATFORM(MAC)
+static void handleZomatoQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "zomato.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    quirksData.needsZomatoEmailLoginLabelQuirk = true;
+}
+#endif
+
 static void handleZoomQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
 {
     if (quirksDomainString != "zoom.us"_s)
@@ -2813,6 +2835,9 @@ void Quirks::determineRelevantQuirks()
 #endif
         { "youtube"_s, &handleYouTubeQuirks },
         { "zillow"_s, &handleZillowQuirks },
+#if PLATFORM(MAC)
+        { "zomato"_s, &handleZomatoQuirks },
+#endif
         { "zoom"_s, &handleZoomQuirks },
     });
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -117,6 +117,7 @@ public:
     bool needsFullscreenDisplayNoneQuirk() const;
     bool needsFullscreenObjectFitQuirk() const;
     bool needsWeChatScrollingQuirk() const;
+    bool needsZomatoEmailLoginLabelQuirk() const;
     bool needsGoogleMapsScrollingQuirk() const;
 
     bool needsPrimeVideoUserSelectNoneQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -125,6 +125,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool isTouchBarUpdateSuppressedForHiddenContentEditableQuirk { false };
     bool needsFormControlToBeMouseFocusableQuirk { false };
     bool needsPrimeVideoUserSelectNoneQuirk { false };
+    bool needsZomatoEmailLoginLabelQuirk { false };
     bool shouldAvoidStartingSelectionOnMouseDown { false };
 #endif
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -42,6 +42,7 @@
 #include "HTMLDialogElement.h"
 #include "HTMLDivElement.h"
 #include "HTMLInputElement.h"
+#include "HTMLLabelElement.h"
 #include "HTMLMarqueeElement.h"
 #include "HTMLNames.h"
 #include "HTMLSlotElement.h"
@@ -973,6 +974,16 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         if (m_element->hasClassName(className))
             style.setUserSelect(UserSelect::None);
     }
+
+#if PLATFORM(MAC)
+    if (m_document->quirks().needsZomatoEmailLoginLabelQuirk()) {
+        static MainThreadNeverDestroyed<const AtomString> class1("eNjKGZ"_s);
+        if (is<HTMLLabelElement>(*m_element)
+            && m_element->hasClassName(class1)
+            && style.backgroundColor() == Color { WebCore::Color::white })
+            style.setBackgroundColor({ WebCore::Color::transparentBlack });
+    }
+#endif
 
 #if PLATFORM(IOS_FAMILY)
     if (m_document->quirks().needsGoogleMapsScrollingQuirk()) {


### PR DESCRIPTION
#### 80af29c993f83bdb5b220f3290cb3e5b6cb6b12f
<pre>
Add a quirk to zomato.com, to prevent hiding the caret in login-by-email
<a href="https://bugs.webkit.org/show_bug.cgi?id=286123">https://bugs.webkit.org/show_bug.cgi?id=286123</a>
<a href="https://rdar.apple.com/128962778">rdar://128962778</a>

Reviewed by Anne van Kesteren.

When trying to log in with an email, the &lt;input&gt; is followed by a &lt;label&gt;
that displays &quot;Email&quot; when the input is empty. (Similar to what a
&apos;placeholder&apos; attribute would do.) But that label has a white background,
which can hide the input&apos;s blinking caret at certain zoom levels.

To make sure the caret stays visible, this patch adds a quirk that
replaces that label&apos;s background color with a fully-transparent color.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsZomatoEmailLoginLabelQuirk const):
(WebCore::handleZomatoQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):

Canonical link: <a href="https://commits.webkit.org/289165@main">https://commits.webkit.org/289165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2087b0146a0cc68b32d2e6b041e07ed28ee63b6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66263 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77411 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46537 "Found 2 new API test failures: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WPE/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35335 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12574 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9171 "Found 2 new test failures: http/tests/navigation/page-cache-requestAnimationFrame.html http/tests/webrtc/filtering-ice-candidate-same-origin-frame2.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74787 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73906 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4564 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12517 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17987 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->