### PR TITLE
StyleGradientImages never cache their image

### DIFF
--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -83,8 +83,6 @@ RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const Flo
 
     bool cacheable = m_knownCacheableBarringFilter && !style.hasAppleColorFilter();
     if (cacheable) {
-        if (!clients().contains(const_cast<RenderElement&>(*renderer)))
-            return nullptr;
         if (auto* result = const_cast<StyleGradientImage&>(*this).cachedImageForSize(size))
             return result;
     }

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -101,8 +101,8 @@ public:
     Color(WebCore::Color);
     Color(SRGBA<uint8_t>);
 
-    Color(ResolvedColor&&);
-    Color(CurrentColor&&);
+    WEBCORE_EXPORT Color(ResolvedColor&&);
+    WEBCORE_EXPORT Color(CurrentColor&&);
     Color(ColorLayers&&);
     Color(ColorMix&&);
     Color(ContrastColor&&);
@@ -125,7 +125,7 @@ public:
     WEBCORE_EXPORT Color(const Color&);
     Color& operator=(const Color&);
 
-    Color(Color&&);
+    WEBCORE_EXPORT Color(Color&&);
     Color& operator=(Color&&);
 
     WEBCORE_EXPORT ~Color();

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Apple Inc. All rights reserved.
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1198,7 +1198,7 @@ static bool stopColorIsCacheable(const Markable<Color>& stopColor)
 
 template<typename Gradient> static bool stopsAreCacheable(const Gradient& gradient)
 {
-    return std::ranges::none_of(gradient.parameters.stops, [](auto& stop) {
+    return std::ranges::all_of(gradient.parameters.stops, [](auto& stop) {
         return stopColorIsCacheable(stop.color);
     });
 }

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -390,7 +390,7 @@ using Gradient = std::variant<
 Ref<WebCore::Gradient> createPlatformGradient(const Gradient&, const FloatSize&, const RenderStyle&);
 
 // Returns whether it caching based on the gradient's stops is allowed.
-bool stopsAreCacheable(const Gradient&);
+WEBCORE_EXPORT bool stopsAreCacheable(const Gradient&);
 
 // Returns whether the gradient is opaque.
 bool isOpaque(const Gradient&, const RenderStyle&);

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -222,6 +222,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/SecurityOrigin.cpp
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp
+        Tests/WebCore/StyleGradient.cpp
         Tests/WebCore/TimeRanges.cpp
         Tests/WebCore/TransformationMatrix.cpp
         Tests/WebCore/URLParserTextEncoding.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1187,6 +1187,7 @@
 		BCB68042126FBFF100642A61 /* DocumentStartUserScriptAlertCrash_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCB68041126FBFF100642A61 /* DocumentStartUserScriptAlertCrash_Bundle.cpp */; };
 		BCE0DFB72D188ADC003F0349 /* CompactVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DFB62D188ADC003F0349 /* CompactVariant.cpp */; };
 		BCEA080E2CD00F5C000AC148 /* VariantList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCEA080D2CD00F5C000AC148 /* VariantList.cpp */; };
+		BCED51762D3B3C1200C57E2D /* StyleGradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCED51752D3B3C1200C57E2D /* StyleGradient.cpp */; };
 		C0BD669F131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0BD669E131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp */; };
 		C0C5D3C61459912900A802A6 /* GetBackingScaleFactor_Bundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0C5D3BD14598B6F00A802A6 /* GetBackingScaleFactor_Bundle.mm */; };
 		C104BC1F2547237100C078C9 /* OverrideAppleLanguagesPreference.mm in Sources */ = {isa = PBXBuildFile; fileRef = C104BC1E2547237100C078C9 /* OverrideAppleLanguagesPreference.mm */; };
@@ -3417,6 +3418,7 @@
 		BCC8B95A12611F4700DE46A4 /* FailedLoad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FailedLoad.cpp; sourceTree = "<group>"; };
 		BCE0DFB62D188ADC003F0349 /* CompactVariant.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CompactVariant.cpp; sourceTree = "<group>"; };
 		BCEA080D2CD00F5C000AC148 /* VariantList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VariantList.cpp; sourceTree = "<group>"; };
+		BCED51752D3B3C1200C57E2D /* StyleGradient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleGradient.cpp; sourceTree = "<group>"; };
 		C02B77F1126612140026BF0F /* SpacebarScrolling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpacebarScrolling.cpp; sourceTree = "<group>"; };
 		C02B7853126613AE0026BF0F /* Carbon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Carbon.framework; sourceTree = SDKROOT; };
 		C02B7882126615410026BF0F /* spacebar-scrolling.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "spacebar-scrolling.html"; sourceTree = "<group>"; };
@@ -4774,6 +4776,7 @@
 				ECA680CD1E68CC0900731D20 /* StringUtilities.mm */,
 				CE4D5DE51F6743BA0072CFC6 /* StringWithDirection.cpp */,
 				41E67A8425D16E83007B0A4C /* STUNMessageParsingTest.cpp */,
+				BCED51752D3B3C1200C57E2D /* StyleGradient.cpp */,
 				1C9DD9222697655B00274DB2 /* SVGImageCasts.cpp */,
 				155B872B2BF55D7800D93968 /* TextBoundaries.cpp */,
 				93A258981F92FF15003E510C /* TextCodec.cpp */,
@@ -7260,6 +7263,7 @@
 				1C8FA53A2685A6D500B7E49E /* StringWidth.mm in Sources */,
 				CE4D5DE71F6743BA0072CFC6 /* StringWithDirection.cpp in Sources */,
 				41E67A8525D16E83007B0A4C /* STUNMessageParsingTest.cpp in Sources */,
+				BCED51762D3B3C1200C57E2D /* StyleGradient.cpp in Sources */,
 				7CCE7ED21A411A7E00447C4C /* SubresourceErrorCrash.mm in Sources */,
 				51EB126724CB8753000CB030 /* SunLightApplicationGenericNES.mm in Sources */,
 				1C9DD9232697655B00274DB2 /* SVGImageCasts.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <WebCore/StyleGradient.h>
+
+namespace TestWebKitAPI {
+
+static WebCore::Style::GradientLinearColorStopList cacheableStops()
+{
+    return {
+        {
+            WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::red } },
+            WebCore::Style::Percentage<> { 50 }
+        },
+        {
+            WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::blue } },
+            WebCore::Style::Percentage<> { 100 }
+        }
+    };
+}
+
+static WebCore::Style::GradientLinearColorStopList someUncacheableStops()
+{
+    return {
+        {
+            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Percentage<> { 50 }
+        },
+        {
+            WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::blue } },
+            WebCore::Style::Percentage<> { 100 }
+        }
+    };
+}
+
+static WebCore::Style::GradientLinearColorStopList allUncacheableStops()
+{
+    return {
+        {
+            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Percentage<> { 50 }
+        },
+        {
+            WebCore::Style::Color { WebCore::Style::CurrentColor { } },
+            WebCore::Style::Percentage<> { 100 }
+        }
+    };
+}
+
+static WebCore::Style::Gradient gradientWithStops(WebCore::Style::GradientLinearColorStopList stops)
+{
+    return WebCore::FunctionNotation<WebCore::CSSValueLinearGradient, WebCore::Style::LinearGradient> {
+        .parameters = {
+            .colorInterpolationMethod = WebCore::CSS::GradientColorInterpolationMethod {
+                .method = { WebCore::ColorInterpolationMethod::SRGB { }, WebCore::AlphaPremultiplication::Premultiplied },
+                .defaultMethod = WebCore::CSS::GradientColorInterpolationMethod::Default::SRGB,
+            },
+            .gradientLine = WebCore::CSS::Horizontal { WebCore::CSS::Keyword::Left { } },
+            .stops = stops
+        }
+    };
+}
+
+TEST(WebCore, StyleGradientStopsAreCacheable)
+{
+    auto cacheableGradient = gradientWithStops(cacheableStops());
+    ASSERT_TRUE(WebCore::Style::stopsAreCacheable(cacheableGradient));
+
+    auto uncacheableGradient1 = gradientWithStops(someUncacheableStops());
+    ASSERT_FALSE(WebCore::Style::stopsAreCacheable(uncacheableGradient1));
+
+    auto uncacheableGradient2 = gradientWithStops(allUncacheableStops());
+    ASSERT_FALSE(WebCore::Style::stopsAreCacheable(uncacheableGradient2));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### f88290ea41bc0d62dcb4a581dfbcd787d4664796
<pre>
StyleGradientImages never cache their image
<a href="https://bugs.webkit.org/show_bug.cgi?id=286186">https://bugs.webkit.org/show_bug.cgi?id=286186</a>

Reviewed by Simon Fraser.

StyleGradientImage backing store caching has been broken since 287234@main.
The fact we were never caching was also masking an issue where we would fail
to draw anything if a cacheable StyleGradientImage was being used as the
input to another StyleImage, such as StyleFilterImage.

* Source/WebCore/style/values/images/StyleGradient.cpp:
     - Fix check for cacheability by updating `none_of` -&gt; `all_of`.
     - Remove unnecessary check for containing the client. Since the
       gradient is cacheable and cannot change we don&apos;t care about
       the client here like we do for StyleCanvasImage where client
       must be notified on changes. Removing this check allows
       gradients used by other StyleImages (like StyleFilterImage)
       to be successfully cached.

* Source/WebCore/style/values/color/StyleColor.h:
    - Export some functions to make unit test work.

* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp: Added.
    - Add unit tests for both cacheable and uncacheable states.

Canonical link: <a href="https://commits.webkit.org/289123@main">https://commits.webkit.org/289123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/964ccc33bfcf10e5abdf6725adcdc5f98cfbb909

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85387 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66379 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24193 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31814 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92034 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74112 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18457 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4771 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18141 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->