### PR TITLE
`input[type="range"]` handles inline-size incorrectly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-block-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-block-size-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS writing-mode: horizontal-tb
+PASS writing-mode: vertical-lr
+PASS writing-mode: vertical-rl
+PASS writing-mode: sideways-lr
+PASS writing-mode: sideways-rl
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-block-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-block-size.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Setting block-size/min-block-size/max-block-size on input[type=range] should be honored.</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/css-writing-modes/">
+</head>
+<body>
+    <input type="range" id="input">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+        const writingModes = [
+            "horizontal-tb",
+            "vertical-lr",
+            "vertical-rl",
+            "sideways-lr",
+            "sideways-rl",
+        ];
+        for (let writingMode of writingModes) {
+            test(t => {
+                t.add_cleanup(() => {
+                    input.style = "";
+                });
+                input.style.writingMode = writingMode;
+                input.style.blockSize = "10px";
+                const blockSize = () => {
+                    return writingMode == "horizontal-tb" ? getComputedStyle(input).height : getComputedStyle(input).width;
+                };
+                assert_equals(blockSize(), "10px", "block-size applies");
+                input.style.maxBlockSize = "8px";
+                assert_equals(blockSize(), "8px", "max-block-size applies");
+                input.style.minBlockSize = "15px";
+                assert_equals(blockSize(), "15px", "min-block-size applies");
+            }, `writing-mode: ${writingMode}`);
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-inline-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-inline-size-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS writing-mode: horizontal-tb
+PASS writing-mode: vertical-lr
+PASS writing-mode: vertical-rl
+PASS writing-mode: sideways-lr
+PASS writing-mode: sideways-rl
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-inline-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-inline-size.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Setting inline-size/min-inline-size/max-inline-size on input[type=range] should be honored.</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/css-writing-modes/">
+</head>
+<body>
+    <input type="range" id="input">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+        const writingModes = [
+            "horizontal-tb",
+            "vertical-lr",
+            "vertical-rl",
+            "sideways-lr",
+            "sideways-rl",
+        ];
+        for (let writingMode of writingModes) {
+            test(t => {
+                t.add_cleanup(() => {
+                    input.style = "";
+                });
+                input.style.writingMode = writingMode;
+                input.style.inlineSize = "10px";
+                const inlineSize = () => {
+                    return writingMode == "horizontal-tb" ? getComputedStyle(input).width : getComputedStyle(input).height;
+                };
+                assert_equals(inlineSize(), "10px", "inline-size applies");
+                input.style.maxInlineSize = "8px";
+                assert_equals(inlineSize(), "8px", "max-inline-size applies");
+                input.style.minInlineSize = "15px";
+                assert_equals(inlineSize(), "15px", "min-inline-size applies");
+            }, `writing-mode: ${writingMode}`);
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <style>
+        div {
+            display: flex;
+        }
+        span {
+            display: inline-block;
+            border-inline-start: 1px solid green;
+        }
+        input[type=range] {
+            visibility: hidden;
+            margin: 0;
+        }
+    </style>
+
+    <p>Test passes if you see no red:</p>
+
+    <div><span></span><input type="range"></div>
+    <div style="writing-mode: vertical-lr;"><span></span><span></span><span></span><span></span><input type="range"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <style>
+        div {
+            display: flex;
+        }
+        span {
+            display: inline-block;
+            border-inline-start: 1px solid green;
+        }
+        input[type=range] {
+            visibility: hidden;
+            margin: 0;
+        }
+    </style>
+
+    <p>Test passes if you see no red:</p>
+
+    <div><span></span><input type="range"></div>
+    <div style="writing-mode: vertical-lr;"><span></span><span></span><span></span><span></span><input type="range"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Setting inline-size to zero on input[type=range] should be honored.</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/css-writing-modes/">
+    <link rel="match" href="input-range-zero-inline-size-ref.html">
+</head>
+<body>
+    <style>
+        div {
+            display: flex;
+            background-color: red;
+            border-inline-start: 1px solid green;
+        }
+        .horizontal {
+            background-color: transparent;
+        }
+        input[type=range] {
+            visibility: hidden;
+            inline-size: 0;
+            margin: 0;
+        }
+    </style>
+
+    <p>Test passes if you see no red:</p>
+
+    <div class="horizontal"><span style="display: inline-flex; background-color: red;"><input type="range"></span></div>
+    <div style="writing-mode: vertical-lr;"><input type="range"></div>
+    <div style="writing-mode: vertical-rl;"><input type="range"></div>
+    <div style="writing-mode: sideways-lr;"><input type="range"></div>
+    <div style="writing-mode: sideways-rl;"><input type="range"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -93,12 +93,12 @@ void RenderSlider::computePreferredLogicalWidths()
     m_minPreferredLogicalWidth = 0;
     m_maxPreferredLogicalWidth = 0;
 
-    if (style().width().isFixed() && style().width().value() > 0)
-        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().width());
+    if (style().logicalWidth().isFixed())
+        m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = adjustContentBoxLogicalWidthForBoxSizing(style().logicalWidth());
     else
         computeIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
 
-    RenderBox::computePreferredLogicalWidths(style().minWidth(), style().maxWidth(), horizontalBorderAndPaddingExtent());
+    RenderBox::computePreferredLogicalWidths(style().logicalMinWidth(), style().logicalMaxWidth(), writingMode().isHorizontal() ? horizontalBorderAndPaddingExtent() : verticalBorderAndPaddingExtent());
 
     setPreferredLogicalWidthsDirty(false); 
 }


### PR DESCRIPTION
#### e033f9b6245bb361ea48a705ec546044d2de6eea
<pre>
`input[type=&quot;range&quot;]` handles inline-size incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=259602">https://bugs.webkit.org/show_bug.cgi?id=259602</a>
<a href="https://rdar.apple.com/113402515">rdar://113402515</a>

Reviewed by Alan Baradlay.

There are two issues:
- width: 0; is not honored because there is a strict check against zero which is incorrect.
- `RenderSlider::computePreferredLogicalWidths` was using physical widths instead of logical widths.

Fix those issues to match the behavior in other browsers and add some WPT.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-block-size-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-block-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-inline-size-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-inline-size.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/input-range-zero-inline-size.html: Added.
* Source/WebCore/rendering/RenderSlider.cpp:
(WebCore::RenderSlider::computePreferredLogicalWidths):

Canonical link: <a href="https://commits.webkit.org/289184@main">https://commits.webkit.org/289184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d289bac7a574c25a6abaa969ce262ed59ba09d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66549 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24354 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32012 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35701 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75287 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74426 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18365 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18641 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5064 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12970 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18347 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->