### PR TITLE
[JSC] Cache FunctionExecutable from `new Function` constructor call with one-entry cache

### DIFF
--- a/LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions-expected.txt
+++ b/LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions-expected.txt
@@ -3,7 +3,7 @@ Tests for the Debugger.scriptParsed messages for identical content should have s
 
 == Running test suite: Debugger.scriptParsed.sourceURLRepeatedIdenticalExecutions
 -- Running test case: CheckFunctionConstructorMultipleTimes
-PASS: Should see 3 Scripts with sourceURL
+PASS: Should see 1 Scripts with sourceURL
 
 -- Running test case: CheckProgramMultipleTimes
 PASS: Should see 3 Scripts with sourceURL

--- a/LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions.html
+++ b/LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions.html
@@ -44,7 +44,7 @@ function test()
                     seen++;
             });
             InspectorTest.evaluateInPage("triggerFunctionConstructorMultipleTimes()", () => {
-                InspectorTest.expectThat(seen === 3, "Should see 3 Scripts with sourceURL");
+                InspectorTest.expectThat(seen === 1, "Should see 1 Scripts with sourceURL");
                 resolve();
             });
         }

--- a/LayoutTests/js/script-tests/regress-150513.js
+++ b/LayoutTests/js/script-tests/regress-150513.js
@@ -26,7 +26,7 @@ function test()
             var result = f(1);
             if (result != 1)
                 testFailed("Wrong result, expected 1, got " + result);
-        } catch (e) {
+        } catch {
         }
     }
 }
@@ -34,5 +34,9 @@ function test()
 init();
 
 test();
+
+try {
+    (function () { }()); // Ensure that failNextNewCodeBlock is cleared regardless of how `new Function` caches the functions.
+} catch { }
 
 testPassed("Didn't crash when calling a virtual JavaScript function that doesn't have a CodeBlock.");

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -47,6 +47,13 @@ enum class CodeGenerationMode : uint8_t {
 
 enum class FunctionMode { None, FunctionExpression, FunctionDeclaration, MethodDefinition };
 
+enum class FunctionConstructionMode : uint8_t {
+    Function,
+    Generator,
+    Async,
+    AsyncGenerator,
+};
+
 // Keep it less than 32, it means this should be within 5 bits.
 enum class SourceParseMode : uint8_t {
     NormalFunctionMode                = 0,

--- a/Source/JavaScriptCore/parser/SourceCodeKey.h
+++ b/Source/JavaScriptCore/parser/SourceCodeKey.h
@@ -65,6 +65,7 @@ private:
 };
 
 class SourceCodeKey {
+    WTF_MAKE_FAST_ALLOCATED(SourceCodeKey);
     friend class CachedSourceCodeKey;
 
 public:
@@ -104,6 +105,8 @@ public:
     StringView string() const { return m_sourceCode.view(); }
 
     StringView host() const { return m_sourceCode.provider().sourceOrigin().url().host(); }
+
+    int functionConstructorParametersEndPosition() const { return m_functionConstructorParametersEndPosition; }
 
     bool operator==(const SourceCodeKey& other) const
     {

--- a/Source/JavaScriptCore/runtime/CodeCache.cpp
+++ b/Source/JavaScriptCore/runtime/CodeCache.cpp
@@ -258,6 +258,9 @@ UnlinkedFunctionExecutable* CodeCache::getUnlinkedGlobalFunctionExecutable(VM& v
     if (!source.provider()->sourceMappingURLDirective().isNull())
         functionExecutable->setSourceMappingURLDirective(source.provider()->sourceMappingURLDirective());
 
+    // We initially start with hasCapturedVariables = false.
+    functionExecutable->recordParse(program->features(), metadata->lexicallyScopedFeatures(), /* hasCapturedVariables */ false);
+
     if (Options::useCodeCache())
         m_sourceCode.addCache(key, SourceCodeValue(vm, functionExecutable, m_sourceCode.age()));
     return functionExecutable;

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -66,23 +66,25 @@ void FunctionConstructor::finishCreation(VM& vm, FunctionPrototype* functionProt
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, functionPrototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 }
 
-static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& args, const Identifier& functionName, FunctionConstructionMode functionConstructionMode, ThrowScope& scope, std::optional<int>& functionConstructorParametersEndPosition)
+ASCIILiteral functionConstructorPrefix(FunctionConstructionMode functionConstructionMode)
 {
-    ASCIILiteral prefix;
     switch (functionConstructionMode) {
     case FunctionConstructionMode::Function:
-        prefix = "function "_s;
-        break;
+        return "function "_s;
     case FunctionConstructionMode::Generator:
-        prefix = "function* "_s;
-        break;
+        return "function* "_s;
     case FunctionConstructionMode::Async:
-        prefix = "async function "_s;
-        break;
+        return "async function "_s;
     case FunctionConstructionMode::AsyncGenerator:
-        prefix = "async function* "_s;
-        break;
+        return "async function* "_s;
     }
+    ASSERT_NOT_REACHED();
+    return ASCIILiteral { };
+}
+
+static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& args, const Identifier& functionName, FunctionConstructionMode functionConstructionMode, ThrowScope& scope, std::optional<int>& functionConstructorParametersEndPosition)
+{
+    ASCIILiteral prefix = functionConstructorPrefix(functionConstructionMode);
 
     // How we stringify functions is sometimes important for web compatibility.
     // See https://bugs.webkit.org/show_bug.cgi?id=24350.
@@ -98,6 +100,18 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
             throwOutOfMemoryError(globalObject, scope);
             return { };
         }
+    } else if (args.size() == 2) {
+        // This is really common since it means (1) arguments + (2) body.
+        auto arg = args.at(0).toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        auto body = args.at(1).toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        program = tryMakeString(prefix, functionName.string(), "("_s, arg, "\n) {\n"_s, body, "\n}"_s);
+        if (UNLIKELY(!program)) {
+            throwOutOfMemoryError(globalObject, scope);
+            return { };
+        }
+        functionConstructorParametersEndPosition = prefix.length() + functionName.string().length() + "("_s.length() + arg.length() + "\n)"_s.length();
     } else {
         StringBuilder builder(OverflowPolicy::RecordOverflow);
         builder.append(prefix, functionName.string(), '(');
@@ -119,7 +133,7 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
             return { };
         }
 
-        functionConstructorParametersEndPosition = builder.length() + sizeof("\n)") - 1;
+        functionConstructorParametersEndPosition = builder.length() + "\n)"_s.length();
 
         auto* bodyString = args.at(args.size() - 1).toString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
@@ -141,7 +155,6 @@ JSObject* constructFunction(JSGlobalObject* globalObject, const ArgList& args, c
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-
     std::optional<int> functionConstructorParametersEndPosition;
     auto code = stringifyFunction(globalObject, args, functionName, functionConstructionMode, scope, functionConstructorParametersEndPosition);
     EXCEPTION_ASSERT(!!scope.exception() == code.isNull());
@@ -188,7 +201,7 @@ JSObject* constructFunctionSkippingEvalEnabledCheck(JSGlobalObject* globalObject
 
     SourceCode source = makeSource(program, sourceOrigin, taintedOrigin, sourceURL, position);
     JSObject* exception = nullptr;
-    FunctionExecutable* function = FunctionExecutable::fromGlobalCode(functionName, globalObject, source, lexicallyScopedFeatures, exception, overrideLineNumber, functionConstructorParametersEndPosition);
+    FunctionExecutable* function = FunctionExecutable::fromGlobalCode(functionName, globalObject, source, lexicallyScopedFeatures, exception, overrideLineNumber, functionConstructorParametersEndPosition, functionConstructionMode);
     if (UNLIKELY(!function)) {
         ASSERT(exception);
         throwException(globalObject, scope, exception);

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.h
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "InternalFunction.h"
+#include "ParserModes.h"
 
 namespace WTF {
 class TextPosition;
@@ -52,12 +53,8 @@ private:
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(FunctionConstructor, InternalFunction);
 
-enum class FunctionConstructionMode {
-    Function,
-    Generator,
-    Async,
-    AsyncGenerator,
-};
+
+ASCIILiteral functionConstructorPrefix(FunctionConstructionMode);
 
 JSObject* constructFunction(JSGlobalObject*, const ArgList&, const Identifier& functionName, const SourceOrigin&, const String& sourceURL, SourceTaintedOrigin, const WTF::TextPosition&, FunctionConstructionMode = FunctionConstructionMode::Function, JSValue newTarget = JSValue());
 JSObject* constructFunction(JSGlobalObject*, CallFrame*, const ArgList&, FunctionConstructionMode = FunctionConstructionMode::Function, JSValue newTarget = JSValue());

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -28,8 +28,10 @@
 
 #include "CodeBlock.h"
 #include "FunctionCodeBlock.h"
+#include "FunctionConstructor.h"
 #include "FunctionExecutableInlines.h"
 #include "FunctionOverrides.h"
+#include "SourceCodeKey.h"
 #include "IsoCellSetInlines.h"
 #include "JSCJSValueInlines.h"
 
@@ -129,15 +131,25 @@ DEFINE_VISIT_OUTPUT_CONSTRAINTS(FunctionExecutable);
 
 FunctionExecutable* FunctionExecutable::fromGlobalCode(
     const Identifier& name, JSGlobalObject* globalObject, const SourceCode& source, LexicallyScopedFeatures lexicallyScopedFeatures,
-    JSObject*& exception, int overrideLineNumber, std::optional<int> functionConstructorParametersEndPosition)
+    JSObject*& exception, int overrideLineNumber, std::optional<int> functionConstructorParametersEndPosition, FunctionConstructionMode functionConstructionMode)
 {
+    if (overrideLineNumber == overrideLineNumberNotFound) {
+        if (auto* executable = globalObject->tryGetCachedFunctionExecutableForFunctionConstructor(name, source, lexicallyScopedFeatures, functionConstructionMode))
+            return executable;
+    }
+
     UnlinkedFunctionExecutable* unlinkedExecutable = 
         UnlinkedFunctionExecutable::fromGlobalCode(
             name, globalObject, source, lexicallyScopedFeatures, exception, overrideLineNumber, functionConstructorParametersEndPosition);
     if (!unlinkedExecutable)
         return nullptr;
 
-    return unlinkedExecutable->link(globalObject->vm(), nullptr, source, overrideLineNumber);
+    auto* executable = unlinkedExecutable->link(globalObject->vm(), nullptr, source, overrideLineNumber);
+    if (overrideLineNumber == overrideLineNumberNotFound) {
+        if (executable)
+            globalObject->cachedFunctionExecutableForFunctionConstructor(executable);
+    }
+    return executable;
 }
 
 FunctionExecutable::RareData& FunctionExecutable::ensureRareDataSlow()

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -54,9 +54,7 @@ public:
         executable->finishCreation(vm);
         return executable;
     }
-    static FunctionExecutable* fromGlobalCode(
-        const Identifier& name, JSGlobalObject*, const SourceCode&, LexicallyScopedFeatures,
-        JSObject*& exception, int overrideLineNumber, std::optional<int> functionConstructorParametersEndPosition);
+    static FunctionExecutable* fromGlobalCode(const Identifier& name, JSGlobalObject*, const SourceCode&, LexicallyScopedFeatures, JSObject*& exception, int overrideLineNumber, std::optional<int> functionConstructorParametersEndPosition, FunctionConstructionMode);
 
     static void destroy(JSCell*);
         
@@ -165,9 +163,10 @@ public:
     DECLARE_VISIT_OUTPUT_CONSTRAINTS;
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
+    static constexpr int overrideLineNumberNotFound = -1;
     void setOverrideLineNumber(int overrideLineNumber)
     {
-        if (overrideLineNumber == -1) {
+        if (overrideLineNumber == overrideLineNumberNotFound) {
             if (UNLIKELY(m_rareData))
                 m_rareData->m_overrideLineNumber = std::nullopt;
             return;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -110,6 +110,7 @@ class SetIteratorPrototype;
 class SetPrototype;
 class ShadowRealmConstructor;
 class ShadowRealmPrototype;
+class SourceCodeKey;
 class SourceOrigin;
 class StringConstructor;
 class WrapperMap;
@@ -119,6 +120,7 @@ enum class ArrayBufferSharingMode : bool;
 enum class CodeGenerationMode : uint8_t;
 enum class ErrorType : uint8_t;
 enum class LinkTimeConstant : int32_t;
+enum class FunctionConstructionMode : uint8_t;
 
 struct GlobalObjectMethodTable;
 
@@ -594,6 +596,7 @@ public:
     RuntimeFlags m_runtimeFlags;
     WeakPtr<ConsoleClient> m_consoleClient;
     std::optional<unsigned> m_stackTraceLimit;
+    Weak<FunctionExecutable> m_executableForCachedFunctionExecutableForFunctionConstructor;
 
     template<typename T>
     struct WeakCustomGetterOrSetterHash {
@@ -1104,6 +1107,9 @@ public:
     JSObject* globalThis() const;
     WriteBarrier<JSObject>* addressOfGlobalThis() { return &m_globalThis; }
     OptionSet<CodeGenerationMode> defaultCodeGenerationMode() const;
+
+    FunctionExecutable* tryGetCachedFunctionExecutableForFunctionConstructor(const Identifier& name, const SourceCode&, LexicallyScopedFeatures, FunctionConstructionMode);
+    void cachedFunctionExecutableForFunctionConstructor(FunctionExecutable*);
 
     static inline Structure* createStructure(VM&, JSValue prototype);
     static inline Structure* createStructureForShadowRealm(VM&, JSValue prototype);

--- a/Source/JavaScriptCore/runtime/SourceOrigin.h
+++ b/Source/JavaScriptCore/runtime/SourceOrigin.h
@@ -51,6 +51,8 @@ public:
 
     ScriptFetcher* fetcher() const { return m_fetcher.get(); }
 
+    friend bool operator==(const SourceOrigin&, const SourceOrigin&) = default;
+
 private:
     URL m_url;
     RefPtr<ScriptFetcher> m_fetcher;


### PR DESCRIPTION
#### 2581d153d8bee7078509ef4b5a27ad2a7090bb72
<pre>
[JSC] Cache FunctionExecutable from `new Function` constructor call with one-entry cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=286233">https://bugs.webkit.org/show_bug.cgi?id=286233</a>
<a href="https://rdar.apple.com/143208554">rdar://143208554</a>

Reviewed by Yijia Huang.

This patch introduces a simple one-entry cache for `new Function`
constructor&apos;s FunctionExecutable. We also handle two-arguments `new
Function` calls efficiently.

* LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions-expected.txt:
* LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions.html:
* LayoutTests/js/script-tests/regress-150513.js:
(test):
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/parser/SourceCodeKey.h:
(JSC::SourceCodeKey::functionConstructorParametersEndPosition const):
* Source/JavaScriptCore/runtime/CodeCache.cpp:
(JSC::CodeCache::getUnlinkedGlobalFunctionExecutable):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::functionConstructorPrefix):
(JSC::stringifyFunction):
(JSC::constructFunction):
(JSC::constructFunctionSkippingEvalEnabledCheck):
* Source/JavaScriptCore/runtime/FunctionConstructor.h:
* Source/JavaScriptCore/runtime/FunctionExecutable.cpp:
(JSC::FunctionExecutable::fromGlobalCode):
* Source/JavaScriptCore/runtime/FunctionExecutable.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::tryGetCachedFunctionExecutableForFunctionConstructor):
(JSC::JSGlobalObject::cachedFunctionExecutableForFunctionConstructor):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/SourceOrigin.h:

Canonical link: <a href="https://commits.webkit.org/289677@main">https://commits.webkit.org/289677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3673e6fe0fcbeafd1282499f1f1ae9eaf5337fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5721 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13491 "Hash b3673e6f for PR 39270 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66655 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24449 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35863 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78815 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92601 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84799 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13123 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/13491 "Hash b3673e6f for PR 39270 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75407 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74552 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6016 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13666 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18510 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107206 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12935 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25824 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->