### PR TITLE
[css-anchor-position-1] Gate anchor-center behind CSS Anchor Positioning feature

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled-expected.txt
@@ -1,0 +1,6 @@
+
+PASS e.style['align-self'] = "anchor-center" should not set the property value
+PASS e.style['align-items'] = "anchor-center" should not set the property value
+PASS e.style['justify-self'] = "anchor-center" should not set the property value
+PASS e.style['justify-items'] = "anchor-center" should not set the property value
+

--- a/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ CSSAnchorPositioningEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Test CSS Anchor Positioning features when the feature flag is disabled</title>
+<meta charset="utf-8">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../imported/w3c/web-platform-tests/css/support/parsing-testcommon.js"></script>
+<script src="../../../imported/w3c/web-platform-tests/css/support/computed-testcommon.js"></script>
+</head>
+
+<body>
+<script>
+// FIXME: test the following features are disabled too:
+// anchor(), anchor-size(), anchor-name, anchor-scope, position-anchor,
+// position-area, position-visibility, position-try-fallbacks, position-try-order,
+// position-try, @position-try.
+
+test_invalid_value('align-self', 'anchor-center');
+test_invalid_value('align-items', 'anchor-center');
+test_invalid_value('justify-self', 'anchor-center');
+test_invalid_value('justify-items', 'anchor-center');
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
#### d9477327f62271df84745c05588d309783c3b4d2
<pre>
[css-anchor-position-1] Gate anchor-center behind CSS Anchor Positioning feature
<a href="https://rdar.apple.com/143097581">rdar://143097581</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286112">https://bugs.webkit.org/show_bug.cgi?id=286112</a>

Reviewed by Tim Nguyen.

anchor-center should be gated behind the CSS Anchor Positioning feature,
but it wasn&apos;t. Fixes this by not parsing anchor-center if the feature is
not enabled.

* LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled-expected.txt: Added.
* LayoutTests/fast/css/css-anchor-position/anchor-feature-disabled.html: Added.
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Align.cpp:
(WebCore::CSSPropertyParserHelpers::isSelfPositionKeyword):
(WebCore::CSSPropertyParserHelpers::consumeSelfPositionOverflowPosition):
(WebCore::CSSPropertyParserHelpers::consumeAlignSelf):
(WebCore::CSSPropertyParserHelpers::consumeJustifySelf):
(WebCore::CSSPropertyParserHelpers::consumeAlignItems):
(WebCore::CSSPropertyParserHelpers::consumeJustifyItems):
(WebCore::CSSPropertyParserHelpers::isSelfPositionOrLeftOrRightKeyword): Deleted.

Canonical link: <a href="https://commits.webkit.org/289170@main">https://commits.webkit.org/289170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/454a7cc49858a07204dfd5f57579f58557502d55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66489 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24301 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31940 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92283 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73511 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74320 "Found 101 new API test failures: /TestWebKit:WebKit2UserMessageRoundTripTest.WKURLRequestRef, /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.PageLoadState, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/current-position, /TestWebKit:WebKit.InjectedBundleBasic, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/create-navigation-data, /TestWebKit:WebKit.GeolocationBasic, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18360 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4973 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18275 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->