### PR TITLE
[JSC] Add a bit adhoc Int52 <-> Int32 round-trip optimization

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -2019,6 +2019,65 @@ private:
                 break;
             }
 
+            if (m_value->child(0)->opcode() == SShr && m_value->child(0)->child(1)->hasInt32()) {
+                int32_t shiftAmountConstant = m_value->child(0)->child(1)->asInt32();
+                auto wrapped = m_value->child(0)->child(0);
+
+                // Turn this: Trunc(SShr(Shl(SExt32(@a), $12), $12))
+                // Into this: @a
+                if (wrapped->opcode() == Shl && wrapped->child(1)->asInt32() == shiftAmountConstant && shiftAmountConstant < 31
+                    && wrapped->child(0)->opcode() == SExt32) {
+                    replaceWithIdentity(wrapped->child(0)->child(0));
+                    break;
+                }
+
+                // Shl(SExt32(@a), $12)
+                auto isInt32ToInt52 = [](Value* value) {
+                    return value->opcode() == Shl && value->child(1)->hasInt32() && value->child(1)->asInt32() == JSValue::int52ShiftAmount
+                        && value->child(0)->opcode() == SExt32;
+                };
+
+                // Trunc(SShr(@a, $12)
+                auto isInt52ToInt32 = [](Value* value) {
+                    return value->opcode() == Trunc
+                        && value->child(0)->opcode() == SShr && value->child(0)->child(1)->hasInt32() && value->child(0)->child(1)->asInt32() == JSValue::int52ShiftAmount;
+                };
+
+                // This is specially handled here. We know that Int52 -> Int32 conversion is
+                //
+                //     Trunc(SShr(@a, $12))
+                //
+                //  Thus, attempt to wipe conversion round-trip.
+                if (isInt52ToInt32(m_value)) {
+                    switch (wrapped->opcode()) {
+                    case Add: {
+                        // Turn this: Trunc(SShr(Add(@a, constant), $12))
+                        // Into this: Add(Trunc(SShr(@a, $12), converted-constant)
+                        if (wrapped->child(1)->hasInt64()) {
+                            auto* shiftAmount = m_value->child(0)->child(1);
+                            int64_t constant = wrapped->child(1)->asInt64();
+                            auto* shifted = m_insertionSet.insert<Value>(m_index, SShr, m_value->child(0)->origin(), wrapped->child(0), shiftAmount);
+                            auto* lhs = m_insertionSet.insert<Value>(m_index, Trunc, m_value->origin(), shifted);
+                            auto* rhs = m_insertionSet.insert<Const32Value>(m_index, m_value->origin(), static_cast<int32_t>(constant >> JSValue::int52ShiftAmount));
+                            replaceWithNew<Value>(Add, m_value->origin(), rhs, lhs);
+                            break;
+                        }
+
+                        // Turn this: Trunc(SShr(Add(Shl(SExt32(@a), $12), Shl(SExt32(@b), $12)), $12))
+                        // Into this: Add(@a, @b)
+                        if (isInt32ToInt52(wrapped->child(0)) && isInt32ToInt52(wrapped->child(1))) {
+                            replaceWithNew<Value>(Add, m_value->origin(), wrapped->child(0)->child(0)->child(0), wrapped->child(1)->child(0)->child(0));
+                            break;
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                    }
+                    break;
+                }
+            }
+
             // Turn this: Trunc(Op(value, constant))
             //     where !(constant & 0xffffffff)
             //       and Op is Add, Sub, BitOr, or BitXor

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1378,4 +1378,7 @@ void testConstFloatMove();
 void testSShrCompare32(int32_t);
 void testSShrCompare64(int64_t);
 
+void testInt52RoundTripUnary(int32_t);
+void testInt52RoundTripBinary();
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -345,6 +345,8 @@ void run(const TestConfig* config)
     RUN_UNARY(testIToF32Imm, int32Operands());
     RUN(testIToDReducedToIToF64Arg());
     RUN(testIToDReducedToIToF32Arg());
+    RUN_UNARY(testInt52RoundTripUnary, int32Operands());
+    RUN(testInt52RoundTripBinary());
 
 #if !CPU(ARM)
     RUN_UNARY(testCheckAddRemoveCheckWithSExt8, int8Operands());


### PR DESCRIPTION
#### 5e4e34976b1cefbe593516a4aeb100516497cfd9
<pre>
[JSC] Add a bit adhoc Int52 &lt;-&gt; Int32 round-trip optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=286243">https://bugs.webkit.org/show_bug.cgi?id=286243</a>
<a href="https://rdar.apple.com/143241302">rdar://143241302</a>

Reviewed by Justin Michaud and Yijia Huang.

This patch adhocly reduces Int52 &lt;-&gt; Int32 round-trips. In B3, we detect
meaningless Int52 promotion and demotion and remove them via pattern
matching.

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testInt52RoundTripUnary):
(testInt52RoundTripBinary):

Canonical link: <a href="https://commits.webkit.org/289679@main">https://commits.webkit.org/289679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef88d32d7cedd8422c7579c8e5c2703bb1a9bcca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24470 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46962 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35895 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78841 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92668 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84825 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13155 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9649 "Found 2 new test failures: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document\|Window\|HTML.*) imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-videoDetectorTest.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75444 "Found 66 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html fast/multicol/columns-on-body.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74595 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6038 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13668 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13186 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18536 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107248 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12961 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25829 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->