### PR TITLE
Fix crashes/assertions when calling internals API on a window without frame

### DIFF
--- a/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash-expected.txt
+++ b/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash or assert.

--- a/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
+++ b/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<iframe id="iframe"></iframe>
+<script>
+if (testRunner)
+    testRunner.dumpAsText();
+
+const skippedInternalFunctions = [
+  // Calling the following internals function can cause crashes or assertions, but
+  // they don't actually involve a DOM tree and shouldn't be covered by this test.
+  "reportBacktrace",
+  "terminateWebContentProcess",
+  "beginAudioSessionInterruption",
+  "beginMediaSessionInterruption",
+  "createFile",
+  "hasSandboxMachLookupAccessToGlobalName",
+  "hasSandboxMachLookupAccessToXPCServiceName",
+  "hasSandboxUnixSyscallAccess",
+  "setHardwareVP9DecoderDisabledForTesting",
+  "setSystemHasACForTesting",
+  "setSystemHasBatteryForTesting",
+  "setVP9DecoderDisabledForTesting",
+  "setVP9ScreenSizeAndScaleForTesting",
+  // These two crashes on mac-wk1, but don't require a frame.
+  "hasServiceWorkerRegistration",
+  "storeRegistrationsOnDisk",
+];
+
+// The following exceptions can be thrown because the internals properties are
+// accessed in a bad state, or because we pass invalid parameters to functions.
+const expectedErrors = [
+  "DataCloneError",
+  "InvalidAccessError",
+  "InvalidStateError",
+  "NotFoundError",
+  "NotSupportedError",
+  "SyntaxError",
+  "TypeError",
+];
+function runAndIgnoreExpectedErrors(property, fn) {
+    try {
+        return fn();
+    } catch(e) {
+        if (!expectedErrors.includes(e.name))
+            throw e;
+    }
+}
+
+const iframe_window = window.frames[0];
+document.adoptNode(document.getElementById("iframe"));
+for (let property in iframe_window.internals) {
+    // Try the getter.
+    let value = runAndIgnoreExpectedErrors(property, function() {
+        return iframe_window.internals[property];
+    });
+
+    if (typeof value == 'function') {
+        if (skippedInternalFunctions.includes(property))
+            continue;
+        // For functions, we don't really have a generic way to produce a valid
+        // set of arguments, so just try some basic call.
+        runAndIgnoreExpectedErrors(property, function() {
+            const argumentCount = 10;
+            iframe_window.internals[property](...Array(argumentCount).fill(1));
+        });
+    } else {
+        // Try the setter.
+        runAndIgnoreExpectedErrors(property, function() {
+            iframe_window.internals[property] = value;
+        });
+    }
+}
+
+document.body.innerHTML = "PASS if no crash or assert.";
+</script>

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -492,7 +492,7 @@ public:
     bool isOverwriteModeEnabled();
     void toggleOverwriteModeEnabled();
 
-    bool testProcessIncomingSyncMessagesWhenWaitingForSyncReply();
+    ExceptionOr<bool> testProcessIncomingSyncMessagesWhenWaitingForSyncReply();
 
     ExceptionOr<RefPtr<Range>> rangeOfString(const String&, RefPtr<Range>&&, const Vector<String>& findOptions);
     ExceptionOr<unsigned> countMatchesForText(const String&, const Vector<String>& findOptions, const String& markMatches);
@@ -600,7 +600,7 @@ public:
     unsigned numberOfResizeObservers(const Document&) const;
 
     String documentIdentifier(const Document&) const;
-    bool isDocumentAlive(const String& documentIdentifier) const;
+    ExceptionOr<bool> isDocumentAlive(const String& documentIdentifier) const;
 
     uint64_t messagePortIdentifier(const MessagePort&) const;
     bool isMessagePortAlive(uint64_t messagePortIdentifier) const;
@@ -656,7 +656,7 @@ public:
         float right { 0 };
     };
     void setFullscreenInsets(FullscreenInsets);
-    void setFullscreenAutoHideDuration(double);
+    ExceptionOr<void> setFullscreenAutoHideDuration(double);
 
 #if ENABLE(VIDEO)
     bool isChangingPresentationMode(HTMLVideoElement&) const;
@@ -1089,7 +1089,7 @@ public:
     NO_RETURN_DUE_TO_CRASH void terminateWebContentProcess();
 
 #if ENABLE(APPLE_PAY)
-    MockPaymentCoordinator& mockPaymentCoordinator(Document&);
+    ExceptionOr<Ref<MockPaymentCoordinator>> mockPaymentCoordinator(Document&);
 #endif
 
     struct ImageOverlayText {
@@ -1400,7 +1400,7 @@ public:
 
     String windowLocationHost(DOMWindow&);
 
-    String systemColorForCSSValue(const String& cssValue, bool useDarkModeAppearance, bool useElevatedUserInterfaceLevel);
+    ExceptionOr<String> systemColorForCSSValue(const String& cssValue, bool useDarkModeAppearance, bool useElevatedUserInterfaceLevel);
 
     bool systemHasBattery() const;
 


### PR DESCRIPTION
#### e63fe9d14548d612e19da56efce3dab4f1a59ae2
<pre>
Fix crashes/assertions when calling internals API on a window without frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=286252">https://bugs.webkit.org/show_bug.cgi?id=286252</a>

Reviewed by Anne van Kesteren and Darin Adler.

There are multiple places in Internals.cpp that assumes a document, a
frame, a page or valid parameters ; and would otherwise crash or assert.
In this patch, we add a generic test case exercising Window.internals
properties when the associated frame is null. It calls the getter and
setter for each of these properties, or if the property is a function,
executes it with ten &apos;1&apos; as arguments. This should cover a large amount
of cases detectable by fuzzers. We also modify the code to fix the
issues found with that new test but there are probably more. Some of
these APIs should probably throw in case of failure, but we don&apos;t
necessarily modify their signature in this patch.

* LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash-expected.txt: Added.
* LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html: Added.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setStrictRawResourceValidationPolicyDisabled): null-check frame.
(WebCore::Internals::numberOfActiveAnimations const): ditto.
(WebCore::Internals::numberOfAnimationTimelineInvalidations const): ditto.
(WebCore::Internals::insertTextPlaceholder): ditto.
(WebCore::Internals::formControlStateOfPreviousHistoryItem): ditto.
(WebCore::Internals::setFormControlStateOfPreviousHistoryItem): ditto.
(WebCore::Internals::testProcessIncomingSyncMessagesWhenWaitingForSyncReply): null-check document, frame and page and throw.
(WebCore::Internals::isDocumentAlive const): Replace ASSERT with an exception.
(WebCore::Internals::openDummyInspectorFrontend): null-check document, frame and page.
(WebCore::Internals::setInspectorIsUnderTest): ditto.
(WebCore::Internals::setFullscreenAutoHideDuration): ditto and replace ASSERT with an exception.
(WebCore::Internals::getReferencedFilePaths const): null-check frame.
(WebCore::Internals::startTrackingRenderingUpdates): null-check document, frame and page.
(WebCore::Internals::renderingUpdateCount): ditto.
(WebCore::Internals::setCompositingPolicyOverride): ditto.
(WebCore::Internals::compositingPolicyOverride const): ditto.
(WebCore::Internals::evaluateInWorldIgnoringException): null-check document and frame.
(WebCore::Internals::forceAXObjectCacheUpdate const): null-check document and axObjectCache.
(WebCore::Internals::forceReload): null-check frame.
(WebCore::Internals::reloadExpiredOnly): ditto.
(WebCore::Internals::setSelectionFromNone): ditto.
(WebCore::Internals::mockPaymentCoordinator): null-check page and throw.
(WebCore::Internals::systemColorForCSSValue): Replace RELEASE_ASSERT with an exception.
(WebCore::Internals::setTopDocumentURLForQuirks): null-check on frame and page.
* Source/WebCore/testing/Internals.h: Change some functions to return Exceptions.

Canonical link: <a href="https://commits.webkit.org/289309@main">https://commits.webkit.org/289309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d245126b9a51a653d883e25c497e487d8d9f332d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91282 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37172 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32548 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36274 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93107 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75672 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74862 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18424 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17501 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13597 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18886 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13350 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->