### PR TITLE
[scroll-animations] multiple `timeline-scope` WPT tests are failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
@@ -1,4 +1,7 @@
 CONSOLE MESSAGE: Error: assert_equals: expected "1px" but got "100px"
+CONSOLE MESSAGE: Error: assert_equals: expected "1px" but got "100px"
+
+Harness Error (FAIL), message = Error: assert_equals: expected "1px" but got "100px"
 
 FAIL Multiple style/layout passes occur when necessary assert_equals: expected 100 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt
@@ -6,5 +6,5 @@ PASS Animation with ranges [0%, 50%]
 PASS Animation with ranges [10%, 50%]
 PASS Animation with ranges [150px, 75em]
 PASS Animation with ranges [calc(1% + 135px), calc(70em + 50px)]
-FAIL Animation with ranges [calc(1% + 135px), calc(70em + 50px)] (scoped) assert_equals: expected "0" but got "100"
+PASS Animation with ranges [calc(1% + 135px), calc(70em + 50px)] (scoped)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL Descendant can attach to deferred timeline assert_equals: expected "100px" but got "0px"
+PASS Descendant can attach to deferred timeline
 PASS Deferred timeline with no attachments
 PASS Inner timeline does not interfere with outer timeline
-PASS Deferred timeline with two attachments
-FAIL Dynamically re-attaching assert_equals: expected "100px" but got "0px"
+FAIL Deferred timeline with two attachments assert_equals: expected "0px" but got "100px"
+PASS Dynamically re-attaching
 FAIL Dynamically detaching assert_equals: expected "0px" but got "100px"
-FAIL Removing/inserting element with attaching timeline assert_equals: expected "100px" but got "0px"
-FAIL Ancestor attached element becoming display:none/block assert_equals: expected "100px" but got "0px"
+FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
+PASS Ancestor attached element becoming display:none/block
 FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
 PASS Animations prefer non-deferred timelines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
@@ -14,5 +14,5 @@ PASS Animation with ranges [exit 20px, exit 80px]
 PASS Animation with ranges [exit-crossing 20px, exit-crossing 80px]
 PASS Animation with ranges [contain 20px, contain calc(100px - 10%)]
 PASS Animation with ranges [exit 2em, exit 8em]
-FAIL Animation with ranges [exit 2em, exit 8em] (scoped) assert_equals: expected "0" but got "100"
+PASS Animation with ranges [exit 2em, exit 8em] (scoped)
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -94,8 +94,12 @@ KeyframeEffect::ParsedKeyframe::~ParsedKeyframe() = default;
 
 static inline void invalidateElement(const std::optional<const Styleable>& styleable)
 {
-    if (styleable)
-        styleable->element.invalidateStyleForAnimation();
+    if (!styleable)
+        return;
+
+    auto& element = styleable->element;
+    if (!element.document().inStyleRecalc())
+        element.invalidateStyleForAnimation();
 }
 
 String KeyframeEffect::CSSPropertyIDToIDLAttributeName(CSSPropertyID property)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2601,6 +2601,7 @@ void Element::invalidateStyleInternal()
 
 void Element::invalidateStyleForAnimation()
 {
+    ASSERT(!document().inStyleRecalc());
     Node::invalidateStyle(Style::Validity::AnimationInvalid);
 }
 


### PR DESCRIPTION
#### 2f41a237286ad02b6bd743fc2c9f596a0c00ae43
<pre>
[scroll-animations] multiple `timeline-scope` WPT tests are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=286264">https://bugs.webkit.org/show_bug.cgi?id=286264</a>
<a href="https://rdar.apple.com/143271212">rdar://143271212</a>

Reviewed by Antti Koivisto and Simon Fraser.

When properties of an animation change, we end up calling `Element::invalidateStyleForAnimation()` on the
associated effect target to ensure that those updated animation properties are represented in the animated
style.

The creation of style-originated animations (CSS Animations and CSS Transitions) occur during style resolution,
typically under `Document::resolveStyle()`. During that process, we ensure that the new style-originated
animations do not call into `Element::invalidateStyleForAnimation()` so as not to produce some inconsistent
state.

As part of scroll-driven animations, in the case of `timeline-scope`, we do new work during style resolution to
set the timeline of a style-originated animation. The previous protections we had in place to avoid calling
`Element::invalidateStyleForAnimation()` did not apply there. This would yield inconsistent node states where
the Style::Validity::AnimationInvalid flag would be set but ancestors would no longer have the
`NodeStyleFlag::DescendantNeedsStyleResolution` flag set, preventing further style resolution on animated
elements.

We now add a more direct check in the `invalidateElement()` static function of `KeyframeEffect.cpp` to check
that we do not call `Element::invalidateStyleForAnimation()` during style resolution. Furthermore, we also
add an `ASSERT()` in `Element::invalidateStyleForAnimation()` to check that this holds true for any future
call to that function.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::invalidateElement):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateStyleForAnimation):

Canonical link: <a href="https://commits.webkit.org/289180@main">https://commits.webkit.org/289180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d046a2d76c5159379a235befc821a52b4c0223d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66483 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24298 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46766 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4047 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31942 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74723 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92281 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75183 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74319 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4971 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13347 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18273 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->