### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebAccessibilityObjectWrapperMac.mm

### DIFF
--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -49,6 +49,7 @@
 #import "AccessibilityTableCell.h"
 #import "AccessibilityTableColumn.h"
 #import "AccessibilityTableRow.h"
+#import "CGUtilities.h"
 #import "Chrome.h"
 #import "ChromeClient.h"
 #import "ContextMenuController.h"
@@ -1433,19 +1434,19 @@ static void convertToVector(NSArray* array, AccessibilityObject::AccessibilityCh
 
 static void WebTransformCGPathToNSBezierPath(void* info, const CGPathElement *element)
 {
+    auto points = pointsSpan(element);
     NSBezierPath *bezierPath = (__bridge NSBezierPath *)info;
     switch (element->type) {
     case kCGPathElementMoveToPoint:
-        [bezierPath moveToPoint:NSPointFromCGPoint(element->points[0])];
+        [bezierPath moveToPoint:NSPointFromCGPoint(points[0])];
         break;
     case kCGPathElementAddLineToPoint:
-        [bezierPath lineToPoint:NSPointFromCGPoint(element->points[0])];
+        [bezierPath lineToPoint:NSPointFromCGPoint(points[0])];
         break;
-    case kCGPathElementAddCurveToPoint:
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        [bezierPath curveToPoint:NSPointFromCGPoint(element->points[0]) controlPoint1:NSPointFromCGPoint(element->points[1]) controlPoint2:NSPointFromCGPoint(element->points[2])];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    case kCGPathElementAddCurveToPoint: {
+        [bezierPath curveToPoint:NSPointFromCGPoint(points[0]) controlPoint1:NSPointFromCGPoint(points[1]) controlPoint2:NSPointFromCGPoint(points[2])];
         break;
+    }
     case kCGPathElementCloseSubpath:
         [bezierPath closePath];
         break;

--- a/Source/WebCore/platform/graphics/cg/CGUtilities.h
+++ b/Source/WebCore/platform/graphics/cg/CGUtilities.h
@@ -92,4 +92,21 @@ inline IntRect cgImageRect(CGImageRef image)
     return { 0, 0, static_cast<int>(CGImageGetWidth(image)), static_cast<int>(CGImageGetHeight(image)) };
 }
 
+inline std::span<CGPoint> pointsSpan(const CGPathElement* element)
+{
+    switch (element->type) {
+    case kCGPathElementMoveToPoint:
+        return unsafeMakeSpan(element->points, 1);
+    case kCGPathElementAddLineToPoint:
+        return unsafeMakeSpan(element->points, 1);
+    case kCGPathElementAddQuadCurveToPoint:
+        return unsafeMakeSpan(element->points, 2);
+    case kCGPathElementAddCurveToPoint:
+        return unsafeMakeSpan(element->points, 3);
+    case kCGPathElementCloseSubpath:
+        break;
+    }
+    return { };
+}
+
 }

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -29,6 +29,7 @@
 
 #if USE(CG)
 
+#include "CGUtilities.h"
 #include "GraphicsContextCG.h"
 #include "PathStream.h"
 #include <wtf/NeverDestroyed.h>
@@ -38,23 +39,6 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PathCG);
-
-static std::span<CGPoint> pointsSpan(const CGPathElement* element)
-{
-    switch (element->type) {
-    case kCGPathElementMoveToPoint:
-        return unsafeMakeSpan(element->points, 1);
-    case kCGPathElementAddLineToPoint:
-        return unsafeMakeSpan(element->points, 1);
-    case kCGPathElementAddQuadCurveToPoint:
-        return unsafeMakeSpan(element->points, 2);
-    case kCGPathElementAddCurveToPoint:
-        return unsafeMakeSpan(element->points, 3);
-    case kCGPathElementCloseSubpath:
-        break;
-    }
-    return { };
-}
 
 Ref<PathCG> PathCG::create()
 {


### PR DESCRIPTION
#### 9f3caf81db71f36f72261e6040b0ea17889f9d32
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebAccessibilityObjectWrapperMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=286218">https://bugs.webkit.org/show_bug.cgi?id=286218</a>
<a href="https://rdar.apple.com/143197653">rdar://143197653</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(WebTransformCGPathToNSBezierPath):
* Source/WebCore/platform/graphics/cg/CGUtilities.h:
(WebCore::pointsSpan):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::pointsSpan): Deleted.

Canonical link: <a href="https://commits.webkit.org/289126@main">https://commits.webkit.org/289126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cd484d6b34f7f38088f36f31212d8bcd6e4b766

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66392 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3896 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/31829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35511 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92054 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9334 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12975 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/73401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74125 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4791 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13325 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18159 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->