### PR TITLE
[WebDriver] Properly use smart pointers instead of raw pointers for the HTTPServer, WebSocketServer, and WebDriverService

### DIFF
--- a/Source/WebDriver/HTTPServer.cpp
+++ b/Source/WebDriver/HTTPServer.cpp
@@ -33,4 +33,9 @@ HTTPServer::HTTPServer(HTTPRequestHandler& requestHandler)
 {
 }
 
+Ref<HTTPServer> HTTPServer::create(HTTPRequestHandler& handler)
+{
+    return adoptRef(*new HTTPServer(handler));
+}
+
 } // namespace WebDriver

--- a/Source/WebDriver/WebDriverMain.cpp
+++ b/Source/WebDriver/WebDriverMain.cpp
@@ -50,6 +50,6 @@ int main(int argc, char** argv)
     WebDriver::logChannels().initializeLogChannelsIfNecessary(WebDriver::logLevelString());
 #endif
 
-    WebDriver::WebDriverService service;
-    return service.run(argc, argv);
+    auto service = WebDriver::WebDriverService::create();
+    return service->run(argc, argv);
 }

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -57,9 +57,9 @@ namespace WebDriver {
 static const double maxSafeInteger = 9007199254740991.0; // 2 ^ 53 - 1
 
 WebDriverService::WebDriverService()
-    : m_server(*this)
+    : m_server(HTTPServer::create(*this))
 #if ENABLE(WEBDRIVER_BIDI)
-    , m_bidiServer(*this, *this)
+    , m_bidiServer(WebSocketServer::create(*this))
     , m_browserTerminatedObserver([this](const String& sessionID) { onBrowserTerminated(sessionID); })
 #endif
 {
@@ -73,6 +73,11 @@ WebDriverService::~WebDriverService()
 #if ENABLE(WEBDRIVER_BIDI)
     SessionHost::removeBrowserTerminatedObserver(m_browserTerminatedObserver);
 #endif
+}
+
+Ref<WebDriverService> WebDriverService::create()
+{
+    return adoptRef(*new WebDriverService);
 }
 
 static void printUsageStatement(const char* programName)
@@ -187,24 +192,26 @@ int WebDriverService::run(int argc, char** argv)
 
     const char* hostStr = host && host->utf8().data() ? host->utf8().data() : "local";
 #if ENABLE(WEBDRIVER_BIDI)
-    if (!m_bidiServer.listen(host ? *host : nullString(), *bidiPort)) {
+    if (!m_bidiServer->listen(host ? *host : nullString(), *bidiPort)) {
         fprintf(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr, *bidiPort);
         return EXIT_FAILURE;
     }
     RELEASE_LOG(WebDriverBiDi, "Started WebSocket BiDi server with host %s and port %d", hostStr, *bidiPort);
 #endif // ENABLE(WEBDRIVER_BIDI)
-    if (!m_server.listen(host, *port)) {
+    if (!m_server->listen(host, *port)) {
         fprintf(stderr, "FATAL: Unable to listen for HTTP server at host %s and port %d.\n", hostStr, *port);
         return EXIT_FAILURE;
     }
     RELEASE_LOG(WebDriverClassic, "Started HTTP server with host %s and port %d", hostStr, *port);
 
+    platformWillStartMainLoop();
+
     RunLoop::run();
 
 #if ENABLE(WEBDRIVER_BIDI)
-    m_bidiServer.disconnect();
+    m_bidiServer->disconnect();
 #endif
-    m_server.disconnect();
+    m_server->disconnect();
 
     return EXIT_SUCCESS;
 }
@@ -413,7 +420,7 @@ bool WebDriverService::acceptHandshake(HTTPRequestHandler::Request&& request)
     // https://w3c.github.io/webdriver-bidi/#transport
     auto& resourceName = request.path;
 
-    auto& resources = m_bidiServer.listener()->resources;
+    auto& resources = m_bidiServer->listener()->resources;
     auto foundResource = std::find(resources.begin(), resources.end(), resourceName);
     if (foundResource == resources.end()) {
         RELEASE_LOG(WebDriverBiDi, "Resource name %s not found in listener's list of WebSocket resources. Rejecting handshake.", resourceName.utf8().data());
@@ -426,7 +433,7 @@ bool WebDriverService::acceptHandshake(HTTPRequestHandler::Request&& request)
         return false;
     }
 
-    auto sessionID = m_bidiServer.getSessionID(resourceName);
+    auto sessionID = m_bidiServer->getSessionID(resourceName);
     if (sessionID.isNull()) {
         RELEASE_LOG(WebDriverBiDi, "No session ID found for resource name %s. Rejecting handshake.", resourceName.utf8().data());
         return false;
@@ -452,9 +459,9 @@ void WebDriverService::handleMessage(WebSocketMessageHandler::Message&& message,
     }
 
     auto connection = message.connection;
-    auto session = m_bidiServer.session(connection);
+    auto session = m_bidiServer->session(connection, m_session);
     if (!session) {
-        if (!m_bidiServer.isStaticConnection(connection)) {
+        if (!m_bidiServer->isStaticConnection(connection)) {
             RELEASE_LOG(WebDriverBiDi, "Unknown connection. Ignoring message.");
             completionHandler(WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidSessionID, connection));
             return;
@@ -1041,7 +1048,7 @@ void WebDriverService::newSession(RefPtr<JSON::Object>&& parameters, Function<vo
         auto session = std::exchange(m_session, nullptr);
         session->close([this, session, matchedCapabilitiesList, completionHandler = WTFMove(completionHandler)](CommandResult&& result) mutable {
 #if ENABLE(WEBDRIVER_BIDI)
-            m_bidiServer.disconnectSession(session->id());
+            m_bidiServer->disconnectSession(session->id());
 #endif
             // Ignore unknown errors when closing the session if the session has abeen actually closed.
             if ((!result.isError()) || (result.errorCode() == CommandResult::ErrorCode::UnknownError && !session->isConnected())) {
@@ -1153,11 +1160,11 @@ void WebDriverService::createSession(Vector<Capabilities>&& capabilitiesList, Re
 #if ENABLE(WEBDRIVER_BIDI)
             // Extension steps defined by BiDi spec: https://w3c.github.io/webdriver-bidi/#establishing
             if (!m_session->hasBiDiEnabled() && capabilities.webSocketURL && *capabilities.webSocketURL) {
-                auto listener = m_bidiServer.startListening(m_session->id());
+                auto listener = m_bidiServer->startListening(m_session->id());
                 // We need to update the listener host to a visible one so remote clients can connect to it.
-                listener->host = m_server.visibleHost();
+                listener->host = m_server->visibleHost();
 
-                auto webSocketURL = m_bidiServer.getWebSocketURL(listener, m_session->id());
+                auto webSocketURL = m_bidiServer->getWebSocketURL(listener, m_session->id());
                 capabilitiesObject->setString("webSocketUrl"_s, webSocketURL);
                 m_session->setHasBiDiEnabled(true);
             } else {
@@ -1194,7 +1201,7 @@ void WebDriverService::deleteSession(RefPtr<JSON::Object>&& parameters, Function
     session->close([this, session, completionHandler = WTFMove(completionHandler)](CommandResult&& result) mutable {
         UNUSED_VARIABLE(this); // Conditionally used in ENABLE(WEBDRIVER_BIDI) block.
 #if ENABLE(WEBDRIVER_BIDI)
-        m_bidiServer.disconnectSession(session->id());
+        m_bidiServer->disconnectSession(session->id());
 #endif
         // Ignore unknown errors when closing the session if the session has abeen actually closed.
         if (result.isError() && result.errorCode() == CommandResult::ErrorCode::UnknownError && !session->isConnected())
@@ -2769,18 +2776,18 @@ void WebDriverService::bidiSessionUnsubscribe(unsigned id, RefPtr<JSON::Object>&
 void WebDriverService::clientDisconnected(const WebSocketMessageHandler::Connection& connection)
 {
     // https://w3c.github.io/webdriver-bidi/#handle-a-connection-closing
-    if (m_bidiServer.session(connection))
-        m_bidiServer.removeConnection(connection);
-    else if (m_bidiServer.isStaticConnection(connection))
-        m_bidiServer.removeStaticConnection(connection);
+    if (m_bidiServer->session(connection, m_session))
+        m_bidiServer->removeConnection(connection);
+    else if (m_bidiServer->isStaticConnection(connection))
+        m_bidiServer->removeStaticConnection(connection);
     // Note from spec: This does not end any session.
 }
 
 void WebDriverService::onBrowserTerminated(const String& sessionID)
 {
     if (m_session && m_session->id() == sessionID) {
-        auto connection = m_bidiServer.connection(sessionID);
-        m_bidiServer.disconnectSession(sessionID);
+        auto connection = m_bidiServer->connection(sessionID);
+        m_bidiServer->disconnectSession(sessionID);
         if (connection)
             clientDisconnected(*connection);
     }

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/text/StringHash.h>
 
 #if ENABLE(WEBDRIVER_BIDI)
@@ -43,22 +44,28 @@ class CommandResult;
 class Session;
 
 class WebDriverService final : public HTTPRequestHandler
+    , public WTF::RefCounted<WebDriverService>
 #if ENABLE(WEBDRIVER_BIDI)
     , public WebSocketMessageHandler
 #endif
 {
 public:
-    WebDriverService();
     ~WebDriverService();
+    static Ref<WebDriverService> create();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     int run(int argc, char** argv);
 
     static void platformInit();
     static bool platformCompareBrowserVersions(const String&, const String&);
+    static void platformWillStartMainLoop();
 
     RefPtr<Session> session() const { return m_session; }
 
 private:
+    WebDriverService();
     enum class HTTPMethod { Get, Post, Delete };
     typedef void (WebDriverService::*CommandHandler)(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
     struct Command {
@@ -174,9 +181,9 @@ private:
     static bool findBidiCommand(RefPtr<JSON::Value>&, BidiCommandHandler*, unsigned& id, RefPtr<JSON::Object>& parsedParams);
 #endif // ENABLE(WEBDRIVER_BIDI)
 
-    HTTPServer m_server;
+    Ref<HTTPServer> m_server;
 #if ENABLE(WEBDRIVER_BIDI)
-    WebSocketServer m_bidiServer;
+    Ref<WebSocketServer> m_bidiServer;
     SessionHost::BrowserTerminatedObserver m_browserTerminatedObserver;
 #endif
     RefPtr<Session> m_session;

--- a/Source/WebDriver/WebSocketServer.cpp
+++ b/Source/WebDriver/WebSocketServer.cpp
@@ -38,10 +38,19 @@
 
 namespace WebDriver {
 
-WebSocketServer::WebSocketServer(WebSocketMessageHandler& messageHandler, WebDriverService& service)
+WebSocketServer::WebSocketServer(WebSocketMessageHandler& messageHandler)
     : m_messageHandler(messageHandler)
-    , m_service(service)
 {
+}
+
+Ref<WebSocketServer> WebSocketServer::create(WebSocketMessageHandler& messageHandler)
+{
+    return adoptRef(*new WebSocketServer(messageHandler));
+}
+
+WebSocketServer::~WebSocketServer()
+{
+    disconnect();
 }
 
 void WebSocketServer::addStaticConnection(WebSocketMessageHandler::Connection&& connection)
@@ -71,7 +80,7 @@ void WebSocketServer::removeConnection(const WebSocketMessageHandler::Connection
         m_connectionToSession.remove(it);
 }
 
-RefPtr<Session> WebSocketServer::session(const WebSocketMessageHandler::Connection& connection)
+RefPtr<Session> WebSocketServer::session(const WebSocketMessageHandler::Connection& connection, RefPtr<Session> existingSession)
 {
     String sessionId;
 
@@ -85,7 +94,6 @@ RefPtr<Session> WebSocketServer::session(const WebSocketMessageHandler::Connecti
     if (sessionId.isNull())
         return { };
 
-    const auto& existingSession = m_service.session();
     if (!existingSession || (existingSession->id() != sessionId))
         return { };
 

--- a/Source/WebDriver/WebSocketServer.h
+++ b/Source/WebDriver/WebSocketServer.h
@@ -30,11 +30,14 @@
 #include <map>
 #include <optional>
 #include <vector>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 #if USE(SOUP)
@@ -81,7 +84,7 @@ private:
 };
 
 
-class WebSocketMessageHandler {
+class WebSocketMessageHandler : public WTF::AbstractRefCountedAndCanMakeWeakPtr<WebSocketMessageHandler> {
 public:
 
 #if USE(SOUP)
@@ -106,13 +109,13 @@ private:
 
 class WebSocketServer : public RefCountedAndCanMakeWeakPtr<WebSocketServer> {
 public:
-    explicit WebSocketServer(WebSocketMessageHandler&, WebDriverService&);
-    virtual ~WebSocketServer() = default;
+    virtual ~WebSocketServer();
+    static Ref<WebSocketServer> create(WebSocketMessageHandler&);
 
     std::optional<String> listen(const String& host, unsigned port);
     void disconnect();
 
-    WebSocketMessageHandler& messageHandler() { return m_messageHandler; }
+    WeakRef<WebSocketMessageHandler> messageHandler() { return m_messageHandler; }
 
     const RefPtr<WebSocketListener>& listener() const { return m_listener; }
 
@@ -121,7 +124,7 @@ public:
     void removeStaticConnection(const WebSocketMessageHandler::Connection&);
 
     void addConnection(WebSocketMessageHandler::Connection&&, const String& sessionId);
-    RefPtr<Session> session(const WebSocketMessageHandler::Connection&);
+    RefPtr<Session> session(const WebSocketMessageHandler::Connection&, RefPtr<Session> existingSession);
     std::optional<WebSocketMessageHandler::Connection> connection(const String& sessionId);
     void removeConnection(const WebSocketMessageHandler::Connection&);
 
@@ -137,8 +140,9 @@ public:
 
 private:
 
-    WebSocketMessageHandler& m_messageHandler;
-    WebDriverService& m_service;
+    explicit WebSocketServer(WebSocketMessageHandler&);
+
+    WeakRef<WebSocketMessageHandler> m_messageHandler;
     String m_listenerURL;
     RefPtr<WebSocketListener> m_listener;
     HashMap<WebSocketMessageHandler::Connection, String> m_connectionToSession;

--- a/Source/WebDriver/gtk/WebDriverServiceGtk.cpp
+++ b/Source/WebDriver/gtk/WebDriverServiceGtk.cpp
@@ -28,6 +28,7 @@
 
 #include "Capabilities.h"
 #include "CommandResult.h"
+#include <glib-unix.h>
 #include <wtf/JSONValues.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -169,6 +170,18 @@ void WebDriverService::platformParseCapabilities(const JSON::Object& matchedCapa
             capabilities.targetPort = parseIntegerAllowingTrailingJunk<uint16_t>(StringView { targetString }.substring(position + 1)).value_or(0);
         }
     }
+}
+
+static int onQuitSignal(gpointer)
+{
+    RunLoop::protectedMain()->stop();
+    return G_SOURCE_REMOVE;
+}
+
+void WebDriverService::platformWillStartMainLoop()
+{
+    g_unix_signal_add(SIGINT, G_SOURCE_FUNC(onQuitSignal), nullptr);
+    g_unix_signal_add(SIGTERM, G_SOURCE_FUNC(onQuitSignal), nullptr);
 }
 
 } // namespace WebDriver

--- a/Source/WebDriver/playstation/WebDriverServicePlayStation.cpp
+++ b/Source/WebDriver/playstation/WebDriverServicePlayStation.cpp
@@ -80,4 +80,8 @@ bool WebDriverService::platformSupportBidi() const
     return false;
 }
 
+void WebDriverService::platformWillStartMainLoop()
+{
+}
+
 } // namespace WebDriver

--- a/Source/WebDriver/socket/HTTPServerSocket.cpp
+++ b/Source/WebDriver/socket/HTTPServerSocket.cpp
@@ -49,7 +49,7 @@ void HTTPServer::disconnect()
 std::optional<ConnectionID> HTTPServer::doAccept(RemoteInspectorSocketEndpoint& endpoint, PlatformSocketType socket)
 {
     if (auto id = endpoint.createClient(socket, m_requestHandler)) {
-        m_requestHandler.connect(id.value());
+        m_requestHandler->connect(id.value());
         return id;
     }
 

--- a/Source/WebDriver/soup/HTTPServerSoup.cpp
+++ b/Source/WebDriver/soup/HTTPServerSoup.cpp
@@ -65,7 +65,7 @@ bool HTTPServer::listen(const std::optional<String>& host, unsigned port)
         auto* httpServer = static_cast<HTTPServer*>(userData);
         GRefPtr<SoupMessage> protectedMessage = message;
         soup_server_pause_message(server, message);
-        httpServer->m_requestHandler.handleRequest({ String::fromUTF8(message->method), String::fromUTF8(path), message->request_body->data, static_cast<size_t>(message->request_body->length) },
+        httpServer->m_requestHandler->handleRequest({ String::fromUTF8(message->method), String::fromUTF8(path), message->request_body->data, static_cast<size_t>(message->request_body->length) },
             [server, message = WTFMove(protectedMessage)](HTTPRequestHandler::Response&& response) {
                 soup_message_set_status(message.get(), response.statusCode);
                 if (!response.data.isNull()) {
@@ -90,7 +90,7 @@ bool HTTPServer::listen(const std::optional<String>& host, unsigned port)
             httpServer.m_visibleHost = visibleHostAndPort ? String::fromLatin1(visibleHostAndPort).split(':').at(0) : "localhost"_s;
         }
 
-        httpServer.m_requestHandler.handleRequest({ String::fromUTF8(soup_server_message_get_method(message)), String::fromUTF8(path), requestBody->data, static_cast<size_t>(requestBody->length) },
+        httpServer.m_requestHandler->handleRequest({ String::fromUTF8(soup_server_message_get_method(message)), String::fromUTF8(path), requestBody->data, static_cast<size_t>(requestBody->length) },
             [server, message = WTFMove(protectedMessage)](HTTPRequestHandler::Response&& response) {
                 soup_server_message_set_status(message.get(), response.statusCode, nullptr);
                 if (!response.data.isNull()) {

--- a/Source/WebDriver/soup/WebSocketServerSoup.cpp
+++ b/Source/WebDriver/soup/WebSocketServerSoup.cpp
@@ -30,7 +30,9 @@
 #include "HTTPServer.h"
 #include "Logging.h"
 #include <cstdio>
+#include <glib-object.h>
 #include <libsoup/soup-websocket-connection.h>
+#include <libsoup/soup-websocket.h>
 #include <libsoup/soup.h>
 #include <optional>
 #include <span>
@@ -77,7 +79,7 @@ static void handleIncomingHandshake(SoupServer*, SoupServerMessage* message, con
     };
 
     auto* webSocketServer = static_cast<WebSocketServer*>(userData);
-    if (webSocketServer->messageHandler().acceptHandshake(WTFMove(handshakeMessage))) // Follow with handshake procedure
+    if (webSocketServer && webSocketServer->messageHandler()->acceptHandshake(WTFMove(handshakeMessage))) // Follow with handshake procedure
         return;
 
     HTTPRequestHandler::Response errorResponse = { 503, "Service Unavailable", "text/plain"_s };
@@ -94,7 +96,7 @@ static void handleWebSocketMessage(SoupWebsocketConnection* connection, SoupWebs
 {
     // https://w3c.github.io/webdriver-bidi/#handle-an-incoming-message
     if (messageType != SOUP_WEBSOCKET_DATA_TEXT) {
-        RELEASE_LOG(WebDriverBiDi, "websocket message handler received non-text message. error return");
+        RELEASE_LOG_ERROR(WebDriverBiDi, "websocket message handler received non-text message. error return");
         auto errorReply = WebSocketMessageHandler::Message::fail(CommandResult::ErrorCode::InvalidArgument, std::nullopt, { "Non-text message received"_s });
         GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(errorReply.payload.data(), errorReply.payload.length()));
         soup_websocket_connection_send_message(connection, SOUP_WEBSOCKET_DATA_TEXT, rawMessage.get());
@@ -105,9 +107,9 @@ static void handleWebSocketMessage(SoupWebsocketConnection* connection, SoupWebs
     gsize messageSize;
     gconstpointer messageData = g_bytes_get_data(message, &messageSize);
     WebSocketMessageHandler::Message messageObj = { connection, { std::span<const char>(static_cast<const char*>(messageData), messageSize) } };
-    webSocketServer->messageHandler().handleMessage(WTFMove(messageObj), [](WebSocketMessageHandler::Message&& message) {
+    webSocketServer->messageHandler()->handleMessage(WTFMove(messageObj), [](WebSocketMessageHandler::Message&& message) {
         if (!message.connection) {
-            RELEASE_LOG(WebDriverBiDi, "No connection found when trying to send message: %s", message.payload.data());
+            RELEASE_LOG_ERROR(WebDriverBiDi, "No connection found when trying to send message: %s", message.payload.data());
             return;
         }
         GRefPtr<GBytes> rawMessage = adoptGRef(g_bytes_new(message.payload.data(), message.payload.length()));
@@ -130,7 +132,7 @@ static void handleWebSocketConnection(SoupServer*, SoupServerMessage*, const cha
 
     g_signal_connect(connection, "closed", G_CALLBACK(+[](SoupWebsocketConnection* connection, gpointer userData) {
         auto webSocketServer = static_cast<WebSocketServer*>(userData);
-        webSocketServer->messageHandler().clientDisconnected(connection);
+        webSocketServer->messageHandler()->clientDisconnected(connection);
     }), webSocketServer);
 
     g_signal_connect(connection, "message", G_CALLBACK(handleWebSocketMessage), webSocketServer);
@@ -192,6 +194,16 @@ void WebSocketServer::disconnect()
 #if USE(SOUP2)
     RELEASE_LOG(WebDriverBiDi, "WebSockets support not implemented yet with libsoup2");
 #else
+    if (!m_soupServer)
+        return;
+
+    for (const auto& connection : m_connectionToSession.keys()) {
+        if (!connection)
+            continue;
+
+        g_signal_handlers_disconnect_by_data(connection.get(), this);
+    }
+
     soup_server_disconnect(m_soupServer.get());
     m_soupServer = nullptr;
 #endif
@@ -204,9 +216,10 @@ void WebSocketServer::disconnectSession(const String& sessionId)
     RELEASE_LOG(WebDriverBiDi, "WebSockets support not implemented yet with libsoup2");
 #else
     auto connection = this->connection(sessionId);
-    if (!connection)
+    if (!connection || !connection->get())
         return;
 
+    g_signal_handlers_disconnect_by_data(connection->get(), this);
     soup_websocket_connection_close(connection->get(), SOUP_WEBSOCKET_CLOSE_NORMAL, nullptr);
 #endif
 }

--- a/Source/WebDriver/win/WebDriverServiceWin.cpp
+++ b/Source/WebDriver/win/WebDriverServiceWin.cpp
@@ -73,4 +73,8 @@ bool WebDriverService::platformSupportBidi() const
     return false;
 }
 
+void WebDriverService::platformWillStartMainLoop()
+{
+}
+
 } // namespace WebDriver


### PR DESCRIPTION
#### bce274ab045857f3084cf32518b327f424272bdb
<pre>
[WebDriver] Properly use smart pointers instead of raw pointers for the HTTPServer, WebSocketServer, and WebDriverService
<a href="https://bugs.webkit.org/show_bug.cgi?id=286274">https://bugs.webkit.org/show_bug.cgi?id=286274</a>

Reviewed by NOBODY (OOPS!).

- Make the HTTP and WebSocket message handler smart pointers instead of
  plain references. They&apos;re WeakPtr&lt;T&gt; to avoid cyclic reference between
  the respective servers and the &quot;owner/implementer&quot; WebDriverService.
- This also plays along with the fact that Session holds a WeakPtr to
  the WebSocketServer.
- As WebDriverService implements the handlers interfaces, make it
  RefCounted, to provide a concrete ref/deref impl for them.
- Avoid WebSocketServer holding a plain reference to WebDriverService.
  Instead, pass the required WebDriveService data as a parameter to the
  WebSocketServer::session method, as we call from the service already.
- Add SIGINT/SIGTERM handler, to ensure we call the destructors upon
  termination. For this, we added a new `platformWillStartMainLoop`
  helper function, so ports can do some late setup.
- Also minor drive-by: ensure we log some errors as actual errors.

* Source/WebDriver/HTTPServer.cpp:
(WebDriver::HTTPServer::create): Added.
* Source/WebDriver/HTTPServer.h:
  * Make handler AbstractRefCountedAndCanMakeWeakPtr.
  * Make HTTPServer RefCounted.
  * Hold handler in a WeakPtr instead of plain Ref.
* Source/WebDriver/WebDriverMain.cpp:
(main): Use WebDriverService::create instead of plain constructor.
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::WebDriverService): Use new create()
(WebDriver::WebDriverService::create): Added.
(WebDriver::WebDriverService::run): Replace &apos;.&apos; with &apos;-&gt;&apos; for new types.
(WebDriver::WebDriverService::acceptHandshake): Ditto.
(WebDriver::WebDriverService::handleMessage): Ditto. Also update to new
WebSocketServer::session api.
(WebDriver::WebDriverService::createSession): Replace &apos;.&apos; with &apos;-&gt;&apos;
(WebDriver::WebDriverService::deleteSession): Ditto.
(WebDriver::WebDriverService::clientDisconnected): Ditto. Also update to
new WebSocketServer::session api.
(WebDriver::WebDriverService::onBrowserTerminated): Replace &apos;.&apos; with
&apos;-&gt;&apos;.
* Source/WebDriver/WebDriverService.h: Make WebDriverService RefCounted.
  * Added concrete impl of ref/deref for the AbstractRefCounted
    interfaces of the messageHandlers.
  * Hold the servers as Ref instead of by value.
* Source/WebDriver/WebSocketServer.cpp:
(WebDriver::WebSocketServer::WebSocketServer): Remove m_service param
and update handler to new WeakRef type.
(WebDriver::WebSocketServer::create): Added.
(WebDriver::WebSocketServer::session): Added the existing session
parameter.
* Source/WebDriver/WebSocketServer.h:
  * Make handler AbstractRefCountedAndCanMakeWeakPtr
  * Hide constructor and add created method
  * Update session method signature
  * Hold the handler in a WeakRef.
  * Remove the m_service attribute.
(WebDriver::WebSocketServer::messageHandler):
* Source/WebDriver/socket/HTTPServerSocket.cpp:
 (WebDriver::HTTPServer::doAccept): Replace &apos;.&apos; with &apos;-&gt;&apos;.
* Source/WebDriver/soup/HTTPServerSoup.cpp: Ditto.
(WebDriver::HTTPServer::listen):
* Source/WebDriver/soup/WebSocketServerSoup.cpp: Ditto.
(WebDriver::handleIncomingHandshake):
(WebDriver::handleWebSocketMessage):
(WebDriver::handleWebSocketConnection):
* Source/WebDriver/gtk/WebDriverServiceGtk.cpp:
(WebDriver::onQuitSignal):
(WebDriver::WebDriverService::platformWillStartMainLoop):
* Source/WebDriver/playstation/WebDriverServicePlayStation.cpp:
(WebDriver::WebDriverService::platformWillStartMainLoop):
* Source/WebDriver/win/WebDriverServiceWin.cpp:
(WebDriver::WebDriverService::platformWillStartMainLoop):
* Source/WebDriver/wpe/WebDriverServiceWPE.cpp:
(WebDriver::onQuitSignal): Added.
(WebDriver::WebDriverService::platformWillStartMainLoop): Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bce274ab045857f3084cf32518b327f424272bdb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/100287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/10234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/105417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50870 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/20241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/28410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/76360 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/33416 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/103294 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/15491 "Found 1 new test failure: fast/forms/ios/file-upload-panel-dismiss-when-view-removed-from-window.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/90586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/15312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/8585 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/50238 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/85223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/8667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/107776 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/27400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/85312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/27763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84851 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/29531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/7269 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/21300 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/27337 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/32570 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/27148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/30464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/28707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->