### PR TITLE
[Intelligence Effects] Smart Replies animation flickers / doesn't animate smoothly

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -63,7 +63,7 @@ public:
     void detach();
 
     WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarkerType, const DocumentMarker::Data& = { });
-    void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
+    void addMarker(Node&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
     WEBCORE_EXPORT void addMarker(Node&, DocumentMarker&&);
     void addDraggedContentMarker(const SimpleRange&);
     WEBCORE_EXPORT void addTransparentContentMarker(const SimpleRange&, WTF::UUID);
@@ -124,6 +124,8 @@ private:
 
     void forEachOfTypes(OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
 
+    void applyToCollapsedRangeMarker(const SimpleRange&, OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
+
     void fadeAnimationTimerFired();
     void writingToolsTextSuggestionAnimationTimerFired();
 
@@ -146,7 +148,7 @@ template<>
 WEBCORE_EXPORT void DocumentMarkerController::forEach<DocumentMarkerController::IterationDirection::Backwards>(const SimpleRange&, OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
 
 WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarkerType, const DocumentMarker::Data& = { });
-void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
+void addMarker(Node&, unsigned startOffset, unsigned length, DocumentMarkerType, DocumentMarker::Data&& = { });
 void removeMarkers(const SimpleRange&, OptionSet<DocumentMarkerType> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
 WEBCORE_EXPORT SimpleRange makeSimpleRange(Node&, const DocumentMarker&);

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -171,6 +171,8 @@ private:
     void compositionSessionDidFinishReplacement();
     void compositionSessionDidFinishReplacement(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const CharacterRange&, const String&);
 
+    void smartReplySessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
+
     void compositionSessionDidReceiveTextWithReplacementRangeAsync(const WTF::UUID&, const WTF::UUID&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
 
     void showOriginalCompositionForSession();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -29,6 +29,7 @@
 
 #import "PDFPluginIdentifier.h"
 #import "WKIntelligenceReplacementTextEffectCoordinator.h"
+#import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
 #import "WKIntelligenceTextEffectCoordinator.h"
 #import "WKTextAnimationType.h"
 #import <WebKit/WKShareSheet.h>

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
@@ -70,6 +70,7 @@ SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKSPreviewWindowControl
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKSRKEntity)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKSTextAnimationManager)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKIntelligenceReplacementTextEffectCoordinator)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKIntelligenceSmartReplyTextEffectCoordinator)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionContainerItem)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionEditable)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionLink)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1280,9 +1280,9 @@ void WebPageProxy::didEndWritingToolsSession(const WebCore::WritingTools::Sessio
     protectedLegacyMainFrameProcess()->send(Messages::WebPage::DidEndWritingToolsSession(session, accepted), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished)
+void WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
-    protectedLegacyMainFrameProcess()->send(Messages::WebPage::CompositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished), webPageIDInMainFrameProcess());
+    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::CompositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session& session, WebCore::WritingTools::Action action)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2515,7 +2515,7 @@ public:
 
     void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
-    void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
+    void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
 
     void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		0735F31C2D3760AA0003D029 /* IntelligenceTextEffectViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735F31B2D3760AA0003D029 /* IntelligenceTextEffectViewManager.swift */; };
 		0735F31E2D3760BC0003D029 /* IntelligenceTextEffectChunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735F31D2D3760BC0003D029 /* IntelligenceTextEffectChunk.swift */; };
 		0735F3202D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0735F31F2D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0735F3222D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735F3212D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift */; };
+		0735F3242D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0735F3232D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0744DA552CE05FE400AACC81 /* WebKitInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0744DA542CE05FE400AACC81 /* WebKitInternal.h */; };
 		074879B92373A90900F5678E /* AppKitSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 074879B72373A90900F5678E /* AppKitSoftLink.h */; };
 		074E75FE1DF2211900D318EC /* UserMediaProcessManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 074E75FB1DF1FD1300D318EC /* UserMediaProcessManager.h */; };
@@ -3089,6 +3091,8 @@
 		0735F31B2D3760AA0003D029 /* IntelligenceTextEffectViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelligenceTextEffectViewManager.swift; sourceTree = "<group>"; };
 		0735F31D2D3760BC0003D029 /* IntelligenceTextEffectChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntelligenceTextEffectChunk.swift; sourceTree = "<group>"; };
 		0735F31F2D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIntelligenceReplacementTextEffectCoordinator.h; sourceTree = "<group>"; };
+		0735F3212D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKIntelligenceSmartReplyTextEffectCoordinator.swift; sourceTree = "<group>"; };
+		0735F3232D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIntelligenceSmartReplyTextEffectCoordinator.h; sourceTree = "<group>"; };
 		0736B753260D039F00E06994 /* RemoteMediaSessionCoordinator.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaSessionCoordinator.messages.in; sourceTree = "<group>"; };
 		0736B754260D039F00E06994 /* RemoteMediaSessionCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaSessionCoordinator.h; sourceTree = "<group>"; };
 		0736B755260D03A000E06994 /* RemoteMediaSessionCoordinator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionCoordinator.cpp; sourceTree = "<group>"; };
@@ -8583,6 +8587,8 @@
 				0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */,
 				0735F31F2D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h */,
 				077FD19F2CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift */,
+				0735F3232D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h */,
+				0735F3212D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift */,
 				074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */,
 			);
 			path = WritingTools;
@@ -17974,6 +17980,7 @@
 				5289527F2C7077B000D0357E /* RealityKitBridging.h in Headers */,
 				A14F9B672B686E0200AD9C56 /* WebKitSwift.h in Headers */,
 				0735F3202D3761A10003D029 /* WKIntelligenceReplacementTextEffectCoordinator.h in Headers */,
+				0735F3242D38C7790003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.h in Headers */,
 				074F34812CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h in Headers */,
 				A14F9B762B68CA6C00AD9C56 /* WKSLinearMediaPlayer.h in Headers */,
 				A14F9B632B686DD300AD9C56 /* WKSLinearMediaTypes.h in Headers */,
@@ -20252,6 +20259,7 @@
 				528952812C70797900D0357E /* RKEntity.swift in Sources */,
 				440DB5B72C1914DC0021639B /* TextAnimationManager.swift in Sources */,
 				077FD1A02CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift in Sources */,
+				0735F3222D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift in Sources */,
 				F48EC3532B75837F00D1B886 /* WKTextExtractionItem.swift in Sources */,
 				F47AA6CA2B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift in Sources */,
 			);

--- a/Source/WebKit/WebKitSwift/WebKitSwift.h
+++ b/Source/WebKit/WebKitSwift/WebKitSwift.h
@@ -26,6 +26,7 @@
 #import <WebKitSwift/LinearMediaKitExtras.h>
 #import <WebKitSwift/RealityKitBridging.h>
 #import <WebKitSwift/WKIntelligenceReplacementTextEffectCoordinator.h>
+#import <WebKitSwift/WKIntelligenceSmartReplyTextEffectCoordinator.h>
 #import <WebKitSwift/WKIntelligenceTextEffectCoordinator.h>
 #import <WebKitSwift/WKSLinearMediaPlayer.h>
 #import <WebKitSwift/WKSLinearMediaTypes.h>

--- a/Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift
@@ -90,7 +90,12 @@ class IntelligenceTextEffectViewManager<Source> where Source: IntelligenceTextEf
     }
 
     func setActivePonderingEffect(_ effect: PlatformIntelligencePonderingTextEffect<IntelligenceTextEffectChunk>?) async {
-        guard (self.activePonderingEffect == nil && effect != nil) || (self.activePonderingEffect != nil && effect == nil) else {
+        if self.activePonderingEffect == nil && effect == nil {
+            return
+        }
+
+        if self.activePonderingEffect != nil && effect != nil {
+            assertionFailure("Intelligence text effect coordinator: trying to either set a new pondering effect when there is an ongoing one.")
             return
         }
 
@@ -117,8 +122,12 @@ class IntelligenceTextEffectViewManager<Source> where Source: IntelligenceTextEf
     }
 
     func setActiveReplacementEffect(_ effect: PlatformIntelligenceReplacementTextEffect<IntelligenceTextEffectChunk>?) async {
-        guard (self.activeReplacementEffect == nil && effect != nil) || (self.activeReplacementEffect != nil && effect == nil) else {
-            assertionFailure("Intelligence text effect coordinator: trying to either set a new replacement effect when there is an ongoing one, or trying to remove an effect when there are none.")
+        if self.activeReplacementEffect == nil && effect == nil {
+            return
+        }
+
+        if self.activeReplacementEffect != nil && effect != nil {
+            assertionFailure("Intelligence text effect coordinator: trying to either set a new replacement effect when there is an ongoing one.")
             return
         }
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import <Foundation/Foundation.h>
 
-#import <wtf/SoftLinking.h>
+#if !TARGET_OS_WATCH && !TARGET_OS_TV && __has_include(<WritingTools/WritingTools.h>)
 
-SOFT_LINK_LIBRARY_FOR_HEADER(WebKit, WebKitSwift)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKGroupSessionObserver)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaContentMetadata)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaPlayer)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaTimeRange)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaTrack)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSPreviewWindowController)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSRKEntity)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSTextAnimationManager)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKIntelligenceReplacementTextEffectCoordinator)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKIntelligenceSmartReplyTextEffectCoordinator)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionContainerItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionEditable)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionLink)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionTextItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionScrollableItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionImageItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaSpatialVideoMetadata)
+#import "WKIntelligenceTextEffectCoordinator.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class WTTextSuggestion;
+
+NS_SWIFT_UI_ACTOR
+@interface WKIntelligenceSmartReplyTextEffectCoordinator : NSObject <WKIntelligenceTextEffectCoordinating>
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
@@ -1,0 +1,288 @@
+// Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if canImport(WritingTools)
+
+import Foundation
+import WebKit
+import WebKitSwift
+@_spi(Private) import WebKit
+@_spiOnly import WritingTools
+
+#if os(macOS)
+@_weakLinked internal import WritingToolsUI_Private._WTTextEffectView
+#endif
+
+// MARK: Implementation
+
+// The Smart Replies flow is:
+//
+// 1. WT calls the delegate methods `willBegin...` and `didBegin...`
+// 2. WT sends a `.compositionRestart` action to the delegate
+// 3. WT creates a text placeholder, and creates a pondering effect themselves to add to the placeholder.
+// 4. WT generates the response (which takes some time)
+// 5. WT removes the text placeholder
+// 6. WT calls the delegate method `didReceiveText...`
+//
+// Then, for each subsequent questionnaire revision update:
+//
+// 7. WT sends a `.compositionRestart` action to the delegate
+// 8. WT generates the response (which takes some time)
+// 9. WT calls the delegate method `didReceiveText...`
+
+@_objcImplementation extension WKIntelligenceSmartReplyTextEffectCoordinator {
+    private struct ReplacementOperationRequest {
+        let processedRange: Range<Int>
+        let characterDelta: Int
+        let operation: (() async -> Void)
+    }
+
+    @nonobjc final private let delegate: (any WKIntelligenceTextEffectCoordinatorDelegate)
+    @nonobjc final private lazy var viewManager = IntelligenceTextEffectViewManager(source: self, contentView: self.delegate.view(forIntelligenceTextEffectCoordinator: self))
+
+    // If there are still pending replacements/animations when the user has accepted or rejected the Writing Tools
+    // suggestions, they first need to all be flushed out and invoked so that the state is not incomplete, and then
+    // the acceptance/rejection can properly occur.
+    @nonobjc final private var onFlushCompletion: (() async -> Void)? = nil
+
+    @nonobjc final private var processedRangeOffset = 0
+    @nonobjc final private var contextRange: Range<Int>? = nil
+
+    @nonobjc final private var replacementQueue: [ReplacementOperationRequest] = []
+
+    @objc(hasActiveEffects)
+    public var hasActiveEffects: Bool {
+        viewManager.hasActiveEffects
+    }
+
+    @objc(initWithDelegate:)
+    public init(delegate: any WKIntelligenceTextEffectCoordinatorDelegate) {
+        self.delegate = delegate
+    }
+
+    @objc(startAnimationForRange:completion:)
+    public func startAnimation(for range: NSRange) async {
+        self.viewManager.assertPonderingEffectIsInactive()
+        self.viewManager.assertReplacementEffectIsInactive()
+
+        guard let contextRange = Range(range) else {
+            assertionFailure("Intelligence text effect coordinator: Unable to create Swift.Range from NSRange \(range)")
+            return
+        }
+
+        let chunk = IntelligenceTextEffectChunk.Pondering(range: contextRange)
+        let effect = PlatformIntelligencePonderingTextEffect(chunk: chunk as IntelligenceTextEffectChunk)
+
+        await self.viewManager.setActivePonderingEffect(effect)
+    }
+
+    @objc(requestReplacementWithProcessedRange:finished:characterDelta:operation:completion:)
+    public func requestReplacement(withProcessedRange processedRange: NSRange, finished: Bool, characterDelta: Int, operation: @escaping (@escaping () -> Void) -> Void) async {
+        guard let range = Range(processedRange) else {
+            assertionFailure("Intelligence text effect coordinator: Unable to create Swift.Range from NSRange \(processedRange)")
+            return
+        }
+
+        // The "context range" for a Smart Replies composition session changes each time the text is replaced,
+        // since there is new "original" text with each subsequent revision.
+        self.contextRange = range
+
+        let asyncBlock = async(operation)
+        let request = Self.ReplacementOperationRequest(processedRange: range, characterDelta: characterDelta, operation: asyncBlock)
+
+        self.replacementQueue.append(request)
+
+        if self.replacementQueue.count == 1 {
+            await self.startReplacementAnimation(using: request)
+        }
+    }
+
+    @objc(flushReplacementsWithCompletion:)
+    public func flushReplacements() async {
+        assert(self.onFlushCompletion == nil)
+
+        // If the replacement queue is empty, there's no effects pending completion and nothing to flush,
+        // so no need to create a completion block, and instead just invoke `removeActiveEffects` immediately.
+
+        if self.replacementQueue.isEmpty {
+            await self.removeActiveEffects()
+            return
+        }
+
+        // This can't be performed immediately since a replacement animation may be ongoing, and they are not interruptible.
+        // So instead, the completion of this async method is stored in state, so that when the current replacement is complete,
+        // the actual flush can occur.
+
+        await withCheckedContinuation { continuation in
+            self.onFlushCompletion = {
+                await self.removeActiveEffects()
+                continuation.resume()
+            }
+        }
+    }
+
+    @objc(restoreSelectionAcceptedReplacements:completion:)
+    public func restoreSelection(acceptedReplacements: Bool) async {
+        guard let contextRange = self.contextRange else {
+            return
+        }
+
+        let range = acceptedReplacements ? contextRange.lowerBound..<(contextRange.upperBound + self.processedRangeOffset) : contextRange;
+        await self.delegate.intelligenceTextEffectCoordinator(self, setSelectionFor: NSRange(range))
+    }
+
+    @objc(hideEffectsWithCompletion:)
+    public func hideEffects() async {
+        await self.viewManager.hideEffects()
+    }
+
+    @objc(showEffectsWithCompletion:)
+    public func showEffects() async {
+        await self.viewManager.showEffects()
+    }
+
+    @nonobjc final private func removeActiveEffects() async {
+        await self.viewManager.removeActiveEffects()
+    }
+
+    @nonobjc final private func startReplacementAnimation(using request: ReplacementOperationRequest) async {
+        self.viewManager.assertReplacementEffectIsInactive()
+
+        if !request.processedRange.isEmpty {
+            // An artificial pondering effect needs to first be created each time a new response is received.
+            // This is because in the platform effect view, when a replacement effect gets created, the underlying text becomes hidden
+            // for a non-instantaneous amount of time while the replacement is performed. So, a pondering effect has to be ongoing when
+            // this happens to avoid the user from seeing the text become briefly hidden.
+            await startAnimation(for: NSRange(request.processedRange))
+        }
+
+        let chunk = IntelligenceTextEffectChunk.Replacement(
+            range: request.processedRange,
+            finished: true, // This is always true for Smart Replies.
+            characterDelta: request.characterDelta,
+            replacement: request.operation
+        )
+
+        let effect = PlatformIntelligenceReplacementTextEffect(chunk: chunk as IntelligenceTextEffectChunk)
+
+        // Start the replacement effect while the pondering effect is still ongoing, so that it can perform
+        // the async replacement without it being visible to the user and without any flickering.
+        await self.viewManager.setActiveReplacementEffect(effect)
+
+        // Smart Replies always replaces the entire context range, so `processedRangeOffset` is not additive, unlike proofreading/composition.
+        self.processedRangeOffset = request.characterDelta
+    }
+}
+
+// MARK: WKIntelligenceReplacementTextEffectCoordinator + IntelligenceTextEffectViewManager.Delegate conformance
+
+extension WKIntelligenceSmartReplyTextEffectCoordinator: IntelligenceTextEffectViewManagerDelegate {
+    func updateTextChunkVisibility(_ chunk: IntelligenceTextEffectChunk, visible: Bool, force: Bool) async {
+        if chunk is IntelligenceTextEffectChunk.Pondering && visible && !force {
+            // Typically, if `chunk` is part of a pondering effect, this delegate method will get called with `visible == true`
+            // once the pondering effect is removed. However, instead of performing that logic here, it is done in `setActivePonderingEffect`
+            // instead.
+            //
+            // This effectively makes this function synchronous in this case.
+            return
+        }
+
+        guard !self.viewManager.suppressEffectView else {
+            // If the effect view is currently suppressed, WTUI will still request making the text not visible since it does not know
+            // it is hidden. However, this needs to not happen since the effect view is hidden and the underlying text needs to remain visible.
+            return
+        }
+
+        await self.delegate.intelligenceTextEffectCoordinator(self, updateTextVisibilityFor: NSRange(chunk.range), visible: visible, identifier: chunk.id)
+    }
+}
+
+// MARK: WKIntelligenceReplacementTextEffectCoordinator + PlatformIntelligenceTextEffectViewSource conformance
+
+extension WKIntelligenceSmartReplyTextEffectCoordinator: PlatformIntelligenceTextEffectViewSource {
+    func textPreview(for chunk: IntelligenceTextEffectChunk) async -> PlatformTextPreview? {
+        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
+        return platformTextPreview(from: previews)
+    }
+
+    func updateTextChunkVisibility(_ chunk: Chunk, visible: Bool) async {
+        await self.updateTextChunkVisibility(chunk, visible: visible, force: false)
+    }
+
+    func performReplacementAndGeneratePreview(for chunk: IntelligenceTextEffectChunk, effect: PlatformIntelligenceReplacementTextEffect<IntelligenceTextEffectChunk>) async -> (PlatformTextPreview?, remainder: PlatformContentPreview?) {
+        // FIXME: Implement the remainder text effect for Smart Replies.
+
+        guard let chunk = chunk as? IntelligenceTextEffectChunk.Replacement else {
+            fatalError()
+        }
+
+        let characterDelta = chunk.characterDelta
+
+        await chunk.replacement()
+        chunk.range = chunk.range.lowerBound..<(chunk.range.upperBound + characterDelta)
+
+        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
+
+        let platformPreview = platformTextPreview(from: previews, suggestionRects: [])
+        return (platformPreview, remainder: nil)
+    }
+
+    func replacementEffectWillBegin(_ effect: PlatformIntelligenceReplacementTextEffect<IntelligenceTextEffectChunk>) async {
+        await self.viewManager.setActivePonderingEffect(nil)
+    }
+
+    func replacementEffectDidComplete(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async {
+        guard effect.chunk is Chunk.Replacement else {
+            assertionFailure("Intelligence text effect coordinator: Replacement effect chunk is not Chunk.Replacement")
+            return
+        }
+
+        await self.viewManager.setActiveReplacementEffect(nil)
+
+        // Perform similar logic as the replacement coordinator with regards to flushing the replacements.
+
+        self.replacementQueue.removeFirst()
+
+        if let next = self.replacementQueue.first {
+            await self.startReplacementAnimation(using: next)
+        } else if let onFlushCompletion = self.onFlushCompletion {
+            await onFlushCompletion()
+            self.onFlushCompletion = nil
+        } else {
+            await self.restoreSelectionAcceptedReplacements(true)
+        }
+    }
+}
+
+// MARK: Misc. helper functions
+
+/// Converts a block with a completion handler into an async block.
+fileprivate func async(_ block: @escaping (@escaping () -> Void) -> Void) -> (() async -> Void) {
+    { @MainActor in
+        await withCheckedContinuation { continuation in
+            block(continuation.resume)
+        }
+    }
+}
+
+#endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -964,9 +964,10 @@ void WebPage::didEndWritingToolsSession(const WebCore::WritingTools::Session& se
     corePage()->didEndWritingToolsSession(session, accepted);
 }
 
-void WebPage::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished)
+void WebPage::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
     corePage()->compositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
+    completionHandler();
 }
 
 void WebPage::writingToolsSessionDidReceiveAction(const WritingTools::Session& session, WebCore::WritingTools::Action action)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2444,7 +2444,7 @@ private:
 
     void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
-    void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
+    void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished, CompletionHandler<void()>&&);
 
     void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -807,7 +807,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     DidEndWritingToolsSession(struct WebCore::WritingTools::Session session, bool accepted)
 
-    CompositionSessionDidReceiveTextWithReplacementRange(struct WebCore::WritingTools::Session session, struct WebCore::AttributedString attributedText, struct WebCore::CharacterRange range, struct WebCore::WritingTools::Context context, bool finished);
+    CompositionSessionDidReceiveTextWithReplacementRange(struct WebCore::WritingTools::Session session, struct WebCore::AttributedString attributedText, struct WebCore::CharacterRange range, struct WebCore::WritingTools::Context context, bool finished) -> ();
 
     WritingToolsSessionDidReceiveAction(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::Action action);
 


### PR DESCRIPTION
#### 3b6a05692af693c269419e4486ddd1ac1190d5a6
<pre>
[Intelligence Effects] Smart Replies animation flickers / doesn&apos;t animate smoothly
<a href="https://bugs.webkit.org/show_bug.cgi?id=286231">https://bugs.webkit.org/show_bug.cgi?id=286231</a>
<a href="https://rdar.apple.com/143206029">rdar://143206029</a>

Reviewed by Aditya Keerthi.

Refactor the Smart Replies implementation to use the new intelligence effects system, which fixes the existing
flickering and broken animations in the current implementation.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::addTransparentContentMarker):
(WebCore::DocumentMarkerController::applyToCollapsedRangeMarker):
(WebCore::DocumentMarkerController::forEach&lt;DocumentMarkerController::IterationDirection::Forwards&gt;):
(WebCore::DocumentMarkerController::forEach&lt;DocumentMarkerController::IterationDirection::Backwards&gt;):
(WebCore::addMarker):
* Source/WebCore/dom/DocumentMarkerController.h:
(WebCore::addMarker):
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::smartReplySessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/WebKitSwift.h:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.h: Copied from Source/WebKit/WebKitSwift/WebKitSwift.h.
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift: Added.
(WKIntelligenceSmartReplyTextEffectCoordinator.onFlushCompletion):
(WKIntelligenceSmartReplyTextEffectCoordinator.hasActiveEffects):
(WKIntelligenceSmartReplyTextEffectCoordinator.startAnimation(for:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.requestReplacement(withProcessedRange:finished:characterDelta:operation:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.flushReplacements):
(WKIntelligenceSmartReplyTextEffectCoordinator.restoreSelection(_:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.hideEffects):
(WKIntelligenceSmartReplyTextEffectCoordinator.showEffects):
(WKIntelligenceSmartReplyTextEffectCoordinator.removeActiveEffects):
(WKIntelligenceSmartReplyTextEffectCoordinator.startReplacementAnimation(withProcessedRange:characterDelta:operation:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.reset):
(WKIntelligenceSmartReplyTextEffectCoordinator.updateTextChunkVisibility(_:visible:force:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.textPreview(for:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.updateTextChunkVisibility(_:visible:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.performReplacementAndGeneratePreview(for:effect:remainder:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.replacementEffectWillBegin(_:)):
(WKIntelligenceSmartReplyTextEffectCoordinator.replacementEffectDidComplete(_:)):
(async(_:)):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::compositionSessionDidReceiveTextWithReplacementRange):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/289354@main">https://commits.webkit.org/289354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f49f762b85b8263ac0a6f4b83b2b2e063635706b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91496 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89655 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/4884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/47337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/4683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/32792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36502 "Failed to checkout and rebase branch from PR 39269") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/33677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13805 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14006 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/74283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/74996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/19296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/17701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13465 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13828 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13566 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->