### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in MediaEngineConfigurationFactory.cpp

### DIFF
--- a/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
@@ -97,8 +97,6 @@ bool MediaEngineConfigurationFactory::hasEncodingConfigurationFactory()
     return mockEnabled() || WTF::anyOf(factories(), [] (auto& factory) { return (bool)factory.createEncodingConfiguration; });
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 void MediaEngineConfigurationFactory::createDecodingConfiguration(MediaDecodingConfiguration&& config, DecodingConfigurationCallback&& callback)
 {
     if (mockEnabled()) {
@@ -106,28 +104,28 @@ void MediaEngineConfigurationFactory::createDecodingConfiguration(MediaDecodingC
         return;
     }
 
-    auto factoryCallback = [] (auto factoryCallback, auto nextFactory, MediaDecodingConfiguration&& config, DecodingConfigurationCallback&& callback) mutable {
-        if (nextFactory == factories().end()) {
+    auto factoryCallback = [] (auto factoryCallback, std::span<const MediaEngineFactory> nextFactories, MediaDecodingConfiguration&& config, DecodingConfigurationCallback&& callback) mutable {
+        if (nextFactories.empty()) {
             callback({ { }, WTFMove(config) });
             return;
         }
 
-        auto& factory = *nextFactory;
+        auto& factory = nextFactories[0];
         if (!factory.createDecodingConfiguration) {
             callback({ { }, WTFMove(config) });
             return;
         }
 
-        factory.createDecodingConfiguration(WTFMove(config), [factoryCallback, nextFactory, config, callback = WTFMove(callback)] (MediaCapabilitiesDecodingInfo&& info) mutable {
+        factory.createDecodingConfiguration(WTFMove(config), [factoryCallback, nextFactories, config, callback = WTFMove(callback)] (MediaCapabilitiesDecodingInfo&& info) mutable {
             if (info.supported) {
                 callback(WTFMove(info));
                 return;
             }
 
-            factoryCallback(factoryCallback, ++nextFactory, WTFMove(info.supportedConfiguration), WTFMove(callback));
+            factoryCallback(factoryCallback, nextFactories.subspan(1), WTFMove(info.supportedConfiguration), WTFMove(callback));
         });
     };
-    factoryCallback(factoryCallback, factories().begin(), WTFMove(config), WTFMove(callback));
+    factoryCallback(factoryCallback, factories().span(), WTFMove(config), WTFMove(callback));
 }
 
 void MediaEngineConfigurationFactory::createEncodingConfiguration(MediaEncodingConfiguration&& config, EncodingConfigurationCallback&& callback)
@@ -137,31 +135,29 @@ void MediaEngineConfigurationFactory::createEncodingConfiguration(MediaEncodingC
         return;
     }
 
-    auto factoryCallback = [] (auto factoryCallback, auto nextFactory, MediaEncodingConfiguration&& config, EncodingConfigurationCallback&& callback) mutable {
-        if (nextFactory == factories().end()) {
+    auto factoryCallback = [] (auto factoryCallback, std::span<const MediaEngineFactory> nextFactories, MediaEncodingConfiguration&& config, EncodingConfigurationCallback&& callback) mutable {
+        if (nextFactories.empty()) {
             callback({ });
             return;
         }
 
-        auto& factory = *nextFactory;
+        auto& factory = nextFactories[0];
         if (!factory.createEncodingConfiguration) {
             callback({ });
             return;
         }
 
-        factory.createEncodingConfiguration(WTFMove(config), [factoryCallback, nextFactory, callback = WTFMove(callback)] (auto&& info) mutable {
+        factory.createEncodingConfiguration(WTFMove(config), [factoryCallback, nextFactories, callback = WTFMove(callback)] (auto&& info) mutable {
             if (info.supported) {
                 callback(WTFMove(info));
                 return;
             }
 
-            factoryCallback(factoryCallback, ++nextFactory, WTFMove(info.supportedConfiguration), WTFMove(callback));
+            factoryCallback(factoryCallback, nextFactories.subspan(1), WTFMove(info.supportedConfiguration), WTFMove(callback));
         });
     };
-    factoryCallback(factoryCallback, factories().begin(), WTFMove(config), WTFMove(callback));
+    factoryCallback(factoryCallback, factories().span(), WTFMove(config), WTFMove(callback));
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void MediaEngineConfigurationFactory::enableMock()
 {


### PR DESCRIPTION
#### 630299e57b2a08a3027b669bb3df88efd058a654
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in MediaEngineConfigurationFactory.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286202">https://bugs.webkit.org/show_bug.cgi?id=286202</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp:
(WebCore::MediaEngineConfigurationFactory::createDecodingConfiguration):
(WebCore::MediaEngineConfigurationFactory::createEncodingConfiguration):

Canonical link: <a href="https://commits.webkit.org/289124@main">https://commits.webkit.org/289124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bdf85b7a3299d1bf760667778a4fee9f54ef674

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66380 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24194 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92024 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74984 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74104 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4773 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13323 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12690 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18142 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->