### PR TITLE
Ignore -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers

### DIFF
--- a/Source/WebCore/dom/TransformSource.h
+++ b/Source/WebCore/dom/TransformSource.h
@@ -22,7 +22,12 @@
 
 #if ENABLE(XSLT)
 
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/tree.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/dom/TransformSourceLibxslt.cpp
+++ b/Source/WebCore/dom/TransformSourceLibxslt.cpp
@@ -28,7 +28,12 @@
 #if ENABLE(XSLT)
 #include "TransformSource.h"
 
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/tree.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/xml/XMLErrors.h
+++ b/Source/WebCore/xml/XMLErrors.h
@@ -28,7 +28,12 @@
 
 #pragma once
 
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -26,8 +26,13 @@
 
 #include "ProcessingInstruction.h"
 #include "StyleSheet.h"
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
 #include <libxslt/transform.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/Ref.h>
 #include <wtf/TypeCasts.h>
 

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -34,8 +34,13 @@
 #include "XMLDocumentParserScope.h"
 #include "XSLImportRule.h"
 #include "XSLTProcessor.h"
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/uri.h>
 #include <libxslt/xsltutils.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/HexNumber.h>
 #include <wtf/text/MakeString.h>
@@ -209,7 +214,10 @@ void XSLStyleSheet::loadChildSheets()
             if (IS_XSLT_ELEM(curr) && IS_XSLT_NAME(curr, "import")) {
                 xmlChar* uriRef = xsltGetNsProp(curr, (const xmlChar*)"href", XSLT_NAMESPACE);
                 loadChildSheet(String::fromUTF8((const char*)uriRef));
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(uriRef);
+IGNORE_WARNINGS_END
             } else
                 break;
             curr = curr->next;
@@ -220,7 +228,10 @@ void XSLStyleSheet::loadChildSheets()
             if (curr->type == XML_ELEMENT_NODE && IS_XSLT_ELEM(curr) && IS_XSLT_NAME(curr, "include")) {
                 xmlChar* uriRef = xsltGetNsProp(curr, (const xmlChar*)"href", XSLT_NAMESPACE);
                 loadChildSheet(String::fromUTF8((const char*)uriRef));
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(uriRef);
+IGNORE_WARNINGS_END
             }
             curr = curr->next;
         }
@@ -290,8 +301,11 @@ xmlDocPtr XSLStyleSheet::locateStylesheetSubResource(xmlDocPtr parentDoc, const 
             xmlChar* base = xmlNodeGetBase(parentDoc, (xmlNodePtr)parentDoc);
             xmlChar* childURI = xmlBuildURI((const xmlChar*)importHref.data(), base);
             bool equalURIs = xmlStrEqual(uri, childURI);
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(base);
             xmlFree(childURI);
+IGNORE_WARNINGS_END
             if (equalURIs) {
                 child->markAsProcessed();
                 return child->document();

--- a/Source/WebCore/xml/XSLTExtensions.cpp
+++ b/Source/WebCore/xml/XSLTExtensions.cpp
@@ -29,11 +29,16 @@
 #if ENABLE(XSLT)
 #include "XSLTExtensions.h"
 
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/xpathInternals.h>
 
-#include <libxslt/xsltutils.h>
 #include <libxslt/extensions.h>
 #include <libxslt/extra.h>
+#include <libxslt/xsltutils.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 
 namespace WebCore {
 
@@ -84,8 +89,11 @@ static void exsltNodeSetFunction(xmlXPathParserContextPtr ctxt, int nargs)
             "WebCore::exsltNodeSetFunction: Failed to create a node set object.\n");
         tctxt->state = XSLT_STATE_STOPPED;
     }
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
     if (strval != NULL)
         xmlFree(strval);
+IGNORE_WARNINGS_END
 
     valuePush(ctxt, obj);
 }

--- a/Source/WebCore/xml/XSLTProcessor.h
+++ b/Source/WebCore/xml/XSLTProcessor.h
@@ -26,8 +26,13 @@
 
 #include "Node.h"
 #include "XSLStyleSheet.h"
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parserInternals.h>
 #include <libxslt/documents.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/HashMap.h>
 #include <wtf/text/StringHash.h>
 

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -112,7 +112,10 @@ static xmlDocPtr docLoaderFunc(const xmlChar* uri,
         xsltTransformContextPtr context = (xsltTransformContextPtr)ctxt;
         xmlChar* base = xmlNodeGetBase(context->document->doc, context->node);
         URL url(URL({ }, String::fromLatin1(byteCast<char>(base))), String::fromLatin1(byteCast<char>(uri)));
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
         xmlFree(base);
+IGNORE_WARNINGS_END
         ResourceError error;
         ResourceResponse response;
 

--- a/Source/WebCore/xml/XSLTUnicodeSort.cpp
+++ b/Source/WebCore/xml/XSLTUnicodeSort.cpp
@@ -72,7 +72,10 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr* rawSorts,
                     number[j] = 1;
                 else
                     xsltTransformError(ctxt, nullptr, sorts[j], "xsltDoSortFunction: no support for data-type = %s\n", stype);
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(stype);
+IGNORE_WARNINGS_END
             }
         } else
             number[j] = comp->number;
@@ -86,7 +89,10 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr* rawSorts,
                     desc[j] = 1;
                 else
                     xsltTransformError(ctxt, nullptr, sorts[j], "xsltDoSortFunction: invalid value %s for order\n", order);
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
                 xmlFree(order);
+IGNORE_WARNINGS_END
             }
         } else
             desc[j] = comp->descending;
@@ -238,7 +244,10 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr* rawSorts,
         if (resultsTab[j].data()) {
             for (int i = 0; i < len; ++i)
                 xmlXPathFreeObject(resultsTab[j][i]);
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(resultsTab[j].data());
+IGNORE_WARNINGS_END
         }
     }
 }

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -30,8 +30,13 @@
 #include "ScriptableDocumentParser.h"
 #include "SegmentedString.h"
 #include "XMLErrors.h"
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/tree.h>
 #include <libxml/xmlstring.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -67,8 +67,13 @@
 #include "TransformSource.h"
 #include "XMLNSNames.h"
 #include "XMLDocumentParserScope.h"
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
 #include <libxml/parserInternals.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -227,6 +232,8 @@ private:
     struct PendingStartElementNSCallback : public PendingCallback {
         virtual ~PendingStartElementNSCallback()
         {
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(xmlLocalName);
             xmlFree(xmlPrefix);
             xmlFree(xmlURI);
@@ -238,6 +245,7 @@ private:
                     xmlFree(attributes[i * 5 + j]);
             }
             xmlFree(attributes);
+IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -265,7 +273,10 @@ private:
     struct PendingCharactersCallback : public PendingCallback {
         virtual ~PendingCharactersCallback()
         {
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(s);
+IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -280,8 +291,11 @@ private:
     struct PendingProcessingInstructionCallback : public PendingCallback {
         virtual ~PendingProcessingInstructionCallback()
         {
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(target);
             xmlFree(data);
+IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -296,7 +310,10 @@ private:
     struct PendingCDATABlockCallback : public PendingCallback {
         virtual ~PendingCDATABlockCallback()
         {
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(s);
+IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -311,7 +328,10 @@ private:
     struct PendingCommentCallback : public PendingCallback {
         virtual ~PendingCommentCallback()
         {
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(s);
+IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -325,9 +345,12 @@ private:
     struct PendingInternalSubsetCallback : public PendingCallback {
         virtual ~PendingInternalSubsetCallback()
         {
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(name);
             xmlFree(externalID);
             xmlFree(systemID);
+IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override
@@ -343,7 +366,10 @@ private:
     struct PendingErrorCallback: public PendingCallback {
         virtual ~PendingErrorCallback()
         {
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
             xmlFree(message);
+IGNORE_WARNINGS_END
         }
 
         void call(XMLDocumentParser* parser) override

--- a/Source/WebCore/xml/parser/XMLDocumentParserScope.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParserScope.h
@@ -25,12 +25,22 @@
 
 #pragma once
 
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #include <wtf/Noncopyable.h>
 #include <wtf/WeakPtr.h>
 
 #if ENABLE(XSLT)
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/xmlerror.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 #endif
 
 namespace WebCore {

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm
@@ -30,7 +30,12 @@
 #include <JavaScriptCore/InitializeThreading.h>
 #include <WebCore/ParserContentPolicy.h>
 #include <WebCore/ProcessIdentifier.h>
+// FIXME (286277): Stop ignoring -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
+IGNORE_WARNINGS_BEGIN("deprecated-declarations")
+IGNORE_WARNINGS_BEGIN("undef")
 #include <libxml/parser.h>
+IGNORE_WARNINGS_END
+IGNORE_WARNINGS_END
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### 9e7dc1e91da1cd556cf902014e8471f48d45734c
<pre>
Ignore -Wundef and -Wdeprecated-declarations in code that imports libxml and libxslt headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=286278">https://bugs.webkit.org/show_bug.cgi?id=286278</a>
<a href="https://rdar.apple.com/143284673">rdar://143284673</a>

Unreviewed build fix.

Due to a regression in the libxml2 library used by Cocoa ports, code that imports libxml and libxslt
headers will fail to compile due to -Wundef and -Wdeprecated-declarations warnings that are promoted
to errors in engineering builds. Silence these errors until the underlying libxml2 regression is
addressed.

* Source/WebCore/dom/TransformSource.h:
* Source/WebCore/dom/TransformSourceLibxslt.cpp:
* Source/WebCore/xml/XMLErrors.h:
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::loadChildSheets):
(WebCore::XSLStyleSheet::locateStylesheetSubResource):
* Source/WebCore/xml/XSLTExtensions.cpp:
(WebCore::exsltNodeSetFunction):
* Source/WebCore/xml/XSLTProcessor.h:
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc):
* Source/WebCore/xml/XSLTUnicodeSort.cpp:
(WebCore::xsltUnicodeSortFunction):
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::PendingCallbacks::PendingStartElementNSCallback::~PendingStartElementNSCallback):
(WebCore::PendingCallbacks::PendingCharactersCallback::~PendingCharactersCallback):
(WebCore::PendingCallbacks::PendingProcessingInstructionCallback::~PendingProcessingInstructionCallback):
(WebCore::PendingCallbacks::PendingCDATABlockCallback::~PendingCDATABlockCallback):
(WebCore::PendingCallbacks::PendingInternalSubsetCallback::~PendingInternalSubsetCallback):
* Source/WebCore/xml/parser/XMLDocumentParserScope.h:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/XMLParsing.mm:

Canonical link: <a href="https://commits.webkit.org/289169@main">https://commits.webkit.org/289169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15ae58f68c9b7693f976dc48600602d3a80ba4d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85588 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90678 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24330 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31977 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35661 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9472 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75234 "Found 68 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html compositing/repaint/copy-forward-dirty-region-purged.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/events/domactivate-sets-underlying-click-event-as-handled.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74371 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17046 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/5027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18310 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->