### PR TITLE
Reduce use of strstr() in the codebase

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -80,7 +80,7 @@ static String createWithFormatAndArguments(const char* format, va_list args)
 ALLOW_NONLITERAL_FORMAT_BEGIN
 
 #if USE(CF)
-    if (strstr(format, "%@")) {
+    if (contains(span8(format), "%@"_span)) {
         auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
         auto result = adoptCF(CFStringCreateWithFormatAndArguments(kCFAllocatorDefault, nullptr, cfFormat.get(), args));
         va_end(argsCopy);
@@ -152,7 +152,7 @@ WTF_ATTRIBUTE_PRINTF(2, 0)
 static void vprintf_stderr_common([[maybe_unused]] WTFLogChannel* channel, const char* format, va_list args)
 {
 #if USE(CF)
-    if (strstr(format, "%@")) {
+    if (contains(span8(format), "%@"_span)) {
         auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, format, kCFStringEncodingUTF8, kCFAllocatorNull));
 
 ALLOW_NONLITERAL_FORMAT_BEGIN

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -81,6 +81,7 @@
 #include <wtf/ASCIICType.h>
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/ThreadSpecific.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
@@ -409,18 +410,13 @@ static int findMonth(std::span<const LChar> monthStr)
     if (monthStr.size() < 3)
         return -1;
 
-    std::array<char, 4> needle;
+    std::array<LChar, 3> needle;
     for (unsigned i = 0; i < 3; ++i)
-        needle[i] = static_cast<char>(toASCIILower(monthStr[i]));
-    needle[3] = '\0';
-    const char* haystack = "janfebmaraprmayjunjulaugsepoctnovdec";
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    const char* str = strstr(haystack, needle.data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    if (str) {
-        int position = static_cast<int>(str - haystack);
-        if (position % 3 == 0)
-            return position / 3;
+        needle[i] = toASCIILower(monthStr[i]);
+    auto haystack = "janfebmaraprmayjunjulaugsepoctnovdec"_span;
+    if (size_t index = find(haystack, std::span { needle }); index != notFound) {
+        if (!(index % 3))
+            return index / 3;
     }
     return -1;
 }

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1032,7 +1032,7 @@ bool equalSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
     static_assert(ignoreTypeChecks == IgnoreTypeChecks::Yes || std::has_unique_object_representations_v<U>);
     if (a.size() != b.size())
         return false;
-    return !memcmp(a.data(), b.data(), a.size_bytes());
+    return !memcmp(a.data(), b.data(), a.size_bytes()); // NOLINT
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
@@ -1043,7 +1043,7 @@ bool spanHasPrefix(std::span<T, TExtent> span, std::span<U, UExtent> prefix)
     static_assert(std::has_unique_object_representations_v<U>);
     if (span.size() < prefix.size())
         return false;
-    return !memcmp(span.data(), prefix.data(), prefix.size_bytes());
+    return !memcmp(span.data(), prefix.data(), prefix.size_bytes()); // NOLINT
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
@@ -1054,7 +1054,7 @@ bool spanHasSuffix(std::span<T, TExtent> span, std::span<U, UExtent> suffix)
     static_assert(std::has_unique_object_representations_v<U>);
     if (span.size() < suffix.size())
         return false;
-    return !memcmp(span.last(suffix.size()).data(), suffix.data(), suffix.size_bytes());
+    return !memcmp(span.last(suffix.size()).data(), suffix.data(), suffix.size_bytes()); // NOLINT
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
@@ -1063,7 +1063,7 @@ int compareSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
     static_assert(sizeof(T) == sizeof(U));
     static_assert(std::has_unique_object_representations_v<T>);
     static_assert(std::has_unique_object_representations_v<U>);
-    int result = memcmp(a.data(), b.data(), std::min(a.size_bytes(), b.size_bytes()));
+    int result = memcmp(a.data(), b.data(), std::min(a.size_bytes(), b.size_bytes())); // NOLINT
     if (!result && a.size() != b.size())
         result = (a.size() > b.size()) ? 1 : -1;
     return result;
@@ -1071,12 +1071,18 @@ int compareSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 
 // Returns the index of the first occurrence of |needed| in |haystack| or notFound if not present.
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
-size_t memmemSpan(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
+size_t find(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
 {
-    auto* result = static_cast<T*>(memmem(haystack.data(), haystack.size(), needle.data(), needle.size()));
+    auto* result = static_cast<T*>(memmem(haystack.data(), haystack.size(), needle.data(), needle.size())); // NOLINT
     if (!result)
         return notFound;
     return result - haystack.data();
+}
+
+template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
+size_t contains(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
+{
+    return !!memmem(haystack.data(), haystack.size(), needle.data(), needle.size()); // NOLINT
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
@@ -1086,7 +1092,7 @@ void memcpySpan(std::span<T, TExtent> destination, std::span<U, UExtent> source)
     static_assert(std::is_trivially_copyable_v<T> || std::is_floating_point_v<T>);
     static_assert(std::is_trivially_copyable_v<U> || std::is_floating_point_v<U>);
     RELEASE_ASSERT(destination.size() >= source.size());
-    memcpy(destination.data(), source.data(), source.size_bytes());
+    memcpy(destination.data(), source.data(), source.size_bytes()); // NOLINT
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
@@ -1096,21 +1102,21 @@ void memmoveSpan(std::span<T, TExtent> destination, std::span<U, UExtent> source
     static_assert(std::is_trivially_copyable_v<T> || std::is_floating_point_v<T>);
     static_assert(std::is_trivially_copyable_v<U> || std::is_floating_point_v<U>);
     RELEASE_ASSERT(destination.size() >= source.size());
-    memmove(destination.data(), source.data(), source.size_bytes());
+    memmove(destination.data(), source.data(), source.size_bytes()); // NOLINT
 }
 
 template<typename T, std::size_t Extent>
 void memsetSpan(std::span<T, Extent> destination, uint8_t byte)
 {
     static_assert(std::is_trivially_copyable_v<T>);
-    memset(destination.data(), byte, destination.size_bytes());
+    memset(destination.data(), byte, destination.size_bytes()); // NOLINT
 }
 
 template<typename T, std::size_t Extent>
 void zeroSpan(std::span<T, Extent> destination)
 {
     static_assert(std::is_trivially_copyable_v<T> || std::is_floating_point_v<T>);
-    memset(destination.data(), 0, destination.size_bytes());
+    memset(destination.data(), 0, destination.size_bytes()); // NOLINT
 }
 
 template<typename T>
@@ -1124,9 +1130,9 @@ void secureMemsetSpan(std::span<T, Extent> destination, uint8_t byte)
 {
     static_assert(std::is_trivially_copyable_v<T>);
 #ifdef __STDC_LIB_EXT1__
-    memset_s(destination.data(), byte, destination.size_bytes());
+    memset_s(destination.data(), byte, destination.size_bytes()); // NOLINT
 #else
-    memset(destination.data(), byte, destination.size_bytes());
+    memset(destination.data(), byte, destination.size_bytes()); // NOLINT
 #endif
 }
 
@@ -1381,8 +1387,10 @@ using WTF::byteCast;
 using WTF::callStatelessLambda;
 using WTF::checkAndSet;
 using WTF::compareSpans;
+using WTF::contains;
 using WTF::constructFixedSizeArrayWithArguments;
 using WTF::equalSpans;
+using WTF::find;
 using WTF::findBitInWord;
 using WTF::insertIntoBoundedVector;
 using WTF::is8ByteAligned;
@@ -1394,7 +1402,6 @@ using WTF::makeUnique;
 using WTF::makeUniqueWithoutFastMallocCheck;
 using WTF::makeUniqueWithoutRefCountedCheck;
 using WTF::memcpySpan;
-using WTF::memmemSpan;
 using WTF::memmoveSpan;
 using WTF::memsetSpan;
 using WTF::mergeDeduplicatedSorted;

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -144,7 +144,7 @@ FetchBodyConsumer& FetchBodyConsumer::operator=(FetchBodyConsumer&&) = default;
 RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* context, const String& contentType, std::span<const uint8_t> data)
 {
     auto parseMultipartPart = [context] (std::span<const uint8_t> part, DOMFormData& form) -> bool {
-        size_t headerEnd = memmemSpan(part, "\r\n\r\n"_span);
+        size_t headerEnd = find(part, "\r\n\r\n"_span);
         if (headerEnd == notFound)
             return false;
         auto headerBytes = part.first(headerEnd);
@@ -203,12 +203,12 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         CString boundary = boundaryWithDashes.utf8();
         size_t boundaryLength = boundary.length();
 
-        size_t currentBoundaryIndex = memmemSpan(data, boundary.span());
+        size_t currentBoundaryIndex = find(data, boundary.span());
         if (currentBoundaryIndex == notFound)
             return nullptr;
         skip(data, currentBoundaryIndex + boundaryLength);
         size_t nextBoundaryIndex;
-        while ((nextBoundaryIndex = memmemSpan(data, boundary.span())) != notFound) {
+        while ((nextBoundaryIndex = find(data, boundary.span())) != notFound) {
             parseMultipartPart(data.first(nextBoundaryIndex - strlen("\r\n")), form.get());
             currentBoundaryIndex = nextBoundaryIndex;
             skip(data, nextBoundaryIndex + boundaryLength);

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -35,6 +35,7 @@
 #include "Logging.h"
 #include "PixelBuffer.h"
 #include "PlatformDisplay.h"
+#include <wtf/StdLibExtras.h>
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
 #include "VideoFrame.h"
@@ -275,7 +276,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
     eglContextAttributes.append(0);
 #endif
 
-    if (strstr(displayExtensions, "EGL_ANGLE_power_preference")) {
+    if (contains(span8(displayExtensions), "EGL_ANGLE_power_preference"_span)) {
         eglContextAttributes.append(EGL_POWER_PREFERENCE_ANGLE);
         // EGL_LOW_POWER_ANGLE is the default. Change to
         // EGL_HIGH_POWER_ANGLE if desired.

--- a/Source/WebKit/Shared/API/c/WKURL.cpp
+++ b/Source/WebKit/Shared/API/c/WKURL.cpp
@@ -38,6 +38,11 @@ WKURLRef WKURLCreateWithUTF8CString(const char* string)
     return WebKit::toAPI(&API::URL::create(String::fromUTF8(string)).leakRef());
 }
 
+WKURLRef WKURLCreateWithUTF8String(const char* string, size_t length)
+{
+    return WebKit::toAPI(&API::URL::create(String::fromUTF8(unsafeMakeSpan(string, length))).leakRef());
+}
+
 WKURLRef WKURLCreateWithBaseURL(WKURLRef baseURL, const char* relative)
 {
     return WebKit::toAPI(&API::URL::create(WebKit::toImpl(baseURL), String::fromUTF8(relative)).leakRef());

--- a/Source/WebKit/Shared/API/c/WKURL.h
+++ b/Source/WebKit/Shared/API/c/WKURL.h
@@ -35,6 +35,7 @@ extern "C" {
 WK_EXPORT WKTypeID WKURLGetTypeID(void);
 
 WK_EXPORT WKURLRef WKURLCreateWithUTF8CString(const char* string);
+WK_EXPORT WKURLRef WKURLCreateWithUTF8String(const char* string, size_t length);
 WK_EXPORT WKURLRef WKURLCreateWithBaseURL(WKURLRef baseURL, const char* relative);
 
 WK_EXPORT WKStringRef WKURLCopyString(WKURLRef url);

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
@@ -119,7 +119,7 @@ bool ResponsivenessTimer::mayBecomeUnresponsive() const
         char* variable = getenv("DYLD_INSERT_LIBRARIES");
         if (!variable)
             return false;
-        if (!strstr(variable, "libgmalloc"))
+        if (!contains(span8(variable), "libgmalloc"_span))
             return false;
         return true;
     }();

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3515,7 +3515,11 @@ def check_safer_cpp(clean_lines, line_number, error):
 
     uses_memmem = search(r'memmem\(', line)
     if uses_memmem:
-        error(line_number, 'safercpp/memmem', 4, "Use memmemSpan() instead of memmem().")
+        error(line_number, 'safercpp/memmem', 4, "Use WTF::find() or WTF::contains() instead of memmem().")
+
+    uses_strstr = search(r'strstr\(', line)
+    if uses_strstr:
+        error(line_number, 'safercpp/strstr', 4, "Use WTF::find() or WTF::contains() instead of strstr().")
 
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
@@ -4863,6 +4867,7 @@ class CppChecker(object):
         'safercpp/memset',
         'safercpp/memset_s',
         'safercpp/weak_ref_exception',
+        'safercpp/strstr',
         'safercpp/timer_exception',
         'security/assertion',
         'security/assertion_fallthrough',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1852,7 +1852,6 @@ class CppStyleTest(CppStyleTestBase):
             'strcpy(destination, source)',
             'Almost always, snprintf is better than strcpy.'
             '  [security/printf] [4]')
-        self.assert_lint('strstr(haystack, "needle")', '')
 
     # Test potential format string bugs like printf(foo).
     def test_format_strings(self):
@@ -5227,14 +5226,14 @@ class WebKitStyleTest(CppStyleTestBase):
             '')
         self.assert_multi_line_lint(
             '#define MyMacro(name, status) \\\n'
-            '    if (strstr(arg, #name) { \\\n'
+            '    if (contains(arg, #name)) { \\\n'
             '        name##_ = !status; \\\n'
             '        continue; \\\n'
             '    }\n',
             '')
         self.assert_multi_line_lint(
             '#define MyMacro(name, status) \\\n'
-            '    if (strstr(arg, #name) \\\n'
+            '    if (contains(arg, #name)) \\\n'
             '        name##_ = !status; \\\n'
             '        continue;\n',
             'Multi line control clauses should use braces.  [whitespace/braces] [4]')
@@ -6296,7 +6295,12 @@ class WebKitStyleTest(CppStyleTestBase):
 
         self.assert_lint(
             'char* result = memmem(haystack, strlen(haystack), needle, strlen(needle));',
-            'Use memmemSpan() instead of memmem().  [safercpp/memmem] [4]',
+            'Use WTF::find() or WTF::contains() instead of memmem().  [safercpp/memmem] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'char* result = strstr(haystack, needle);',
+            'Use WTF::find() or WTF::contains() instead of strstr().  [safercpp/strstr] [4]',
             'foo.cpp')
 
     def test_ctype_fucntion(self):

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -453,7 +453,7 @@ private:
     void runTestingServerLoop();
     bool runTest(const char* pathOrURL);
 
-    WKURLRef createTestURL(const char* pathOrURL);
+    WKURLRef createTestURL(std::span<const char> pathOrURL);
 
     // Returns false if timed out.
     bool waitForCompletion(const WTF::Function<void ()>&, WTF::Seconds timeout);


### PR DESCRIPTION
#### 51549f23c7f2ef9ae0c98ddb9581b4793de4f49f
<pre>
Reduce use of strstr() in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=286276">https://bugs.webkit.org/show_bug.cgi?id=286276</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/Assertions.cpp:
(WTF::createWithFormatAndArguments):
* Source/WTF/wtf/DataLog.cpp:
(WTF::initializeLogFileOnce):
(WTF::setDataFile):
* Source/WTF/wtf/DateMath.cpp:
(WTF::findMonth):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::initializeEGLDisplay):
(WebCore::GraphicsContextGLCocoa::platformInitializeContext):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitializeContext):
* Source/WebKit/UIProcess/ResponsivenessTimer.cpp:
(WebKit::ResponsivenessTimer::mayBecomeUnresponsive const):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(shouldLogFrameLoadDelegates):
(shouldLogHistoryDelegates):
(shouldDumpAsText):
(shouldMakeViewportFlexible):
(shouldUseEphemeralSession):
(runTest):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createTestURL):
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/289197@main">https://commits.webkit.org/289197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb6055c11444a678b01a1a80609a2af134e1592c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13387 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/24408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88723 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/4331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46890 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/85189 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/4191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32099 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35784 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78727 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92498 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84705 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13037 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74502 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18707 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/17154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5147 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13358 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13063 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107095 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12853 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25806 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->