### PR TITLE
[Buildstream SDK] Bump to ffmpeg 7.0.x

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -24,6 +24,8 @@ sources:
   path: patches/fdo-0011-GStreamer-Vendor-rtpfunnel-patch-scheduled-to-ship-i.patch
 - kind: patch
   path: patches/fdo-0012-GStreamer-Vendor-GstPad-patch-scheduled-to-ship-in-1.patch
+- kind: patch
+  path: patches/fdo-0013-ffmpeg-Bump-to-version-7.0.2.patch
 config:
   options:
     target_arch: '%{arch}'

--- a/Tools/buildstream/patches/fdo-0013-ffmpeg-Bump-to-version-7.0.2.patch
+++ b/Tools/buildstream/patches/fdo-0013-ffmpeg-Bump-to-version-7.0.2.patch
@@ -1,0 +1,264 @@
+From 0da24fa6e28a74c7f77ea09d09920a07ba3babe0 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Fri, 17 Jan 2025 11:53:37 +0000
+Subject: [PATCH] ffmpeg: Bump to version 7.0.2
+
+Version used in current upstream FDO SDK 24.08 branch.
+
+Vulkan is disabled, because the version required is now higher than what we
+ship.
+---
+ elements/include/ffmpeg.yml                   |  9 +-
+ ...h-Makefile-Fix-vc1dsp_lasx.o-build-c.patch | 28 ++++++
+ patches/ffmpeg/binutils-2.41.patch            | 74 --------------
+ patches/ffmpeg/libx2654-build-fix.patch       | 96 +++++++++++++++++++
+ 4 files changed, 128 insertions(+), 79 deletions(-)
+ create mode 100644 patches/ffmpeg/0001-avcodec-loongarch-Makefile-Fix-vc1dsp_lasx.o-build-c.patch
+ delete mode 100644 patches/ffmpeg/binutils-2.41.patch
+ create mode 100644 patches/ffmpeg/libx2654-build-fix.patch
+
+diff --git a/elements/include/ffmpeg.yml b/elements/include/ffmpeg.yml
+index 7221f63..339ea84 100644
+--- a/elements/include/ffmpeg.yml
++++ b/elements/include/ffmpeg.yml
+@@ -79,7 +79,6 @@ variables:
+     --enable-openal
+     --enable-opengl
+     --enable-sdl2
+-    --enable-vulkan
+     --enable-zlib
+     --enable-libv4l2
+     --enable-libxcb
+@@ -114,9 +113,9 @@ config:
+ sources:
+ - kind: git_repo
+   url: ffmpeg:ffmpeg.git
+-  track: n*
++  track: n7.0.*
+   exclude:
+   - '*-dev'
+-  ref: n6.0-0-gea3d24bbe3c58b171e55fe2151fc7ffaca3ab3d2
+-- kind: patch
+-  path: patches/ffmpeg/binutils-2.41.patch
++  ref: n7.0.2-0-ge3a61e91030696348b56361bdf80ea358aef4a19
++- kind: patch_queue
++  path: patches/ffmpeg
+diff --git a/patches/ffmpeg/0001-avcodec-loongarch-Makefile-Fix-vc1dsp_lasx.o-build-c.patch b/patches/ffmpeg/0001-avcodec-loongarch-Makefile-Fix-vc1dsp_lasx.o-build-c.patch
+new file mode 100644
+index 0000000..3cae19a
+--- /dev/null
++++ b/patches/ffmpeg/0001-avcodec-loongarch-Makefile-Fix-vc1dsp_lasx.o-build-c.patch
+@@ -0,0 +1,28 @@
++From b515088576bbeb746aa34a222bba76cc01b29e44 Mon Sep 17 00:00:00 2001
++From: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
++Date: Sat, 15 Jun 2024 20:29:09 +0200
++Subject: [PATCH] avcodec/loongarch/Makefile: Fix vc1dsp_lasx.o build criterion
++
++Fixes ticket #11057.
++
++Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
++---
++ libavcodec/loongarch/Makefile | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/libavcodec/loongarch/Makefile b/libavcodec/loongarch/Makefile
++index 07da2964e4..92c8b35906 100644
++--- a/libavcodec/loongarch/Makefile
+++++ b/libavcodec/loongarch/Makefile
++@@ -12,7 +12,7 @@ OBJS-$(CONFIG_HEVC_DECODER)           += loongarch/hevcdsp_init_loongarch.o
++ LASX-OBJS-$(CONFIG_H264QPEL)          += loongarch/h264qpel_lasx.o
++ LASX-OBJS-$(CONFIG_H264DSP)           += loongarch/h264dsp_lasx.o \
++                                          loongarch/h264_deblock_lasx.o
++-LASX-OBJS-$(CONFIG_VC1_DECODER)       += loongarch/vc1dsp_lasx.o
+++LASX-OBJS-$(CONFIG_VC1DSP)            += loongarch/vc1dsp_lasx.o
++ LASX-OBJS-$(CONFIG_HPELDSP)           += loongarch/hpeldsp_lasx.o
++ LASX-OBJS-$(CONFIG_IDCTDSP)           += loongarch/simple_idct_lasx.o  \
++                                          loongarch/idctdsp_lasx.o
++-- 
++2.45.2
++
+diff --git a/patches/ffmpeg/binutils-2.41.patch b/patches/ffmpeg/binutils-2.41.patch
+deleted file mode 100644
+index 849d50b..0000000
+--- a/patches/ffmpeg/binutils-2.41.patch
++++ /dev/null
+@@ -1,74 +0,0 @@
+-From cc703cf60759d9798f440a9417e4efa2fcbe2747 Mon Sep 17 00:00:00 2001
+-From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+-Date: Sun, 16 Jul 2023 18:18:02 +0300
+-Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+- instructions within inline assembly
+-
+-Fixes assembling with binutil as >= 2.41
+-
+-Signed-off-by: James Almer <jamrial@gmail.com>
+-(cherry picked from commit effadce6c756247ea8bae32dc13bb3e6f464f0eb)
+----
+- libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+- 1 file changed, 23 insertions(+), 3 deletions(-)
+-
+-diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+-index 6298f5ed1983..ca7e2dffc107 100644
+---- a/libavcodec/x86/mathops.h
+-+++ b/libavcodec/x86/mathops.h
+-@@ -35,12 +35,20 @@
+- static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+- {
+-     int rt, dummy;
+-+    if (__builtin_constant_p(shift))
+-     __asm__ (
+-         "imull %3               \n\t"
+-         "shrdl %4, %%edx, %%eax \n\t"
+-         :"=a"(rt), "=d"(dummy)
+--        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
+-+        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+-     );
+-+    else
+-+        __asm__ (
+-+            "imull %3               \n\t"
+-+            "shrdl %4, %%edx, %%eax \n\t"
+-+            :"=a"(rt), "=d"(dummy)
+-+            :"a"(a), "rm"(b), "c"((uint8_t)shift)
+-+        );
+-     return rt;
+- }
+- 
+-@@ -113,19 +121,31 @@ __asm__ volatile(\
+- // avoid +32 for shift optimization (gcc should do that ...)
+- #define NEG_SSR32 NEG_SSR32
+- static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
+-+    if (__builtin_constant_p(s))
+-     __asm__ ("sarl %1, %0\n\t"
+-          : "+r" (a)
+--         : "ic" ((uint8_t)(-s))
+-+         : "i" (-s & 0x1F)
+-     );
+-+    else
+-+        __asm__ ("sarl %1, %0\n\t"
+-+               : "+r" (a)
+-+               : "c" ((uint8_t)(-s))
+-+        );
+-     return a;
+- }
+- 
+- #define NEG_USR32 NEG_USR32
+- static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
+-+    if (__builtin_constant_p(s))
+-     __asm__ ("shrl %1, %0\n\t"
+-          : "+r" (a)
+--         : "ic" ((uint8_t)(-s))
+-+         : "i" (-s & 0x1F)
+-     );
+-+    else
+-+        __asm__ ("shrl %1, %0\n\t"
+-+               : "+r" (a)
+-+               : "c" ((uint8_t)(-s))
+-+        );
+-     return a;
+- }
+- 
+diff --git a/patches/ffmpeg/libx2654-build-fix.patch b/patches/ffmpeg/libx2654-build-fix.patch
+new file mode 100644
+index 0000000..3eecb7f
+--- /dev/null
++++ b/patches/ffmpeg/libx2654-build-fix.patch
+@@ -0,0 +1,96 @@
++From f6f2531e989ea3f3019703522b3d390bbd2577fc Mon Sep 17 00:00:00 2001
++From: bbhtt <bbhtt.zn0i8@slmail.me>
++Date: Sat, 23 Nov 2024 11:16:01 +0530
++Subject: [PATCH] Fix build with libx265 >=4.0
++
++Backport of
++
++https://github.com/FFmpeg/FFmpeg/commit/1f801dfdb5066aadf0ade9cb5e94d620f33eacdc
++https://github.com/FFmpeg/FFmpeg/commit/099f88b8641dfc299f3896d17d9addc5b9ae7799
++---
++ libavcodec/libx265.c | 41 +++++++++++++++++++++++++++++++----------
++ 1 file changed, 31 insertions(+), 10 deletions(-)
++
++diff --git a/libavcodec/libx265.c b/libavcodec/libx265.c
++index d3e74eaacf..afe187552e 100644
++--- a/libavcodec/libx265.c
+++++ b/libavcodec/libx265.c
++@@ -646,7 +646,13 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
++ {
++     libx265Context *ctx = avctx->priv_data;
++     x265_picture x265pic;
++-    x265_picture x265pic_out = { 0 };
+++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
+++    x265_picture x265pic_layers_out[MAX_SCALABLE_LAYERS];
+++    x265_picture* x265pic_lyrptr_out[MAX_SCALABLE_LAYERS];
+++#else
+++    x265_picture x265pic_solo_out = { 0 };
+++#endif
+++    x265_picture* x265pic_out;
++     x265_nal *nal;
++     x265_sei *sei;
++     uint8_t *dst;
++@@ -764,8 +770,17 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
++         }
++     }
++ 
+++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
+++    for (i = 0; i < MAX_SCALABLE_LAYERS; i++)
+++        x265pic_lyrptr_out[i] = &x265pic_layers_out[i];
+++
+++    ret = ctx->api->encoder_encode(ctx->encoder, &nal, &nnal,
+++                                   pic ? &x265pic : NULL, x265pic_lyrptr_out);
+++#else
+++
++     ret = ctx->api->encoder_encode(ctx->encoder, &nal, &nnal,
++-                                   pic ? &x265pic : NULL, &x265pic_out);
+++                                   pic ? &x265pic : NULL, &x265pic_solo_out);
+++#endif
++ 
++     for (i = 0; i < sei->numPayloads; i++)
++         av_free(sei->payloads[i].payload);
++@@ -795,10 +810,16 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
++             pkt->flags |= AV_PKT_FLAG_KEY;
++     }
++ 
++-    pkt->pts = x265pic_out.pts;
++-    pkt->dts = x265pic_out.dts;
+++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
+++    x265pic_out = x265pic_lyrptr_out[0];
+++#else
+++    x265pic_out = &x265pic_solo_out;
+++#endif
+++
+++    pkt->pts = x265pic_out->pts;
+++    pkt->dts = x265pic_out->dts;
++ 
++-    switch (x265pic_out.sliceType) {
+++    switch (x265pic_out->sliceType) {
++     case X265_TYPE_IDR:
++     case X265_TYPE_I:
++         pict_type = AV_PICTURE_TYPE_I;
++@@ -816,16 +837,16 @@ static int libx265_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
++     }
++ 
++ #if X265_BUILD >= 130
++-    if (x265pic_out.sliceType == X265_TYPE_B)
+++    if (x265pic_out->sliceType == X265_TYPE_B)
++ #else
++-    if (x265pic_out.frameData.sliceType == 'b')
+++    if (x265pic_out->frameData.sliceType == 'b')
++ #endif
++         pkt->flags |= AV_PKT_FLAG_DISPOSABLE;
++ 
++-    ff_side_data_set_encoder_stats(pkt, x265pic_out.frameData.qp * FF_QP2LAMBDA, NULL, 0, pict_type);
+++    ff_side_data_set_encoder_stats(pkt, x265pic_out->frameData.qp * FF_QP2LAMBDA, NULL, 0, pict_type);
++ 
++-    if (x265pic_out.userData) {
++-        int idx = (int)(intptr_t)x265pic_out.userData - 1;
+++    if (x265pic_out->userData) {
+++        int idx = (int)(intptr_t)x265pic_out->userData - 1;
++         ReorderedData *rd = &ctx->rd[idx];
++ 
++         pkt->duration           = rd->duration;
++-- 
++2.47.0
++
+-- 
+2.48.0
+


### PR DESCRIPTION
#### ad09a65516e029d718fe7a47e5287418291f7637
<pre>
[Buildstream SDK] Bump to ffmpeg 7.0.x
<a href="https://bugs.webkit.org/show_bug.cgi?id=286139">https://bugs.webkit.org/show_bug.cgi?id=286139</a>

Reviewed by Adrian Perez de Castro.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0013-ffmpeg-Bump-to-version-7.0.2.patch: Added.

Canonical link: <a href="https://commits.webkit.org/289057@main">https://commits.webkit.org/289057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fb475e764ace8f638bc1d25cff431345469ba0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66267 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24085 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46543 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35344 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12583 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74800 "Found 66 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html fast/multicol/columns-on-body.html fast/ruby/annotation-with-line-gap.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73923 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4586 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13279 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12526 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12356 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->