### PR TITLE
Generate all style builder functions for font-feature-settings

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/inheritance-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL Property font-family inherits assert_not_equals: got disallowed value "\"Not Initial!\""
 PASS Property font-feature-settings has initial value normal
-FAIL Property font-feature-settings inherits assert_not_equals: got disallowed value "\"smcp\", \"swsh\" 2"
+PASS Property font-feature-settings inherits
 PASS Property font-kerning has initial value auto
 PASS Property font-kerning inherits
 FAIL Property font-language-override has initial value normal assert_true: font-language-override doesn't seem to be supported in the computed style expected true got false

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -800,7 +800,6 @@
             "codegen-properties": {
                 "name-for-methods": "FeatureSettings",
                 "converter": "FontFeatureSettings",
-                "custom": "Initial|Inherit",
                 "font-property": true,
                 "high-priority": true,
                 "parser-grammar": "normal | <feature-tag-value>#@(no-single-item-opt)",
@@ -819,7 +818,6 @@
             "codegen-properties": {
                 "name-for-methods": "VariationSettings",
                 "converter": "FontVariationSettings",
-                "custom": "Initial|Inherit",
                 "font-property": true,
                 "high-priority": true,
                 "enable-if": "ENABLE_VARIATION_FONTS",

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3365,7 +3365,8 @@ class GenerateStyleBuilderGenerated:
 
     def _generate_font_property_inherit_value_setter(self, to, property):
         to.write(f"auto fontDescription = builderState.fontDescription();")
-        to.write(f"fontDescription.{property.codegen_properties.setter}(builderState.parentFontDescription().{property.codegen_properties.getter}());")
+        to.write(f"auto inheritedValue = builderState.parentFontDescription().{property.codegen_properties.getter}();")
+        to.write(f"fontDescription.{property.codegen_properties.setter}(WTFMove(inheritedValue));")
         to.write(f"builderState.setFontDescription(WTFMove(fontDescription));")
 
     def _generate_font_property_value_setter(self, to, property, value):

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -148,6 +148,8 @@ public:
     static FontSizeAdjust initialFontSizeAdjust() { return { FontSizeAdjust::Metric::ExHeight }; }
     static TextSpacingTrim initialTextSpacingTrim() { return { }; }
     static TextAutospace initialTextAutospace() { return { }; }
+    static FontFeatureSettings initialFeatureSettings() { return { }; }
+    static FontVariationSettings initialVariationSettings() { return { }; }
 
 private:
     Ref<RefCountedFixedVector<AtomString>> m_families;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -130,14 +130,6 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(WebkitBoxShadow);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Zoom);
 
-    // Custom handling of initial + inherit value setting only.
-    static void applyInitialFontFeatureSettings(BuilderState&) { }
-    static void applyInheritFontFeatureSettings(BuilderState&) { }
-    static void applyInitialFontVariationSettings(BuilderState&);
-    static void applyInheritFontVariationSettings(BuilderState&);
-    static void applyInitialWebkitMaskImage(BuilderState&) { }
-    static void applyInheritWebkitMaskImage(BuilderState&) { }
-
     // Custom handling of inherit + value setting only.
     static void applyInheritVerticalAlign(BuilderState&);
     static void applyValueVerticalAlign(BuilderState&, CSSValue&);
@@ -892,16 +884,6 @@ inline void BuilderCustom::applyValueBorderTopRightRadius(BuilderState& builderS
     builderState.style().setHasExplicitlySetBorderTopRightRadius(true);
 }
 
-inline void BuilderCustom::applyInitialFontVariationSettings(BuilderState& builderState)
-{
-    builderState.style().setFontVariationSettings({ });
-}
-
-inline void BuilderCustom::applyInheritFontVariationSettings(BuilderState& builderState)
-{
-    builderState.style().setFontVariationSettings(builderState.parentStyle().fontVariationSettings());
-}
-
 inline void BuilderCustom::applyInheritBaselineShift(BuilderState& builderState)
 {
     auto& svgStyle = builderState.style().accessSVGStyle();
@@ -1330,8 +1312,10 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
         return;
     }
 
-    if (!hasAltTextContent)
+    if (!hasAltTextContent) {
+        builderState.style().setContentAltText({ });
         return;
+    }
 
     auto& altTextContentList = downcast<CSSValuePair>(value).second();
     StringBuilder altText;


### PR DESCRIPTION
#### 206e15e58c13e2648c97490244dbe34b1e113a39
<pre>
Generate all style builder functions for font-feature-settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=286258">https://bugs.webkit.org/show_bug.cgi?id=286258</a>
<a href="https://rdar.apple.com/143263787">rdar://143263787</a>

Reviewed by Alan Baradlay.

They are handwritten and incomplete. This becomes a problem for future optimizations.

 LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/inheritance-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/process-css-properties.py:

Allow move-only setters.

* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::initialFeatureSettings):
(WebCore::FontCascadeDescription::initialVariationSettings):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueContent):

Also fix reseting content alt text. All paths for a given property should set all fields.

(WebCore::Style::BuilderCustom::applyInitialFontFeatureSettings): Deleted.
(WebCore::Style::BuilderCustom::applyInheritFontFeatureSettings): Deleted.
(WebCore::Style::BuilderCustom::applyInitialWebkitMaskImage): Deleted.
(WebCore::Style::BuilderCustom::applyInheritWebkitMaskImage): Deleted.
(WebCore::Style::BuilderCustom::applyInitialFontVariationSettings): Deleted.
(WebCore::Style::BuilderCustom::applyInheritFontVariationSettings): Deleted.

Canonical link: <a href="https://commits.webkit.org/289152@main">https://commits.webkit.org/289152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba97fdd32829d0adde6afe00012fdd8798716462

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13218 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24294 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88552 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/4167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46761 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/4035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/31929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35616 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92263 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12859 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73500 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/74310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18347 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17001 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4960 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18264 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->