### PR TITLE
[GStreamer] Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebRTC endpoint

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -341,6 +341,8 @@ inline GstWebRTCKind webrtcKindFromCaps(const GRefPtr<GstCaps>& caps)
     return GST_WEBRTC_KIND_UNKNOWN;
 }
 
+void forEachTransceiver(const GRefPtr<GstElement>&, Function<bool(GRefPtr<GstWebRTCRTPTransceiver>&&)>&&);
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)


### PR DESCRIPTION
#### ba2d6da1d4c521a644df32594d2ecec23f701597
<pre>
[GStreamer] Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebRTC endpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=286270">https://bugs.webkit.org/show_bug.cgi?id=286270</a>

Reviewed by Xabier Rodriguez-Calvar.

The get-transceivers signal and logic to iterate on transceivers was refactored to a new
forEachTransceiver() utility function. If an early break from the loop is desired, the callback
should return true.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::transceiverStatesFromWebRTCBin):
(WebCore::GStreamerMediaEndpoint::doSetLocalDescription):
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
(WebCore::GStreamerMediaEndpoint::requestPad):
(WebCore::GStreamerMediaEndpoint::pickAvailablePayloadType):
(WebCore::GStreamerMediaEndpoint::transceiverBackendFromSender):
(WebCore::GStreamerMediaEndpoint::collectTransceivers):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::forEachTransceiver):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:

Canonical link: <a href="https://commits.webkit.org/289496@main">https://commits.webkit.org/289496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fef6db7587b704a209c4ab452c281de3685b541

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47694 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33279 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37028 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75376 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18544 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7252 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19646 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->