### PR TITLE
[webkitscmpy] Support calling classify without repository

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
@@ -37,7 +37,7 @@ class CommitClassifier(object):
             try:
                 from rapidfuzz import fuzz
             except ModuleNotFoundError:
-                return re.compile(string)
+                return lambda x: re.compile(string).match(x)
 
             ratio = cls.DEFAULT_FUZZ_RATIO if not ratio else ratio
             return lambda x: fuzz.partial_ratio(string, x) >= ratio
@@ -109,7 +109,7 @@ class CommitClassifier(object):
         header = commit.message.splitlines()[0]
         trailers = commit.trailers
         paths_for = CallByNeed(
-            callback=lambda: repository.files_changed(commit.hash or str(commit)),
+            callback=lambda: repository.files_changed(commit.hash or str(commit)) if repository else [],
             type=list,
         )
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py
@@ -155,3 +155,21 @@ class TestClassify(testing.PathTestCase):
             captured.stderr.getvalue(),
             'Provided commit does not match a known class in this repository\n',
         )
+
+    def test_path_no_repository(self):
+        classifier = CommitClassifier([CommitClassifier.CommitClass(
+            name='Tools',
+            paths=['Tests', 'metadata'],
+        )])
+        self.assertIsNone(
+            classifier.classify(Commit(
+            revision=10,
+            hash='898d20c0b1efc7b717173804676349f079df3b7e',
+            identifier='6@main',
+            timestamp=int(time.time()),
+            author=Contributor.Encoder().default(Contributor.from_scm_log('Author: jbedard@apple.com <jbedard@apple.com>')),
+            message='Commit title\n'
+                    'https://bugs.example.com/show_bug.cgi?id=1\n\n'
+                    'Reviewed by NOBODY (OOPS!)\n\n'
+                    'cherry-pick: 2.3@branch-b (790725a6d79e)\n',
+        )))


### PR DESCRIPTION
#### 0b1ed539b43175c7c96a85c969c97799a9a389bf
<pre>
[webkitscmpy] Support calling classify without repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=286183">https://bugs.webkit.org/show_bug.cgi?id=286183</a>
<a href="https://rdar.apple.com/143161683">rdar://143161683</a>

Reviewed by Brianna Fan.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py:
(CommitClassifier.LineFilter.fuzzy): Drive-by fix to support classifiers when rapidfuzz is unavailable.
(CommitClassifier.classify): Support undefined repository in function call.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/classify_unittest.py:
(TestClassify.test_path_no_repository): Add test.

Canonical link: <a href="https://commits.webkit.org/289193@main">https://commits.webkit.org/289193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc385a475109bad9d80e50cd3ac18bec07d513b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85337 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66340 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24151 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46622 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/85198 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31774 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91927 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9270 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74897 "Found 56 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html fast/multicol/columns-on-body.html fast/ruby/annotation-with-line-gap.html fast/ruby/bopomofo-rl.html ... (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/84965 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74014 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4705 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13355 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->