### PR TITLE
Border doesn't show when linear gradient and border radius are set

### DIFF
--- a/LayoutTests/fast/backgrounds/opaque-background-bleed-avoidance-expected.html
+++ b/LayoutTests/fast/backgrounds/opaque-background-bleed-avoidance-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .bordered {
+        margin: 50px;
+        border: 100px solid green;
+        border-bottom: none;
+        border-radius: 16px;
+        width: 300px;
+        height: 100px;
+        background: linear-gradient(transparent, black);
+    }
+    
+    #obscurer {
+        position: absolute;
+        background-color: gray;
+        top: 140px;
+        left: 150px;
+        width: 320px;
+        height: 120px;
+    }
+</style>
+</head>
+<body>
+    <div class="bordered"></div>
+    <div id="obscurer"></div>
+</body>
+</html>

--- a/LayoutTests/fast/backgrounds/opaque-background-bleed-avoidance.html
+++ b/LayoutTests/fast/backgrounds/opaque-background-bleed-avoidance.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-64; totalPixels=0-98">
+<style>
+    .bordered {
+        margin: 50px;
+        border: 100px solid green;
+        border-bottom: none;
+        border-radius: 16px;
+        width: 300px;
+        height: 100px;
+        background: linear-gradient(white, black);
+    }
+    
+    #obscurer {
+        position: absolute;
+        background-color: gray;
+        top: 140px;
+        left: 150px;
+        width: 320px;
+        height: 120px;
+    }
+</style>
+</head>
+<body>
+    <div class="bordered"></div>
+    <div id="obscurer"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1626,6 +1626,7 @@ BleedAvoidance RenderBox::determineBleedAvoidance(GraphicsContext& context) cons
 
     if (borderObscuresBackgroundEdge(contextScaling))
         return BleedAvoidance::ShrinkBackground;
+
     if (!style.hasUsedAppearance() && borderObscuresBackground() && backgroundHasOpaqueTopLayer())
         return BleedAvoidance::BackgroundOverBorder;
 


### PR DESCRIPTION
#### a74c01d2221ac24385491ae159d42d52fae3210f
<pre>
Border doesn&apos;t show when linear gradient and border radius are set
<a href="https://bugs.webkit.org/show_bug.cgi?id=285300">https://bugs.webkit.org/show_bug.cgi?id=285300</a>
<a href="https://rdar.apple.com/142617573">rdar://142617573</a>

Reviewed by Alan Baradlay.

The BleedAvoidance::BackgroundOverBorder logic fixes edge antialiasing issues by painting the border first,
and then painting a clipped background over the top. This worked for solid color backgrounds, where
`BackgroundPainter::paintFillLayer()` filled the inner shape, but did not work for opaque image backgrounds
(like opaque gradients, or opaque images like JPEG). To fix that, we need to clip to the padding box before
painting the background.

* LayoutTests/fast/backgrounds/opaque-background-bleed-avoidance-expected.html: Added.
* LayoutTests/fast/backgrounds/opaque-background-bleed-avoidance.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::determineBleedAvoidance const):

Canonical link: <a href="https://commits.webkit.org/289101@main">https://commits.webkit.org/289101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd5afcfea839c0cfda8a2d4bf38579f196d6c225

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66341 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24156 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35451 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91937 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73354 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/74026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18322 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running checkout-pull-request; Reviewed by Alan Baradlay; Compiled WebKit (warnings); Skipped layout-tests; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4709 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18096 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->