### PR TITLE
[WebDriver][BiDi] Fix error response id, type, and error name fields

### DIFF
--- a/Source/WebDriver/CommandResult.cpp
+++ b/Source/WebDriver/CommandResult.cpp
@@ -175,8 +175,12 @@ unsigned CommandResult::errorCodeToHTTPStatusCode(ErrorCode errorCode)
 String CommandResult::errorString() const
 {
     ASSERT(isError());
+    return errorCodeToString(m_errorCode.value());
+}
 
-    switch (m_errorCode.value()) {
+String CommandResult::errorCodeToString(ErrorCode errorCode)
+{
+    switch (errorCode) {
     case ErrorCode::ElementClickIntercepted:
         return "element click intercepted"_s;
     case ErrorCode::ElementNotSelectable:

--- a/Source/WebDriver/CommandResult.h
+++ b/Source/WebDriver/CommandResult.h
@@ -80,6 +80,7 @@ public:
 
     unsigned httpStatusCode() const;
     static unsigned errorCodeToHTTPStatusCode(ErrorCode);
+    static String errorCodeToString(ErrorCode);
     const RefPtr<JSON::Value>& result() const { return m_result; };
     void setAdditionalErrorData(RefPtr<JSON::Object>&& errorData) { m_errorAdditionalData = WTFMove(errorData); }
     bool isError() const { return !!m_errorCode; }

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -2707,7 +2707,7 @@ void WebDriverService::bidiSessionSubscribe(unsigned id, RefPtr<JSON::Object>&&p
     auto eventNames = parameters->getArray("events"_s);
 
     if (!eventNames) {
-        completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt));
+        completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Missing 'events' parameter"_s, id));
         return;
     }
 
@@ -2729,7 +2729,7 @@ void WebDriverService::bidiSessionUnsubscribe(unsigned id, RefPtr<JSON::Object>&
     auto eventNames = parameters->getArray("events"_s);
 
     if (!eventNames) {
-        completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt));
+        completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, "Missing 'events' parameter"_s, id));
         return;
     }
 

--- a/Source/WebDriver/WebSocketServer.cpp
+++ b/Source/WebDriver/WebSocketServer.cpp
@@ -167,7 +167,8 @@ WebSocketMessageHandler::Message WebSocketMessageHandler::Message::fail(CommandR
     if (errorMessage)
         reply->setString("message"_s, *errorMessage);
 
-    reply->setInteger("error"_s, CommandResult::errorCodeToHTTPStatusCode(errorCode));
+    reply->setString("error"_s, CommandResult::errorCodeToString(errorCode));
+    reply->setString("type"_s, "error"_s);
 
     return { (connection ? (*connection) : nullptr), reply->toJSONString().utf8() };
 }


### PR DESCRIPTION
#### faec608ad6c7afa447303f174843ff400fb03ca6
<pre>
[WebDriver][BiDi] Fix error response id, type, and error name fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=286163">https://bugs.webkit.org/show_bug.cgi?id=286163</a>

Reviewed by Carlos Garcia Campos.

- Attach the command&apos;s &quot;id&quot; field in some `Message::fail` calls,
so the client know what command caused the error response
- Add the &quot;type&quot; field, with value &quot;error&quot;, mirroring the other
types (&quot;event&quot;, and &quot;response&quot;)
- The &quot;error&quot; field should be the JSON error name string, per
<a href="https://w3c.github.io/webdriver/#dfn-error-code.">https://w3c.github.io/webdriver/#dfn-error-code.</a> Currently,
we were sending the corresponding HTTP status code.

* Source/WebDriver/CommandResult.cpp:
(WebDriver::CommandResult::errorString const):
(WebDriver::CommandResult::errorCodeToErrorString):
* Source/WebDriver/CommandResult.h:
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::bidiSessionSubscribe):
(WebDriver::WebDriverService::bidiSessionUnsubscribe):
* Source/WebDriver/WebSocketServer.cpp:
(WebDriver::WebSocketMessageHandler::Message::fail):

Canonical link: <a href="https://commits.webkit.org/289728@main">https://commits.webkit.org/289728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6712aecdfc67594355a992678aea8ddae5b6f98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15502 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5683 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37670 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14981 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75889 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20261 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18697 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7983 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14997 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->