### PR TITLE
[iOS] Add support for bidi content-aware paste and drop

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-rtl-text-in-empty-ltr-paragraph-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-rtl-text-in-empty-ltr-paragraph-expected.txt
@@ -1,0 +1,14 @@
+Verifies that copying and pasting Arabic text in an empty paragraph produces right-to-left text
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(container).direction is "rtl"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+الإنجليزي مثلالإنجليزي مثل “hello world” يُكتب من اليسار إلىالاتجاهين
+
+Click to copy
+Testing
+الإنجليزي مثل “hello world” يُكتب من اليسار إلى

--- a/LayoutTests/editing/pasteboard/paste-rtl-text-in-empty-ltr-paragraph.html
+++ b/LayoutTests/editing/pasteboard/paste-rtl-text-in-empty-ltr-paragraph.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true BidiContentAwarePasteEnabled=true ] -->
+<html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+div[contenteditable] {
+    border: 1px solid orange;
+    padding: 1em;
+    outline: none;
+}
+
+.rtl {
+    direction: rtl;
+    margin: 1em;
+}
+
+button {
+    font-size: 20px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that copying and pasting Arabic text in an empty paragraph produces right-to-left text");
+
+    const source = document.querySelector(".source");
+    const copyButton = document.querySelector("button");
+    copyButton.addEventListener("click", () => {
+        getSelection().selectAllChildren(source);
+        document.execCommand("Copy");
+    });
+
+    await UIHelper.activateElement(copyButton);
+
+    const destination = document.querySelector(".destination");
+    getSelection().selectAllChildren(destination);
+    document.execCommand("Paste");
+
+    container = getSelection().anchorNode;
+    if (!(container instanceof Element))
+        container = container.parentElement;
+
+    shouldBeEqualToString("getComputedStyle(container).direction", "rtl");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="rtl">
+        <p>الإنجليزي مثل<span class="source">الإنجليزي مثل “hello world” يُكتب من اليسار إلى</span>الاتجاهين</p>
+        <button>Click to copy</button>
+    </div>
+    <div contenteditable>
+        Testing
+        <br>
+        <span class="destination">Foo</span>
+    </div>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -860,6 +860,20 @@ BeaconAPIEnabled:
     WebCore:
       default: false
 
+BidiContentAwarePasteEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Bidi Content Aware Paste"
+  humanReadableDescription: "Bidi content aware paste"
+  defaultValue:
+    WebKit:
+      "PLATFORM(IOS_FAMILY)": WebKit::defaultBidiContentAwarePasteEnabled()
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 BlobFileAccessEnforcementEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2756,6 +2756,7 @@ platform/text/TextBoundaries.cpp
 platform/text/TextFlags.cpp
 platform/text/TextSpacing.cpp
 platform/text/UnicodeBidi.cpp
+platform/text/UnicodeHelpers.cpp
 platform/video-codecs/BitReader.cpp
 platform/xr/openxr/OpenXRInput.cpp
 platform/xr/openxr/OpenXRInputSource.cpp

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -115,7 +115,7 @@ Ref<HTMLElement> createStyleSpanElement(Document& document)
     return createHTMLElement(document, spanTag);
 }
 
-ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyle* style, EditAction editingAction, PropertyLevel propertyLevel)
+ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyle* style, EditAction editingAction, ApplyStylePropertyLevel propertyLevel)
     : CompositeEditCommand(WTFMove(document), editingAction)
     , m_style(style->copy())
     , m_propertyLevel(propertyLevel)
@@ -126,7 +126,7 @@ ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyl
 {
 }
 
-ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction, PropertyLevel propertyLevel)
+ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction, ApplyStylePropertyLevel propertyLevel)
     : CompositeEditCommand(WTFMove(document), editingAction)
     , m_style(style->copy())
     , m_propertyLevel(propertyLevel)
@@ -192,7 +192,7 @@ Position ApplyStyleCommand::endPosition()
 void ApplyStyleCommand::doApply()
 {
     switch (m_propertyLevel) {
-    case PropertyLevel::Default: {
+    case ApplyStylePropertyLevel::Default: {
         // Apply the block-centric properties of the style.
         auto blockStyle = m_style->extractAndRemoveBlockProperties();
         if (!blockStyle->isEmpty())
@@ -204,7 +204,7 @@ void ApplyStyleCommand::doApply()
         }
         break;
     }
-    case PropertyLevel::ForceBlock:
+    case ApplyStylePropertyLevel::ForceBlock:
         // Force all properties to be applied as block styles.
         applyBlockStyle(*m_style);
         break;

--- a/Source/WebCore/editing/ApplyStyleCommand.h
+++ b/Source/WebCore/editing/ApplyStyleCommand.h
@@ -42,16 +42,15 @@ enum ShouldIncludeTypingStyle {
 
 class ApplyStyleCommand : public CompositeEditCommand {
 public:
-    enum class PropertyLevel : bool { Default, ForceBlock };
     enum class InlineStyleRemovalMode : uint8_t { IfNeeded, Always, None };
     enum class AddStyledElement : bool { No, Yes };
     typedef bool (*IsInlineElementToRemoveFunction)(const Element*);
 
-    static Ref<ApplyStyleCommand> create(Ref<Document>&& document, const EditingStyle* style, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
+    static Ref<ApplyStyleCommand> create(Ref<Document>&& document, const EditingStyle* style, EditAction action = EditAction::ChangeAttributes, ApplyStylePropertyLevel level = ApplyStylePropertyLevel::Default)
     {
         return adoptRef(*new ApplyStyleCommand(WTFMove(document), style, action, level));
     }
-    static Ref<ApplyStyleCommand> create(Ref<Document>&& document, const EditingStyle* style, const Position& start, const Position& end, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
+    static Ref<ApplyStyleCommand> create(Ref<Document>&& document, const EditingStyle* style, const Position& start, const Position& end, EditAction action = EditAction::ChangeAttributes, ApplyStylePropertyLevel level = ApplyStylePropertyLevel::Default)
     {
         return adoptRef(*new ApplyStyleCommand(WTFMove(document), style, start, end, action, level));
     }
@@ -65,8 +64,8 @@ public:
     }
 
 private:
-    ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, EditAction, PropertyLevel);
-    ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, const Position& start, const Position& end, EditAction, PropertyLevel);
+    ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, EditAction, ApplyStylePropertyLevel);
+    ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, const Position& start, const Position& end, EditAction, ApplyStylePropertyLevel);
     ApplyStyleCommand(Ref<Element>&&, bool removeOnly, EditAction);
     ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, bool (*isInlineElementToRemove)(const Element*), EditAction);
 
@@ -120,7 +119,7 @@ private:
     Position endPosition();
 
     RefPtr<EditingStyle> m_style;
-    PropertyLevel m_propertyLevel { PropertyLevel::Default };
+    ApplyStylePropertyLevel m_propertyLevel { ApplyStylePropertyLevel::Default };
     Position m_start;
     Position m_end;
     bool m_useEndingSelection;

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -530,9 +530,9 @@ void CompositeEditCommand::applyStyle(const EditingStyle* style, EditAction edit
     applyCommandToComposite(ApplyStyleCommand::create(protectedDocument(), style, editingAction));
 }
 
-void CompositeEditCommand::applyStyle(const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction)
+void CompositeEditCommand::applyStyle(const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction, ApplyStylePropertyLevel level)
 {
-    applyCommandToComposite(ApplyStyleCommand::create(protectedDocument(), style, start, end, editingAction));
+    applyCommandToComposite(ApplyStyleCommand::create(protectedDocument(), style, start, end, editingAction, level));
 }
 
 void CompositeEditCommand::applyStyledElement(Ref<Element>&& element)

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -67,6 +67,8 @@ private:
     VisiblePositionIndexRange m_rangeDeletedByReapply;
 };
 
+enum class ApplyStylePropertyLevel : bool { Default, ForceBlock };
+
 class EditCommandComposition : public UndoStep {
 public:
     enum class AddToUndoStack : bool {
@@ -152,7 +154,7 @@ protected:
     void applyCommandToComposite(Ref<EditCommand>&&);
     void applyCommandToComposite(Ref<CompositeEditCommand>&&, const VisibleSelection&);
     void applyStyle(const EditingStyle*, EditAction = EditAction::ChangeAttributes);
-    void applyStyle(const EditingStyle*, const Position& start, const Position& end, EditAction = EditAction::ChangeAttributes);
+    void applyStyle(const EditingStyle*, const Position& start, const Position& end, EditAction = EditAction::ChangeAttributes, ApplyStylePropertyLevel = ApplyStylePropertyLevel::Default);
     void applyStyledElement(Ref<Element>&&);
     void removeStyledElement(Ref<Element>&&);
     void deleteSelection(bool smartDelete = false, bool mergeBlocksAfterDelete = true, bool replace = false, bool expandForSpecialElements = true, bool sanitizeMarkup = true);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1059,7 +1059,7 @@ void Editor::applyParagraphStyle(StyleProperties* style, EditAction editingActio
     if (document->selection().isNone())
         return;
 
-    ApplyStyleCommand::create(WTFMove(document), EditingStyle::create(style).ptr(), editingAction, ApplyStyleCommand::PropertyLevel::ForceBlock)->apply();
+    ApplyStyleCommand::create(WTFMove(document), EditingStyle::create(style).ptr(), editingAction, ApplyStylePropertyLevel::ForceBlock)->apply();
 
     if (client())
         client()->didApplyStyle();

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -32,6 +32,7 @@
 #include "BeforeTextInsertedEvent.h"
 #include "BreakBlockquoteCommand.h"
 #include "CSSComputedStyleDeclaration.h"
+#include "CSSPrimitiveValueMappings.h"
 #include "CSSStyleDeclaration.h"
 #include "CommonAtomStrings.h"
 #include "DOMWrapperWorld.h"
@@ -71,6 +72,7 @@
 #include "Text.h"
 #include "TextIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include "UnicodeHelpers.h"
 #include "VisibleUnits.h"
 #include "markup.h"
 #include <wtf/NeverDestroyed.h>
@@ -1509,7 +1511,10 @@ void ReplaceSelectionCommand::doApply()
     // no style matching is necessary.
     if (plainTextFragment)
         m_matchStyle = false;
-        
+
+    if (selectionStartWasStartOfParagraph && selectionEndWasEndOfParagraph)
+        updateDirectionForStartOfInsertedContentIfNeeded();
+
     completeHTMLReplacement(lastPositionToSelect);
 }
 
@@ -1897,6 +1902,31 @@ bool ReplaceSelectionCommand::performTrivialReplace(const ReplacementFragment& f
 std::optional<SimpleRange> ReplaceSelectionCommand::insertedContentRange() const
 {
     return makeSimpleRange(m_startOfInsertedContent, m_endOfInsertedContent);
+}
+
+void ReplaceSelectionCommand::updateDirectionForStartOfInsertedContentIfNeeded()
+{
+    if (!document().settings().bidiContentAwarePasteEnabled())
+        return;
+
+    auto editAction = editingAction();
+    if (editAction != EditAction::Paste && editAction != EditAction::InsertFromDrop)
+        return;
+
+    VisiblePosition visibleStartOfInsertedContent { m_startOfInsertedContent };
+    auto firstParagraphRange = makeSimpleRange({ visibleStartOfInsertedContent, endOfParagraph(visibleStartOfInsertedContent) });
+    if (!firstParagraphRange)
+        return;
+
+    auto direction = baseTextDirection(plainText(*firstParagraphRange));
+    if (!direction)
+        return;
+
+    if (direction == directionOfEnclosingBlock(m_startOfInsertedContent))
+        return;
+
+    Ref style = EditingStyle::create(CSSPropertyDirection, toCSSValueID(*direction));
+    applyStyle(style.ptr(), m_startOfInsertedContent, m_startOfInsertedContent, EditAction::SetBlockWritingDirection, ApplyStylePropertyLevel::ForceBlock);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -127,6 +127,8 @@ private:
     ReplacementFragment* ensureReplacementFragment();
     bool performTrivialReplace(const ReplacementFragment&);
 
+    void updateDirectionForStartOfInsertedContentIfNeeded();
+
     RefPtr<DocumentFragment> protectedDocumentFragment() const { return m_documentFragment; }
 
     VisibleSelection m_visibleSelectionForInsertedText;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -38,8 +38,8 @@
 #include "SurrogatePairAwareTextIterator.h"
 #include "TextRun.h"
 #include "TextSpacing.h"
+#include "UnicodeHelpers.h"
 #include "WidthIterator.h"
-#include <unicode/ubidi.h>
 #include <wtf/text/CharacterProperties.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/TextBreakIterator.h>
@@ -574,8 +574,7 @@ TextDirection TextUtil::directionForTextContent(StringView content)
 {
     if (content.is8Bit())
         return TextDirection::LTR;
-    auto characters = content.span16();
-    return ubidi_getBaseDirection(characters.data(), characters.size()) == UBIDI_RTL ? TextDirection::RTL : TextDirection::LTR;
+    return baseTextDirection(content).value_or(TextDirection::LTR);
 }
 
 AtomString TextUtil::ellipsisTextInInlineDirection(bool isHorizontal)

--- a/Source/WebCore/platform/text/UnicodeHelpers.cpp
+++ b/Source/WebCore/platform/text/UnicodeHelpers.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "UnicodeHelpers.h"
+
+#include "WritingMode.h"
+#include <unicode/ubidi.h>
+
+namespace WebCore {
+
+std::optional<TextDirection> baseTextDirection(StringView content)
+{
+    auto characters = content.span16();
+    switch (ubidi_getBaseDirection(characters.data(), characters.size())) {
+    case UBIDI_RTL:
+        return TextDirection::RTL;
+    case UBIDI_LTR:
+        return TextDirection::LTR;
+    case UBIDI_NEUTRAL:
+    case UBIDI_MIXED:
+        return std::nullopt;
+    }
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/text/UnicodeHelpers.h
+++ b/Source/WebCore/platform/text/UnicodeHelpers.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+enum class TextDirection : bool;
+
+// std::nullopt represents neutral or mixed bidi text direction.
+std::optional<TextDirection> baseTextDirection(StringView);
+
+} // namespace WebCore

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -140,6 +140,7 @@ bool defaultGamepadVibrationActuatorEnabled();
 #if PLATFORM(IOS_FAMILY)
 bool defaultAutomaticLiveResizeEnabled();
 bool defaultVisuallyContiguousBidiTextSelectionEnabled();
+bool defaultBidiContentAwarePasteEnabled();
 #endif
 
 bool defaultRunningBoardThrottlingEnabled();

--- a/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
+++ b/Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm
@@ -132,6 +132,10 @@ bool defaultVisuallyContiguousBidiTextSelectionEnabled()
 {
     return false;
 }
+bool defaultBidiContentAwarePasteEnabled()
+{
+    return false;
+}
 #endif
 
 } // namespace WebKit


### PR DESCRIPTION
#### d833553549aa3a434c2b7402e48d73615e77fc8b
<pre>
[iOS] Add support for bidi content-aware paste and drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=286240">https://bugs.webkit.org/show_bug.cgi?id=286240</a>
<a href="https://rdar.apple.com/142486815">rdar://142486815</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Add support for new editing behaviors when pasting and dropping text, behind a new internal runtime
flag `BidiContentAwarePasteEnabled`. Currently, pasted content always takes on the text direction at
the start of the selection. When this feature is enabled and only when the user is pasting or
dropping text at the start of a new (empty) paragraph, the text direction of the inserted content
will automatically take the natural text direction of the pasted text, by setting a direction for
the enclosing containing block at the start of the inserted content range.

* LayoutTests/editing/pasteboard/paste-rtl-text-in-empty-ltr-paragraph-expected.txt: Added.
* LayoutTests/editing/pasteboard/paste-rtl-text-in-empty-ltr-paragraph.html: Added.

Add a new layout test to exercise the change.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::ApplyStyleCommand):
(WebCore::ApplyStyleCommand::doApply):
* Source/WebCore/editing/ApplyStyleCommand.h:

Move the `PropertyLevel` enum out of this class, and into `CompositeEditCommand.h` as a separate
enum — `ApplyStylePropertyLevel`. This is so that `CompositeEditCommand::applyStyle` can take an
optional property level argument, which is passed back into `ApplyStyleCommand` when creating and
applying the command.

(WebCore::ApplyStyleCommand::create):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::applyStyle):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::applyParagraphStyle):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::doApply):
(WebCore::ReplaceSelectionCommand::updateDirectionForStartOfInsertedContentIfNeeded):

See description above for more details.

* Source/WebCore/editing/ReplaceSelectionCommand.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:

Make this use the new `baseTextDirection` helper (see below).

(WebCore::Layout::TextUtil::directionForTextContent):
* Source/WebCore/platform/text/UnicodeHelpers.cpp: Added.
(WebCore::baseTextDirection):
* Source/WebCore/platform/text/UnicodeHelpers.h: Added.

Add a new helper function to determine the text direction for a given string. This is just a thin
wrapper around `ubidi_getBaseDirection`, which (respectively) returns `TextDirection::(LTR|RTL)` for
`UBIDI_(LTR|RTL)`, and `nullopt` for `UBIDI_NEUTRAL`.

* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/Shared/ios/WebPreferencesDefaultValuesIOS.mm:
(WebKit::defaultBidiContentAwarePasteEnabled):

Canonical link: <a href="https://commits.webkit.org/289195@main">https://commits.webkit.org/289195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be2f15e3c8c87b82c25eec1d58a1ef838b566672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66432 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24247 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31871 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35564 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78476 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92157 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84492 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9379 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75091 "Found 68 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html compositing/repaint/copy-forward-dirty-region-purged.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/events/domactivate-sets-underlying-click-event-as-handled.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74215 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18370 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4884 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18213 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106883 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12611 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25765 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->