### PR TITLE
Adopt more spans in CSSParserTokenRange

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -469,7 +469,7 @@ static bool allCharactersAllowedByTLDRules(std::span<const UChar> buffer)
 {
     // Skip trailing dot for root domain.
     if (buffer.back() == '.')
-        buffer = buffer.first(buffer.size() - 1);
+        dropLast(buffer);
 
     // http://cctld.ru/files/pdf/docs/rules_ru-rf.pdf
     static constexpr std::array<UChar, 3> cyrillicRF {

--- a/Source/WTF/wtf/text/ParsingUtilities.h
+++ b/Source/WTF/wtf/text/ParsingUtilities.h
@@ -47,6 +47,18 @@ template<typename T> void skip(std::span<T>& data, size_t amountToSkip)
     data = data.subspan(amountToSkip);
 }
 
+template<typename T> void dropLast(std::span<T>& data, size_t amountToDrop = 1)
+{
+    data = data.first(data.size() - amountToDrop);
+}
+
+template<typename T> T& consumeLast(std::span<T>& data)
+{
+    auto* last = &data.back();
+    data = data.first(data.size() - 1);
+    return *last;
+}
+
 template<typename T> void clampedMoveCursorWithinSpan(std::span<T>& cursor, std::span<T> container, int delta)
 {
     ASSERT(cursor.data() >= container.data());
@@ -283,7 +295,9 @@ using WTF::LCharPredicateAdapter;
 using WTF::clampedMoveCursorWithinSpan;
 using WTF::consume;
 using WTF::consumeAndCastTo;
+using WTF::consumeLast;
 using WTF::consumeSpan;
+using WTF::dropLast;
 using WTF::isNotASCIISpace;
 using WTF::skip;
 using WTF::skipCharactersExactly;

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -120,10 +120,10 @@ template <typename CharacterType>
 static inline bool parseSimpleLength(std::span<const CharacterType> characters, CSSUnitType& unit, double& number)
 {
     if (characters.size() > 2 && isASCIIAlphaCaselessEqual(characters[characters.size() - 2], 'p') && isASCIIAlphaCaselessEqual(characters[characters.size() - 1], 'x')) {
-        characters = characters.first(characters.size() - 2);
+        dropLast(characters, 2);
         unit = CSSUnitType::CSS_PX;
     } else if (!characters.empty() && characters.back() == '%') {
-        characters = characters.first(characters.size() - 1);
+        dropLast(characters);
         unit = CSSUnitType::CSS_PERCENTAGE;
     }
 
@@ -140,10 +140,10 @@ static inline bool parseSimpleAngle(std::span<const CharacterType> characters, R
     // "0deg" or "1rad"
     if (characters.size() >= 4) {
         if (isASCIIAlphaCaselessEqual(characters[characters.size() - 3], 'd') && isASCIIAlphaCaselessEqual(characters[characters.size() - 2], 'e') && isASCIIAlphaCaselessEqual(characters[characters.size() - 1], 'g')) {
-            characters = characters.first(characters.size() - 3);
+            dropLast(characters, 3);
             unit = CSS::AngleUnit::Deg;
         } else if (isASCIIAlphaCaselessEqual(characters[characters.size() - 3], 'r') && isASCIIAlphaCaselessEqual(characters[characters.size() - 2], 'a') && isASCIIAlphaCaselessEqual(characters[characters.size() - 1], 'd')) {
-            characters = characters.first(characters.size() - 3);
+            dropLast(characters, 3);
             unit = CSS::AngleUnit::Rad;
         } else if (requireUnits == RequireUnits::Yes)
             return false;
@@ -164,7 +164,7 @@ static inline bool parseSimpleNumberOrPercentage(std::span<const CharacterType> 
 {
     unit = CSSUnitType::CSS_NUMBER;
     if (!characters.empty() && characters.back() == '%') {
-        characters = characters.first(characters.size() - 1);
+        dropLast(characters);
         unit = CSSUnitType::CSS_PERCENTAGE;
     }
 

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -32,6 +32,7 @@
 #include "CSSParserToken.h"
 #include "CSSTokenizer.h"
 #include <wtf/Forward.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -46,38 +47,38 @@ public:
 
     template<size_t inlineBuffer>
     CSSParserTokenRange(const Vector<CSSParserToken, inlineBuffer>& vector)
-        : m_first(vector.begin())
-        , m_last(vector.end())
+        : m_tokens(vector.span())
     {
     }
 
     // This should be called on a range with tokens returned by that range.
     CSSParserTokenRange makeSubRange(const CSSParserToken* first, const CSSParserToken* last) const;
+    CSSParserTokenRange makeSubRange(std::span<const CSSParserToken> subrange) const;
 
-    bool atEnd() const { return m_first == m_last; }
-    const CSSParserToken* end() const { return m_last; }
+    bool atEnd() const { return m_tokens.empty(); }
 
-    size_t size() const { return end() - begin(); }
+    const CSSParserToken* begin() const { return std::to_address(m_tokens.begin()); }
+    const CSSParserToken* end() const { return std::to_address(m_tokens.end()); }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    const CSSParserToken& peek(unsigned offset = 0) const
+    size_t size() const { return m_tokens.size(); }
+
+    const CSSParserToken& peek(size_t offset = 0) const
     {
-        if (m_first + offset >= m_last)
-            return eofToken();
-        return *(m_first + offset);
+        if (offset < m_tokens.size())
+            return m_tokens[offset];
+        return eofToken();
     }
 
     const CSSParserToken& consume()
     {
-        if (m_first == m_last)
+        if (m_tokens.empty())
             return eofToken();
-        return *m_first++;
+        return WTF::consume(m_tokens);
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     const CSSParserToken& consumeIncludingWhitespace()
     {
-        const CSSParserToken& result = consume();
+        auto& result = consume();
         consumeWhitespace();
         return result;
     }
@@ -88,34 +89,30 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     void consumeComponentValue();
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void consumeWhitespace()
     {
-        while (CSSTokenizer::isWhitespace(peek().type()))
-            ++m_first;
+        size_t i = 0;
+        for (; i < m_tokens.size() && CSSTokenizer::isWhitespace(m_tokens[i].type()); ++i) { }
+        skip(m_tokens, i);
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     void trimTrailingWhitespace();
     const CSSParserToken& consumeLast();
 
-    CSSParserTokenRange consumeAll() { return { std::exchange(m_first, m_last), m_last }; }
+    CSSParserTokenRange consumeAll() { return { std::exchange(m_tokens, std::span<const CSSParserToken> { }) }; }
 
     String serialize(CSSParserToken::SerializationMode = CSSParserToken::SerializationMode::Normal) const;
 
-    const CSSParserToken* begin() const { return m_first; }
-    std::span<const CSSParserToken> span() const { return unsafeMakeSpan(begin(), size()); }
+    std::span<const CSSParserToken> span() const { return m_tokens; }
 
     static CSSParserToken& eofToken();
 
 private:
-    CSSParserTokenRange(const CSSParserToken* first, const CSSParserToken* last)
-        : m_first(first)
-        , m_last(last)
+    CSSParserTokenRange(std::span<const CSSParserToken> tokens)
+        : m_tokens(tokens)
     { }
 
-    const CSSParserToken* m_first { nullptr };
-    const CSSParserToken* m_last { nullptr };
+    std::span<const CSSParserToken> m_tokens;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -182,9 +182,9 @@ static Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(std::span<
         // 8. If url ends with a U+002C COMMA character (,)
         if (isComma(imageURLSpan.back())) {
             // Remove all trailing U+002C COMMA characters from url.
-            imageURLSpan = imageURLSpan.first(imageURLSpan.size() - 1);
+            dropLast(imageURLSpan);
             while (!imageURLSpan.empty() && isComma(imageURLSpan.back()))
-                imageURLSpan = imageURLSpan.first(imageURLSpan.size() - 1);
+                dropLast(imageURLSpan);
 
             // If url is empty, then jump to the step labeled splitting loop.
             if (imageURLSpan.empty())

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -72,6 +72,7 @@
 #include <wtf/NotFound.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 
 using JSON::ArrayOf;
@@ -335,7 +336,7 @@ template <typename CharacterType> inline void StyleSheetHandler::setRuleHeaderEn
 {
     while (data.size() > m_currentRuleDataStack.last()->ruleHeaderRange.start) {
         if (isASCIIWhitespace<CharacterType>(data[data.size() - 1]))
-            data = data.first(data.size() - 1);
+            dropLast(data);
         else
             break;
     }

--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 // On Windows, use the threadsafe *_r functions provided by pthread.
@@ -377,7 +378,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
                     if (pos > 4) {
                         p = &(tokens[0][pos - 4]);
                         if (p[0] == '.' && p[1] == 'D' && p[2] == 'I' && p[3] == 'R') {
-                            result.filename = result.filename.first(result.filename.size() - 4);
+                            dropLast(result.filename, 4);
                             result.type = FTPDirectoryEntry;
                         }
                     }
@@ -995,15 +996,15 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
                     pos = result.type;
                     if (pos == 'd') {
                         if (*p == '/')
-                            result.filename = result.filename.first(result.filename.size() - 1); /* directory */
+                            dropLast(result.filename); /* directory */
                     } else if (pos == 'l') {
                         if (*p == '@')
-                            result.filename = result.filename.first(result.filename.size() - 1); /* symlink */
+                            dropLast(result.filename); /* symlink */
                     } else if (pos == 'f') {
                         if (*p == '*')
-                            result.filename = result.filename.first(result.filename.size() - 1); /* executable */
+                            dropLast(result.filename); /* executable */
                     } else if (*p == '=' || *p == '%' || *p == '|')
-                        result.filename = result.filename.first(result.filename.size() - 1); /* socket, whiteout, fifo */
+                        dropLast(result.filename); /* socket, whiteout, fifo */
                 }
 #endif
 
@@ -1271,7 +1272,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
                     if (result.linkname.size() == 1)
                         result.type = FTPJunkEntry;
                     else {
-                        result.filename = result.filename.first(result.filename.size() - 1);
+                        dropLast(result.filename);
                         result.type = FTPDirectoryEntry;
                     }
                 } else if (isASCIIDigit(*tokens[tokmarker])) {
@@ -1349,7 +1350,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
                         result.type = FTPLinkEntry;
                         result.linkname = std::span(tokens[pos + 1], p - result.linkname.data());
                         if (result.linkname.size() > 1 && result.linkname[result.linkname.size() - 1] == '/')
-                            result.linkname = result.linkname.first(result.linkname.size() - 1);
+                            dropLast(result.linkname);
                     }
                 } /* if (numtoks > (tokmarker+2)) */
 


### PR DESCRIPTION
#### 643a222312ff1d998bd15e8fedf5a7d7441b2cc8
<pre>
Adopt more spans in CSSParserTokenRange
<a href="https://bugs.webkit.org/show_bug.cgi?id=286214">https://bugs.webkit.org/show_bug.cgi?id=286214</a>

Reviewed by Geoffrey Garen.

This tested as performance neutral on Speedometer.

* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
(WebCore::CSSParserTokenRange::makeSubRange const):
(WebCore::CSSParserTokenRange::consumeBlock):
(WebCore::CSSParserTokenRange::consumeBlockCheckingForEditability):
(WebCore::CSSParserTokenRange::consumeComponentValue):
(WebCore::CSSParserTokenRange::trimTrailingWhitespace):
(WebCore::CSSParserTokenRange::consumeLast):
(WebCore::CSSParserTokenRange::serialize const):
* Source/WebCore/css/parser/CSSParserTokenRange.h:
(WebCore::CSSParserTokenRange::CSSParserTokenRange):
(WebCore::CSSParserTokenRange::atEnd const):
(WebCore::CSSParserTokenRange::begin const):
(WebCore::CSSParserTokenRange::end const):
(WebCore::CSSParserTokenRange::size const):
(WebCore::CSSParserTokenRange::peek const):
(WebCore::CSSParserTokenRange::consume):
(WebCore::CSSParserTokenRange::consumeIncludingWhitespace):
(WebCore::CSSParserTokenRange::consumeWhitespace):
(WebCore::CSSParserTokenRange::consumeAll):
(WebCore::CSSParserTokenRange::span const):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/289131@main">https://commits.webkit.org/289131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d411aa0dab758bc0dabe4201dc15bd2079837720

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31833 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35518 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78401 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92071 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84447 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75019 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12982 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/73405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74140 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16907 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4800 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13329 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18166 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106837 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12545 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25746 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->