### PR TITLE
Remove `textpath-local-url-reference` in favor of `url-reference-local-textpath` of WPT

### DIFF
--- a/LayoutTests/svg/text/textpath-local-url-reference-expected.html
+++ b/LayoutTests/svg/text/textpath-local-url-reference-expected.html
@@ -1,2 +1,0 @@
-<!DOCTYPE html>
-<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/text/textpath-local-url-reference.html
+++ b/LayoutTests/svg/text/textpath-local-url-reference.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<base href="http://www.example.com/">
-<script src="../../resources/ahem.js"></script>
-<svg>
-  <path id="path" d="M0,80h100"/>
-  <text font-size="100" font-family="Ahem" fill="green"><textPath href="#path">X</textPath></textPath>
-</svg>


### PR DESCRIPTION
#### 2e66a1e354e7447813d139e5ae50051fabf2cd8b
<pre>
Remove `textpath-local-url-reference` in favor of `url-reference-local-textpath` of WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=286209">https://bugs.webkit.org/show_bug.cgi?id=286209</a>
<a href="https://rdar.apple.com/143186525">rdar://143186525</a>

Reviewed by Tim Nguyen.

This patch removes local test, which was uploaded to WPT by Blink in following [1]:

[1] <a href="https://source.chromium.org/chromium/chromium/src/+/048dd965a8c6e4b041bf46b77f3d0c5dcfd4e8e1">https://source.chromium.org/chromium/chromium/src/+/048dd965a8c6e4b041bf46b77f3d0c5dcfd4e8e1</a>

The WPT test is present below directory and passing on Safari Technology Preview 210.

&gt; svg/linking/reftests/url-reference-local-textpath.svg

* LayoutTests/svg/text/textpath-local-url-reference-expected.html: Removed.
* LayoutTests/svg/text/textpath-local-url-reference.html: Removed.

Canonical link: <a href="https://commits.webkit.org/289104@main">https://commits.webkit.org/289104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb75327e074f47d968ed91aa6ef441b2eb986629

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36417 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66373 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88421 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35485 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32650 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9312 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74968 "34 flakes 92 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74088 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18326 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18451 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4758 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12675 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->