### PR TITLE
Treat web extension resources as UTF-8 by default.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -154,7 +154,8 @@ NSSet *toAPI(const HashSet<String>&);
 NSArray *toAPIArray(const HashSet<String>&);
 HashSet<String> toImpl(NSSet *);
 
-HashMap<String, Ref<API::Data>> toDataMap(NSDictionary *);
+using DataMap = HashMap<String, std::variant<String, Ref<API::Data>>>;
+DataMap toDataMap(NSDictionary *);
 
 } // namespace WebKit
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -505,9 +505,9 @@ HashSet<String> toImpl(NSSet *set)
     return result;
 }
 
-HashMap<String, Ref<API::Data>> toDataMap(NSDictionary *dictionary)
+DataMap toDataMap(NSDictionary *dictionary)
 {
-    HashMap<String, Ref<API::Data>> result;
+    DataMap result;
     result.reserveInitialCapacity(dictionary.count);
 
     for (id key in dictionary) {
@@ -519,7 +519,7 @@ HashMap<String, Ref<API::Data>> toDataMap(NSDictionary *dictionary)
 
         id value = dictionary[key];
         if (auto *valueString = dynamic_objc_cast<NSString>(value)) {
-            result.add(keyString, API::Data::create(String(valueString).utf8().span()));
+            result.add(keyString, valueString);
             continue;
         }
 
@@ -530,11 +530,11 @@ HashMap<String, Ref<API::Data>> toDataMap(NSDictionary *dictionary)
 
         if (isValidJSONObject(value, JSONOptions::FragmentsAllowed)) {
             NSError *error;
-            auto *jsonData = encodeJSONData(value, JSONOptions::FragmentsAllowed, &error);
-            if (!jsonData || error)
+            auto *jsonString = encodeJSONString(value, JSONOptions::FragmentsAllowed, &error);
+            if (!jsonString || error)
                 continue;
 
-            result.add(keyString, API::Data::createWithoutCopying(jsonData));
+            result.add(keyString, jsonString);
             continue;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -633,7 +633,7 @@ RefPtr<API::Data> WebExtensionContext::localizedResourceData(const RefPtr<API::D
     if (!equalLettersIgnoringASCIICase(mimeType, "text/css"_s) || !resourceData)
         return resourceData;
 
-    RefPtr decoder = WebCore::TextResourceDecoder::create(mimeType, { }, true);
+    RefPtr decoder = WebCore::TextResourceDecoder::create(mimeType, PAL::UTF8Encoding());
     auto stylesheetContents = decoder->decode(resourceData->span());
 
     auto localizedString = localizedResourceString(stylesheetContents, mimeType);

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -61,7 +61,7 @@ class WebExtension : public API::ObjectImpl<API::Object::Type::WebExtension>, pu
 public:
     using IconCacheEntry = std::variant<RefPtr<WebCore::Icon>, Vector<double>>;
     using IconsCache = HashMap<String, IconCacheEntry>;
-    using Resources = HashMap<String, Ref<API::Data>>;
+    using Resources = HashMap<String, std::variant<String, Ref<API::Data>>>;
 
     template<typename... Args>
     static Ref<WebExtension> create(Args&&... args)


### PR DESCRIPTION
#### 39e8e2a5ef2b52761cacc02231d039d55632741e
<pre>
Treat web extension resources as UTF-8 by default.
<a href="https://webkit.org/b/286165">https://webkit.org/b/286165</a>
<a href="https://rdar.apple.com/143079179">rdar://143079179</a>

Reviewed by Brian Weinstein.

Stop auto-detecting text encoding when handling string resources, just default to UTF-8.
This matches Chrome and Firefox and avoid the more costly decoding detection.

Also cache resources as String or Data using a variant, so we can avoid encoding and decoding
to and from UTF-8 when accessing existing resources.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toDataMap):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::resourceDataForPath):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::localizedResourceData):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::resourceStringForPath):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:

Canonical link: <a href="https://commits.webkit.org/289086@main">https://commits.webkit.org/289086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79f49e15afddc5229f6d04c2c4763a1429ffdbcc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13009 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24124 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88344 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3788 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35408 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91877 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12645 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73971 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4664 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13297 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12588 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->