### PR TITLE
[WebGPU] Pipeline layout for compute pipelines is not validated to be valid

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_1380-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_1380-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+CONSOLE MESSAGE: Resource usage limits exceeded: uniformBufferCount(0) > deviceLimits.maxUniformBuffersPerShaderStage(12) || storageBufferCount(9) > deviceLimits.maxStorageBuffersPerShaderStage(8) || samplerCount(0) > deviceLimits.maxSamplersPerShaderStage(16) || textureCount(0) > deviceLimits.maxSampledTexturesPerShaderStage(16) || storageTextureCount(0) > deviceLimits.maxStorageTexturesPerShaderStage(4)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_1380.html
+++ b/LayoutTests/fast/webgpu/regression/repro_1380.html
@@ -1,0 +1,76 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@group(0) @binding(0) var<storage, read_write> buf0: array<u32>;
+
+@compute @workgroup_size(1)
+fn c() {
+  buf0[0x40] = arrayLength(&buf0);
+}
+`;
+    let module = device.createShaderModule({code});
+    let bindGroupLayout0 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 1, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 2, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 3, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 4, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 5, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 6, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 7, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let bindGroupLayout1 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let storageBuffer0 = device.createBuffer({usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, size: 256});
+    let outputBuffer0 = device.createBuffer({size: storageBuffer0.size, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1]});
+    let computePipeline1 = device.createComputePipeline({
+      layout: pipelineLayout,
+      compute: {module},
+    });
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout0,
+      entries: [
+        {binding: 0, resource: {buffer: storageBuffer0}},
+        {binding: 1, resource: {buffer: storageBuffer0}},
+        {binding: 2, resource: {buffer: storageBuffer0}},
+        {binding: 3, resource: {buffer: storageBuffer0}},
+        {binding: 4, resource: {buffer: storageBuffer0}},
+        {binding: 5, resource: {buffer: storageBuffer0}},
+        {binding: 6, resource: {buffer: storageBuffer0}},
+        {binding: 7, resource: {buffer: storageBuffer0}},
+      ],
+    });
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    computePassEncoder.setPipeline(computePipeline1);
+    computePassEncoder.setBindGroup(0, bindGroup0);
+    computePassEncoder.dispatchWorkgroups(1);
+    computePassEncoder.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer0.mapAsync(GPUMapMode.READ);
+    log([...new Uint32Array(outputBuffer0.getMappedRange())].map(x => x.toString(0x10)).join(', '));
+    outputBuffer0.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_1380b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_1380b-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Resource usage limits exceeded: uniformBufferCount(0) > deviceLimits.maxUniformBuffersPerShaderStage(12) || storageBufferCount(9) > deviceLimits.maxStorageBuffersPerShaderStage(8) || samplerCount(0) > deviceLimits.maxSamplersPerShaderStage(16) || textureCount(0) > deviceLimits.maxSampledTexturesPerShaderStage(16) || storageTextureCount(0) > deviceLimits.maxStorageTexturesPerShaderStage(4)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_1380b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_1380b.html
@@ -1,0 +1,57 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@group(12) @binding(345678) var<storage, read_write> buf0: array<u32>;
+
+@compute @workgroup_size(1)
+fn c() {
+  buf0[12345] = 6;
+}
+`;
+    let module = device.createShaderModule({code});
+    let bindGroupLayout0 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 1, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 2, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 3, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 4, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 5, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 6, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 7, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let bindGroupLayout1 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1]});
+    let computePipeline1 = device.createComputePipeline({
+      layout: pipelineLayout,
+      compute: {module},
+    });
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    computePassEncoder.setPipeline(computePipeline1);
+    computePassEncoder.dispatchWorkgroups(1);
+    computePassEncoder.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_1380c-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_1380c-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_1380c.html
+++ b/LayoutTests/fast/webgpu/regression/repro_1380c.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ enableMetalDebugDevice=true ] -->
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    let code = `
+@group(12) @binding(345678) var<storage, read_write> buf0: array<u32>;
+
+@compute @workgroup_size(1)
+fn c() {
+  buf0[12345] = 6;
+}
+`;
+    let module = device.createShaderModule({code});
+    let bindGroupLayout0 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 1, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 2, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 3, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 4, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 5, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 6, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 7, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let bindGroupLayout1 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let pipelineLayout = device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout0, bindGroupLayout1]});
+    let computePipeline1 = device.createComputePipeline({
+      layout: pipelineLayout,
+      compute: {module},
+    });
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    computePassEncoder.setPipeline(computePipeline1);
+    computePassEncoder.dispatchWorkgroups(1);
+    await device.queue.onSubmittedWorkDone();
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_1380d-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_1380d-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+CONSOLE MESSAGE: Resource usage limits exceeded: uniformBufferCount(0) > deviceLimits.maxUniformBuffersPerShaderStage(12) || storageBufferCount(9) > deviceLimits.maxStorageBuffersPerShaderStage(8) || samplerCount(0) > deviceLimits.maxSamplersPerShaderStage(16) || textureCount(0) > deviceLimits.maxSampledTexturesPerShaderStage(16) || storageTextureCount(0) > deviceLimits.maxStorageTexturesPerShaderStage(4)
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_1380d.html
+++ b/LayoutTests/fast/webgpu/regression/repro_1380d.html
@@ -1,0 +1,67 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@group(0) @binding(0) var<storage, read_write> buf0: array<u32>;
+
+@compute @workgroup_size(1)
+fn c() {
+  buf0[0x40] = arrayLength(&buf0);
+}
+`;
+    let module = device.createShaderModule({code});
+    let bindGroupLayout0 = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 1, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+        {binding: 2, buffer: {type: 'storage'}, visibility: GPUShaderStage.COMPUTE},
+      ],
+    });
+    let storageBuffer0 = device.createBuffer({usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, size: 256});
+    let outputBuffer0 = device.createBuffer({size: storageBuffer0.size, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    let pipelineLayout = device.createPipelineLayout({
+      bindGroupLayouts: [
+        bindGroupLayout0,
+        bindGroupLayout0,
+        bindGroupLayout0,
+      ],
+    });
+    let computePipeline1 = device.createComputePipeline({
+      layout: pipelineLayout,
+      compute: {module},
+    });
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout0,
+      entries: [
+        {binding: 0, resource: {buffer: storageBuffer0}},
+        {binding: 1, resource: {buffer: storageBuffer0}},
+        {binding: 2, resource: {buffer: storageBuffer0}},
+      ],
+    });
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    computePassEncoder.setPipeline(computePipeline1);
+    computePassEncoder.setBindGroup(0, bindGroup0);
+    computePassEncoder.dispatchWorkgroups(1);
+    computePassEncoder.end();
+    let commandBuffer = commandEncoder.finish();
+    device.queue.submit([commandBuffer]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer0.mapAsync(GPUMapMode.READ);
+    log([...new Uint32Array(outputBuffer0.getMappedRange())].map(x => x.toString(0x10)).join(', '));
+    outputBuffer0.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -29,6 +29,7 @@
 #import "APIConversions.h"
 #import "BindGroupLayout.h"
 #import "Device.h"
+#import "IsValidToUseWith.h"
 #import "Pipeline.h"
 #import "PipelineLayout.h"
 #import "ShaderModule.h"
@@ -88,6 +89,9 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
         return returnInvalidComputePipeline(*this, isAsync);
 
     Ref pipelineLayout = WebGPU::protectedFromAPI(descriptor.layout);
+    if (!isValidToUseWithDevice(pipelineLayout.get(), *this))
+        return returnInvalidComputePipeline(*this, isAsync, @"GPUDevice.createComputePipeline: Pipeline layout is invalid");
+
     auto& deviceLimits = limits();
     auto label = fromAPI(descriptor.label);
     auto entryPointName = descriptor.compute.entryPoint ? fromAPI(descriptor.compute.entryPoint) : shaderModule->defaultComputeEntryPoint();

--- a/Source/WebGPU/WebGPU/IsValidToUseWith.h
+++ b/Source/WebGPU/WebGPU/IsValidToUseWith.h
@@ -45,6 +45,23 @@ bool isValidToUseWith(const T& object, const U& targetObject)
 }
 
 template <typename T, typename U>
+bool isValidToUseWithDevice(const T& object, const U& targetObject)
+{
+    // https://gpuweb.github.io/gpuweb/#abstract-opdef-valid-to-use-with
+
+    if (!object.isValid())
+        return false;
+
+    if (!object.device().isValid())
+        return false;
+
+    if (&object.device() != &targetObject)
+        return false;
+
+    return true;
+}
+
+template <typename T, typename U>
 bool isValidToUseWith(const Ref<T>& object, const U& targetObject)
 {
     return isValidToUseWith(object.get(), targetObject);

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -29,6 +29,7 @@
 #import "APIConversions.h"
 #import "BindGroupLayout.h"
 #import "Device.h"
+#import "IsValidToUseWith.h"
 #import "Pipeline.h"
 #import "RenderBundleEncoder.h"
 #import "WGSLShaderModule.h"
@@ -1336,10 +1337,8 @@ std::pair<Ref<RenderPipeline>, NSString*> Device::createRenderPipeline(const WGP
     Vector<Vector<WGPUBindGroupLayoutEntry>> bindGroupEntries;
     if (descriptor.layout) {
         Ref layout = WebGPU::protectedFromAPI(descriptor.layout);
-        if (!layout->isValid())
-            return returnInvalidRenderPipeline(*this, isAsync, "Pipeline layout is not valid"_s);
-        if (&layout->device() != this)
-            return returnInvalidRenderPipeline(*this, isAsync, "Pipeline layout created from different device"_s);
+        if (!isValidToUseWithDevice(layout.get(), *this))
+            return returnInvalidRenderPipeline(*this, isAsync, "Pipeline layout is not valid or created from different device"_s);
 
         if (!layout->isAutoLayout())
             pipelineLayout = layout.ptr();


### PR DESCRIPTION
#### 2c15e1198606b092facb2395ba04471e7fcd53a7
<pre>
[WebGPU] Pipeline layout for compute pipelines is not validated to be valid
<a href="https://bugs.webkit.org/show_bug.cgi?id=286250">https://bugs.webkit.org/show_bug.cgi?id=286250</a>
<a href="https://rdar.apple.com/143249146">rdar://143249146</a>

Reviewed by Tadeu Zagallo.

Unlike RenderPipelines, creating a ComputePipeline did not check if the
associated PipelineLayout was invalid. Attempting to do so should result
in an invalid ComputePipeline according to the WebGPU specification, see
<a href="https://www.w3.org/TR/webgpu/#dom-gpudevice-createcomputepipeline">https://www.w3.org/TR/webgpu/#dom-gpudevice-createcomputepipeline</a>

* LayoutTests/fast/webgpu/regression/repro_1380-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_1380.html: Added.
* LayoutTests/fast/webgpu/regression/repro_1380b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_1380b.html: Added.
* LayoutTests/fast/webgpu/regression/repro_1380c-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_1380c.html: Added.
* LayoutTests/fast/webgpu/regression/repro_1380d-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_1380d.html: Added.
Add associated regression tests and expectations.

* Source/WebGPU/WebGPU/ComputePipeline.mm:
* Source/WebGPU/WebGPU/IsValidToUseWith.h:
(WebGPU::isValidToUseWithDevice):
* Source/WebGPU/WebGPU/RenderPipeline.mm:

Canonical link: <a href="https://commits.webkit.org/289162@main">https://commits.webkit.org/289162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6620cc5e1ccb31da0aac4f961e094727531ff83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36516 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66451 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92206 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75129 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18536 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4915 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12833 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18234 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->