### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PixelBufferConformerCV.cpp

### DIFF
--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <CoreVideo/CoreVideo.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/SoftLinking.h>
 #include <wtf/StdLibExtras.h>
 
@@ -174,8 +175,19 @@ inline std::span<uint8_t> CVPixelBufferGetSpanOfPlane(CVPixelBufferRef pixelBuff
     if (!baseAddress)
         return { };
 
-    auto bytesPerRow = WebCore::CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
+    CheckedSize bytesPerRow = WebCore::CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
     auto height = WebCore::CVPixelBufferGetHeightOfPlane(pixelBuffer, planeIndex);
+    return unsafeMakeSpan(baseAddress, bytesPerRow * height);
+}
+
+inline std::span<uint8_t> CVPixelBufferGetSpan(CVPixelBufferRef pixelBuffer)
+{
+    auto* baseAddress = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer));
+    if (!baseAddress)
+        return { };
+
+    CheckedSize bytesPerRow = WebCore::CVPixelBufferGetBytesPerRow(pixelBuffer);
+    auto height = WebCore::CVPixelBufferGetHeight(pixelBuffer);
     return unsafeMakeSpan(baseAddress, bytesPerRow * height);
 }
 }

--- a/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
+++ b/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
@@ -37,8 +37,6 @@
 #include "CoreVideoSoftLink.h"
 #include "VideoToolboxSoftLink.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PixelBufferConformerCV);
@@ -51,10 +49,10 @@ static constexpr int kDefaultFramesToSkip = 2;
 
 static void logStackTrace(WTFLogChannel* channel)
 {
-    void* stack[kDefaultFramesToShow + kDefaultFramesToSkip];
-    int frames = kDefaultFramesToShow + kDefaultFramesToSkip;
-    WTFGetBacktrace(stack, &frames);
-    StackTraceSymbolResolver { { stack, static_cast<size_t>(frames) } }.forEach([&](int frameNumber, void* stackFrame, const char* name) {
+    std::array<void*, kDefaultFramesToShow + kDefaultFramesToSkip> stack;
+    int frameCount = kDefaultFramesToShow + kDefaultFramesToSkip;
+    WTFGetBacktrace(stack.data(), &frameCount);
+    StackTraceSymbolResolver { std::span { stack }.first(frameCount) }.forEach([&](int frameNumber, void* stackFrame, const char* name) {
         if (name)
             os_log(channel->osLogChannel, "%-3d %p %{public}s", frameNumber, stackFrame, name);
         else
@@ -97,18 +95,16 @@ static const void* CVPixelBufferGetBytePointerCallback(void* refcon)
     }
 
     ++info->lockCount;
-    void* address = CVPixelBufferGetBaseAddress(info->pixelBuffer.get());
-    if (!address) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferGetBaseAddress returned null");
+    auto bytes = CVPixelBufferGetSpan(info->pixelBuffer.get());
+    if (!bytes.data()) {
+        RELEASE_LOG_ERROR(Media, "CVPixelBufferGetSpan returned null");
         RELEASE_LOG_STACKTRACE(Media);
         return nullptr;
     }
 
-    size_t byteLength = CVPixelBufferGetBytesPerRow(info->pixelBuffer.get()) * CVPixelBufferGetHeight(info->pixelBuffer.get());
-
-    verifyImageBufferIsBigEnough({ static_cast<const uint8_t*>(address), byteLength });
-    RELEASE_LOG_INFO(Media, "CVPixelBufferGetBytePointerCallback() returning bytePointer: %p, size: %zu", address, byteLength);
-    return address;
+    verifyImageBufferIsBigEnough(bytes);
+    RELEASE_LOG_INFO(Media, "CVPixelBufferGetBytePointerCallback() returning bytePointer: %p, size: %zu", bytes.data(), bytes.size());
+    return bytes.data();
 }
 
 static void CVPixelBufferReleaseBytePointerCallback(void* refcon, const void*)
@@ -229,5 +225,3 @@ RetainPtr<CGImageRef> PixelBufferConformerCV::imageFrom32BGRAPixelBuffer(RetainP
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 590ffa215a1485491f92bfecf337f98aa004272f
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PixelBufferConformerCV.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286197">https://bugs.webkit.org/show_bug.cgi?id=286197</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/cocoa/CoreVideoSoftLink.h:
(WebCore::CVPixelBufferGetSpanOfPlane):
(WebCore::CVPixelBufferGetSpan):
* Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp:
(WebCore::logStackTrace):
(WebCore::CVPixelBufferGetBytePointerCallback):

Canonical link: <a href="https://commits.webkit.org/289117@main">https://commits.webkit.org/289117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55bc21a9bbda3aefbaf874a6d07003fe4da27c19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36404 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66362 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24175 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91966 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74933 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74052 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4730 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12652 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18120 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15975 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->