### PR TITLE
Prepare for -Wunsafe-buffer-usage-in-libc-call

### DIFF
--- a/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
+++ b/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
@@ -25,6 +25,9 @@
 
 #include "config.h"
 #include "PASReportCrashPrivate.h"
+#include <wtf/Compiler.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Apple ports
 
 #if !USE(SYSTEM_MALLOC)
 #include <bmalloc/BPlatform.h>
@@ -32,6 +35,8 @@
 #include <bmalloc/pas_report_crash.h>
 #endif
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 using namespace JSC;
 

--- a/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
+++ b/Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp
@@ -42,6 +42,8 @@
 #include <dispatch/dispatch.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 using JSC::Options;
 
 static JSGlobalContextRef context = nullptr;
@@ -564,3 +566,5 @@ int testExecutionTimeLimit()
     
     return failed;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
+++ b/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
@@ -83,7 +83,9 @@ int testFunctionOverrides()
     JSC::Options::functionOverrides() = oldFunctionOverrides;
     JSC::FunctionOverrides::reinstallOverrides();
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("%s: function override tests.\n", failed ? "FAIL" : "PASS");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return failed;
 }

--- a/Source/JavaScriptCore/API/tests/FunctionToStringTests.cpp
+++ b/Source/JavaScriptCore/API/tests/FunctionToStringTests.cpp
@@ -106,7 +106,9 @@ int testFunctionToString()
         failed = true;
 
     JSGlobalContextRelease(context);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("%s: function toString tests.\n", failed ? "FAIL" : "PASS");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return failed;
 }

--- a/Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp
+++ b/Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp
@@ -43,7 +43,9 @@ int testJSObjectGetProxyTarget()
     printf("JSObjectGetProxyTargetTest:\n");
     
     auto test = [&] (const char* description, bool currentResult) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         printf("    %s: %s\n", description, currentResult ? "PASS" : "FAIL");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         overallResult &= currentResult;
     };
     
@@ -98,7 +100,9 @@ int testJSObjectGetProxyTarget()
     JSGlobalContextRelease(context);
     JSContextGroupRelease(group);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("JSObjectGetProxyTargetTest: %s\n", overallResult ? "PASS" : "FAIL");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return !overallResult;
 }
 

--- a/Source/JavaScriptCore/API/tests/MultithreadedMultiVMExecutionTest.cpp
+++ b/Source/JavaScriptCore/API/tests/MultithreadedMultiVMExecutionTest.cpp
@@ -53,7 +53,9 @@ void startMultithreadedMultiVMExecutionTest()
 
 #define CHECK(condition, threadNumber, count, message) do { \
         if (!condition) { \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
             printf("FAIL: MultithreadedMultiVMExecutionTest: %d %d %s\n", threadNumber, count, message); \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
             failuresFound++; \
         } \
     } while (false)
@@ -86,11 +88,15 @@ void startMultithreadedMultiVMExecutionTest()
                     buffer.resize(JSStringGetMaximumUTF8CStringSize(string));
                     JSStringGetUTF8CString(string, buffer.data(), buffer.size());
 IGNORE_GCC_WARNINGS_BEGIN("format-overflow")
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     printf("FAIL: MultithreadedMultiVMExecutionTest: %d %d %s\n", threadNumber, i, buffer.data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 IGNORE_GCC_WARNINGS_END
                     JSStringRelease(string);
                 } else
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     printf("FAIL: MultithreadedMultiVMExecutionTest: %d %d stringifying exception failed\n", threadNumber, i);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             }
             CHECK(jsScript, threadNumber, i, "script eval");
             JSStringRelease(jsScriptString);
@@ -112,6 +118,8 @@ int finalizeMultithreadedMultiVMExecutionTest()
     for (auto& thread : threads)
         thread.join();
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("%s: MultithreadedMultiVMExecutionTest\n", failuresFound ? "FAIL" : "PASS");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return (failuresFound > 0);
 }

--- a/Source/JavaScriptCore/API/tests/testapi.mm
+++ b/Source/JavaScriptCore/API/tests/testapi.mm
@@ -493,7 +493,9 @@ static bool blockSignatureContainsClass()
 {
     static bool containsClass = ^{
         id block = ^(NSString *string){ return string; };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return _Block_has_signature(block) && strstr(_Block_signature(block), "NSString");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }();
     return containsClass;
 }
@@ -2088,7 +2090,9 @@ static NSURL* cacheFileInDataVault(NSString* name)
         char userDir[PATH_MAX];
         RELEASE_ASSERT(confstr(_CS_DARWIN_USER_DIR, userDir, sizeof(userDir)));
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         NSString *userDirPath = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:userDir length:strlen(userDir)];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         dataVaultURL = [NSURL fileURLWithPath:userDirPath isDirectory:YES];
         dataVaultURL = [dataVaultURL URLByAppendingPathComponent:@"JavaScriptCore" isDirectory:YES];
         rootless_mkdir_datavault(dataVaultURL.path.UTF8String, 0700, "JavaScriptCore");

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py
@@ -132,7 +132,7 @@ public:
     explicit ${objectName}BuiltinsWrapper(JSC::VM& vm)
         : m_vm(vm)
         ${macroPrefix}_FOREACH_${objectMacro}_BUILTIN_FUNCTION_NAME(INITIALIZE_BUILTIN_NAMES)
-#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying({ s_##name, static_cast<size_t>(length) }), { }, JSC::SourceTaintedOrigin::Untainted))
+#define INITIALIZE_BUILTIN_SOURCE_MEMBERS(name, functionName, overriddenName, length) , m_##name##Source(JSC::makeSource(StringImpl::createWithoutCopying(unsafeMakeSpan(s_##name, static_cast<size_t>(length))), { }, JSC::SourceTaintedOrigin::Untainted))
         ${macroPrefix}_FOREACH_${objectMacro}_BUILTIN_CODE(INITIALIZE_BUILTIN_SOURCE_MEMBERS)
 #undef INITIALIZE_BUILTIN_SOURCE_MEMBERS
     {

--- a/Source/JavaScriptCore/assembler/AssemblerCommon.h
+++ b/Source/JavaScriptCore/assembler/AssemblerCommon.h
@@ -356,6 +356,8 @@ enum class MachineCodeCopyMode : uint8_t {
     JITMemcpy,
 };
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 static ALWAYS_INLINE void* memcpyAtomicIfPossible(void* dst, const void* src, size_t n)
 {
 #if !CPU(NEEDS_ALIGNED_ACCESS)
@@ -403,5 +405,7 @@ ALWAYS_INLINE void* machineCodeCopy(void* dst, const void* src, size_t n)
     else
         return performJITMemcpy(dst, src, n);
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace JSC.

--- a/Source/JavaScriptCore/assembler/Printer.h
+++ b/Source/JavaScriptCore/assembler/Printer.h
@@ -45,7 +45,9 @@ union Data {
     Data()
     {
         const intptr_t uninitialized = 0xdeadb0d0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memcpy(&buffer, &uninitialized, sizeof(uninitialized));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     Data(uintptr_t value)
         : Data(&value, sizeof(value))
@@ -56,7 +58,9 @@ union Data {
     Data(void* src, size_t size)
     {
         RELEASE_ASSERT(size <= sizeof(buffer));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memcpy(&buffer, src, size);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     template<typename T, typename = typename std::enable_if<std::is_integral<T>::value>::type>

--- a/Source/JavaScriptCore/b3/B3ValueRep.h
+++ b/Source/JavaScriptCore/b3/B3ValueRep.h
@@ -364,7 +364,9 @@ private:
 
         U()
         {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             memset(static_cast<void*>(this), 0, sizeof(*this));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     } u;
     Kind m_kind;

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -301,6 +301,8 @@ void checkDisassembly(Compilation& compilation, const Func& func, const CString&
     CRASH();
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 inline void checkUsesInstruction(Compilation& compilation, const char* text, bool regex = false)
 {
     checkDisassembly(
@@ -322,6 +324,8 @@ inline void checkDoesNotUseInstruction(Compilation& compilation, const char* tex
         },
         toCString("Did not expected to find ", text, " but it's there!"));
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 template<typename Type>
 struct B3Operand {

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.h
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.h
@@ -51,13 +51,17 @@ public:
     PropertyCondition()
         : m_header(nullptr, Presence)
     {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memset(&u, 0, sizeof(u));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     
     PropertyCondition(WTF::HashTableDeletedValueType)
         : m_header(nullptr, Absence)
     {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memset(&u, 0, sizeof(u));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     static PropertyCondition presenceWithoutBarrier(UniquedStringImpl* uid, PropertyOffset offset, unsigned attributes)

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -906,6 +906,7 @@ SpeculatedType typeOfDoubleUnaryOp(SpeculatedType value)
 
 SpeculatedType speculationFromString(const char* speculation)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (!strncmp(speculation, "SpecNone", strlen("SpecNone")))
         return SpecNone;
     if (!strncmp(speculation, "SpecFinalObject", strlen("SpecFinalObject")))
@@ -1043,6 +1044,7 @@ SpeculatedType speculationFromString(const char* speculation)
     if (!strncmp(speculation, "SpecCellCheck", strlen("SpecCellCheck")))
         return SpecCellCheck;
     RELEASE_ASSERT_NOT_REACHED();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -527,7 +527,9 @@ void AbstractValue::ensureCanInitializeWithZeros()
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     std::aligned_storage<sizeof(AbstractValue), alignof(AbstractValue)>::type zeroFilledStorage;
     ALLOW_DEPRECATED_DECLARATIONS_END
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memset(static_cast<void*>(&zeroFilledStorage), 0, sizeof(AbstractValue));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     ASSERT(*this == *static_cast<AbstractValue*>(static_cast<void*>(&zeroFilledStorage)));
 }
 #endif

--- a/Source/JavaScriptCore/dfg/DFGVariableEvent.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableEvent.cpp
@@ -34,6 +34,8 @@
 
 namespace JSC { namespace DFG {
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 void VariableEvent::dump(PrintStream& out) const
 {
     switch (kind()) {
@@ -90,6 +92,8 @@ void VariableEvent::dumpSpillInfo(const char* name, PrintStream& out) const
 {
     out.print(name, "(", id(), ", ", spillRegister(), ", ", dataFormatToString(dataFormat()), ")");
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -476,14 +476,18 @@ void BlockDirectory::dumpBits(PrintStream& out)
     forEachBitVectorWithName(
         [&](auto vectorRef, const char* name) {
             UNUSED_PARAM(vectorRef);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             unsigned length = strlen(name);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             maxNameLength = std::max(maxNameLength, length);
         });
     
     forEachBitVectorWithName(
         [&](auto vectorRef, const char* name) {
             out.print("    ", name, ": ");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             for (unsigned i = maxNameLength - strlen(name); i--;)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 out.print(" ");
             out.print(vectorRef, "\n");
         });

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1526,12 +1526,14 @@ NEVER_INLINE bool Heap::runFixpointPhase(GCConductor conn)
                 visitMap.add(visitor.codeName(), visitor.bytesVisited() / 1024);
             });
         
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         auto perVisitorDump = sortedMapDump(
             visitMap,
             [] (const char* a, const char* b) -> bool {
                 return strcmp(a, b) < 0;
             },
             ":"_s, " "_s);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         
         dataLog("v=", bytesVisited() / 1024, "kb (", perVisitorDump, ") o=", m_opaqueRoots.size(), " b=", m_barriersExecuted, " ");
     }

--- a/Source/JavaScriptCore/heap/PreciseAllocation.cpp
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.cpp
@@ -144,7 +144,9 @@ PreciseAllocation* PreciseAllocation::tryReallocate(size_t size, Subspace* subsp
     PreciseAllocation* newAllocation = std::bit_cast<PreciseAllocation*>(newBasePointer);
     if (oldAdjustment != newAdjustment) {
         void* basePointerAfterRealloc = std::bit_cast<void*>(std::bit_cast<uintptr_t>(newSpace) + oldAdjustment);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memmove(newBasePointer, basePointerAfterRealloc, oldCellSize + PreciseAllocation::headerSize());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     newAllocation->m_cellSize = size;

--- a/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
+++ b/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
@@ -52,8 +52,10 @@ static String escapeStringForRegularExpressionSource(const String& text)
 
     for (unsigned i = 0; i < text.length(); i++) {
         UChar character = text[i];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (isASCII(character) && strchr(regexSpecialCharacters, character))
             result.append('\\');
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         result.append(character);
     }
 

--- a/Source/JavaScriptCore/jit/CallFrameShuffler.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler.cpp
@@ -87,6 +87,7 @@ CallFrameShuffler::CallFrameShuffler(CCallHelpers& jit, const CallFrameShuffleDa
 #endif
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void CallFrameShuffler::dump(PrintStream& out) const
 {
     static const char* delimiter             = " +-------------------------------+ ";
@@ -222,6 +223,7 @@ void CallFrameShuffler::dump(PrintStream& out) const
         out.print("   NumberTag is currently in ", m_numberTagRegister, "\n");
 #endif
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 CachedRecovery* CallFrameShuffler::getCachedRecovery(ValueRecovery recovery)
 {

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -357,8 +357,10 @@ static ALWAYS_INLINE void initializeSeparatedWXHeaps(void* stubBase, size_t stub
     result = vm_protect(mach_task_self(), static_cast<vm_address_t>(writableAddr), jitSize, true, VM_PROT_READ | VM_PROT_WRITE);
     RELEASE_ASSERT(!result);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Zero out writableAddr to avoid leaking the address of the writable mapping.
     memset_s(&writableAddr, sizeof(writableAddr), 0, sizeof(writableAddr));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if ENABLE(SEPARATED_WX_HEAP)
     g_jscConfig.jitWriteSeparateHeaps = reinterpret_cast<JITWriteSeparateHeapsFunction>(writeThunk.code().taggedPtr());

--- a/Source/JavaScriptCore/jit/ICStats.cpp
+++ b/Source/JavaScriptCore/jit/ICStats.cpp
@@ -39,7 +39,9 @@ bool ICEvent::operator<(const ICEvent& other) const
             return true;
         if (!other.m_classInfo)
             return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return strcmp(m_classInfo->className, other.m_classInfo->className) < 0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     
     if (m_propertyName != other.m_propertyName)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -163,6 +163,8 @@
 #include <wtf/linux/ProcessMemoryFootprint.h>
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if OS(DARWIN) || OS(LINUX)
 struct MemoryFootprint : ProcessMemoryFootprint {
     MemoryFootprint(const ProcessMemoryFootprint& src)
@@ -4526,3 +4528,5 @@ int jscmain(int argc, char** argv)
 
     return result;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/ExceptionFuzz.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionFuzz.cpp
@@ -48,7 +48,9 @@ void doExceptionFuzzing(JSGlobalObject* globalObject, ThrowScope& scope, const c
     
     unsigned fireTarget = Options::fireExceptionFuzzAt();
     if (fireTarget == s_numberOfExceptionFuzzChecks) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         printf("JSC EXCEPTION FUZZ: Throwing fuzz exception with call frame %p, seen in %s and return address %p.\n", globalObject, where, returnPC);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         fflush(stdout);
 
         // The ThrowScope also checks for unchecked simulated exceptions before throwing a

--- a/Source/JavaScriptCore/runtime/FuzzerPredictions.cpp
+++ b/Source/JavaScriptCore/runtime/FuzzerPredictions.cpp
@@ -41,7 +41,9 @@ static String readFileIntoString(const char* fileName)
 
     std::span<LChar> buffer;
     String string = String::createUninitialized(bufferCapacity, buffer);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     size_t readSize = fread(buffer.data(), 1, buffer.size(), file);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     fclose(file);
     RELEASE_ASSERT(readSize == static_cast<size_t>(bufferCapacity));
     return string;

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h
@@ -95,7 +95,9 @@ RefPtr<GenericTypedArrayView<Adaptor>> GenericTypedArrayView<Adaptor>::tryCreate
     RefPtr<GenericTypedArrayView> result = tryCreate(length);
     if (!result)
         return nullptr;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(result->data(), array, length * sizeof(typename Adaptor::Type));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return result;
 }
 

--- a/Source/JavaScriptCore/runtime/IndexingType.cpp
+++ b/Source/JavaScriptCore/runtime/IndexingType.cpp
@@ -129,7 +129,9 @@ void dumpIndexingType(PrintStream& out, IndexingType indexingType)
         break;
     }
     
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     out.printf("%s%s", basicName, (indexingType & MayHaveIndexedAccessors) ? "|MayHaveIndexedAccessors" : "");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -49,12 +49,16 @@
 #include <wtf/Threading.h>
 #include <wtf/threads/Signals.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if !USE(SYSTEM_MALLOC)
 #include <bmalloc/BPlatform.h>
 #if BUSE(LIBPAS)
 #include <bmalloc/pas_scavenger.h>
 #endif
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if ENABLE(LLVM_PROFILE_GENERATION)
 extern "C" char __llvm_profile_filename[] = "/private/tmp/WebKitPGO/JavaScriptCore_%m_pid%p%c.profraw";

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -67,6 +67,8 @@
 extern "C" char **environ;
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace JSC {
 
 bool useOSLogOptionHasChanged = false;
@@ -1509,3 +1511,5 @@ bool hasCapacityToUseLargeGigacage()
 }
 
 } // namespace JSC
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -175,8 +175,10 @@ static bool enableAssembler()
         return false;
 
     char* canUseJITString = getenv("JavaScriptCoreUseJIT");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (canUseJITString && !atoi(canUseJITString))
         return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     ExecutableAllocator::initializeUnderlyingAllocator();
     if (!ExecutableAllocator::singleton().isValid()) {

--- a/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
+++ b/Source/JavaScriptCore/tools/CompilerTimingScope.cpp
@@ -48,7 +48,9 @@ public:
         Locker locker { lock };
 
         for (auto& tuple : totals) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             if (!strcmp(std::get<0>(tuple), compilerName) && !strcmp(std::get<1>(tuple), name)) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 std::get<2>(tuple) += duration;
                 std::get<3>(tuple) = std::max(std::get<3>(tuple), duration);
                 return std::get<2>(tuple);

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -207,7 +207,9 @@ static bool hasDisallowedCharacters(const char* str, size_t length)
 static String parseClause(const char* keyword, size_t keywordLength, FILE* file, const char* line, char* buffer, size_t bufferSize)
 {
     FunctionOverridesAssertScope assertScope;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const char* keywordPos = strstr(line, keyword);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (!keywordPos)
         FAIL_WITH_ERROR(SYNTAX_ERROR, ("Expecting '", keyword, "' clause:\n", line, "\n"));
     if (keywordPos != line)
@@ -232,17 +234,21 @@ static String parseClause(const char* keyword, size_t keywordLength, FILE* file,
 
     StringBuilder builder;
     do {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const char* p = strstr(line, terminator);
         if (p) {
             if (p[strlen(terminator)] != '\n')
                 FAIL_WITH_ERROR(SYNTAX_ERROR, ("Unexpected characters after '", keyword, "' clause end delimiter '", delimiter, "':\n", line, "\n"));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
             builder.append(std::span { line, p + 1 });
             return builder.toString();
         }
         builder.append(span(line));
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     } while ((line = fgets(buffer, bufferSize, file)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     FAIL_WITH_ERROR(SYNTAX_ERROR, ("'", keyword, "' clause end delimiter '", delimiter, "' not found:\n", builder.toString(), "\n", "Are you missing a '}' before the delimiter?\n"));
 }
@@ -260,9 +266,11 @@ void FunctionOverrides::parseOverridesInFile(const char* fileName)
 
     char* line;
     char buffer[BUFSIZ];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     while ((line = fgets(buffer, sizeof(buffer), file))) {
         if (strstr(line, "//") == line)
             continue;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         if (line[0] == '\n' || line[0] == '\0')
             continue;
@@ -272,7 +280,9 @@ void FunctionOverrides::parseOverridesInFile(const char* fileName)
         keywordLength = sizeof("override") - 1;
         String keyStr = parseClause("override", keywordLength, file, line, buffer, sizeof(buffer));
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         line = fgets(buffer, sizeof(buffer), file);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         keywordLength = sizeof("with") - 1;
         String valueStr = parseClause("with", keywordLength, file, line, buffer, sizeof(buffer));

--- a/Source/JavaScriptCore/tools/Integrity.cpp
+++ b/Source/JavaScriptCore/tools/Integrity.cpp
@@ -64,6 +64,8 @@ PrintStream& logFile()
 #endif
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 void logF(const char* format, ...)
 {
     va_list argList;
@@ -80,6 +82,8 @@ void logLnF(const char* format, ...)
     va_end(argList);
     logFile().println();
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 Random::Random(VM& vm)
 {

--- a/Source/JavaScriptCore/wasm/WasmValueLocation.h
+++ b/Source/JavaScriptCore/wasm/WasmValueLocation.h
@@ -123,7 +123,9 @@ private:
 
         U()
         {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             memset(static_cast<void*>(this), 0, sizeof(*this));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     } u;
     Kind m_kind;

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -414,7 +414,9 @@ static int findMonth(std::span<const LChar> monthStr)
         needle[i] = static_cast<char>(toASCIILower(monthStr[i]));
     needle[3] = '\0';
     const char* haystack = "janfebmaraprmayjunjulaugsepoctnovdec";
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const char* str = strstr(haystack, needle.data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (str) {
         int position = static_cast<int>(str - haystack);
         if (position % 3 == 0)
@@ -426,7 +428,9 @@ static int findMonth(std::span<const LChar> monthStr)
 static bool parseInt(std::span<const LChar>& string, int base, int* result)
 {
     char* stopPosition;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     long longResult = strtol(byteCast<char>(string.data()), &stopPosition, base);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // Avoid the use of errno as it is not available on Windows CE
     if (byteCast<char>(string.data()) == stopPosition || longResult <= std::numeric_limits<int>::min() || longResult >= std::numeric_limits<int>::max())
         return false;
@@ -438,7 +442,9 @@ static bool parseInt(std::span<const LChar>& string, int base, int* result)
 static bool parseLong(std::span<const LChar>& string, int base, long* result)
 {
     char* stopPosition;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     *result = strtol(byteCast<char>(string.data()), &stopPosition, base);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // Avoid the use of errno as it is not available on Windows CE
     if (byteCast<char>(string.data()) == stopPosition || *result == std::numeric_limits<long>::min() || *result == std::numeric_limits<long>::max())
         return false;

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -117,6 +117,8 @@ void fastSetMaxSingleAllocationSize(size_t size)
 
 #endif // !defined(NDEBUG)
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 char* fastStrDup(const char* src)
 {
     size_t len = strlen(src) + 1;
@@ -152,6 +154,8 @@ void* fastCompactMemDup(const void* mem, size_t bytes)
     memcpy(result, mem, bytes);
     return result;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -685,10 +685,10 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 // Note: WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR must be declared in every subclass.
 #define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(T) \
 void operator delete(T* object, std::destroying_delete_t, size_t size) { \
-    ASSERT(sizeof(T) == size); \
+    ASSERT_UNUSED(size, sizeof(T) == size); \
     object->T::~T(); \
     if (UNLIKELY(object->checkedPtrCountWithoutThreadCheck())) { \
-        memset(static_cast<void*>(object), 0, size); \
+        zeroBytes(object); \
         return; \
     } \
     T::operator delete(object); \

--- a/Source/WTF/wtf/FilePrintStream.cpp
+++ b/Source/WTF/wtf/FilePrintStream.cpp
@@ -52,7 +52,9 @@ std::unique_ptr<FilePrintStream> FilePrintStream::open(const char* filename, con
 
 void FilePrintStream::vprintf(const char* format, va_list argList)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     vfprintf(m_file, format, argList);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void FilePrintStream::flush()

--- a/Source/WTF/wtf/Int128.cpp
+++ b/Source/WTF/wtf/Int128.cpp
@@ -304,7 +304,9 @@ void printInternal(PrintStream& out, UInt128 value)
 {
     auto vector = numberToStringUnsigned<Vector<LChar, 50>>(value);
     vector.append('\0');
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     out.printf("%s", std::bit_cast<const char*>(vector.data()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void printInternal(PrintStream& out, Int128 value)
@@ -320,7 +322,9 @@ void printInternal(PrintStream& out, Int128 value)
         positive = -value;
     auto vector = numberToStringUnsigned<Vector<LChar, 50>>(positive);
     vector.append('\0');
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     out.printf("-%s", std::bit_cast<const char*>(vector.data()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 }  // namespace WTF

--- a/Source/WTF/wtf/LockedPrintStream.cpp
+++ b/Source/WTF/wtf/LockedPrintStream.cpp
@@ -38,7 +38,9 @@ LockedPrintStream::~LockedPrintStream() = default;
 void LockedPrintStream::vprintf(const char* format, va_list args)
 {
     Locker locker { m_lock };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     m_target->vprintf(format, args);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void LockedPrintStream::flush()

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -47,6 +47,7 @@ int numberOfProcessorCores()
     if (s_numberOfCores > 0)
         return s_numberOfCores;
     
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (const char* coresEnv = getenv("WTF_numberOfProcessorCores")) {
         unsigned numberOfCores;
         if (sscanf(coresEnv, "%u", &numberOfCores) == 1) {
@@ -55,6 +56,7 @@ int numberOfProcessorCores()
         } else
             fprintf(stderr, "WARNING: failed to parse WTF_numberOfProcessorCores=%s\n", coresEnv);
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if OS(DARWIN)
     unsigned result;

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -30,6 +30,8 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WTF {
 
 PrintStream::PrintStream() = default;
@@ -231,3 +233,4 @@ void dumpCharacter(PrintStream& out, char value)
 
 } // namespace WTF
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -106,7 +106,9 @@ WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const char*);
 template<std::size_t Extent>
 inline void printInternal(PrintStream& out, std::span<const char, Extent> string)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     out.printf("%.*s", static_cast<int>(string.size()), string.data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, StringView);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const CString&);

--- a/Source/WTF/wtf/SafeStrerror.cpp
+++ b/Source/WTF/wtf/SafeStrerror.cpp
@@ -38,10 +38,14 @@ CString safeStrerror(int errnum)
     constexpr size_t bufferLength = 1024;
     std::span<char> cstringBuffer;
     auto result = CString::newUninitialized(bufferLength, cstringBuffer);
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if OS(WINDOWS)
     strerror_s(cstringBuffer.data(), cstringBuffer.size(), errnum);
 #else
     auto ret = strerror_r(errnum, cstringBuffer.data(), cstringBuffer.size());
+
     if constexpr (std::is_same<decltype(ret), char*>::value) {
         // We have GNU strerror_r(), which returns char*. This may or may not be a pointer into
         // cstringBuffer. We also have to be careful because this has to compile even if ret is
@@ -55,6 +59,9 @@ CString safeStrerror(int errnum)
             snprintf(cstringBuffer.data(), cstringBuffer.size(), "%s %d", "Unknown error", errnum);
     }
 #endif // OS(WINDOWS)
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     return result;
 }
 

--- a/Source/WTF/wtf/ScopedPrintStream.h
+++ b/Source/WTF/wtf/ScopedPrintStream.h
@@ -43,10 +43,12 @@ public:
         m_out.flush();
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void vprintf(const char* format, va_list argList) final WTF_ATTRIBUTE_PRINTF(2, 0)
     {
         m_buffer.vprintf(format, argList);
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     void reset() { m_buffer.reset(); }
 

--- a/Source/WTF/wtf/StackTrace.cpp
+++ b/Source/WTF/wtf/StackTrace.cpp
@@ -154,9 +154,11 @@ auto StackTraceSymbolResolver::demangle(void* pc) -> std::optional<DemangleEntry
 
 void StackTracePrinter::dump(PrintStream& out) const
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     StackTraceSymbolResolver { m_stack }.forEach([&](int frameNumber, void* stackFrame, const char* name) {
         out.printf("%s%-3d %p %s\n", m_prefix ? m_prefix : "", frameNumber, stackFrame, name);
     });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/StringPrintStream.cpp
+++ b/Source/WTF/wtf/StringPrintStream.cpp
@@ -45,6 +45,8 @@ StringPrintStream::~StringPrintStream()
         fastFree(m_buffer.data());
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 void StringPrintStream::vprintf(const char* format, va_list argList)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(m_length < m_buffer.size());
@@ -112,6 +114,8 @@ String StringPrintStream::toStringWithLatin1Fallback() const
     ASSERT(m_length == strlen(m_buffer.data()));
     return String::fromUTF8WithLatin1Fallback(m_buffer.first(m_length));
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void StringPrintStream::increaseSize(size_t newSize)
 {

--- a/Source/WTF/wtf/SystemMalloc.h
+++ b/Source/WTF/wtf/SystemMalloc.h
@@ -51,7 +51,9 @@ struct SystemMalloc {
         auto* result = ::malloc(size);
         if (!result)
             CRASH();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memset(result, 0, size);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return result;
     }
 
@@ -60,7 +62,9 @@ struct SystemMalloc {
         auto* result = ::malloc(size);
         if (!result)
             return nullptr;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         memset(result, 0, size);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return result;
     }
 

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -900,7 +900,9 @@ bool protocolIs(StringView string, ASCIILiteral protocol)
 
 void URL::print() const
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("%s\n", m_string.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #endif

--- a/Source/WTF/wtf/cocoa/CrashReporter.cpp
+++ b/Source/WTF/wtf/cocoa/CrashReporter.cpp
@@ -41,8 +41,10 @@ struct crashreporter_annotations_t gCRAnnotations
 namespace WTF {
 void setCrashLogMessage(const char* message)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // We have to copy the string because CRSetCrashLogMessage doesn't.
     char* copiedMessage = message ? strdup(message) : nullptr;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     CRSetCrashLogMessage(copiedMessage);
 

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -138,8 +138,10 @@ std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, Strin
     if (!confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryFilePath.data(), temporaryFilePath.size()))
         return { String(), invalidPlatformFileHandle };
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Shrink the vector.
     temporaryFilePath.shrink(strlen(temporaryFilePath.data()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     ASSERT(temporaryFilePath.last() == '/');
 

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -51,6 +51,7 @@ static BOOL readIDNAllowedScriptListFile(NSString *filename)
     if (!file)
         return NO;
     
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Read a word at a time.
     // Allow comments, starting with # character to the end of the line.
     while (1) {
@@ -69,6 +70,8 @@ static BOOL readIDNAllowedScriptListFile(NSString *filename)
             URLHelpers::addScriptToIDNAllowedScriptList(word);
         }
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     fclose(file);
     return YES;
 }

--- a/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
@@ -112,8 +112,10 @@ bool WTFSignpostHandleIndirectLog(os_log_t log, pid_t pid, std::span<const char>
     uint64_t timestamp = 0;
     int bytesConsumed = 0;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (sscanf(nullTerminatedLogString.data(), "type=%d name=%d p=%" SCNuPTR " ts=%llu %n", &signpostType, &signpostName, &signpostIdentifierPointer, &timestamp, &bytesConsumed) != 4)
         return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (signpostType < 0 || signpostType >= WTFOSSignpostTypeCount)
         return false;

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -134,10 +134,12 @@ void LibraryPathDiagnosticsLogger::logObject(const Vector<String>& path, Ref<JSO
 void LibraryPathDiagnosticsLogger::logError(const char* format, ...)
 {
     StringPrintStream stream;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     va_list argList;
     va_start(argList, format);
     stream.vprintf(format, argList);
     va_end(argList);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     os_log_error(m_osLog, "%{public}s", stream.toCString().data());
 }

--- a/Source/WTF/wtf/dtoa/utils.h
+++ b/Source/WTF/wtf/dtoa/utils.h
@@ -193,7 +193,9 @@ static T Min(T a, T b) {
 
 
 inline int StrLength(const char* string) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
   size_t length = strlen(string);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
   ASSERT_WITH_SECURITY_IMPLICATION(length == static_cast<size_t>(static_cast<int>(length)));
   return static_cast<int>(length);
 }
@@ -276,7 +278,9 @@ class StringBuilder {
   // builder. The input string must have enough characters.
   void AddSubstring(const char* s, int n) {
     ASSERT_WITH_SECURITY_IMPLICATION(!is_finalized() && position_ + n < static_cast<int>(buffer_.length()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT_WITH_SECURITY_IMPLICATION(static_cast<size_t>(n) <= strnlen(s, n));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     memmoveSpan(buffer_.start().subspan(position_), unsafeMakeSpan(s, n));
     position_ += n;
   }
@@ -303,7 +307,9 @@ class StringBuilder {
     buffer_[length] = '\0';
     // Make sure nobody managed to add a 0-character to the
     // buffer while building the string.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(strlen(buffer_.start().data()) == length);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     position_ = -1;
     ASSERT(is_finalized());
     return buffer_.start().first(length);

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -178,8 +178,10 @@ void Thread::initializePlatformThreading()
         g_wtfConfig.sigThreadSuspendResume = SIGUSR1;
         if (const char* string = getenv("JSC_SIGNAL_FOR_GC")) {
             int32_t value = 0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             if (sscanf(string, "%d", &value) == 1)
                 g_wtfConfig.sigThreadSuspendResume = value;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
     g_wtfConfig.isThreadSuspendResumeSignalConfigured = true;

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -105,14 +105,16 @@ inline bool operator==(ASCIILiteral a, const char* b)
 {
     if (!a || !b)
         return a.characters() == b;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return !strcmp(a.characters(), b);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 inline bool operator==(ASCIILiteral a, ASCIILiteral b)
 {
     if (!a || !b)
         return a.characters() == b.characters();
-    return !strcmp(a.characters(), b.characters());
+    return equalSpans(a.span(), b.span());
 }
 
 inline unsigned ASCIILiteral::hash() const

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -139,7 +139,9 @@ bool operator==(const CString& a, const char* b)
         return false;
     if (!b)
         return true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return !strcmp(a.data(), b);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 unsigned CString::hash() const
@@ -158,7 +160,9 @@ bool operator<(const CString& a, const CString& b)
         return !b.isNull();
     if (b.isNull())
         return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return strcmp(a.data(), b.data()) < 0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 bool CStringHash::equal(const CString& a, const CString& b)

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -52,27 +52,37 @@ inline std::span<const UChar> span(const UChar& character)
 
 inline std::span<const LChar> span8(const char* string)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(byteCast<LChar>(string), string ? strlen(string) : 0);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 inline std::span<const LChar> span8IncludingNullTerminator(const char* string)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(byteCast<LChar>(string), string ? strlen(string) + 1 : 0);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 inline std::span<const char> span(const char* string)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(string, string ? strlen(string) : 0);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 inline std::span<const char> spanIncludingNullTerminator(const char* string)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(string, string ? strlen(string) + 1 : 0);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 inline std::span<const LChar> span(const LChar* string)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(string, string ? strlen(byteCast<char>(string)) : 0);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -115,7 +115,9 @@ TextStream& TextStream::operator<<(const char* string)
 TextStream& TextStream::operator<<(const void* p)
 {
     char buffer[printBufferSize];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     snprintf(buffer, sizeof(buffer) - 1, "%p", p);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return *this << buffer;
 }
 

--- a/Source/WTF/wtf/text/icu/UTextProvider.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProvider.cpp
@@ -57,10 +57,14 @@ UText* uTextCloneImpl(UText* destination, const UText* source, UBool deep, UErro
     void* extraNew = destination->pExtra;
     int32_t flags = destination->flags;
     int sizeToCopy = std::min(source->sizeOfStruct, destination->sizeOfStruct);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(destination, source, sizeToCopy);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     destination->pExtra = extraNew;
     destination->flags = flags;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(destination->pExtra, source->pExtra, extraSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     fixPointer(source, destination, destination->context);
     fixPointer(source, destination, destination->p);
     fixPointer(source, destination, destination->q);

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -83,7 +83,9 @@ static UText* uTextLatin1Clone(UText* destination, const UText* source, UBool de
     result->a = source->a;
     result->pFuncs = &uTextLatin1Funcs;
     result->chunkContents = static_cast<UChar*>(result->pExtra);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memset(const_cast<UChar*>(result->chunkContents), 0, sizeof(UChar) * UTextWithBufferInlineCapacity);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return result;
 }
@@ -234,7 +236,9 @@ UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, std::span<const LC
     text->a = string.size();
     text->pFuncs = &uTextLatin1Funcs;
     text->chunkContents = static_cast<UChar*>(text->pExtra);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memset(const_cast<UChar*>(text->chunkContents), 0, sizeof(UChar) * UTextWithBufferInlineCapacity);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return text;
 }

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -342,7 +342,9 @@ kern_return_t catch_mach_exception_raise_state(
     ptrauth_generic_signature_t inStateHash = hashThreadState(inState);
 #endif
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(outState, inState, inStateCount * sizeof(inState[0]));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if CPU(X86_64)
     RELEASE_ASSERT(*stateFlavor == x86_THREAD_STATE);

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -61,11 +61,13 @@ static inline const char* resolveDefaultLocale(const char* locale)
 
 static inline char* copyShortASCIIString(CFStringRef string)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // OK to have a fixed size buffer and to only handle ASCII since we only use this for locale names.
     char buffer[256];
     if (!string || !CFStringGetCString(string, buffer, sizeof(buffer), kCFStringEncodingASCII))
         return strdup("");
     return strdup(buffer);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 static char* copyDefaultLocale()
@@ -96,8 +98,10 @@ static inline const char* resolveDefaultLocale(const char* locale)
 
 static inline bool localesMatch(const char* a, const char* b)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Two null locales are equal, other locales are compared with strcmp.
     return a == b || (a && b && !strcmp(a, b));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 Collator::Collator(const char* locale, bool shouldSortLowercaseFirst)
@@ -258,7 +262,9 @@ int Collator::collate(StringView a, StringView b) const
 static UCharIterator createIterator(const char8_t* string)
 {
     UCharIterator iterator;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     uiter_setUTF8(&iterator, byteCast<char>(string), strlen(byteCast<char>(string)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return iterator;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
@@ -51,7 +51,9 @@ bool WebSocketExtensionParser::parsedSuccessfully()
 static bool isSeparator(char character)
 {
     static constexpr auto separatorCharacters = "()<>@,;:\\\"/[]?={} \t"_s;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const char* p = strchr(separatorCharacters.characters(), character);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return p && *p;
 }
 

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -50,12 +50,16 @@ std::span<char> TextCodec::getUnencodableReplacement(char32_t codePoint, Unencod
 
     switch (handling) {
     case UnencodableHandling::Entities: {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         int count = snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "&#%u;", static_cast<unsigned>(codePoint));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         ASSERT(count >= 0);
         return std::span { replacement }.first(std::max<int>(0, count));
     }
     case UnencodableHandling::URLEncodedEntities: {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         int count = snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "%%26%%23%u%%3B", static_cast<unsigned>(codePoint));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         ASSERT(count >= 0);
         return std::span { replacement }.first(std::max<int>(0, count));
     } }

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -162,10 +162,12 @@ void TextCodecICU::createICUConverter() const
     if (cachedConverter) {
         UErrorCode error = U_ZERO_ERROR;
         const char* cachedConverterName = ucnv_getName(cachedConverter.get(), &error);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (U_SUCCESS(error) && !strcmp(m_canonicalConverterName, cachedConverterName)) {
             m_converter = WTFMove(cachedConverter);
             return;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     UErrorCode error = U_ZERO_ERROR;
@@ -207,7 +209,9 @@ public:
             UConverterToUCallback oldAction;
             ucnv_setToUCallBack(&m_converter, m_savedAction, m_savedContext, &oldAction, &oldContext, &err);
             ASSERT(oldAction == UCNV_TO_U_CALLBACK_SUBSTITUTE);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             ASSERT(!strcmp(static_cast<const char*>(oldContext), UCNV_SUB_STOP_ON_ILLEGAL));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             ASSERT(U_SUCCESS(err));
         }
     }

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -125,8 +125,10 @@ static constexpr ASCIILiteral textEncodingNameBlocklist[] = { "UTF-7"_s, "BOCU-1
 static bool isUndesiredAlias(ASCIILiteral alias)
 {
     // Reject aliases with version numbers that are supported by some back-ends (such as "ISO_2022,locale=ja,version=0" in ICU).
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (strchr(alias.characters(), ','))
         return true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // 8859_1 is known to (at least) ICU, but other browsers don't support this name - and having it caused a compatibility
     // problem, see bug 43554.
     if (alias == "8859_1"_s)
@@ -136,7 +138,9 @@ static bool isUndesiredAlias(ASCIILiteral alias)
 
 static void addToTextEncodingNameMap(ASCIILiteral alias, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(strlen(alias) <= maxEncodingNameLength);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (isUndesiredAlias(alias))
         return;
     ASCIILiteral atomName = textEncodingNameMap->get(name);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -910,8 +910,10 @@ AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(AXCore
     if ([startElement isKindOfClass:[WebAccessibilityObjectWrapperBase class]])
         criteria.startObject = startElement.axBackingObject;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if ([startRange isKindOfClass:[NSValue class]] && !strcmp([(NSValue *)startRange objCType], @encode(NSRange)))
         criteria.startRange = [(NSValue *)startRange rangeValue];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #if PLATFORM(MAC)
     else if (startRange && CFGetTypeID((__bridge CFTypeRef)startRange) == AXTextMarkerRangeGetTypeID()) {
         AXTextMarkerRange markerRange { (AXTextMarkerRangeRef)startRange };

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2390,8 +2390,10 @@ id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>& backingObje
         markerRef = (AXTextMarkerRef)parameter;
     else if (AXObjectIsTextMarkerRange(parameter))
         markerRangeRef = (AXTextMarkerRangeRef)parameter;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     else if ([parameter isKindOfClass:[NSValue class]] && !strcmp([(NSValue *)parameter objCType], @encode(NSRange)))
         nsRange = [(NSValue*)parameter rangeValue];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     else
         return nil;
 
@@ -3087,7 +3089,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 static void formatForDebugger(const VisiblePositionRange& range, char* buffer, unsigned length)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     strlcpy(buffer, makeString("from "_s, range.start.debugDescription(), " to "_s, range.end.debugDescription()).utf8().data(), length);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 #endif
 
@@ -3307,6 +3311,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     bool rangeSet = false;
     NSRect rect = NSZeroRect;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
     // common parameter type check/casting.  Nil checks in handlers catch wrong type case.
     // NOTE: This assumes nil is not a valid parameter, because it is indistinguishable from
     // a parameter of the wrong type.
@@ -3338,6 +3344,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         // Attribute type is not supported. Allow super to handle.
         return [super accessibilityAttributeValue:attribute forParameter:parameter];
     }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // dispatch
     if ([attribute isEqualToString:NSAccessibilitySelectTextWithCriteriaParameterizedAttribute]) {

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -66,7 +66,9 @@ CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
             {
                 // Move item from the parser selector vector into m_selectorArray without invoking destructor (Ugh.)
                 CSSSelector* currentSelector = current->releaseSelector().release();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                 memcpy(static_cast<void*>(&m_selectorArray[arrayIndex]), static_cast<void*>(currentSelector), sizeof(CSSSelector));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
                 // Free the underlying memory without invoking the destructor.
                 operator delete (currentSelector);

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -432,7 +432,9 @@ static_assert(sizeof(StyleProperties) == sizeof(SameSizeAsStyleProperties), "sty
 #ifndef NDEBUG
 void StyleProperties::showStyle()
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     fprintf(stderr, "%s\n", asText().ascii().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 #endif
 

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -142,7 +142,9 @@ UniqueElementData::UniqueElementData(const UniqueElementData& other)
 
 UniqueElementData::UniqueElementData(const ShareableElementData& other)
     : ElementData(other, true)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     , m_attributeVector(std::span { other.m_attributeArray, other.length() })
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 {
     // An ShareableElementData should never have a mutable inline StyleProperties attached.
     ASSERT(!other.m_inlineStyle || !other.m_inlineStyle->isMutable());

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -314,6 +314,7 @@ void Node::dumpStatistics()
         }
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Number of Nodes: %d\n\n", liveNodeSet().computeSize());
     printf("Number of Nodes with RareData: %zu\n", nodesWithRareData);
     printf("  Mixed use: %zu\n", mixedRareDataUseCount);
@@ -344,7 +345,9 @@ void Node::dumpStatistics()
     printf("  Number of Elements with attribute storage: %zu [%zu]\n", elementsWithAttributeStorage, sizeof(ElementData));
     printf("  Number of Elements with RareData: %zu\n", elementsWithRareData);
     printf("  Number of Elements with NamedNodeMap: %zu [%zu]\n", elementsWithNamedNodeMap, sizeof(NamedNodeMap));
-#endif
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // DUMP_NODE_STATISTICS
 }
 
 DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, nodeCounter, ("WebCoreNode"));
@@ -2000,6 +2003,7 @@ static void appendAttributeDesc(const Node* node, StringBuilder& stringBuilder, 
     stringBuilder.append(attr);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void Node::showNode(ASCIILiteral prefix) const
 {
     if (prefix.isNull())
@@ -2015,11 +2019,14 @@ void Node::showNode(ASCIILiteral prefix) const
         fprintf(stderr, "%s%s\t%p (renderer %p) %s%s%s\n", prefix.characters(), nodeName().utf8().data(), this, renderer(), attrs.toString().utf8().data(), needsStyleRecalc() ? " (needs style recalc)" : "", childNeedsStyleRecalc() ? " (child needs style recalc)" : "");
     }
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void Node::showTreeForThis() const
 {
     showTreeAndMark(this, "*");
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 void Node::showNodePathForThis() const
 {
@@ -2094,6 +2101,8 @@ static void traverseTreeAndMark(const String& baseIndent, const Node* rootNode, 
     }
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 void Node::showTreeAndMark(const Node* markedNode1, const char* markedLabel1, const Node* markedNode2, const char* markedLabel2) const
 {
     const Node* node = this;
@@ -2115,9 +2124,11 @@ static ContainerNode* parentOrShadowHostOrFrameOwner(const Node* node)
 
 static void showSubTreeAcrossFrame(const Node* node, const Node* markedNode, const String& indent)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (node == markedNode)
         fputs("*", stderr);
     fputs(indent.utf8().data(), stderr);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     node->showNode();
     if (!node->isShadowRoot()) {
         if (auto* frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(node))

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1384,6 +1384,8 @@ TextDirection Position::primaryDirection() const
 
 #if ENABLE(TREE_DEBUGGING)
 
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void Position::debugPosition(const char* msg) const
 {
     if (isNull())
@@ -1422,6 +1424,8 @@ void Position::showAnchorTypeAndOffset() const
     }
     fprintf(stderr, ", offset:%d\n", m_offset);
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void Position::showTreeForThis() const
 {

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -46,8 +46,10 @@ ExceptionOr<Ref<TextDecoder>> TextDecoder::create(const String& label, Options o
     if (trimmedLabel.contains(nullCharacter))
         return Exception { ExceptionCode::RangeError };
     auto decoder = adoptRef(*new TextDecoder(trimmedLabel, options));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (!decoder->m_textEncoding.isValid() || !strcmp(decoder->m_textEncoding.name(), "replacement"))
         return Exception { ExceptionCode::RangeError };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return decoder;
 }
 

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -694,12 +694,14 @@ int VisiblePosition::lineDirectionPointForBlockDirectionNavigation() const
 
 void VisiblePosition::debugPosition(const char* msg) const
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (isNull())
         fprintf(stderr, "Position [%s]: null\n", msg);
     else {
         fprintf(stderr, "Position [%s]: %s, ", msg, m_deepPosition.deprecatedNode()->nodeName().utf8().data());
         m_deepPosition.showAnchorTypeAndOffset();
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 String VisiblePosition::debugDescription() const

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -722,6 +722,8 @@ bool VisibleSelection::isInAutoFilledAndViewableField() const
 
 #if ENABLE(TREE_DEBUGGING)
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 void VisibleSelection::debugPosition() const
 {
     fprintf(stderr, "VisibleSelection ===============\n");
@@ -758,6 +760,8 @@ void VisibleSelection::showTreeForThis() const
         end().showAnchorTypeAndOffset();
     }
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif
 

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -455,7 +455,9 @@ int HistoryItem::showTreeWithIndent(unsigned indentLevel) const
         prefix.append("  "_span);
     prefix.append('\0');
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     fprintf(stderr, "%s+-%s (%p)\n", prefix.data(), m_urlString.utf8().data(), this);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     
     int totalSubItems = 0;
     for (unsigned i = 0; i < m_children.size(); ++i)

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -95,7 +95,9 @@ static CString compactStackTrace(StackTrace& stackTrace)
     stackTrace.forEachFrame([&stack](int, void*, const char* fullName) {
         constexpr size_t maxWorkLen = 1023;
         constexpr bool is8Bit = true;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         StringView name { fullName ? fullName : "?", fullName ? unsigned(std::min(strlen(fullName), maxWorkLen)) : 1u, is8Bit };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         for (const auto& prefix : { "auto void "_s, "auto "_s }) {
             if (name.startsWith(prefix)) {

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1354,7 +1354,9 @@ void dumpInnerHTML(WebCore::HTMLElement*);
 
 void dumpInnerHTML(WebCore::HTMLElement* element)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("%s\n", element->innerHTML().ascii().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #endif

--- a/Source/WebCore/html/ImageDataArray.cpp
+++ b/Source/WebCore/html/ImageDataArray.cpp
@@ -75,7 +75,9 @@ static void fillTypedArray(TypedArray& typedArray, std::span<const uint8_t> opti
         return typedArray.zeroFill();
     auto bufferViewSpan = typedArray.mutableSpan();
     RELEASE_ASSERT(bufferViewSpan.size_bytes() == optionalBytes.size_bytes(), "Caller should provide correctly-sized buffer to copy");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(bufferViewSpan.data(), optionalBytes.data(), optionalBytes.size_bytes());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 std::optional<ImageDataArray> ImageDataArray::tryCreate(size_t length, ImageDataStorageFormat storageFormat, std::span<const uint8_t> optionalBytes)

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -574,7 +574,9 @@ void printLayoutTreeForLiveDocuments()
             continue;
         if (document->frame() && document->frame()->isMainFrame())
             fprintf(stderr, "----------------------main frame--------------------------\n");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         fprintf(stderr, "%s\n", document->url().string().utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         // FIXME: Need to find a way to output geometry without layout context.
         auto& renderView = *document->renderView();
         auto layoutTree = TreeBuilder::buildLayoutTree(renderView);

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -65,7 +65,7 @@ public:
     void useLenientXMLDecoding() { m_useLenientXMLDecoding = true; }
     bool sawError() const { return m_sawError; }
 
-    void setAlwaysUseUTF8() { ASSERT(!strcmp(m_encoding.name(), "UTF-8")); m_alwaysUseUTF8 = true; }
+    void setAlwaysUseUTF8() { ASSERT(m_encoding.name() == "UTF-8"); m_alwaysUseUTF8 = true; }
 
 private:
     TextResourceDecoder(const String& mimeType, const PAL::TextEncoding& defaultEncoding, bool usesEncodingDetector);

--- a/Source/WebCore/loader/appcache/ApplicationCache.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCache.cpp
@@ -171,7 +171,9 @@ void ApplicationCache::clearStorageID()
 void ApplicationCache::dump()
 {
     for (const auto& urlAndResource : m_resources) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         printf("%s ", urlAndResource.key.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         ApplicationCacheResource::dumpType(urlAndResource.value->type());
     }
 }

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -593,6 +593,8 @@ bool isTopTargetFrameName(StringView name)
 
 #ifndef NDEBUG
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 static void printIndent(int indent)
 {
     for (int i = 0; i < indent; ++i)
@@ -629,6 +631,8 @@ static void printFrames(const WebCore::Frame& frame, const WebCore::Frame* targe
     for (auto* child = frame.tree().firstChild(); child; child = child->tree().nextSibling())
         printFrames(*child, targetFrame, indent + 1);
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void showFrameTree(const WebCore::Frame* frame)
 {

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -373,6 +373,8 @@ String PrintContext::pageProperty(LocalFrame* frame, const char* propertyName, i
     document->updateLayout();
     auto style = document->styleScope().resolver().styleForPage(pageNumber);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
     // Implement formatters for properties we care about.
     if (!strcmp(propertyName, "margin-left")) {
         if (style->marginLeft().isAuto())
@@ -387,6 +389,8 @@ String PrintContext::pageProperty(LocalFrame* frame, const char* propertyName, i
         return style->fontDescription().firstFamily();
     if (!strcmp(propertyName, "size"))
         return makeString(style->pageSize().width.value(), ' ', style->pageSize().height.value());
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return makeString("pageProperty() unimplemented for: "_s, span(propertyName));
 }

--- a/Source/WebCore/platform/FileHandle.cpp
+++ b/Source/WebCore/platform/FileHandle.cpp
@@ -117,6 +117,8 @@ int FileHandle::write(std::span<const uint8_t> data)
     return FileSystem::writeToFile(m_fileHandle, data);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 bool FileHandle::printf(const char* format, ...)
 {
     va_list args;
@@ -134,6 +136,8 @@ bool FileHandle::printf(const char* format, ...)
 
     return write(byteCast<uint8_t>(buffer.mutableSpan()).first(stringLength)) >= 0;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void FileHandle::close()
 {

--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -38,7 +38,9 @@ bool isMemoryAttributionDisabled()
         const char* value = getenv("WEBKIT_DISABLE_MEMORY_ATTRIBUTION");
         if (!value)
             return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return !strcmp(value, "1");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }();
     return result;
 }

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -137,7 +137,7 @@ SincResampler::SincResampler(double scaleFactor, unsigned requestFrames, Functio
     , m_requestFrames(requestFrames)
     , m_provideInput(WTFMove(provideInput))
     , m_inputBuffer(m_requestFrames + kernelSize) // See input buffer layout above.
-    , m_r1(m_inputBuffer.data(), m_inputBuffer.size())
+    , m_r1(m_inputBuffer.span())
     , m_r2(m_inputBuffer.span().subspan(kernelSize / 2))
 {
     ASSERT(m_provideInput);

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -50,7 +50,9 @@ WebAudioBufferList::WebAudioBufferList(const CAAudioStreamDescription& format)
     bufferListSize += CheckedSize { sizeof(AudioBuffer) } * std::max(1U, bufferCount);
     m_listBufferSize = bufferListSize;
     m_canonicalList = std::unique_ptr<AudioBufferList>(static_cast<AudioBufferList*>(::operator new (m_listBufferSize)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memset(m_canonicalList.get(), 0, m_listBufferSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     m_canonicalList->mNumberBuffers = bufferCount;
     auto canonicalListBuffers = span(*m_canonicalList);
     for (uint32_t buffer = 0; buffer < bufferCount; ++buffer)
@@ -179,7 +181,9 @@ void WebAudioBufferList::reset()
 {
     if (!m_list)
         m_list = std::unique_ptr<AudioBufferList>(static_cast<AudioBufferList*>(::operator new (m_listBufferSize)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(m_list.get(), m_canonicalList.get(), m_listBufferSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 IteratorRange<AudioBuffer*> WebAudioBufferList::buffers() const

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -914,7 +914,9 @@ bool GraphicsContextGLANGLE::getBufferSubDataImpl(GCGLenum target, GCGLintptr of
     void* ptr = GL_MapBufferRange(target, offset, data.size(), GraphicsContextGL::MAP_READ_BIT);
     if (!ptr)
         return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memcpy(data.data(), ptr, data.size());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (!GL_UnmapBuffer(target))
         addError(GCGLErrorCode::InvalidOperation);
     return true;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -334,7 +334,9 @@ void AudioSourceProviderAVFObjC::prepare(CMItemCount maxFrames, const AudioStrea
     // with a custom size, and initialize the struct manually.
     size_t bufferListSize = sizeof(AudioBufferList) + (sizeof(AudioBuffer) * std::max(1, numberOfChannels - 1));
     m_list = std::unique_ptr<AudioBufferList>((AudioBufferList*) ::operator new (bufferListSize));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     memset(m_list.get(), 0, bufferListSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     m_list->mNumberBuffers = numberOfChannels;
 
     callOnMainThread([weakThis = m_weakFactory.createWeakPtr(*this), numberOfChannels, sampleRate] {

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -123,7 +123,9 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     }
 #if PLATFORM(MAC)
     else if (attrs.windowGPUID) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         ASSERT(strstr(clientExtensions, "EGL_ANGLE_platform_angle_device_id"));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         // If the power preference is default, use the GPU the context window is on.
         // If the power preference is low power, and we know which GPU the context window is on,
         // most likely the lowest power is the GPU that drives the context window, as that GPU
@@ -135,7 +137,9 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
         displayAttributes.append(static_cast<EGLAttrib>(attrs.windowGPUID));
     }
 #endif
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(strstr(clientExtensions, "EGL_ANGLE_feature_control"));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     displayAttributes.append(EGL_FEATURE_OVERRIDES_DISABLED_ANGLE);
     displayAttributes.append(reinterpret_cast<EGLAttrib>(disabledANGLEMetalFeatures));
     displayAttributes.append(EGL_NONE);
@@ -151,7 +155,9 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
 
 #if ASSERT_ENABLED && ENABLE(WEBXR)
     const char* displayExtensions = EGL_QueryString(display, EGL_EXTENSIONS);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(strstr(displayExtensions, "EGL_ANGLE_metal_shared_event_sync"));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
     return display;
@@ -260,7 +266,9 @@ bool GraphicsContextGLCocoa::platformInitializeContext()
 
 #if HAVE(TASK_IDENTITY_TOKEN)
     auto displayExtensions = EGL_QueryString(m_displayObj, EGL_EXTENSIONS);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     bool supportsOwnershipIdentity = strstr(displayExtensions, "EGL_ANGLE_metal_create_context_ownership_identity");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (m_resourceOwner && supportsOwnershipIdentity) {
         eglContextAttributes.append(EGL_CONTEXT_METAL_OWNERSHIP_IDENTITY_ANGLE);
         eglContextAttributes.append(m_resourceOwner.taskIdToken());

--- a/Source/WebCore/platform/graphics/cocoa/TransformationMatrixCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/TransformationMatrixCocoa.cpp
@@ -30,6 +30,8 @@
 
 #include <simd/simd.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 TransformationMatrix::TransformationMatrix(const simd_float4x4& t)
@@ -51,5 +53,7 @@ TransformationMatrix::operator simd_float4x4() const
 }
 
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -291,8 +291,10 @@ std::optional<OpusCookieContents> parseOpusPrivateData(std::span<const uint8_t> 
     //
     //     This is an 8-octet (64-bit) field that allows codec
     //     identification and is human readable.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (strncmp("OpusHead", byteCast<char>(codecPrivateData.data()), 8))
         return { };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     OpusCookieContents cookie;
 

--- a/Source/WebCore/platform/mac/CursorMac.mm
+++ b/Source/WebCore/platform/mac/CursorMac.mm
@@ -131,6 +131,7 @@ static Class coreCursorClass()
 
 static NSCursor *cursor(const char *name)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     __strong NSCursor **slot = nullptr;
     
     if (!strcmp(name, "BusyButClickable"))
@@ -178,6 +179,7 @@ static NSCursor *cursor(const char *name)
     if (!*slot)
         *slot = [[coreCursorClass() alloc] init];
     return *slot;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #else

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -95,9 +95,11 @@ static void appendFormURLEncoded(Vector<uint8_t>& buffer, std::span<const uint8_
     static const char safeCharacters[] = "-._*";
     for (size_t i = 0; i < string.size(); ++i) {
         auto character = string[i];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (isASCIIAlphanumeric(character)
             || (character != '\0' && strchr(safeCharacters, character)))
             append(buffer, character);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         else if (character == ' ')
             append(buffer, '+');
         else if (character == '\n' || (character == '\r' && (i + 1 >= string.size() || string[i + 1] != '\n')))

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -103,7 +103,9 @@ void SQLiteFileSystem::setCanSuspendLockedFileAttribute(const String& filePath)
         auto path = makeString(filePath, suffix);
         char excluded = 0xff;
         auto result = setxattr(FileSystem::fileSystemRepresentation(path).data(), "com.apple.runningboard.can-suspend-locked", &excluded, sizeof(excluded), 0, 0);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (result < 0 && !strcmp(suffix, ""))
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             RELEASE_LOG_ERROR(SQLDatabase, "SQLiteFileSystem::setCanSuspendLockedFileAttribute: setxattr failed: %" PUBLIC_LOG_STRING, strerror(errno));
     }
 }

--- a/Source/WebCore/platform/text/SegmentedString.cpp
+++ b/Source/WebCore/platform/text/SegmentedString.cpp
@@ -246,7 +246,9 @@ void SegmentedString::setCurrentPosition(OrdinalNumber line, OrdinalNumber colum
 SegmentedString::AdvancePastResult SegmentedString::advancePastSlowCase(ASCIILiteral literal, bool lettersIgnoringASCIICase)
 {
     constexpr unsigned maxLength = 10;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(!strchr(literal.characters(), '\n'));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     auto length = literal.length();
     ASSERT(length <= maxLength);
     if (length > this->length())

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -306,7 +306,9 @@ template<bool lettersIgnoringASCIICase> SegmentedString::AdvancePastResult Segme
 {
     unsigned length = literal.length();
     ASSERT(!literal[length]);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(!strchr(literal.characters(), '\n'));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (length + 1 < m_currentSubstring.length()) {
         if (m_currentSubstring.is8Bit) {
             for (unsigned i = 0; i < length; ++i) {

--- a/Source/WebCore/rendering/CounterNode.cpp
+++ b/Source/WebCore/rendering/CounterNode.cpp
@@ -347,6 +347,7 @@ static void showTreeAndMark(const CounterNode* node)
         root = root->parent();
 
     for (const CounterNode* current = root; current; current = current->nextInPreOrder()) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         fprintf(stderr, "%c", (current == node) ? '*' : ' ');
         for (const CounterNode* parent = current; parent && parent != root; parent = parent->parent())
             fprintf(stderr, "    ");
@@ -354,6 +355,7 @@ static void showTreeAndMark(const CounterNode* node)
             current, current->actsAsReset() ? "reset____" : "increment", current->value(),
             current->countInParent(), current->parent(), current->previousSibling(),
             current->nextSibling(), &current->owner());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     fflush(stderr);
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6405,7 +6405,9 @@ void showLayerTree(const WebCore::RenderLayer* layer)
         WebCore::RenderAsTextFlag::DontUpdateLayout,
         WebCore::RenderAsTextFlag::ShowLayoutState,
     });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     fprintf(stderr, "\n%s\n", output.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void showLayerTree(const WebCore::RenderObject* renderer)

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -105,6 +105,7 @@ static SubtagComparison subtagCompare(std::span<const LChar> key, std::span<cons
 
     result.keyLength = key.size();
     result.keyContinue = result.keyLength;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (auto* hyphenPointer = memchr(key.data(), '-', key.size())) {
         result.keyLength = static_cast<const LChar*>(hyphenPointer) - key.data();
         result.keyContinue = result.keyLength + 1;
@@ -116,6 +117,7 @@ static SubtagComparison subtagCompare(std::span<const LChar> key, std::span<cons
         result.rangeLength = static_cast<const LChar*>(hyphenPointer) - range.data();
         result.rangeContinue = result.rangeLength + 1;
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (result.keyLength == result.rangeLength)
         result.comparison = compareSpans(key.first(result.keyLength), range.first(result.keyLength));
@@ -400,8 +402,10 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
 
     QuotesForLanguage languageKey = { languageKeyBuffer.span(), 0, 0, 0, 0, 0 };
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return static_cast<const QuotesForLanguage*>(bsearch(&languageKey,
         quoteTable.data(), std::size(quoteTable), sizeof(quoteTable[0]), quoteTableLanguageComparisonFunction));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 static StringImpl* stringForQuoteCharacter(UChar character)

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -54,7 +54,9 @@ RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, Re
     , m_renderBundleEncoder(encoder)
     , m_renderBundlesResources(resources)
     , m_descriptor(descriptor)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(std::span { descriptor.colorFormats, descriptor.colorFormatCount }) : Vector<WGPUTextureFormat>())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     , m_commandCount(commandCount)
     , m_makeSubmitInvalid(makeSubmitInvalid)
 {

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -213,7 +213,9 @@ RenderBundleEncoder::RenderBundleEncoder(MTLIndirectCommandBufferDescriptor *ind
     , m_icbDescriptor(indirectCommandBufferDescriptor)
     , m_resources([NSMapTable strongToStrongObjectsMapTable])
     , m_descriptor(descriptor)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(std::span { descriptor.colorFormats, descriptor.colorFormatCount }) : Vector<WGPUTextureFormat>())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 {
     if (m_descriptorColorFormats.size())
         m_descriptor.colorFormats = &m_descriptorColorFormats[0];

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -72,7 +72,9 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
     , m_parentEncoder(rawParentEncoder)
     , m_visibilityResultBuffer(visibilityResultBuffer)
     , m_descriptor(descriptor)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     , m_descriptorColorAttachments(descriptor.colorAttachmentCount ? Vector<WGPURenderPassColorAttachment>(std::span { descriptor.colorAttachments, descriptor.colorAttachmentCount }) : Vector<WGPURenderPassColorAttachment>())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     , m_descriptorDepthStencilAttachment(descriptor.depthStencilAttachment ? *descriptor.depthStencilAttachment : WGPURenderPassDepthStencilAttachment())
 #if CPU(X86_64)
     , m_metalDescriptor(metalDescriptor)

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1625,7 +1625,9 @@ RenderPipeline::RenderPipeline(id<MTLRenderPipelineState> renderPipelineState, M
     , m_descriptor(descriptor)
     , m_descriptorDepthStencil(descriptor.depthStencil ? *descriptor.depthStencil : WGPUDepthStencilState())
     , m_descriptorFragment(descriptor.fragment ? *descriptor.fragment : WGPUFragmentState())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     , m_descriptorTargets(descriptor.fragment && descriptor.fragment->targetCount ? Vector<WGPUColorTargetState>(std::span { descriptor.fragment->targets, descriptor.fragment->targetCount }) : Vector<WGPUColorTargetState>())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     , m_minimumBufferSizes(minimumBufferSizes)
 {
     if (descriptor.depthStencil)

--- a/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -62,10 +62,12 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
             if (type == XPC_TYPE_ERROR || !weakThis)
                 return;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             if (type != XPC_TYPE_DICTIONARY || strcmp(xpc_dictionary_get_string(event.get(), ClientCertificateAuthentication::XPCMessageNameKey), ClientCertificateAuthentication::XPCMessageNameValue)) {
                 ASSERT_NOT_REACHED();
                 return;
             }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
             auto challengeID = xpc_dictionary_get_uint64(event.get(), ClientCertificateAuthentication::XPCChallengeIDKey);
             if (!challengeID)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -1344,7 +1344,9 @@ void Storage::deleteOldVersions()
                 return;
             if (!subdirName.startsWith(versionDirectoryPrefix))
                 return;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             auto directoryVersion = parseInteger<unsigned>(StringView { subdirName }.substring(strlen(versionDirectoryPrefix)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             if (!directoryVersion || *directoryVersion >= version)
                 return;
             auto oldVersionPath = FileSystem::pathByAppendingComponent(cachePath, subdirName);

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -286,6 +286,7 @@ static void encodeInvocationArguments(WKRemoteObjectEncoder *encoder, NSInvocati
             break;
         }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         // struct
         case '{':
             if (!strcmp(type, @encode(NSRange))) {
@@ -303,6 +304,7 @@ static void encodeInvocationArguments(WKRemoteObjectEncoder *encoder, NSInvocati
                 break;
             }
             FALLTHROUGH;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         default:
             [NSException raise:NSInvalidArgumentException format:@"Unsupported invocation argument type '%s'", type];
@@ -809,7 +811,9 @@ static const HashSet<CFTypeRef> alwaysAllowedClasses()
 NO_RETURN static void crashWithClassName(const char* className)
 {
     std::array<uint64_t, 6> values { 0, 0, 0, 0, 0, 0 };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     strncpy(reinterpret_cast<char*>(values.data()), className, sizeof(values));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     CRASH_WITH_INFO(values[0], values[1], values[2], values[3], values[4], values[5]);
 }
 
@@ -964,6 +968,7 @@ static void decodeInvocationArguments(WKRemoteObjectDecoder *decoder, NSInvocati
             break;
         }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         // struct
         case '{':
             if (!strcmp(type, @encode(NSRange))) {
@@ -978,6 +983,7 @@ static void decodeInvocationArguments(WKRemoteObjectDecoder *decoder, NSInvocati
                 break;
             }
             FALLTHROUGH;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         default:
             [NSException raise:NSInvalidArgumentException format:@"Unsupported invocation argument type '%s' for argument %zu", type, (unsigned long)i];

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -145,8 +145,10 @@ static uint64_t generateReplyIdentifier()
     for (NSUInteger i = 0, count = methodSignature.numberOfArguments; i < count; ++i) {
         const char *type = [methodSignature getArgumentTypeAtIndex:i];
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (strcmp(type, "@?"))
             continue;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         if (replyInfo)
             [NSException raise:NSInvalidArgumentException format:@"Only one reply block is allowed per message send. (%s)", sel_getName(invocation.selector)];
@@ -158,8 +160,10 @@ static uint64_t generateReplyIdentifier()
 
         const char* replyBlockSignature = _Block_signature((__bridge void*)replyBlock);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (strcmp([NSMethodSignature signatureWithObjCTypes:replyBlockSignature].methodReturnType, "v"))
             [NSException raise:NSInvalidArgumentException format:@"Return value of block argument must be 'void'. (%s)", sel_getName(invocation.selector)];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         replyInfo = makeUnique<WebKit::RemoteObjectInvocation::ReplyInfo>(generateReplyIdentifier(), String::fromLatin1(replyBlockSignature));
 
@@ -231,8 +235,10 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
     for (NSUInteger i = 0, count = methodSignature.numberOfArguments; i < count; ++i) {
         const char *type = [methodSignature getArgumentTypeAtIndex:i];
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (strcmp(type, "@?"))
             continue;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         // We found the block.
         // If the wire had no block signature but we expect one, we drop the message.

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
@@ -46,11 +46,13 @@ CoreIPCNSValue::CoreIPCNSValue(Value&& value)
 
 auto CoreIPCNSValue::valueFromNSValue(NSValue *nsValue) -> Value
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (!strcmp(nsValue.objCType, @encode(NSRange)))
         return nsValue.rangeValue;
 
     if (!strcmp(nsValue.objCType, @encode(CGRect)))
         return nsValue.rectValue;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return makeUniqueRef<CoreIPCNSCFObject>(nsValue);
 }

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -43,22 +43,29 @@ std::unique_ptr<SandboxExtensionImpl> SandboxExtensionImpl::create(const char* p
         return nullptr;
     if (!impl->m_token[0]) // Make sure strlen is > 0 without iterating the whole string.
         return nullptr;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(strlen(impl->m_token));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return impl;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 SandboxExtensionImpl::SandboxExtensionImpl(std::span<const uint8_t> serializedFormat)
     : m_token { strndup(byteCast<char>(serializedFormat.data()), serializedFormat.size()) }
 {
     ASSERT(!serializedFormat.empty());
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 SandboxExtensionImpl::~SandboxExtensionImpl()
 {
     if (!m_token)
         return;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     auto length = strlen(m_token);
     memset_s(m_token, length, 0, length);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     free(m_token);
 }
 
@@ -84,7 +91,9 @@ bool SandboxExtensionImpl::invalidate()
 std::span<const uint8_t> SandboxExtensionImpl::getSerializedFormat()
 {
     ASSERT(m_token);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(strlen(m_token));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return span8(m_token);
 }
 
@@ -236,8 +245,10 @@ auto SandboxExtension::createHandleForTemporaryFile(StringView prefix, Type type
     if (!confstr(_CS_DARWIN_USER_TEMP_DIR, path.data(), path.size()))
         return std::nullopt;
     
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Shrink the vector.   
     path.shrink(strlen(path.data()));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     ASSERT(path.last() == '/');
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -122,6 +122,8 @@ static void connectionRemoved(xpc_connection_t connection)
     PCM::DaemonConnectionSet::singleton().remove(connection);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 int PCMDaemonMain(int argc, const char** argv)
 {
     auto arguments = unsafeMakeSpan(argv, argc);
@@ -150,5 +152,7 @@ int PCMDaemonMain(int argc, const char** argv)
     CFRunLoopRun();
     return 0;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
@@ -70,6 +70,8 @@ void handleXPCEndpointMessage(xpc_object_t message, const char* messageName)
     ASSERT_UNUSED(messageName, messageName);
     RELEASE_ASSERT(xpc_get_type(message) == XPC_TYPE_DICTIONARY);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 #if HAVE(LSDATABASECONTEXT)
     if (!strcmp(messageName, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName)) {
         handleLaunchServiceDatabaseMessage(message);
@@ -85,6 +87,9 @@ void handleXPCEndpointMessage(xpc_object_t message, const char* messageName)
         return;
     }
 #endif
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -159,6 +159,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
             RELEASE_LOG_ERROR(IPC, "XPCServiceEventHandler: 'message-name' is not present in the XPC dictionary");
             return;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (!strcmp(messageName, "bootstrap")) {
             WTF::initialize();
 
@@ -209,6 +210,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 RELEASE_LOG_ERROR(IPC, "XPCServiceEventHandler: Unexpected 'service-name': %{public}s", serviceName);
                 return;
             }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
             CFBundleRef webKitBundle = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.WebKit"));
             typedef void (*InitializerFunction)(xpc_connection_t, xpc_object_t);

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -99,6 +99,8 @@ RefPtr<JSON::Object> mergeJSON(RefPtr<JSON::Object> jsonA, RefPtr<JSON::Object> 
     return mergedObject;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 WTF_ATTRIBUTE_PRINTF(1, 0)
 static String formatString(const char* format, va_list arguments)
 {
@@ -157,6 +159,8 @@ ALLOW_NONLITERAL_FORMAT_END
     va_end(args);
     return result;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static inline String lowercaseFirst(const String& input)
 {

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatatypeTraits.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatatypeTraits.h
@@ -163,8 +163,10 @@ public:
 
         const char* objCType = [value objCType];
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (!strcmp(objCType, @encode(double)) || !strcmp(objCType, @encode(float)))
             return sqlite3_bind_double(statement, index, value.doubleValue);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         return sqlite3_bind_int64(statement, index, value.longLongValue);
     }

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -88,6 +88,8 @@ void WebMemorySampler::start(SandboxExtension::Handle&& sampleLogFileHandle, con
 
 void WebMemorySampler::initializeTimers(double interval)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
     m_sampleTimer.startRepeating(1_s);
     printf("Started memory sampler for process %s %d", processName().utf8().data(), getCurrentProcessID());
     if (interval > 0) {
@@ -97,6 +99,8 @@ void WebMemorySampler::initializeTimers(double interval)
     printf("; Sampler log file stored at: %s\n", m_sampleLogFilePath.utf8().data());
     m_runningTime = interval;
     m_isRunning = true;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void WebMemorySampler::stop() 
@@ -106,7 +110,9 @@ void WebMemorySampler::stop()
     m_sampleTimer.stop();
     FileSystem::closeFile(m_sampleLogFile);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Stopped memory sampler for process %s %d\n", processName().utf8().data(), getCurrentProcessID());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // Flush stdout buffer so python script can be guaranteed to read up to this point.
     fflush(stdout);
     m_isRunning = false;
@@ -159,7 +165,9 @@ void WebMemorySampler::stopTimerFired()
 {
     if (!m_isRunning)
         return;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("%g seconds elapsed. Stopping memory sampler...\n", m_runningTime);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     stop();
 }
 

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -414,6 +414,7 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
         CachedSandboxVersionNumber,
         static_cast<uint32_t>(libsandboxVersion),
         safeCast<uint32_t>(info.header.length()),
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         haveBuiltin ? safeCast<uint32_t>(strlen(sandboxProfile->builtin)) : std::numeric_limits<uint32_t>::max(),
         safeCast<uint32_t>(sandboxProfile->size),
         { 0 },
@@ -424,6 +425,7 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
     ASSERT_UNUSED(copied, copied == guidSize - 1);
     copied = strlcpy(cachedHeader.osVersion, osVersion.utf8().data(), sizeof(cachedHeader.osVersion));
     ASSERT(copied < versionSize - 1);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     const size_t expectedFileSize = sizeof(cachedHeader) + cachedHeader.headerSize + (haveBuiltin ? cachedHeader.builtinSize : 0) + cachedHeader.dataSize;
 
@@ -469,8 +471,10 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
         return false;
     if (static_cast<uint32_t>(libsandboxVersion) != cachedSandboxHeader.libsandboxVersion)
         return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (std::strcmp(cachedSandboxHeader.sandboxBuildID, SANDBOX_BUILD_ID))
         return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (StringView::fromLatin1(cachedSandboxHeader.osVersion) != osVersion)
         return false;
 

--- a/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
+++ b/Source/WebKit/Shared/mac/WebMemorySampler.mac.mm
@@ -75,12 +75,14 @@ SystemMallocStats WebMemorySampler::sampleSystemMalloc() const
             stats.max_size_in_use = 0;
             stats.size_allocated = 0;
             malloc_zone_statistics(reinterpret_cast<malloc_zone_t*>(zone), &stats);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             if (!strcmp(name, defaultMallocZoneName))
                 mallocStats.defaultMallocZoneStats = stats;
             else if (!strcmp(name, dispatchContinuationMallocZoneName))
                 mallocStats.dispatchContinuationMallocZoneStats = stats;
             else if (!strcmp(name, purgeableMallocZoneName))
                 mallocStats.purgeableMallocZoneStats = stats;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
     return mallocStats;

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
@@ -41,7 +41,9 @@ void* WebKitSwiftLibrary(bool isOptional)
 
         // Then search in the Frameworks/ directory of the currently loaded version of WebKit.framework:
         Dl_info info { };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (dladdr((const void*)&WebKitSwiftLibrary, &info) && strlen(info.dli_fname)) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             auto dliPath = String::fromUTF8(info.dli_fname);
             if (dliPath.isNull())
                 return;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -508,7 +508,9 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
         // launching and we already took care of cleaning things up.
         if (isLaunching() && xpc_get_type(reply) != XPC_TYPE_ERROR) {
             ASSERT(xpc_get_type(reply) == XPC_TYPE_DICTIONARY);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             ASSERT(!strcmp(xpc_dictionary_get_string(reply, "message-name"), "process-finished-launching"));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if ASSERT_ENABLED
             mach_port_urefs_t sendRightCount = 0;

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -521,7 +521,9 @@ static NSString *pathToPDFOnDisk(const String& suggestedFilename)
         NSString *pathTemplate = [pathTemplatePrefix stringByAppendingString:suggestedFilename];
         CString pathTemplateRepresentation = [pathTemplate fileSystemRepresentation];
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         int fd = mkstemps(pathTemplateRepresentation.mutableSpanIncludingNullTerminator().data(), pathTemplateRepresentation.length() - strlen([pathTemplatePrefix fileSystemRepresentation]) + 1);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (fd < 0) {
             WTFLogAlways("Cannot create PDF file in the temporary directory (%s).", suggestedFilename.utf8().data());
             return nil;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
@@ -101,8 +101,10 @@ static bool pdfDocumentContainsPrintScript(RetainPtr<CGPDFDocumentRef> pdfDocume
 
         // A JavaScript action must have an action type of "JavaScript".
         const char* actionType = nullptr;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (!CGPDFDictionaryGetName(javaScriptAction, "S", &actionType) || strcmp(actionType, "JavaScript"))
             continue;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         auto scriptFromBytes = [](std::span<const uint8_t> bytes) {
             CFStringEncoding encoding = (bytes.size() > 1 && bytes[0] == 0xFE && bytes[1] == 0xFF) ? kCFStringEncodingUnicode : kCFStringEncodingUTF8;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -311,7 +311,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     WebCore::FloatPoint pageOverlayPoint;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if ([parameter isKindOfClass:[NSValue class]] && !strcmp([(NSValue *)parameter objCType], @encode(NSPoint)))
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         pageOverlayPoint = [self convertScreenPointToRootView:[(NSValue *)parameter pointValue]];
     else
         return nil;

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -82,7 +82,9 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 
     xpc_connection_set_event_handler(m_connection.get(), [](xpc_object_t event) {
         if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_CONNECTION_INTERRUPTED) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             fprintf(stderr, "Unexpected XPC connection issue: %s\n", event.debugDescription.UTF8String);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             return;
         }
 
@@ -91,8 +93,10 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 
     if (waitForServiceToExist == WaitForServiceToExist::Yes) {
         auto result = maybeConnectToService(m_serviceName);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (result == MACH_PORT_NULL)
             printf("Waiting for service '%s' to be available\n", m_serviceName.characters());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         while (result == MACH_PORT_NULL) {
             usleep(1000);
@@ -100,7 +104,9 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
         }
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Connecting to service '%s'\n", m_serviceName.characters());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     xpc_connection_activate(m_connection.get());
 
     sendAuditToken();
@@ -108,21 +114,27 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 
 void Connection::sendPushMessage(PushMessageForTesting&& message, CompletionHandler<void(String)>&& completionHandler)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Injecting push message\n");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(WTFMove(message)), WTFMove(completionHandler));
 }
 
 void Connection::getPushPermissionState(const String& scope, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Getting push permission state\n");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
 }
 
 void Connection::requestPushPermission(const String& scope, CompletionHandler<void(bool)>&& completionHandler)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Request push permission state for %s\n", scope.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RequestPushPermission(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
 }
@@ -132,10 +144,12 @@ void Connection::sendAuditToken()
     audit_token_t token = { 0, 0, 0, 0, 0, 0, 0, 0 };
     mach_msg_type_number_t auditTokenCount = TASK_AUDIT_TOKEN_COUNT;
     kern_return_t result = task_info(mach_task_self(), TASK_AUDIT_TOKEN, (task_info_t)(&token), &auditTokenCount);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (result != KERN_SUCCESS) {
         printf("Unable to get audit token to send\n");
         return;
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration;
     configuration.bundleIdentifierOverride = m_bundleIdentifier;

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -37,6 +37,8 @@
 
 using WebKit::WebPushD::PushMessageForTesting;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 __attribute__((__noreturn__))
 static void printUsageAndTerminate(NSString *message)
 {
@@ -72,6 +74,8 @@ static void printUsageAndTerminate(NSString *message)
 
     exitProcess(-1);
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static std::unique_ptr<PushMessageForTesting> pushMessageFromArguments(NSEnumerator<NSString *> *enumerator)
 {
@@ -174,6 +178,7 @@ public:
         pushMessage.targetAppCodeSigningIdentifier = connection.bundleIdentifier();
         pushMessage.pushPartitionString = connection.pushPartition();
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         connection.sendPushMessage(WTFMove(pushMessage), [this, bundleIdentifier = connection.bundleIdentifier(), webClipIdentifier = connection.pushPartition()](String error) mutable {
             if (error.isEmpty())
                 printf("Successfully injected push message %s for [bundleID = %s, webClipIdentifier = %s, scope = %s]\n", m_pushMessage.payload.utf8().data(), bundleIdentifier.utf8().data(), webClipIdentifier.utf8().data(), m_pushMessage.registrationURL.string().utf8().data());
@@ -181,6 +186,7 @@ public:
                 printf("Injected push message with error: %s\n", error.utf8().data());
             done();
         });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
 private:
@@ -197,7 +203,9 @@ public:
     void run(WebPushTool::Connection& connection) override
     {
         connection.getPushPermissionState(m_scope, [this](WebCore::PushPermissionState state) mutable {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             printf("Got push permission status: %u\n", static_cast<unsigned>(state));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             done();
         });
     }
@@ -216,7 +224,9 @@ public:
     void run(WebPushTool::Connection& connection) override
     {
         connection.requestPushPermission(m_scope, [this](bool granted) mutable {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             printf("Requested push permission with result: %d\n", granted);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             done();
         });
     }

--- a/Source/bmalloc/bmalloc/CompactAllocationMode.h
+++ b/Source/bmalloc/bmalloc/CompactAllocationMode.h
@@ -29,7 +29,9 @@
 #include "BInline.h"
 
 #if BUSE(LIBPAS)
+BALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "pas_allocation_mode.h"
+BALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
 namespace bmalloc {


### PR DESCRIPTION
#### 9b61e37d88b779af79004c38d19ce30b172eed44
<pre>
Prepare for -Wunsafe-buffer-usage-in-libc-call
<a href="https://bugs.webkit.org/show_bug.cgi?id=286175">https://bugs.webkit.org/show_bug.cgi?id=286175</a>
<a href="https://rdar.apple.com/143158556">rdar://143158556</a>

Reviewed by Chris Dumez.

I enabled the setting locally and bracketed the failures with skip macros.

I also fixed a couple hyper-trivial cases.

We now have an Apple-port specific skip, so Apple engineers searching for
skips needs two regexes:

        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN(?! //.*port)

and

        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN.*[^-]Apple

* Source/JavaScriptCore/API/PASReportCrashPrivate.cpp:
* Source/JavaScriptCore/API/tests/ExecutionTimeLimitTest.cpp:
* Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp:
(testFunctionOverrides):
* Source/JavaScriptCore/API/tests/FunctionToStringTests.cpp:
(testFunctionToString):
* Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp:
(testJSObjectGetProxyTarget):
* Source/JavaScriptCore/API/tests/MultithreadedMultiVMExecutionTest.cpp:
(startMultithreadedMultiVMExecutionTest):
* Source/JavaScriptCore/API/tests/testapi.mm:
(blockSignatureContainsClass):
(cacheFileInDataVault):
* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_templates.py:
* Source/JavaScriptCore/assembler/AssemblerCommon.h:
* Source/JavaScriptCore/assembler/Printer.h:
* Source/JavaScriptCore/b3/B3ValueRep.h:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/bytecode/PropertyCondition.h:
(JSC::PropertyCondition::PropertyCondition):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::speculationFromString):
* Source/JavaScriptCore/dfg/DFGAbstractValue.cpp:
(JSC::DFG::AbstractValue::ensureCanInitializeWithZeros):
* Source/JavaScriptCore/dfg/DFGVariableEvent.cpp:
* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::dumpBits):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runFixpointPhase):
* Source/JavaScriptCore/heap/PreciseAllocation.cpp:
(JSC::PreciseAllocation::tryReallocate):
* Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp:
(Inspector::ContentSearchUtilities::escapeStringForRegularExpressionSource):
* Source/JavaScriptCore/jit/CallFrameShuffler.cpp:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeSeparatedWXHeaps):
* Source/JavaScriptCore/jit/ICStats.cpp:
(JSC::ICEvent::operator&lt; const):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/runtime/ExceptionFuzz.cpp:
(JSC::doExceptionFuzzing):
* Source/JavaScriptCore/runtime/FuzzerPredictions.cpp:
(JSC::readFileIntoString):
* Source/JavaScriptCore/runtime/GenericTypedArrayViewInlines.h:
(JSC::GenericTypedArrayView&lt;Adaptor&gt;::tryCreate):
* Source/JavaScriptCore/runtime/IndexingType.cpp:
(JSC::dumpIndexingType):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
* Source/JavaScriptCore/runtime/Options.cpp:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::enableAssembler):
* Source/JavaScriptCore/tools/CompilerTimingScope.cpp:
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::parseClause):
(JSC::FunctionOverrides::parseOverridesInFile):
* Source/JavaScriptCore/tools/Integrity.cpp:
* Source/JavaScriptCore/wasm/WasmValueLocation.h:
* Source/WTF/wtf/DateMath.cpp:
(WTF::findMonth):
(WTF::parseInt):
(WTF::parseLong):
* Source/WTF/wtf/FastMalloc.cpp:
* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/FilePrintStream.cpp:
(WTF::FilePrintStream::vprintf):
* Source/WTF/wtf/Int128.cpp:
(WTF::printInternal):
* Source/WTF/wtf/LockedPrintStream.cpp:
(WTF::LockedPrintStream::vprintf):
* Source/WTF/wtf/NumberOfCores.cpp:
(WTF::numberOfProcessorCores):
* Source/WTF/wtf/PrintStream.cpp:
* Source/WTF/wtf/PrintStream.h:
(WTF::printInternal):
* Source/WTF/wtf/SafeStrerror.cpp:
(WTF::safeStrerror):
* Source/WTF/wtf/ScopedPrintStream.h:
* Source/WTF/wtf/StackTrace.cpp:
(WTF::StackTracePrinter::dump const):
* Source/WTF/wtf/StringPrintStream.cpp:
* Source/WTF/wtf/SystemMalloc.h:
(WTF::SystemMalloc::zeroedMalloc):
(WTF::SystemMalloc::tryZeroedMalloc):
* Source/WTF/wtf/URL.cpp:
(WTF::URL::print const):
* Source/WTF/wtf/cocoa/CrashReporter.cpp:
(WTF::setCrashLogMessage):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::readIDNAllowedScriptListFile):
* Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp:
(WTFSignpostHandleIndirectLog):
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logError):
* Source/WTF/wtf/dtoa/utils.h:
(WTF::double_conversion::StrLength):
(WTF::double_conversion::StringBuilder::AddSubstring):
(WTF::double_conversion::StringBuilder::Finalize):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::Thread::initializePlatformThreading):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::operator==):
* Source/WTF/wtf/text/CString.cpp:
(WTF::operator==):
(WTF::operator&lt;):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::span8):
(WTF::span8IncludingNullTerminator):
(WTF::span):
(WTF::spanIncludingNullTerminator):
* Source/WTF/wtf/text/TextStream.cpp:
(WTF::TextStream::operator&lt;&lt;):
* Source/WTF/wtf/text/icu/UTextProvider.cpp:
(WTF::uTextCloneImpl):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::uTextLatin1Clone):
(WTF::openLatin1UTextProvider):
* Source/WTF/wtf/threads/Signals.cpp:
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::copyShortASCIIString):
(WTF::localesMatch):
(WTF::createIterator):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::isSeparator):
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::createICUConverter const):
(PAL::ErrorCallbackSetter::~ErrorCallbackSetter):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::isUndesiredAlias):
(PAL::WTF_REQUIRES_LOCK):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(accessibilitySearchCriteriaForSearchPredicate):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(parameterizedAttributeValueForTesting):
(formatForDebugger):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::showStyle):
* Source/WebCore/dom/ElementData.cpp:
(WebCore::UniqueElementData::UniqueElementData):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::dumpStatistics):
(WebCore::showSubTreeAcrossFrame):
* Source/WebCore/dom/Position.cpp:
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::create):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::debugPosition const):
* Source/WebCore/editing/VisibleSelection.cpp:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::showTreeWithIndent const):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::compactStackTrace):
* Source/WebCore/html/HTMLElement.cpp:
(dumpInnerHTML):
* Source/WebCore/html/ImageDataArray.cpp:
(WebCore::fillTypedArray):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::printLayoutTreeForLiveDocuments):
* Source/WebCore/loader/TextResourceDecoder.h:
(WebCore::TextResourceDecoder::setAlwaysUseUTF8):
* Source/WebCore/loader/appcache/ApplicationCache.cpp:
(WebCore::ApplicationCache::dump):
* Source/WebCore/page/FrameTree.cpp:
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::pageProperty):
* Source/WebCore/platform/FileHandle.cpp:
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::isMemoryAttributionDisabled):
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::SincResampler):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::WebAudioBufferList):
(WebCore::WebAudioBufferList::reset):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getBufferSubDataImpl):
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::prepare):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::initializeEGLDisplay):
(WebCore::GraphicsContextGLCocoa::platformInitializeContext):
* Source/WebCore/platform/graphics/cocoa/TransformationMatrixCocoa.cpp:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::parseOpusPrivateData):
* Source/WebCore/platform/mac/CursorMac.mm:
(WebCore::cursor):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::appendFormURLEncoded):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::setCanSuspendLockedFileAttribute):
* Source/WebCore/platform/text/SegmentedString.cpp:
(WebCore::SegmentedString::advancePastSlowCase):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::advancePast):
* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::showTreeAndMark):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::showLayerTree):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::subtagCompare):
(WebCore::quotesForLanguage):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::RenderBundleEncoder):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::RenderPipeline):
* Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::deleteOldVersions):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(encodeInvocationArguments):
(crashWithClassName):
(decodeInvocationArguments):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _sendInvocation:interface:]):
(-[_WKRemoteObjectRegistry _invokeMethod:]):
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm:
(WebKit::CoreIPCNSValue::valueFromNSValue):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::create):
(WebKit::SandboxExtensionImpl::~SandboxExtensionImpl):
(WebKit::SandboxExtensionImpl::getSerializedFormat):
(WebKit::SandboxExtension::createHandleForTemporaryFile):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm:
(WebKit::handleXPCEndpointMessage):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatatypeTraits.h:
(WebKit::_WKWebExtensionSQLiteDatatypeTraits&lt;NSNumber::bind):
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::initializeTimers):
(WebKit::WebMemorySampler::stop):
(WebKit::WebMemorySampler::stopTimerFired):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndCacheSandboxProfile):
(WebKit::tryApplyCachedSandbox):
* Source/WebKit/Shared/mac/WebMemorySampler.mac.mm:
(WebKit::WebMemorySampler::sampleSystemMalloc const):
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm:
(WebKit::WebKitSwiftLibrary):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::pathToPDFOnDisk):
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm:
(WebKit::PDFScriptEvaluation::pdfDocumentContainsPrintScript):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:forParameter:]):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::connectToService):
(WebPushTool::Connection::sendPushMessage):
(WebPushTool::Connection::getPushPermissionState):
(WebPushTool::Connection::requestPushPermission):
(WebPushTool::Connection::sendAuditToken):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
* Source/bmalloc/bmalloc/CompactAllocationMode.h:

Canonical link: <a href="https://commits.webkit.org/289133@main">https://commits.webkit.org/289133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb87bbea23513c8ec3a4c5362bbf04386c34f6c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85399 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46677 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31824 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35502 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92063 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84433 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74137 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4784 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13331 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18152 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106823 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12527 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25744 "Failed to compile JSC") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->