### PR TITLE
User activation should be enabled for gamepadconnected event

### DIFF
--- a/LayoutTests/gamepad/gamepad-user-activation-expected.txt
+++ b/LayoutTests/gamepad/gamepad-user-activation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS gamepadconnected should allow to play audio
+

--- a/LayoutTests/gamepad/gamepad-user-activation.html
+++ b/LayoutTests/gamepad/gamepad-user-activation.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+<script>
+promise_test(async () => {
+    if (!window.testRunner)
+        return;
+
+    const promise = new Promise(resolve => window.ongamepadconnected = resolve);
+
+    testRunner.setMockGamepadDetails(0, "Test Joystick", "", 2, 2, false);
+    testRunner.connectMockGamepad(0);
+    testRunner.setMockGamepadAxisValue(0, 0, 3);
+    testRunner.setMockGamepadAxisValue(0, 1, -1.0);
+
+    await promise;
+    assert_true(internals.isProcessingUserGesture());
+}, "gamepadconnected should allow to play audio");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -181,8 +181,10 @@ void GamepadManager::makeGamepadVisible(PlatformGamepad& platformGamepad, WeakHa
         NavigatorGamepad& navigator = navigatorGamepadFromDOMWindow(*window);
 
         Ref gamepad = navigator.gamepadFromPlatformGamepad(platformGamepad);
+        RefPtr document = navigator.navigator().document();
 
         LOG(Gamepad, "(%u) GamepadManager::makeGamepadVisible - Dispatching gamepadconnected event for gamepad '%s'", (unsigned)getpid(), platformGamepad.id().utf8().data());
+        UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document.get());
         window->dispatchEvent(GamepadEvent::create(eventNames().gamepadconnectedEvent, gamepad.get()), window->document());
     }
 }


### PR DESCRIPTION
#### 642206b4fe41ffa4b671f18ccae0d828a97405ec
<pre>
User activation should be enabled for gamepadconnected event
<a href="https://rdar.apple.com/131557341">rdar://131557341</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286259">https://bugs.webkit.org/show_bug.cgi?id=286259</a>

Reviewed by Brady Eidson.

As per <a href="https://w3c.github.io/gamepad/#dfn-update-gamepad-state">https://w3c.github.io/gamepad/#dfn-update-gamepad-state</a>, the gamepadconnected event is fired if a gamepad contains a user gesture,
<a href="https://w3c.github.io/gamepad/#dfn-gamepad-user-gesture.">https://w3c.github.io/gamepad/#dfn-gamepad-user-gesture.</a>

It follows that it should be feasible to play audio within gamepadconnected callback, as done by websites such as xbox.com.
We add a user gesture indicator before firing the gamepadconnected event to follow the spec.

* LayoutTests/gamepad/gamepad-user-activation-expected.txt: Added.
* LayoutTests/gamepad/gamepad-user-activation.html: Added.
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::makeGamepadVisible):

Canonical link: <a href="https://commits.webkit.org/289179@main">https://commits.webkit.org/289179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d38fe95ab69bd42daa89efb6332a8d9e03fc7f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66471 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75178 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74313 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4949 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12866 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18253 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->