### PR TITLE
[CoordinatedGraphics] Update backing store after layer flush

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -170,6 +170,8 @@ public:
     void setShowRepaintCounter(bool);
 
     void updateContents(bool affectedByTransformAnimation);
+    void updateBackingStore();
+
     void flushCompositingState(TextureMapper&);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
@@ -186,7 +188,6 @@ private:
     void notifyCompositionRequired();
 
     bool needsBackingStore() const;
-    void updateBackingStore();
     void purgeBackingStores();
 
     enum class Change : uint32_t {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -178,7 +178,6 @@ private:
     void updateAnimations();
     void updateVisibleRect(const FloatRect&);
     void updateIndicators();
-    void updateContents(bool affectedByTransformAnimation);
     bool isRunningTransformAnimation() const;
     bool filtersCanBeComposited(const FilterOperations&) const;
 
@@ -190,6 +189,9 @@ private:
     void commitLayerChanges(CommitState&, float pageScaleFactor, const FloatPoint&, bool affectedByTransformAnimation);
     bool needsCommit(CommitState&) const;
     void recursiveCommitChanges(CommitState&, float pageScaleFactor = 1, const FloatPoint& positionRelativeToBase = FloatPoint(), bool affectedByPageScale = false);
+
+    bool updateBackingStoresIfNeeded();
+    bool updateBackingStoreIfNeeded();
 
     Ref<CoordinatedPlatformLayer> m_platformLayer;
     OptionSet<Change> m_pendingChanges;


### PR DESCRIPTION
#### c697001dea589dc476c36ddf19275ddd378fb5ab
<pre>
[CoordinatedGraphics] Update backing store after layer flush
<a href="https://bugs.webkit.org/show_bug.cgi?id=286141">https://bugs.webkit.org/show_bug.cgi?id=286141</a>

Reviewed by Miguel Gomez.

In 287731@main I moved the update backing store to be done during the
layer flush with the idea of starting earlier and avoid another
iteration fo the layers, but it has the side effects of invert the order
in which the layers are painted. This patch splits updateContents()
again so that backing store is created during layer flush and updated
right after.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::updateBackingStore):
(WebCore::CoordinatedPlatformLayer::updateContents):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::flushCompositingState):
(WebCore::GraphicsLayerCoordinated::flushCompositingStateForThisLayerOnly):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):
(WebCore::GraphicsLayerCoordinated::recursiveCommitChanges):
(WebCore::GraphicsLayerCoordinated::updateBackingStoresIfNeeded):
(WebCore::GraphicsLayerCoordinated::updateBackingStoreIfNeeded):
(WebCore::GraphicsLayerCoordinated::updateContents): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

Canonical link: <a href="https://commits.webkit.org/289145@main">https://commits.webkit.org/289145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/557ae690a10d1dc6ed08e7e818387427cc668023

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24220 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3922 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31846 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_keyPath.any.worker.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35536 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75038 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74161 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16919 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4832 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18185 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14332 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->