### PR TITLE
Don't update column position in StyleDidChange

### DIFF
--- a/LayoutTests/fast/table/relayout-out-of-flow-with-border-spacing-expected.txt
+++ b/LayoutTests/fast/table/relayout-out-of-flow-with-border-spacing-expected.txt
@@ -1,0 +1,7 @@
+The two Xs below should be horizontally aligned
+
+X
+X
+
+PASS Test a re-layout of out-of-flow children of a table cell with border-spacing.
+

--- a/LayoutTests/fast/table/relayout-out-of-flow-with-border-spacing.html
+++ b/LayoutTests/fast/table/relayout-out-of-flow-with-border-spacing.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  body { margin: 0 }
+  #ref { margin-left: 100px }
+  #table { border-spacing: 100px 0 }
+  #cell { position: relative }
+  #div { position: absolute }
+</style>
+<p>The two Xs below should be horizontally aligned</p>
+<div id="ref">X</div>
+<table id="table">
+  <td id="cell">
+    <div id="div">X</div>
+  </td>
+</table>
+<script>
+  test(() => {
+    // Force initial layout of the table.
+    table.offsetTop;
+    // Trigger StyleDidChange() on LayoutTable to cause crbug.com/716006
+    table.style.backgroundColor = "white";
+    table.offsetTop;
+    // Trigger a re-layout which does not update the column positions.
+    div.appendChild(document.createTextNode(' '));
+
+    assert_equals(cell.offsetLeft, 100, "Check that cell is offset by border-spacing.");
+  }, "Test a re-layout of out-of-flow children of a table cell with border-spacing.");
+</script>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2019 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
@@ -143,7 +143,6 @@ void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldSty
     // In the collapsed border model, there is no cell spacing.
     m_hSpacing = collapseBorders() ? 0 : style().horizontalBorderSpacing();
     m_vSpacing = collapseBorders() ? 0 : style().verticalBorderSpacing();
-    m_columnPos[0] = m_hSpacing;
 
     if (!m_tableLayout || style().isFixedTableLayout() != oldFixedTableLayout) {
         // According to the CSS2 spec, you only use fixed table layout if an explicit width is specified on the table. Auto width implies auto table layout.


### PR DESCRIPTION
#### 82f304b2ff6b7848247973d468ad00d18e474c73
<pre>
Don&apos;t update column position in StyleDidChange

<a href="https://bugs.webkit.org/show_bug.cgi?id=286271">https://bugs.webkit.org/show_bug.cgi?id=286271</a>
<a href="https://rdar.apple.com/143276513">rdar://143276513</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/d3c625b0b03346472e45dc1fda33d35b1d40efd3">https://chromium.googlesource.com/chromium/src.git/+/d3c625b0b03346472e45dc1fda33d35b1d40efd3</a>

StyleDidChange set the first column position to the horizontal border
spacing value regardless of whether this value changed or not.

During relayout, a table cell because it has out-of-flow content which
needs layout, the first effective column position is set wrongly. It gets
its value from this line but the spacing is also subtracted once more in
RenderTableSection::setcelllogicalwidth(). So this patch is to remove this
one.

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::styleDidChange):
* LayoutTests/fast/table/relayout-out-of-flow-with-border-spacing-expected.txt:
* LayoutTests/fast/table/relayout-out-of-flow-with-border-spacing.html:

Canonical link: <a href="https://commits.webkit.org/289178@main">https://commits.webkit.org/289178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6268c61dfaffc03b934fa9393c712a1d337828f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66499 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24312 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31959 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12892 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9453 "Found 1 new test failure: media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75206 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74344 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18362 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5010 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->