### PR TITLE
[JSC] Clean up wasm initialization code

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1292,9 +1292,7 @@ private:
                 if (!wasmFunction)
                     break;
                 const auto& signature = Wasm::TypeInformation::getFunctionSignature(wasmFunction->typeIndex());
-                const Wasm::WasmCallingConvention& wasmCC = Wasm::wasmCallingConvention();
-                Wasm::CallInformation wasmCallInfo = wasmCC.callInformationFor(signature);
-                if (wasmCallInfo.argumentsOrResultsIncludeV128 || wasmCallInfo.argumentsOrResultsIncludeExnref)
+                if (signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref())
                     break;
 
                 unsigned numPassedArgs = m_node->numChildren() - /* |callee| and |this| */ 2;

--- a/Source/JavaScriptCore/jit/Width.h
+++ b/Source/JavaScriptCore/jit/Width.h
@@ -32,7 +32,7 @@
 namespace JSC {
 
 enum class Width : uint8_t {
-    Width8,
+    Width8 = 0,
     Width16,
     Width32,
     Width64,
@@ -74,20 +74,7 @@ ALWAYS_INLINE constexpr Width widthForBytes(unsigned bytes)
 
 ALWAYS_INLINE constexpr unsigned bytesForWidth(Width width)
 {
-    switch (width) {
-    case Width8:
-        return 1;
-    case Width16:
-        return 2;
-    case Width32:
-        return 4;
-    case Width64:
-        return 8;
-    case Width128:
-        return 16;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return 0;
+    return 1 << static_cast<uint8_t>(width);
 }
 
 ALWAYS_INLINE constexpr unsigned alignmentForWidth(Width width)

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -294,7 +294,9 @@ inline bool isSubtypeIndex(TypeIndex sub, TypeIndex parent)
     return subRTT.value()->isSubRTT(*parentRTT.value());
 }
 
-inline bool isSubtype(Type sub, Type parent)
+bool isSubtype(Type, Type);
+
+inline bool isSubtypeSlow(Type sub, Type parent)
 {
     // Before the typed funcref proposal there is no non-trivial subtyping.
     if (sub.isNullable() && !parent.isNullable())
@@ -338,7 +340,15 @@ inline bool isSubtype(Type sub, Type parent)
     if (sub.isRef() && parent.isRefNull())
         return sub.index == parent.index;
 
-    return sub == parent;
+    return false;
+}
+
+ALWAYS_INLINE bool isSubtype(Type sub, Type parent)
+{
+    // Fast path.
+    if (sub == parent)
+        return true;
+    return isSubtypeSlow(sub, parent);
 }
 
 inline bool isSubtype(StorageType sub, StorageType parent)

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -61,8 +61,8 @@ struct JumpTableEntry;
 
 #define WRITE_TO_METADATA(dst, src, type) \
     do { \
-        type tmp = src; \
-        memcpy(dst, &tmp, sizeof(type)); \
+        type tmp = (src); \
+        memcpy((dst), &tmp, sizeof(type)); \
     } while (false)
 
 class FunctionIPIntMetadataGenerator {

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1507,7 +1507,7 @@ auto FunctionParser<Context>::parseTableIndex(unsigned& result) -> PartialResult
 }
 
 template<typename Context>
-auto FunctionParser<Context>::parseIndexForLocal(uint32_t& resultIndex) -> PartialResult
+ALWAYS_INLINE auto FunctionParser<Context>::parseIndexForLocal(uint32_t& resultIndex) -> PartialResult
 {
     uint32_t index;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get index for local"_s);

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -314,7 +314,7 @@ JSC_DEFINE_JIT_OPERATION(operationWasmToJSExitMarshalArguments, bool, (void* sp,
     const auto& wasmCC = wasmCallingConvention().callInformationFor(typeDefinition, CallRole::Caller);
     const auto& jsCC = jsCallingConvention().callInformationFor(typeDefinition, CallRole::Callee);
 
-    if (UNLIKELY(wasmCC.argumentsOrResultsIncludeV128 || wasmCC.argumentsOrResultsIncludeExnref))
+    if (UNLIKELY(signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()))
         OPERATION_RETURN(scope, false);
 
     for (unsigned argNum = 0; argNum < argCount; ++argNum) {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -358,6 +358,8 @@ public:
     Type returnType(FunctionArgCount i) const { ASSERT(i < returnCount()); return const_cast<FunctionSignature*>(this)->getReturnType(i); }
     bool returnsVoid() const { return !returnCount(); }
     Type argumentType(FunctionArgCount i) const { return const_cast<FunctionSignature*>(this)->getArgumentType(i); }
+    bool argumentsOrResultsIncludeI64() const { return m_argumentsOrResultsIncludeI64; }
+    void setArgumentsOrResultsIncludeI64(bool value) { m_argumentsOrResultsIncludeI64 = value; }
     bool argumentsOrResultsIncludeV128() const { return m_argumentsOrResultsIncludeV128; }
     void setArgumentsOrResultsIncludeV128(bool value) { m_argumentsOrResultsIncludeV128 = value; }
     bool argumentsOrResultsIncludeExnref() const { return m_argumentsOrResultsIncludeExnref; }
@@ -429,6 +431,7 @@ private:
     // FIXME: Support caching wasmToJSEntrypoints too.
 #endif
     bool m_hasRecursiveReference : 1 { false };
+    bool m_argumentsOrResultsIncludeI64 : 1 { false };
     bool m_argumentsOrResultsIncludeV128 : 1 { false };
     bool m_argumentsOrResultsIncludeExnref : 1 { false };
 };

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -492,7 +492,7 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
 
     const Wasm::WasmCallingConvention& wasmCC = Wasm::wasmCallingConvention();
     Wasm::CallInformation wasmCallInfo = wasmCC.callInformationFor(*this);
-    if (UNLIKELY(wasmCallInfo.argumentsOrResultsIncludeV128 || wasmCallInfo.argumentsOrResultsIncludeExnref))
+    if (UNLIKELY(argumentsOrResultsIncludeV128() || argumentsOrResultsIncludeExnref()))
         return nullptr;
     Wasm::CallInformation jsCallInfo = Wasm::jsCallingConvention().callInformationFor(*this, Wasm::CallRole::Callee);
     RegisterAtOffsetList savedResultRegisters = wasmCallInfo.computeResultsOffsetList();
@@ -504,7 +504,7 @@ CodePtr<JSEntryPtrTag> FunctionSignature::jsToWasmICEntrypoint() const
     totalFrameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(totalFrameSize);
 
 #if USE(JSVALUE32_64)
-    if (wasmCallInfo.argumentsIncludeI64)
+    if (argumentsOrResultsIncludeI64())
         return nullptr;
 #endif
 

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -103,7 +103,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
     // https://webassembly.github.io/spec/js-api/index.html#exported-function-exotic-objects
     // If parameters or results contain v128, throw a TypeError.
     // Note: the above error is thrown each time the [[Call]] method is invoked.
-    if (UNLIKELY(wasmCallInfo.argumentsOrResultsIncludeV128 || wasmCallInfo.argumentsOrResultsIncludeExnref))
+    if (UNLIKELY(signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()))
         return handleBadImportTypeUse(jit, importIndex, ExceptionType::TypeErrorInvalidValueUse);
 
     // Here we assume that the JS calling convention saves at least all the wasm callee saved. We therefore don't need to save and restore more registers since the wasm callee already took care of this.
@@ -305,7 +305,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(TypeIn
 
     CCallHelpers::JumpList exceptionChecks;
 
-    if (wasmCallInfo.argumentsIncludeI64) {
+    if (signature.argumentsOrResultsIncludeI64()) {
         // Since all argument GPRs and FPRs are stored into stack frames, clobbering caller-save registers is OK here.
         // We call functions to convert I64 to BigInt.
         unsigned calleeFrameOffset = CallFrameSlot::firstArgument * static_cast<int>(sizeof(Register));


### PR DESCRIPTION
#### a67312798948b7fb4d775ba29de566f51de81dd6
<pre>
[JSC] Clean up wasm initialization code
<a href="https://bugs.webkit.org/show_bug.cgi?id=286281">https://bugs.webkit.org/show_bug.cgi?id=286281</a>
<a href="https://rdar.apple.com/143288327">rdar://143288327</a>

Reviewed by Justin Michaud.

This patch carefully analyzes wasm startup time and optimizes costly
operations in that.

* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/jit/Width.h:
(JSC::bytesForWidth):
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::CallInformation::computeResultsOffsetList):
(JSC::Wasm::WasmCallingConvention::callInformationFor const):
(JSC::Wasm::JSCallingConvention::callInformationFor const):
(JSC::Wasm::CCallingConventionArmThumb2::callInformationFor const):
(): Deleted.
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isSubtypeSlow):
(JSC::Wasm::isSubtype):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseIndexForLocal):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addSwitch):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addTailCallCommonData):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::FunctionParameterTypes::translate):
(JSC::Wasm::TypeInformation::TypeInformation):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::FunctionSignature::argumentsOrResultsIncludeI64 const):
(JSC::Wasm::FunctionSignature::setArgumentsOrResultsIncludeI64):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::FunctionSignature::jsToWasmICEntrypoint const):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):

Canonical link: <a href="https://commits.webkit.org/289682@main">https://commits.webkit.org/289682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/475f6f9b56732044d89a22230ccd79d22cb9b9d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87653 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38397 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67680 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25423 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90655 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5759 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37510 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80450 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94404 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86428 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14821 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10864 "Found 4 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html media/media-session/actionHandler-no-document-leak.html media/video-replaces-poster.html svg/custom/use-image-in-g.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76527 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75754 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7772 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13670 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20138 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108921 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14581 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26192 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->