### PR TITLE
Fuzzilli build is broken due to -Wunsafe-buffer-usage

### DIFF
--- a/Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp
+++ b/Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp
@@ -58,8 +58,10 @@ size_t Fuzzilli::numPendingRejectedPromises { 0 };
 void Fuzzilli::resetCoverageEdges()
 {
     uint64_t n = 0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (uint32_t* edge = edgesStart; edge < edgesStop && n < MAX_EDGES; edge++)
         *edge = ++n;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 FilePrintStream& Fuzzilli::logFile()
@@ -171,7 +173,9 @@ extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t* guard)
     // instrumentation ignores the first edge (see libcoverage.c) and so the race is unproblematic.
 
     uint32_t index = *guard;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     Fuzzilli::sharedData->edges[index / 8] |= 1 << (index % 8);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     *guard = 0;
 }


### PR DESCRIPTION
#### 240f71c9eaacea01ace06eb6d162fea912349727
<pre>
Fuzzilli build is broken due to -Wunsafe-buffer-usage
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=286213">https://bugs.webkit.org/show_bug.cgi?id=286213</a>&gt;
&lt;<a href="https://rdar.apple.com/143194698">rdar://143194698</a>&gt;

Unreviewed build fix.

* Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp:
(Fuzzilli::resetCoverageEdges):
(__sanitizer_cov_trace_pc_guard):
- Skip -Wunsafe-buffer-usage warnings in Fuzzilli.

Canonical link: <a href="https://commits.webkit.org/289121@main">https://commits.webkit.org/289121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/126fc1ed7baeb53e0fc1af9a2a87eb1cc0df4a1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39818 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36429 "Failed to checkout and rebase branch from PR 39254") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/90515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/36429 "Failed to checkout and rebase branch from PR 39254") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88433 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/4000 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/77558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3885 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/31819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/35497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/78374 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/32661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84428 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12735 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/92036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12963 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/73395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/18462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4777 "Failed to checkout and rebase branch from PR 39254") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13322 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18147 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106818 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12521 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/25743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->