### PR TITLE
Use arrays instead of sets in generate-process-sync-data.py

### DIFF
--- a/Source/WebCore/Scripts/generate-process-sync-data.py
+++ b/Source/WebCore/Scripts/generate-process-sync-data.py
@@ -82,13 +82,13 @@ class SyncedData(object):
             self.fully_qualified_type = underlying_type_namespace + '::' + underlying_type
 
 
-def sorted_headers_from_datas(datas):
-    header_set = set()
+def headers_from_datas(datas):
+    header_list = []
     for data in datas:
         if data.header is None:
             continue
-        header_set.add(data.header)
-    return sorted(list(header_set))
+        header_list.append(data.header)
+    return header_list
 
 
 def parse_process_sync_data(file):
@@ -154,11 +154,11 @@ def generate_process_sync_client_header(synched_datas):
     result.append(_header_license)
     result.append('#pragma once\n')
 
-    headers = sorted_headers_from_datas(synched_datas)
+    headers = headers_from_datas(synched_datas)
 
     headers_set = set(headers)
     headers_set.add('<wtf/TZoneMallocInlines.h>')
-    headers = sorted(list(headers_set))
+    headers = list(headers_set)
     for header in headers:
         result.append('#include %s' % header)
 
@@ -222,9 +222,9 @@ def generate_process_sync_data_header(synched_datas, document_synched_datas):
     result.append(_header_license)
     result.append('#pragma once\n')
 
-    headers = sorted_headers_from_datas(synched_datas)
+    headers = headers_from_datas(synched_datas)
     headers.append('<variant>')
-    for header in sorted(headers):
+    for header in headers:
         result.append('#include %s' % header)
 
     result.append('\nnamespace WebCore {\n')
@@ -306,7 +306,7 @@ def generate_document_synched_data_header(synched_datas):
             continue
         headers.append(data.header)
 
-    for header in sorted(headers):
+    for header in headers:
         result.append('#include %s' % header)
 
     result.append(_document_synced_data_header_midfix)
@@ -513,17 +513,14 @@ def generate_process_sync_data_serialiation_in(synched_datas, document_synched_d
 
 
 def sort_data_lists(synched_datas):
-    type_set = set()
-    conditional_type_set = set()
+    type_list = []
+    conditional_type_list = []
 
     for data in synched_datas:
         if data.conditional is None:
-            type_set.add(data)
+            type_list.append(data)
         else:
-            conditional_type_set.add(data)
-
-    type_list = sorted(list(type_set), key=lambda data: data.fully_qualified_type)
-    conditional_type_list = sorted(list(conditional_type_set), key=lambda data: data.fully_qualified_type)
+            conditional_type_list.append(data)
 
     return type_list, conditional_type_list
 

--- a/Source/WebCore/Scripts/tests/DocumentSyncData.h
+++ b/Source/WebCore/Scripts/tests/DocumentSyncData.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
-#include "DOMAudioSession.h"
-#include <wtf/RefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include "DOMAudioSession.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Scripts/tests/ProcessSyncClient.h
+++ b/Source/WebCore/Scripts/tests/ProcessSyncClient.h
@@ -24,9 +24,9 @@
 
 #pragma once
 
+#include <wtf/URL.h>
 #include "DOMAudioSession.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/URL.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Scripts/tests/ProcessSyncData.h
+++ b/Source/WebCore/Scripts/tests/ProcessSyncData.h
@@ -25,8 +25,8 @@
 #pragma once
 
 #include "DOMAudioSession.h"
-#include <variant>
 #include <wtf/URL.h>
+#include <variant>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 982e09ae1be8227a09329367c4c5924dbc6c755c
<pre>
Use arrays instead of sets in generate-process-sync-data.py
<a href="https://rdar.apple.com/143026894">rdar://143026894</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286172">https://bugs.webkit.org/show_bug.cgi?id=286172</a>

Reviewed by Brady Eidson.

We are seeing some nondeterministic output reordering the members of the DocumentSyncData
class in the generated header.  I found that we use python sets, which could be the cause.
I replaced them with uses of arrays.

Also don&apos;t use sorted() because that could be a cause of nondeterministic output.

* Source/WebCore/Scripts/generate-process-sync-data.py:
(sorted_headers_from_datas):
(sort_data_lists):
* Source/WebCore/Scripts/tests/DocumentSyncData.h:

Canonical link: <a href="https://commits.webkit.org/289090@main">https://commits.webkit.org/289090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b77fb8766a4a85a9d228eeb034cf5b82ae00f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85318 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13029 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24143 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77498 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35428 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12665 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74000 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16833 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4686 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13300 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12608 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->