### PR TITLE
Remove explicit opt-ins to modern media controls from tests

### DIFF
--- a/LayoutTests/media/ios/viewport-change-with-video.html
+++ b/LayoutTests/media/ios/viewport-change-with-video.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ modernMediaControls=true useFlexibleViewport=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <body>
 <p>This tests changing the viewport after a video element. WebKit should not crash.</p>

--- a/LayoutTests/media/modern-media-controls/media-documents/background-color-and-centering.html
+++ b/LayoutTests/media/modern-media-controls/media-documents/background-color-and-centering.html
@@ -1,2 +1,2 @@
-<!DOCTYPE html><!-- webkit-test-runner [ modernMediaControls=true ] -->
+<!DOCTYPE html>
 <iframe src="../../content/test.mp4" style="width: 360px; height: 400px; border: none; -webkit-clip-path: polygon(0px 0px, 20px 0px, 20px 20px, 0px 20px);"></iframe>

--- a/LayoutTests/media/modern-media-controls/media-documents/insert-style-should-not-crash.html
+++ b/LayoutTests/media/modern-media-controls/media-documents/insert-style-should-not-crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ modernMediaControls=true ] -->
+<!DOCTYPE html>
 <script>
 if (window.testRunner)
     testRunner.dumpAsText();


### PR DESCRIPTION
#### 7829051d4c24ac207b805e3f2ab9e5978102219b
<pre>
Remove explicit opt-ins to modern media controls from tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=202742">https://bugs.webkit.org/show_bug.cgi?id=202742</a>

Reviewed by Tim Nguyen.

This preference has been long gone.

* LayoutTests/media/ios/viewport-change-with-video.html:
* LayoutTests/media/modern-media-controls/media-documents/background-color-and-centering.html:
* LayoutTests/media/modern-media-controls/media-documents/insert-style-should-not-crash.html:

Canonical link: <a href="https://commits.webkit.org/289171@main">https://commits.webkit.org/289171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79ac2c1fdc017cf55b6960d92302860b37170017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36540 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66473 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24287 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77659 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46755 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31922 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35610 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9426 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75188 "Found 68 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html fast/multicol/columns-on-body.html fast/repaint/no-animation-outside-viewport-subframe.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4954 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13340 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12871 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->