### PR TITLE
[CoordinatedGraphics] Swap contents buffer earlier when flushing layers

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -461,8 +461,6 @@ void CoordinatedPlatformLayer::setContentsBuffer(TextureMapperPlatformLayerProxy
         return;
 
     m_contentsBuffer = contentsBuffer;
-    if (m_contentsBuffer)
-        m_contentsBufferNeedsDisplay = true;
     m_pendingChanges.add(Change::ContentsBuffer);
     notifyCompositionRequired();
 }
@@ -470,10 +468,10 @@ void CoordinatedPlatformLayer::setContentsBuffer(TextureMapperPlatformLayerProxy
 void CoordinatedPlatformLayer::setContentsBufferNeedsDisplay()
 {
     ASSERT(m_lock.isHeld());
-    if (!m_contentsBuffer || m_contentsBufferNeedsDisplay)
+    if (!m_contentsBuffer)
         return;
 
-    m_contentsBufferNeedsDisplay = true;
+    m_contentsBuffer->swapBuffersIfNeeded();
     notifyCompositionRequired();
 }
 
@@ -710,12 +708,6 @@ void CoordinatedPlatformLayer::updateBackingStore()
 void CoordinatedPlatformLayer::updateContents(bool affectedByTransformAnimation)
 {
     Locker locker { m_lock };
-
-    if (m_contentsBufferNeedsDisplay) {
-        if (m_contentsBuffer)
-            m_contentsBuffer->swapBuffersIfNeeded();
-        m_contentsBufferNeedsDisplay = false;
-    }
 
     if (needsBackingStore()) {
         if (!m_backingStoreProxy) {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -267,7 +267,6 @@ private:
     float m_contentsScale WTF_GUARDED_BY_LOCK(m_lock) { 1. };
     RefPtr<TextureMapperPlatformLayerProxy> m_contentsBuffer WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<TextureMapperPlatformLayerProxy> m_committedContentsBuffer WTF_GUARDED_BY_LOCK(m_lock);
-    bool m_contentsBufferNeedsDisplay WTF_GUARDED_BY_LOCK(m_lock) { false };
     RefPtr<CoordinatedBackingStoreProxy> m_backingStoreProxy WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedBackingStore> m_backingStore WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient WTF_GUARDED_BY_LOCK(m_lock);


### PR DESCRIPTION
#### bb9d048ddb6ccce717ab32f383bf3060a6b4d640
<pre>
[CoordinatedGraphics] Swap contents buffer earlier when flushing layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=286137">https://bugs.webkit.org/show_bug.cgi?id=286137</a>

Reviewed by Miguel Gomez.

We currently update the contents buffer after all layers have committed
changes, but we can do it earlier, when the contents are set or marked
for display.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setContentsBuffer):
(WebCore::CoordinatedPlatformLayer::setContentsBufferNeedsDisplay):
(WebCore::CoordinatedPlatformLayer::updateContents):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setContentsNeedsDisplay):
(WebCore::GraphicsLayerCoordinated::setContentsToPlatformLayer):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):

Canonical link: <a href="https://commits.webkit.org/289052@main">https://commits.webkit.org/289052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cb2d0a85cab13e006d18f9518a95fac86e0d738

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90360 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66266 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24083 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77417 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46542 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35341 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91793 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73913 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18324 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16752 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4581 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13277 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12523 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12353 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->