### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE use in CSSParserToken.cpp

### DIFF
--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -399,21 +399,19 @@ CSSParserToken::CSSParserToken(HashTokenType type, StringView value)
     initValueFromStringView(value);
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static StringView mergeIfAdjacent(StringView a, StringView b)
 {
     if (a.is8Bit() && b.is8Bit()) {
         auto characters = a.span8();
         if (std::to_address(characters.end()) == std::to_address(b.span8().begin()))
-            return std::span { characters.data(), a.length() + b.length() };
+            return unsafeMakeSpan(characters.data(), a.length() + b.length());
     } else if (!a.is8Bit() && !b.is8Bit()) {
         auto characters = a.span16();
         if (std::to_address(characters.end()) == std::to_address(b.span16().begin()))
-            return std::span { characters.data(), a.length() + b.length() };
+            return unsafeMakeSpan(characters.data(), a.length() + b.length());
     }
     return { };
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void CSSParserToken::convertToDimensionWithUnit(StringView unit)
 {


### PR DESCRIPTION
#### a81cfa28e6412c68013776ac009bb8857304cff3
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE use in CSSParserToken.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286174">https://bugs.webkit.org/show_bug.cgi?id=286174</a>

Reviewed by Darin Adler.

* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::mergeIfAdjacent):

Canonical link: <a href="https://commits.webkit.org/289111@main">https://commits.webkit.org/289111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab16ac091c18ee5ac381eab3a0a88f7877434b83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66325 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46607 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31756 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32594 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91975 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Running checkout-pull-request; Compiled WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74942 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74061 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18401 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16830 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4688 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13309 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18073 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->