### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in MenuListButtonMac.mm & SliderTrackMac.mm

### DIFF
--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -43,14 +43,15 @@ MenuListButtonMac::MenuListButtonMac(MenuListButtonPart& owningPart, ControlFact
 {
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static void interpolateGradient(const CGFloat* inData, CGFloat* outData, std::span<const float, 4> dark, std::span<const float, 4> light)
+static void interpolateGradient(const CGFloat* rawInData, CGFloat* rawOutData, std::span<const float, 4> dark, std::span<const float, 4> light)
 {
+    auto inData = unsafeMakeSpan(rawInData, 1);
+    auto outData = unsafeMakeSpan(rawOutData, 4);
+
     float a = inData[0];
     for (size_t i = 0; i < 4; ++i)
         outData[i] = (1.0f - a) * dark[i] + a * light[i];
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void topGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -62,16 +62,17 @@ FloatRect SliderTrackMac::rectForBounds(const FloatRect& bounds, const ControlSt
     return rect;
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static void trackGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
+static void trackGradientInterpolate(void*, const CGFloat* rawInData, CGFloat* rawOutData)
 {
+    auto inData = unsafeMakeSpan(rawInData, 1);
+    auto outData = unsafeMakeSpan(rawOutData, 4);
+
     static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.678f };
     static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.13f };
     float a = inData[0];
     for (size_t i = 0; i < 4; ++i)
         outData[i] = (1.0f - a) * dark[i] + a * light[i];
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle& style)
 {


### PR DESCRIPTION
#### e12b81b76dc5ffbc23361f61f2ceb6343d1b4fa1
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in MenuListButtonMac.mm &amp; SliderTrackMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=286198">https://bugs.webkit.org/show_bug.cgi?id=286198</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
(WebCore::interpolateGradient):
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm:
(WebCore::trackGradientInterpolate):

Canonical link: <a href="https://commits.webkit.org/289118@main">https://commits.webkit.org/289118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2945b28f96d1cb9d0d2575159b160494fd2dd74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66363 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24176 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88409 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3958 "13 new passes 8 flakes 5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31796 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35473 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32636 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91978 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9299 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74944 "Found 63 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/hidpi/filters-and-image-buffer-resolution.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12939 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73372 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74064 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4731 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12653 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18121 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Checked out pull request; Found 48574 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->