### PR TITLE
Safari 18 regression: revert-layer is broken when logical group CSS properties are explicitly inherited

### DIFF
--- a/LayoutTests/fast/css/revert-layer-explicit-inherit-mdc-expected.html
+++ b/LayoutTests/fast/css/revert-layer-explicit-inherit-mdc-expected.html
@@ -1,0 +1,16 @@
+<style>
+@layer a {
+  .outer {
+    background: green;
+  }
+
+  .inner {
+    padding-top: 50px;
+  }
+}
+</style>
+<div id=t class="outer">
+  <div class="inner">
+    This text should have padding above.
+  </div>
+</div>

--- a/LayoutTests/fast/css/revert-layer-explicit-inherit-mdc.html
+++ b/LayoutTests/fast/css/revert-layer-explicit-inherit-mdc.html
@@ -1,0 +1,29 @@
+<style>
+@layer a {
+  .outer {
+    background: red;
+  }
+
+  .inner {
+    padding-top: 50px;
+    top: inherit;
+  }
+
+  .hover {
+    background: green;
+  }
+}
+
+.inner {
+  padding-top: revert-layer;
+}
+</style>
+<div id=t class="outer">
+  <div class="inner">
+    This text should have padding above.
+  </div>
+</div>
+<script>
+document.body.offsetLeft;
+t.classList.add('hover');
+</script>

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -53,7 +53,7 @@ PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel ma
 
 PropertyCascade::PropertyCascade(const PropertyCascade& parent, CascadeLevel maximumCascadeLevel, std::optional<ScopeOrdinal> rollbackScope, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback)
     : m_matchResult(parent.m_matchResult)
-    , m_includedProperties(parent.m_includedProperties)
+    , m_includedProperties(normalProperties()) // Include all properties to the rollback cascade, lower prority layers may not get included otherwise.
     , m_maximumCascadeLevel(maximumCascadeLevel)
     , m_rollbackScope(rollbackScope)
     , m_maximumCascadeLayerPriorityForRollback(maximumCascadeLayerPriorityForRollback)


### PR DESCRIPTION
#### b7426636d8785247f4c1689f3295f8fb4ebacff1
<pre>
Safari 18 regression: revert-layer is broken when logical group CSS properties are explicitly inherited
<a href="https://bugs.webkit.org/show_bug.cgi?id=283942">https://bugs.webkit.org/show_bug.cgi?id=283942</a>
<a href="https://rdar.apple.com/140819138">rdar://140819138</a>

Reviewed by Alan Baradlay.

This happens when we do partial applying of explicitly inherited properties after matched declarations
cache hit. If the property is a logical group property we also decide to apply all subsequent logical
group properties (as they might override this property). This is in itself fine.

However when applying revert-layer we need to construct a revert cascade that also includes lower priority layers.
We still limit the cascade building to explicitly inherited properties which may mean we miss a value from
a lower priority layer for a property we actually decided to apply.

* LayoutTests/fast/css/revert-layer-explicit-inherit-mdc-expected.html: Added.
* LayoutTests/fast/css/revert-layer-explicit-inherit-mdc.html: Added.
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):

Fix by ensuring rollback cascade applies all properties.

Canonical link: <a href="https://commits.webkit.org/289183@main">https://commits.webkit.org/289183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52a0a12da49ed76718134be3d2b7f16383ac48e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66568 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24377 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32045 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35734 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92434 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75308 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74446 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18364 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18666 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18380 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->