### PR TITLE
[WebGPU] Out of bounds read with index buffer shared between GPURenderBundles and GPURenderPass

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286215-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286215-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286215.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286215.html
@@ -1,0 +1,258 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({});
+// START
+c = device0.createBuffer({
+  size : 3,
+  usage : GPUBufferUsage.VERTEX})
+d = device0.createCommandEncoder()
+f = device0.createTexture({
+  size : {width : 2 },
+  format : 'rg32uint',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT 
+              })
+j = f.createView()
+k = device0.createShaderModule({
+  code : ` 
+                        struct l {
+                      @location(0) m: vec2u}
+                        @vertex fn n(@location(7) o: f32) -> @builtin(position) vec4f {
+                      var out: vec4f;
+                      while bool(o) {}
+                      return out;
+                    }
+                        @fragment fn p() -> l {
+                      var out: l;
+                      return out;
+                    }
+                       `})
+q = d.beginRenderPass({
+  colorAttachments : [ {
+    view : j,
+    loadOp : 'clear',
+    storeOp : 'discard'} ]
+  })
+t = device0.createCommandEncoder()
+u = t.beginRenderPass({
+  colorAttachments : [ {
+    view : j,
+    loadOp : 'clear',
+    storeOp : 'discard'} ]})
+buffer14 = device0.createBuffer({
+  size : 374,
+  usage : GPUBufferUsage.INDEX 
+              })
+v = device0.createPipelineLayout({bindGroupLayouts : []})
+pipeline8 = device0.createRenderPipeline({
+  layout : v,
+  fragment : {
+    module : k,
+    targets : [ {format : 'rg32uint' } ]
+  },
+  vertex : {
+    module : k,
+    buffers : [
+      {
+        arrayStride : 2048,
+        attributes : [
+          {format : 'float32x2', offset : 0   , shaderLocation : 7}]}]}})
+w = device0.createRenderBundleEncoder({
+  colorFormats : [ 'rg32uint' ]
+  })
+try {
+  w.setIndexBuffer(buffer14, 'uint16' )
+  w.setVertexBuffer(0, c)} catch {}
+try {
+  w.setPipeline(pipeline8)} catch {}
+try {
+  w.drawIndexed(32)} catch {}
+x = w.finish()
+try {
+  u.executeBundles(
+      [ x ])
+  u.drawIndexed(6)
+  await device0.queue.onSubmittedWorkDone()
+  q.executeBundles([ x ])} catch {}
+try {
+  q.end()} catch {}
+y = d.finish()
+try {
+  device0.queue.submit([ y ])} catch {}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -111,11 +111,11 @@ public:
     void indirectBufferRecomputed(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
     void indirectIndexedBufferRecomputed(MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
-    bool canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType) const;
-    void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType);
+    bool canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, id<MTLIndirectCommandBuffer> = nil) const;
+    void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, id<MTLIndirectCommandBuffer> = nil);
 
-    bool didReadOOB() const { return m_didReadOOB; }
-    void didReadOOB(uint32_t v) { m_didReadOOB = !!v; }
+    bool didReadOOB(id<MTLIndirectCommandBuffer> = nil) const;
+    void didReadOOB(uint32_t v, id<MTLIndirectCommandBuffer> = nil);
 
     void indirectBufferInvalidated();
 #if ENABLE(WEBGPU_SWIFT)
@@ -163,14 +163,15 @@ private:
         MTLIndexType indexType { MTLIndexTypeUInt16 };
     } m_indirectCache;
 
-    HashMap<uint64_t, uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_drawIndexedCache;
+    using DrawIndexCacheContainer = HashMap<uint64_t, uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+    HashMap<uint64_t, DrawIndexCacheContainer, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_drawIndexedCache;
 
     const Ref<Device> m_device;
     mutable WeakHashSet<CommandEncoder> m_commandEncoders;
 #if CPU(X86_64)
     bool m_mappedAtCreation { false };
 #endif
-    bool m_didReadOOB { false };
+    HashMap<uint64_t, bool, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_didReadOOB;
 } SWIFT_SHARED_REFERENCE(refBuffer, derefBuffer);
 
 } // namespace WebGPU


### PR DESCRIPTION
#### ff9bb65302c896d0c21632b1c11fda6fb51f1744
<pre>
[WebGPU] Out of bounds read with index buffer shared between GPURenderBundles and GPURenderPass
<a href="https://bugs.webkit.org/show_bug.cgi?id=286215">https://bugs.webkit.org/show_bug.cgi?id=286215</a>
<a href="https://rdar.apple.com/142756512">rdar://142756512</a>

Reviewed by Tadeu Zagallo.

Unlike normal GPURenderPass calls, GPURenderBundles rewrite the ICB contents
when an OOB read occurs. This is specific to each GPURenderBundle. Using a single
flag per index buffer is wrong here since a valid GPURenderPass call would allow
an invalid GPURenderBundle call to be processed.

Resolve this by tracking state per ICB. Normal render passes get id=zero which
is not a value MTLResourceID.

* LayoutTests/fast/webgpu/nocrash/fuzz-286215-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-286215.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Buffer.h:
(WebGPU::Buffer::didReadOOB const): Deleted.
(WebGPU::Buffer::didReadOOB): Deleted.
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::canSkipDrawIndexedValidation const):
(WebGPU::Buffer::drawIndexedValidated):
(WebGPU::Buffer::didReadOOB const):
(WebGPU::Buffer::didReadOOB):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):
Track OOB reads per ICB.

Canonical link: <a href="https://commits.webkit.org/289163@main">https://commits.webkit.org/289163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a79f1e23777648b534d9ac4cc930f58e5f70f72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36433 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66384 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24197 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31834 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92057 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75008 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74128 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4783 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12703 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18151 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12526 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->