### PR TITLE
Crash under WebCore::collectDescendantLayersAtPoint()

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -147,7 +147,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found " << layersAtPoint.size() << " layers");
 #if !LOG_DISABLED
     for (auto [layer, point] : layersAtPoint)
-        LOG_WITH_STREAM(Scrolling, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
+        LOG_WITH_STREAM(Scrolling, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer.get()));
 #endif
 
     if (layersAtPoint.size()) {
@@ -155,7 +155,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
         for (size_t i = 0 ; i < layersAtPoint.size() ; i++) {
             auto [layer, point] = layersAtPoint[i];
 
-            if (!layerEventRegionContainsPoint(layer, point))
+            if (!layerEventRegionContainsPoint(layer.get(), point))
                 continue;
 
             if (!frontmostInteractiveLayer)
@@ -163,7 +163,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
 
             auto scrollingNodeForLayer = [&] (auto layer, auto point) -> RefPtr<ScrollingTreeNode> {
                 UNUSED_PARAM(point);
-                auto nodeID = scrollingNodeIDForLayer(layer);
+                auto nodeID = scrollingNodeIDForLayer(layer.get());
                 RefPtr scrollingNode = nodeForID(nodeID);
                 if (!is<ScrollingTreeScrollingNode>(scrollingNode))
                     return nullptr;
@@ -215,7 +215,7 @@ OptionSet<EventListenerRegionType> ScrollingTreeMac::eventListenerRegionTypesFor
     if (!hitLayer)
         return { };
 
-    auto platformCALayer = PlatformCALayer::platformCALayerForLayer((__bridge void*)hitLayer);
+    auto platformCALayer = PlatformCALayer::platformCALayerForLayer((__bridge void*)hitLayer.get());
     if (!platformCALayer)
         return { };
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
@@ -52,7 +52,7 @@
 
 namespace WebCore {
 
-using LayerAndPoint = std::pair<CALayer *, FloatPoint>;
+using LayerAndPoint = std::pair<RetainPtr<CALayer>, FloatPoint>;
 WEBCORE_EXPORT void collectDescendantLayersAtPoint(Vector<LayerAndPoint, 16>& layersAtPoint, CALayer *parent, CGPoint, const std::function<bool(CALayer *, CGPoint localPoint)>& pointInLayerFunction = { });
 
 WEBCORE_EXPORT Vector<LayerAndPoint, 16> layersAtPointToCheckForScrolling(std::function<bool(CALayer*, CGPoint)> layerEventRegionContainsPoint, std::function<std::optional<ScrollingNodeID>(CALayer*)> scrollingNodeIDForLayer, CALayer*, const FloatPoint&, bool& hasAnyNonInteractiveScrollingLayers);

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
@@ -155,8 +155,9 @@ void collectDescendantLayersAtPoint(Vector<LayerAndPoint, 16>& layersAtPoint, CA
     if (parent.mask && ![parent _web_maskContainsPoint:point])
         return;
 
-    for (CALayer *layer in [parent sublayers]) {
-        CALayer *layerWithResolvedAnimations = layer;
+    RetainPtr sublayers = adoptNS([[parent sublayers] copy]);
+    for (CALayer* layer : sublayers.get()) {
+        RetainPtr layerWithResolvedAnimations = layer;
 
         if ([[layer animationKeys] count])
             layerWithResolvedAnimations = [layer presentationLayer];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -494,7 +494,7 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
     LOG_WITH_STREAM(UIHitTesting, stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " (converted to layer point " << pointInContentsLayer << ") found " << layersAtPoint.size() << " layers");
 #if !LOG_DISABLED
     for (auto [layer, point] : layersAtPoint)
-        LOG_WITH_STREAM(UIHitTesting, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
+        LOG_WITH_STREAM(UIHitTesting, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer.get()));
 #endif
 
     if (layersAtPoint.size()) {
@@ -502,7 +502,7 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
         for (size_t i = 0 ; i < layersAtPoint.size() ; i++) {
             auto [layer, point] = layersAtPoint[i];
 
-            if (!layerEventRegionContainsPoint(layer, point))
+            if (!layerEventRegionContainsPoint(layer.get(), point))
                 continue;
 
             if (!frontmostInteractiveLayer)
@@ -510,7 +510,7 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
 
             auto scrollingNodeForLayer = [&] (auto layer, auto point) -> RefPtr<ScrollingTreeNode> {
                 UNUSED_PARAM(point);
-                auto nodeID = scrollingNodeIDForLayer(layer);
+                auto nodeID = scrollingNodeIDForLayer(layer.get());
                 RefPtr scrollingNode = nodeForID(nodeID);
                 if (!is<ScrollingTreeScrollingNode>(scrollingNode))
                     return nullptr;
@@ -562,7 +562,7 @@ OptionSet<EventListenerRegionType> RemoteScrollingTreeMac::eventListenerRegionTy
     if (!hitLayer)
         return { };
 
-    auto* eventRegion = eventRegionForLayer(hitLayer);
+    auto* eventRegion = eventRegionForLayer(hitLayer.get());
     if (!eventRegion)
         return { };
 


### PR DESCRIPTION
#### 7bccd6eb4c1e5548762f7b53d4f99dd31d9a0c94
<pre>
Crash under WebCore::collectDescendantLayersAtPoint()
<a href="https://bugs.webkit.org/show_bug.cgi?id=286169">https://bugs.webkit.org/show_bug.cgi?id=286169</a>
<a href="https://rdar.apple.com/112855701">rdar://112855701</a>

Reviewed by Tim Horton.

The UI process calls `collectDescendantLayersAtPoint()` on the scrolling thread
to hit-test layers, but this can be traversing the -sublayers array while other
threads mutate it.

So copy -sublayers. Also deploy RetainPtr in a few places in this code.

* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(ScrollingTreeMac::scrollingNodeForPoint):
(ScrollingTreeMac::eventListenerRegionTypesForPoint const):
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm:
(WebCore::collectDescendantLayersAtPoint):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingNodeForPoint):
(WebKit::RemoteScrollingTreeMac::eventListenerRegionTypesForPoint const):

Canonical link: <a href="https://commits.webkit.org/289093@main">https://commits.webkit.org/289093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b9e84324c8639e311e81777b885251ef03da422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66321 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24136 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35425 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91901 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9251 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74880 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73996 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18320 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18396 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16827 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4683 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18067 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12435 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->