### PR TITLE
[CoordinatedGraphics] Remove TextureMapperPlatformLayerProxy::swapBuffersIfNeeded

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2437,12 +2437,16 @@ AffineTransform CanvasRenderingContext2DBase::baseTransform() const
 void CanvasRenderingContext2DBase::prepareForDisplay()
 {
     if (auto buffer = canvasBase().buffer())
-        buffer->flushDrawingContextAsync();
+        buffer->prepareForDisplay();
 }
 
 bool CanvasRenderingContext2DBase::needsPreparationForDisplay() const
 {
+#if USE(SKIA)
+    return isAccelerated();
+#else
     return false;
+#endif
 }
 
 ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::createImageData(ImageData& existingImageData) const

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -302,6 +302,13 @@ bool ImageBuffer::flushDrawingContextAsync()
     return true;
 }
 
+void ImageBuffer::prepareForDisplay()
+{
+    flushDrawingContextAsync();
+    if (auto* backend = ensureBackend())
+        backend->prepareForDisplay();
+}
+
 void ImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
 {
     if (m_backend.get() == backend.get())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -143,6 +143,8 @@ public:
     WEBCORE_EXPORT virtual void flushDrawingContext();
     WEBCORE_EXPORT virtual bool flushDrawingContextAsync();
 
+    void prepareForDisplay();
+
     WEBCORE_EXPORT IntSize backendSize() const;
 
     virtual void ensureBackendCreated() const { ensureBackend(); }

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -171,6 +171,8 @@ public:
 
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const { return nullptr; }
 
+    virtual void prepareForDisplay() { }
+
     const Parameters& parameters() const { return m_parameters; }
 
     WEBCORE_EXPORT virtual String debugDescription() const = 0;

--- a/Source/WebCore/platform/graphics/gbm/GraphicsLayerContentsDisplayDelegateGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsLayerContentsDisplayDelegateGBM.h
@@ -47,7 +47,6 @@ private:
 
     bool m_isOpaque { false };
     RefPtr<DMABufBuffer> m_buffer;
-    std::unique_ptr<GLFence> m_fence;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -49,6 +49,8 @@ private:
     static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const Parameters&, const ImageBufferCreationContext&, sk_sp<SkSurface>&&);
     ImageBufferSkiaAcceleratedBackend(const Parameters&, sk_sp<SkSurface>&&);
 
+    void prepareForDisplay() final;
+
     RefPtr<NativeImage> copyNativeImage() final;
     RefPtr<NativeImage> createNativeImageReference() final;
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -32,10 +32,6 @@
 
 namespace WebCore {
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
-class GLFence;
-#endif
-
 class TextureMapperGCGLPlatformLayer;
 
 class GraphicsContextGLTextureMapperANGLE : public GLContextWrapper, public GraphicsContextGLANGLE {
@@ -83,10 +79,6 @@ private:
 
     GCGLuint m_compositorTexture { 0 };
     bool m_isCompositorTextureInitialized { false };
-
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    std::unique_ptr<GLFence> m_frameFence;
-#endif
 
 #if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     GCGLuint m_textureID { 0 };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp
@@ -160,12 +160,6 @@ void TextureMapperPlatformLayerProxy::pushNextBuffer(std::unique_ptr<Coordinated
         m_targetLayer->requestComposition();
 }
 
-void TextureMapperPlatformLayerProxy::swapBuffersIfNeeded()
-{
-    if (m_swapBuffersFunction)
-        m_swapBuffersFunction(*this);
-}
-
 void TextureMapperPlatformLayerProxy::dropCurrentBufferWhilePreservingTexture(bool shouldWait)
 {
     auto dropBufferFunction = [this, protectedThis = Ref { *this }, shouldWait] {

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
@@ -63,8 +63,6 @@ public:
 
     void pushNextBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);
     void dropCurrentBufferWhilePreservingTexture(bool shouldWait);
-    void setSwapBuffersFunction(Function<void(TextureMapperPlatformLayerProxy&)>&& function) { m_swapBuffersFunction = WTFMove(function); }
-    void swapBuffersIfNeeded();
 
 private:
     explicit TextureMapperPlatformLayerProxy(ContentType);
@@ -85,7 +83,6 @@ private:
     ContentType m_contentType;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_currentBuffer;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_pendingBuffer;
-    Function<void(TextureMapperPlatformLayerProxy&)> m_swapBuffersFunction;
 
     Lock m_wasBufferDroppedLock;
     Condition m_wasBufferDroppedCondition;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -471,7 +471,6 @@ void CoordinatedPlatformLayer::setContentsBufferNeedsDisplay()
     if (!m_contentsBuffer)
         return;
 
-    m_contentsBuffer->swapBuffersIfNeeded();
     notifyCompositionRequired();
 }
 


### PR DESCRIPTION
#### affcb2b627ebae2a7a75c84722586088a3522e8c
<pre>
[CoordinatedGraphics] Remove TextureMapperPlatformLayerProxy::swapBuffersIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=286291">https://bugs.webkit.org/show_bug.cgi?id=286291</a>

Reviewed by Alejandro G. Castro.

We don&apos;t need to call swapBuffersIfNeeded() during layer flush because
prepareForDisplay is already called by Page::updateRendering right
before the layer flush, so we can push the new buffer from there without
having to install a swap buffer function in the proxy. For WebGL we
already have prepareForDisplay in the graphics context, but for
accelerated 2D canvas we need to add it to ImageBufferBackend.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::prepareForDisplay):
(WebCore::CanvasRenderingContext2DBase::needsPreparationForDisplay const):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::prepareForDisplay):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::prepareForDisplay):
* Source/WebCore/platform/graphics/gbm/GraphicsLayerContentsDisplayDelegateGBM.cpp:
(WebCore::GraphicsLayerContentsDisplayDelegateGBM::GraphicsLayerContentsDisplayDelegateGBM):
(WebCore::GraphicsLayerContentsDisplayDelegateGBM::setDisplayBuffer):
* Source/WebCore/platform/graphics/gbm/GraphicsLayerContentsDisplayDelegateGBM.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::prepareForDisplay):
(WebCore::ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::~GraphicsContextGLTextureMapperANGLE):
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitialize):
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareForDisplay):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp:
(WebCore::TextureMapperPlatformLayerProxy::swapBuffersIfNeeded): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setContentsBufferNeedsDisplay):
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:

Canonical link: <a href="https://commits.webkit.org/289282@main">https://commits.webkit.org/289282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d96d0e38e37a5b31f43255ec62c099c25e7e6d49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66566 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24375 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35732 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12983 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9530 "Found 1 new test failure: media/video-canvas-createPattern.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74443 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18664 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17109 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5092 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13420 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18378 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12800 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->