### PR TITLE
Consider lowercasing CSS keywords at source

### DIFF
--- a/Source/WebCore/css/process-css-values.py
+++ b/Source/WebCore/css/process-css-values.py
@@ -209,14 +209,6 @@ class GenerationContext:
         to.write("%%\n")
 
     def _generate_name_string_tables(self, *, to):
-        to.write(f"constexpr ASCIILiteral valueList[] = {{\n")
-        to.write(f"    \"\"_s,\n")
-
-        for value in self.values:
-            to.write(f"    \"{value.name}\"_s,\n")
-
-        to.write(f"    ASCIILiteral()\n")
-        to.write(f"}};\n")
         to.write(f"constexpr ASCIILiteral valueListForSerialization[] = {{\n")
         to.write(f"    \"\"_s,\n")
 
@@ -238,16 +230,14 @@ class GenerationContext:
             {
                 if (static_cast<uint16_t>(id) >= numCSSValueKeywords)
                     return { };
-                return valueList[id];
+                return valueListForSerialization[id];
             }
 
             // When serializing a CSS keyword, it should be converted to ASCII lowercase.
             // https://drafts.csswg.org/cssom/#serialize-a-css-component-value
             ASCIILiteral nameLiteralForSerialization(CSSValueID id)
             {
-                if (static_cast<uint16_t>(id) >= numCSSValueKeywords)
-                    return { };
-                return valueListForSerialization[id];
+                return nameLiteral(id);
             }
 
             const AtomString& nameString(CSSValueID id)
@@ -258,7 +248,7 @@ class GenerationContext:
                 static NeverDestroyed<std::array<AtomString, numCSSValueKeywords>> strings;
                 auto& string = strings.get()[id];
                 if (string.isNull())
-                    string = valueList[id];
+                    string = valueListForSerialization[id];
                 return string;
             }
 
@@ -266,14 +256,7 @@ class GenerationContext:
             // https://drafts.csswg.org/cssom/#serialize-a-css-component-value
             const AtomString& nameStringForSerialization(CSSValueID id)
             {
-                if (static_cast<uint16_t>(id) >= numCSSValueKeywords)
-                    return nullAtom();
-
-                static NeverDestroyed<std::array<AtomString, numCSSValueKeywords>> strings;
-                auto& string = strings.get()[id];
-                if (string.isNull())
-                    string = valueListForSerialization[id];
-                return string;
+                return nameString(id);
             }
 
             """))


### PR DESCRIPTION
#### 20cb8caf80c2ca2f91cd0bbf546df683c2336f9b
<pre>
Consider lowercasing CSS keywords at source
<a href="https://bugs.webkit.org/show_bug.cgi?id=266863">https://bugs.webkit.org/show_bug.cgi?id=266863</a>
<a href="https://rdar.apple.com/120323932">rdar://120323932</a>

Reviewed by NOBODY (OOPS!).

TEST COMMIT TO SEE WHAT TESTS FAIL IF WE ALWAYS LOWERCASE CSS IDENTIFIERS.

* Source/WebCore/css/process-css-values.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20cb8caf80c2ca2f91cd0bbf546df683c2336f9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13237 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66491 "Found 20 new test failures: imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-box-size.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-matrix.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list-box-size.tentative.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24304 "Found 1 new test failure: transforms/2d/transform-value-types.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88573 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4185 "Found 1 new test failure: transforms/2d/transform-value-types.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46774 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4053 "Found 22 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-box-size.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-matrix.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31948 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-inline-value.html imported/w3c/web-platform-tests/css/css-transforms/parsing/transform-valid.html imported/w3c/web-platform-tests/css/css-transforms/transform-important.html transforms/2d/transform-value-types.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74728 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32803 "Found 20 new test failures: imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-box-size.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-matrix.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list-box-size.tentative.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92296 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12882 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9445 "Found 20 new test failures: imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-box-size.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-matrix.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list-box-size.tentative.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75194 "Found 89 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html compositing/repaint/copy-forward-dirty-region-purged.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/events/domactivate-sets-underlying-click-event-as-handled.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74331 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18579 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17019 "Found 20 new test failures: imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-box-size.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-matrix.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-function.html imported/w3c/web-platform-tests/css/css-properties-values-api/animation/custom-property-transition-transform-list-box-size.tentative.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5001 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18281 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12701 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->