### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in ComposedCharacterClusterTextIterator.h

### DIFF
--- a/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
+++ b/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
@@ -28,8 +28,6 @@
 #include <unicode/utf16.h>
 #include <wtf/text/TextBreakIterator.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class ComposedCharacterClusterTextIterator {
@@ -37,7 +35,7 @@ public:
     // The passed in UChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
     ComposedCharacterClusterTextIterator(std::span<const UChar> characters, unsigned currentIndex, unsigned lastIndex)
         : m_iterator(characters, { }, TextBreakIterator::CaretMode { }, nullAtom())
-        , m_characters(characters.data())
+        , m_characters(characters)
         , m_originalIndex(currentIndex)
         , m_currentIndex(currentIndex)
         , m_lastIndex(lastIndex)
@@ -72,23 +70,21 @@ public:
         m_currentIndex = index;
     }
 
-    const UChar* remainingCharacters() const
+    std::span<const UChar> remainingCharacters() const
     {
         auto relativeIndex = m_currentIndex - m_originalIndex;
-        return m_characters + relativeIndex;
+        return m_characters.subspan(relativeIndex);
     }
 
     unsigned currentIndex() const { return m_currentIndex; }
-    const UChar* characters() const { return m_characters; }
+    std::span<const UChar> characters() const { return m_characters; }
 
 private:
     CachedTextBreakIterator m_iterator;
-    const UChar* const m_characters;
+    std::span<const UChar> m_characters;
     const unsigned m_originalIndex { 0 };
     unsigned m_currentIndex { 0 };
     const unsigned m_lastIndex { 0 };
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 40417bd63a0a2ba192d3bec13721c8b87b234fdb
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in ComposedCharacterClusterTextIterator.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=286192">https://bugs.webkit.org/show_bug.cgi?id=286192</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h:
(WebCore::ComposedCharacterClusterTextIterator::remainingCharacters const):
(WebCore::ComposedCharacterClusterTextIterator::characters const):

Canonical link: <a href="https://commits.webkit.org/289114@main">https://commits.webkit.org/289114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/024f9a51f13a6642ea110aed6186ad20d67c8813

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66353 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31787 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32625 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91979 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Running checkout-pull-request; Running compile-webkit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74945 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74065 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18428 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4721 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13313 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18109 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->