### PR TITLE
[WASM] WASM GC Objects should have null prototype

### DIFF
--- a/JSTests/wasm/stress/wasm-gc-object-prototype.js
+++ b/JSTests/wasm/stress/wasm-gc-object-prototype.js
@@ -1,0 +1,84 @@
+function assert(b) {
+  if (!b)
+      throw new Error("bad!");
+}
+
+/*
+  (module
+  ;; Define a struct type with one i32 field
+  (type $myStruct (struct (field i32)))
+
+  ;; Define an array type with i32 elements
+  (type $myArray (array (mut i32)))
+
+  ;; Export a function to create a struct
+  (func (export "createStruct") (param i32) (result eqref)
+      (struct.new $myStruct (local.get 0)))
+
+  ;; Export a function to retrieve a field from a struct
+  (func (export "getStructField") (param (ref null $myStruct)) (result i32)
+      (struct.get $myStruct 0 (local.get 0))
+
+  ;; Export a function to create an array with default values (0 for i32)
+  (func (export "createArray") (param i32) (result (ref $myArray))
+      (array.new_default $myArray (local.get 0)))
+
+  ;; Export a function to set an array element
+  (func (export "setArrayElement") (param (ref null $myArray)) (param i32) (param i32)
+      (array.set $myArray (local.get 0) (local.get 1) (local.get 2)))
+
+  ;; Export a function to get an array element
+  (func (export "getArrayElement") (param (ref null $myArray)) (param i32) (result i32)
+      (array.get $myArray (local.get 0) (local.get 1)))
+  )
+*/
+const wasmModuleBytes = new Uint8Array([
+  0, 97, 115, 109, 1, 0, 0, 0, 1, 167, 128, 128, 128, 0, 7, 95, 1, 127, 0, 94, 127, 1, 96, 1, 127, 1, 109, 96, 1, 99, 0, 1, 127, 96, 1, 127, 1, 100, 1, 96, 3, 99, 1, 127, 127, 0, 96, 2, 99, 1, 127, 1, 127, 3, 134, 128, 128, 128, 0, 5, 2, 3, 4, 5, 6, 7, 211, 128, 128, 128, 0, 5, 12, 99, 114, 101, 97, 116, 101, 83, 116, 114, 117, 99, 116, 0, 0, 14, 103, 101, 116, 83, 116, 114, 117, 99, 116, 70, 105, 101, 108, 100, 0, 1, 11, 99, 114, 101, 97, 116, 101, 65, 114, 114, 97, 121, 0, 2, 15, 115, 101, 116, 65, 114, 114, 97, 121, 69, 108, 101, 109, 101, 110, 116, 0, 3, 15, 103, 101, 116, 65, 114, 114, 97, 121, 69, 108, 101, 109, 101, 110, 116, 0, 4, 10, 196, 128, 128, 128, 0, 5, 135, 128, 128, 128, 0, 0, 32, 0, 251, 0, 0, 11, 136, 128, 128, 128, 0, 0, 32, 0, 251, 2, 0, 0, 11, 135, 128, 128, 128, 0, 0, 32, 0, 251, 7, 1, 11, 139, 128, 128, 128, 0, 0, 32, 0, 32, 1, 32, 2, 251, 14, 1, 11, 137, 128, 128, 128, 0, 0, 32, 0, 32, 1, 251, 11, 1, 11
+]);
+
+// Compile the module
+const module = new WebAssembly.Module(wasmModuleBytes);
+
+// Instantiate the module
+const instance = new WebAssembly.Instance(module);
+const { createStruct, getStructField, createArray, setArrayElement, getArrayElement } = instance.exports;
+
+// Test struct creation
+const wasmStruct = createStruct(42);
+const fieldValue = getStructField(wasmStruct);
+assert(fieldValue == 42);
+const structPrototype = Object.getPrototypeOf(wasmStruct);
+assert(structPrototype === null);
+
+let shouldThrow = false;
+try {
+  const newPrototype = { protoKey: "protoValue" };
+  Object.setPrototypeOf(wasmStruct, newPrototype);
+} catch (error) {
+  shouldThrow = true;
+}
+assert(shouldThrow);
+
+// Create an array with 5 elements
+const wasmArray = createArray(5);
+
+// Set values in the array
+setArrayElement(wasmArray, 0, 42); // Set index 0 to 42
+setArrayElement(wasmArray, 1, 99); // Set index 1 to 99
+
+// Retrieve values from the array
+assert(42 == getArrayElement(wasmArray, 0));
+assert(99 == getArrayElement(wasmArray, 1));
+assert(0 == getArrayElement(wasmArray, 2));
+
+const arrayPrototype = Object.getPrototypeOf(wasmArray);
+assert(arrayPrototype === null);
+
+shouldThrow = false
+try {
+  const newPrototype = { protoKey: "protoValue" };
+  Object.setPrototypeOf(wasmArray, newPrototype);
+} catch (error) {
+  shouldThrow = true;
+}
+assert(shouldThrow);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -174,7 +174,7 @@ constexpr bool typeExposedByDefault = true;
 
 #if ENABLE(WEBASSEMBLY)
 #define FOR_EACH_WEBASSEMBLY_CONSTRUCTOR_TYPE(macro) \
-    macro(WebAssemblyArray,        webAssemblyArray,        webAssemblyArray,        JSWebAssemblyArray,        Array,        object, typeExposedByDefault) \
+    macro(WebAssemblyArray,        webAssemblyArray,        webAssemblyArray,        JSWebAssemblyArray,        Array,        null,   typeExposedByDefault) \
     macro(WebAssemblyCompileError, webAssemblyCompileError, webAssemblyCompileError, ErrorInstance,             CompileError, error,  typeExposedByDefault) \
     macro(WebAssemblyException,    webAssemblyException,    webAssemblyException,    JSWebAssemblyException,    Exception,    object, typeExposedByDefault) \
     macro(WebAssemblyGlobal,       webAssemblyGlobal,       webAssemblyGlobal,       JSWebAssemblyGlobal,       Global,       object, typeExposedByDefault) \
@@ -183,7 +183,7 @@ constexpr bool typeExposedByDefault = true;
     macro(WebAssemblyMemory,       webAssemblyMemory,       webAssemblyMemory,       JSWebAssemblyMemory,       Memory,       object, typeExposedByDefault) \
     macro(WebAssemblyModule,       webAssemblyModule,       webAssemblyModule,       JSWebAssemblyModule,       Module,       object, typeExposedByDefault) \
     macro(WebAssemblyRuntimeError, webAssemblyRuntimeError, webAssemblyRuntimeError, ErrorInstance,             RuntimeError, error,  typeExposedByDefault) \
-    macro(WebAssemblyStruct,       webAssemblyStruct,       webAssemblyStruct,       JSWebAssemblyStruct,       Struct,       object, typeExposedByDefault) \
+    macro(WebAssemblyStruct,       webAssemblyStruct,       webAssemblyStruct,       JSWebAssemblyStruct,       Struct,       null,   typeExposedByDefault) \
     macro(WebAssemblyTable,        webAssemblyTable,        webAssemblyTable,        JSWebAssemblyTable,        Table,        object, typeExposedByDefault) \
     macro(WebAssemblyTag,          webAssemblyTag,          webAssemblyTag,          JSWebAssemblyTag,          Tag,          object, typeExposedByDefault) 
 #else
@@ -779,6 +779,7 @@ public:
     JSPromisePrototype* promisePrototype() const { return m_promisePrototype.get(); }
     AsyncGeneratorPrototype* asyncGeneratorPrototype() const { return m_asyncGeneratorPrototype.get(); }
     AsyncGeneratorFunctionPrototype* asyncGeneratorFunctionPrototype() const { return m_asyncGeneratorFunctionPrototype.get(); }
+    JSValue nullPrototype() const { return jsNull(); }
 
     Structure* debuggerScopeStructure() const { return m_debuggerScopeStructure.get(this); }
     Structure* withScopeStructure() const { return m_withScopeStructure.get(this); }


### PR DESCRIPTION
#### 6032e158dbd5e3b8d9571f316d74a0d654ab954e
<pre>
[WASM] WASM GC Objects should have null prototype
<a href="https://bugs.webkit.org/show_bug.cgi?id=286282">https://bugs.webkit.org/show_bug.cgi?id=286282</a>
<a href="https://rdar.apple.com/143291159">rdar://143291159</a>

Reviewed by Yusuke Suzuki and Mark Lam.

Per the WebAssembly GC specification, WebAssembly GC objects (e.g.,
`WebAssembly.Struct` and `WebAssembly.Array`) must return a null
prototype [1]. This commit updates the `Structure`&apos;s `prototypeBase`
for these objects to ensure compliance with the spec.

[1] <a href="https://github.com/WebAssembly/gc/blob/756060f5816c7e2159f4817fbdee76cf52f9c923/proposals/gc/MVP-JS.md?plain=1#L15-L25">https://github.com/WebAssembly/gc/blob/756060f5816c7e2159f4817fbdee76cf52f9c923/proposals/gc/MVP-JS.md?plain=1#L15-L25</a>

* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::nullPrototype const):

Canonical link: <a href="https://commits.webkit.org/289191@main">https://commits.webkit.org/289191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbf01d60d7e5c54741fd0b2e9ad223ef3b6fe50b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85754 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/5427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/40156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/36727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/5651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/13419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/90824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/36727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/5651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/40156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/5651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/40156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/35805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/78753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/5651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/40156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/84737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/13063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/13419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/92530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/13273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/40156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/40156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/5168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13354 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/13093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/107132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/12873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/25808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/16300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/14660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->