### PR TITLE
Remove userAgentAppearanceStyle

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -68,7 +68,7 @@ public:
     // metrics and defaults given the contents of the style.  This includes sophisticated operations like
     // selection of control size based off the font, the disabling of appearance when CSS properties that
     // disable native appearance are set, or if the appearance is not supported by the theme.
-    void adjustStyle(RenderStyle&, const Element*, const RenderStyle* userAgentAppearanceStyle);
+    void adjustStyle(RenderStyle&, const Element*);
 
     virtual bool canCreateControlPartForRenderer(const RenderObject&) const { return false; }
     virtual bool canCreateControlPartForBorderOnly(const RenderObject&) const { return false; }
@@ -115,7 +115,7 @@ public:
     virtual bool controlSupportsTints(const RenderObject&) const { return false; }
 
     // Whether or not the control has been styled enough by the author to disable the native appearance.
-    virtual bool isControlStyled(const RenderStyle&, const RenderStyle& userAgentStyle) const;
+    virtual bool isControlStyled(const RenderStyle&) const;
 
     // A general method asking if any control tinting is supported at all.
     virtual bool supportsControlTints() const { return false; }
@@ -246,6 +246,8 @@ public:
 
     virtual void paintPlatformResizer(const RenderLayerModelObject&, GraphicsContext&, const LayoutRect&);
     virtual void paintPlatformResizerFrame(const RenderLayerModelObject&, GraphicsContext&, const LayoutRect&);
+
+    static bool hasAppearanceForElementTypeFromUAStyle(const Element&);
 
 protected:
     ControlStyle extractControlStyleForRenderer(const RenderObject&) const;

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -287,13 +287,13 @@ Color RenderThemeAdwaita::systemColor(CSSValueID cssValueID, OptionSet<StyleColo
     }
 }
 
-bool RenderThemeAdwaita::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
+bool RenderThemeAdwaita::isControlStyled(const RenderStyle& style) const
 {
     auto appearance = style.usedAppearance();
     if (appearance == StyleAppearance::TextField || appearance == StyleAppearance::TextArea || appearance == StyleAppearance::SearchField || appearance == StyleAppearance::Listbox)
-        return style.border() != userAgentStyle.border();
+        return style.nativeAppearanceDisabled();
 
-    return RenderTheme::isControlStyled(style, userAgentStyle);
+    return RenderTheme::isControlStyled(style);
 }
 
 void RenderThemeAdwaita::adjustTextFieldStyle(RenderStyle& style, const Element*) const

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
@@ -40,7 +40,7 @@ public:
     bool canCreateControlPartForBorderOnly(const RenderObject&) const final;
     bool canCreateControlPartForDecorations(const RenderObject&) const final;
 
-    bool isControlStyled(const RenderStyle&, const RenderStyle& userAgentStyle) const final;
+    bool isControlStyled(const RenderStyle&) const final;
 
     void setAccentColor(const Color&);
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -75,7 +75,7 @@ private:
 
     int baselinePosition(const RenderBox&) const override;
 
-    bool isControlStyled(const RenderStyle&, const RenderStyle& userAgentStyle) const override;
+    bool isControlStyled(const RenderStyle&) const override;
 
     // Methods for each appearance value.
     void adjustCheckboxStyle(RenderStyle&, const Element*) const override;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -175,16 +175,16 @@ int RenderThemeIOS::baselinePosition(const RenderBox& box) const
     return baseline;
 }
 
-bool RenderThemeIOS::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
+bool RenderThemeIOS::isControlStyled(const RenderStyle& style) const
 {
     // Buttons and MenulistButtons are styled if they contain a background image.
     if (style.usedAppearance() == StyleAppearance::PushButton || style.usedAppearance() == StyleAppearance::MenulistButton)
         return !style.visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || style.backgroundLayers().hasImage();
 
     if (style.usedAppearance() == StyleAppearance::TextField || style.usedAppearance() == StyleAppearance::TextArea || style.usedAppearance() == StyleAppearance::SearchField)
-        return !style.borderAndBackgroundEqual(userAgentStyle);
+        return style.nativeAppearanceDisabled();
 
-    return RenderTheme::isControlStyled(style, userAgentStyle);
+    return RenderTheme::isControlStyled(style);
 }
 
 void RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance(StyleAppearance appearance, RenderStyle& style) const

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -45,7 +45,7 @@ public:
     void inflateRectForControlRenderer(const RenderObject&, FloatRect&) final;
     void adjustRepaintRect(const RenderBox&, FloatRect&) final;
 
-    bool isControlStyled(const RenderStyle&, const RenderStyle& userAgentStyle) const final;
+    bool isControlStyled(const RenderStyle&) const final;
 
     bool supportsSelectionForegroundColors(OptionSet<StyleColorOptions>) const final;
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -735,11 +735,11 @@ bool RenderThemeMac::searchFieldShouldAppearAsTextField(const RenderStyle& style
 
 }
 
-bool RenderThemeMac::isControlStyled(const RenderStyle& style, const RenderStyle& userAgentStyle) const
+bool RenderThemeMac::isControlStyled(const RenderStyle& style) const
 {
     auto appearance = style.usedAppearance();
     if (appearance == StyleAppearance::TextField || appearance == StyleAppearance::TextArea || appearance == StyleAppearance::SearchField || appearance == StyleAppearance::Listbox)
-        return style.border() != userAgentStyle.border();
+        return style.nativeAppearanceDisabled();
 
     // FIXME: This is horrible, but there is not much else that can be done. Menu lists cannot draw properly when
     // scaled.  They can't really draw properly when transformed either.  We can't detect the transform case at style
@@ -749,7 +749,7 @@ bool RenderThemeMac::isControlStyled(const RenderStyle& style, const RenderStyle
     if (appearance == StyleAppearance::Menulist && (style.usedZoom() != 1.0f || !style.writingMode().isHorizontal()))
         return true;
 
-    return RenderTheme::isControlStyled(style, userAgentStyle);
+    return RenderTheme::isControlStyled(style);
 }
 
 static FloatRect inflateRect(const FloatRect& rect, const IntSize& size, std::span<const int, 4> margins, float zoomLevel)

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -77,7 +77,6 @@ inline UnadjustedStyle copy(const UnadjustedStyle& other)
 {
     return {
         .style = RenderStyle::clonePtr(*other.style),
-        .userAgentAppearanceStyle = other.userAgentAppearanceStyle ? RenderStyle::clonePtr(*other.userAgentAppearanceStyle) : nullptr,
         .relations = other.relations ? makeUnique<Relations>(*other.relations) : std::unique_ptr<Relations> { },
         .matchResult = other.matchResult
     };

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -161,19 +161,13 @@ std::optional<MatchedDeclarationsCache::Result> MatchedDeclarationsCache::find(u
     return std::nullopt;
 }
 
-void MatchedDeclarationsCache::add(const RenderStyle& style, const RenderStyle& parentStyle, const RenderStyle* userAgentAppearanceStyle, unsigned hash, const MatchResult& matchResult)
+void MatchedDeclarationsCache::add(const RenderStyle& style, const RenderStyle& parentStyle, unsigned hash, const MatchResult& matchResult)
 {
     constexpr unsigned additionsBetweenSweeps = 100;
     if (++m_additionsSinceLastSweep >= additionsBetweenSweeps && !m_sweepTimer.isActive()) {
         constexpr auto sweepDelay = 1_min;
         m_sweepTimer.startOneShot(sweepDelay);
     }
-
-    auto userAgentAppearanceStyleCopy = [&]() -> std::unique_ptr<RenderStyle> {
-        if (userAgentAppearanceStyle)
-            return RenderStyle::clonePtr(*userAgentAppearanceStyle);
-        return { };
-    };
 
     ASSERT(hash);
     // Note that we don't cache the original RenderStyle instance. It may be further modified.
@@ -185,7 +179,7 @@ void MatchedDeclarationsCache::add(const RenderStyle& style, const RenderStyle& 
         return newBucket;
     });
     if (addResult.iterator->value.size() < maxEntriesPerHash)
-        addResult.iterator->value.append(Entry { &matchResult, RenderStyle::clonePtr(style), RenderStyle::clonePtr(parentStyle), userAgentAppearanceStyleCopy() });
+        addResult.iterator->value.append(Entry { &matchResult, RenderStyle::clonePtr(style), RenderStyle::clonePtr(parentStyle) });
 }
 
 void MatchedDeclarationsCache::remove(unsigned hash)

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -50,7 +50,6 @@ public:
         RefPtr<const MatchResult> matchResult;
         std::unique_ptr<const RenderStyle> renderStyle;
         std::unique_ptr<const RenderStyle> parentRenderStyle;
-        std::unique_ptr<const RenderStyle> userAgentAppearanceStyle;
 
         bool isUsableAfterHighPriorityProperties(const RenderStyle&) const;
     };
@@ -61,7 +60,7 @@ public:
     };
 
     std::optional<Result> find(unsigned hash, const MatchResult&, const StyleCustomPropertyData& inheritedCustomProperties, const RenderStyle&);
-    void add(const RenderStyle&, const RenderStyle& parentStyle, const RenderStyle* userAgentAppearanceStyle, unsigned hash, const MatchResult&);
+    void add(const RenderStyle&, const RenderStyle& parentStyle,  unsigned hash, const MatchResult&);
     void remove(unsigned hash);
 
     // Every N additions to the matched declaration cache trigger a sweep where entries holding

--- a/Source/WebCore/style/ResolvedStyle.h
+++ b/Source/WebCore/style/ResolvedStyle.h
@@ -28,7 +28,6 @@ namespace Style {
 
 struct UnadjustedStyle {
     std::unique_ptr<RenderStyle> style;
-    std::unique_ptr<RenderStyle> userAgentAppearanceStyle { };
     std::unique_ptr<Relations> relations { };
     RefPtr<const MatchResult> matchResult { };
 };

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -477,7 +477,7 @@ void Adjuster::adjustFromBuilder(RenderStyle& style)
     style.adjustViewTimelines();
 }
 
-void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearanceStyle) const
+void Adjuster::adjust(RenderStyle& style) const
 {
     if (style.display() == DisplayType::Contents)
         adjustDisplayContentsStyle(style);
@@ -717,7 +717,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
 
     // Let the theme also have a crack at adjusting the style.
     if (style.hasAppearance())
-        adjustThemeStyle(style, userAgentAppearanceStyle);
+        adjustThemeStyle(style);
 
     // This should be kept in sync with requiresRenderingConsolidationForViewTransition
     if (style.preserves3D()) {
@@ -924,7 +924,7 @@ void Adjuster::adjustSVGElementStyle(RenderStyle& style, const SVGElement& svgEl
 
 void Adjuster::adjustAnimatedStyle(RenderStyle& style, OptionSet<AnimationImpact> impact) const
 {
-    adjust(style, nullptr);
+    adjust(style);
 
     // Set an explicit used z-index in two cases:
     // 1. When the element respects z-index, and the style has an explicit z-index set (for example, the animation
@@ -937,7 +937,7 @@ void Adjuster::adjustAnimatedStyle(RenderStyle& style, OptionSet<AnimationImpact
         style.setUsedZIndex(0);
 }
 
-void Adjuster::adjustThemeStyle(RenderStyle& style, const RenderStyle* userAgentAppearanceStyle) const
+void Adjuster::adjustThemeStyle(RenderStyle& style) const
 {
     ASSERT(style.hasAppearance());
     auto isOldWidthAuto = style.width().isAuto();
@@ -945,7 +945,7 @@ void Adjuster::adjustThemeStyle(RenderStyle& style, const RenderStyle* userAgent
     auto isOldHeightAuto = style.height().isAuto();
     auto isOldMinHeightAuto = style.minHeight().isAuto();
 
-    RenderTheme::singleton().adjustStyle(style, m_element.get(), userAgentAppearanceStyle);
+    RenderTheme::singleton().adjustStyle(style, m_element.get());
 
     if (style.containsSize()) {
         if (style.containIntrinsicWidthType() != ContainIntrinsicSizeType::None) {

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -50,7 +50,7 @@ public:
     Adjuster(const Document&, const RenderStyle& parentStyle, const RenderStyle* parentBoxStyle, Element*);
 
     static void adjustFromBuilder(RenderStyle&);
-    void adjust(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
+    void adjust(RenderStyle&) const;
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
 
     static void adjustVisibilityForPseudoElement(RenderStyle&, const Element& host);
@@ -75,7 +75,7 @@ private:
     void adjustDisplayContentsStyle(RenderStyle&) const;
     void adjustForSiteSpecificQuirks(RenderStyle&) const;
 
-    void adjustThemeStyle(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
+    void adjustThemeStyle(RenderStyle&) const;
 
     static OptionSet<EventListenerRegionType> computeEventListenerRegionTypes(const Document&, const RenderStyle&, const EventTarget&, OptionSet<EventListenerRegionType>);
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -421,8 +421,8 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
 
     BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), valueType);
 
-    if (!isRevertOrRevertLayer && cascadeLevel == CascadeLevel::Author && m_state.element()->isDevolvableWidget() && CSSProperty::disablesNativeAppearance(id) && m_state.applyPropertyToRegularStyle())
-        style.setNativeAppearanceDisabled(true);
+    if (!isRevertOrRevertLayer)
+        m_state.disableNativeAppearanceIfNeeded(id, cascadeLevel);
 
     if (!isUnset && !isRevertOrRevertLayer && m_state.isCurrentPropertyInvalidAtComputedValueTime()) {
         // https://drafts.csswg.org/css-variables-2/#invalid-variables

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -373,5 +373,22 @@ unsigned BuilderState::siblingIndex()
     return count;
 }
 
+void BuilderState::disableNativeAppearanceIfNeeded(CSSPropertyID propertyID, CascadeLevel cascadeLevel)
+{
+    auto shouldDisable = [&] {
+        if (cascadeLevel != CascadeLevel::Author)
+            return false;
+        if (!CSSProperty::disablesNativeAppearance(propertyID))
+            return false;
+        if (!applyPropertyToRegularStyle())
+            return false;
+        return element()->isDevolvableWidget() || RenderTheme::hasAppearanceForElementTypeFromUAStyle(*element());
+    };
+
+    if (shouldDisable())
+        style().setNativeAppearanceDisabled(true);
+}
+
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -204,6 +204,8 @@ public:
     void setFontDescriptionVariantNumericOrdinal(FontVariantNumericOrdinal);
     void setFontDescriptionVariantNumericSlashedZero(FontVariantNumericSlashedZero);
 
+    void disableNativeAppearanceIfNeeded(CSSPropertyID, CascadeLevel);
+
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.
     friend void maybeUpdateFontForLetterSpacing(BuilderState&, CSSValue&);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -190,7 +190,7 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
     // Fully custom styles in UA shadow trees that don't originate from selector matching don't need adjusting.
     if (unadjustedStyle.matchResult) {
         Adjuster adjuster(m_document, *resolutionContext.parentStyle, resolutionContext.parentBoxStyle, &element);
-        adjuster.adjust(*style, unadjustedStyle.userAgentAppearanceStyle.get());
+        adjuster.adjust(*style);
     }
 
     return {
@@ -892,7 +892,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const 
         return nullptr;
 
     Adjuster adjuster(m_document, parentStyle, resolutionContext.parentBoxStyle, !styleable.pseudoElementIdentifier ? &styleable.element : nullptr);
-    adjuster.adjust(*newStyle, nullptr);
+    adjuster.adjust(*newStyle);
 
     return newStyle;
 }


### PR DESCRIPTION
#### 93f03ffffb803aebc218be3fb210db9672bc99a2
<pre>
Remove userAgentAppearanceStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=286288">https://bugs.webkit.org/show_bug.cgi?id=286288</a>
<a href="https://rdar.apple.com/143305321">rdar://143305321</a>

Reviewed by Aditya Keerthi.

We now track in style builder if author mutated border or background properties that disable
native control styling. Checking for this is the only reason we generate and cache this style.

The userAgentAppearanceStyle is already unused and maintained unnecessarily when &quot;devolved widget&quot;
feature is enabled (which it is by default). This patch aligns the legacy case with the standard too
by having any author mutation to border and background style disable the native appearance
(rather than requiring it to bet set to something that differs from UA style). The legacy list of
affected controls is maintained.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::hasAppearanceForElementTypeFromUAStyle):
(WebCore::RenderTheme::adjustStyle):
(WebCore::RenderTheme::isControlStyled const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::isControlStyled const):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::isControlStyled const):
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::isControlStyled const):
* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::copy):
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::add):
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/style/ResolvedStyle.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustAnimatedStyle const):
(WebCore::Style::Adjuster::adjustThemeStyle const):
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::disableNativeAppearanceIfNeeded):

Factor into a function in BuilderState.
Set the nativeAppearanceDisabled bit also in the legacy hasAppearanceForElementTypeFromUAStyle case.

* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::State::takeStyle):
(WebCore::Style::Resolver::unadjustedStyleForElement):
(WebCore::Style::Resolver::styleForElement):
(WebCore::Style::Resolver::unadjustedStyleForCachedMatchResult):
(WebCore::Style::Resolver::styleForKeyframe):
(WebCore::Style::Resolver::styleForPseudoElement):
(WebCore::Style::Resolver::applyMatchedProperties):
(WebCore::Style::Resolver::State::takeUserAgentAppearanceStyle): Deleted.
(WebCore::Style::Resolver::State::userAgentAppearanceStyle const): Deleted.
(WebCore::Style::Resolver::State::setUserAgentAppearanceStyle): Deleted.
(WebCore::Style::elementTypeHasAppearanceFromUAStyle): Deleted.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):

Canonical link: <a href="https://commits.webkit.org/294554@main">https://commits.webkit.org/294554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c53d61bb359350bf3c6ab7dee003deb0a2223de9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/102297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/21966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/12280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/107458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/52933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/104336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/22274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/30472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/77840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/105303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/17243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/92344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/58178 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/17077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/10372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/52291 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/10442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/109832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/29429 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/21696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/86820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/29793 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/88543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/86409 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21973 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/31219 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/8938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/23671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/29357 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/34652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/29168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/32491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/30727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->