### PR TITLE
[WebGPUSwift] fix validation errors in copyBufferToTexture swift implementation.

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -813,7 +813,7 @@ extension WebGPU.CommandEncoder {
                     let blockSizeValue: UInt32 = blockSize.value()
                     let (result, didOverflow) = blockSizeValue.multipliedReportingOverflow(by: device.limitsCopy().maxTextureDimension1D)
                     if !didOverflow {
-                        sourceBytesPerRow = UInt(result)
+                        sourceBytesPerRow = min(sourceBytesPerRow, UInt(result))
                     }
                 }
             case WGPUTextureDimension_2D, WGPUTextureDimension_3D:
@@ -822,7 +822,7 @@ extension WebGPU.CommandEncoder {
                     let blockSizeValue: UInt32 = blockSize.value()
                     let (result, didOverflow) = blockSizeValue.multipliedReportingOverflow(by: device.limitsCopy().maxTextureDimension2D)
                     if !didOverflow {
-                        sourceBytesPerRow = UInt(result)
+                        sourceBytesPerRow = min(sourceBytesPerRow, UInt(result))
                     }
                 }
             case WGPUTextureDimension_Force32:
@@ -1010,7 +1010,7 @@ extension WebGPU.CommandEncoder {
                 let destinationOrigin = MTLOriginMake(Int(destination.origin.x), Int(destination.origin.y), 0);
                 for layer in 0..<copySize.depthOrArrayLayers {
                     var layerTimesSourceBytesPerImage = UInt(layer)
-                    (layerTimesSourceBytesPerImage, didOverflow) = layerTimesSourceBytesPerImage.addingReportingOverflow(sourceBytesPerImage)
+                    (layerTimesSourceBytesPerImage, didOverflow) = layerTimesSourceBytesPerImage.multipliedReportingOverflow(by: sourceBytesPerImage)
                     guard !didOverflow else {
                         return
                     }


### PR DESCRIPTION
#### 2a5242c44540bcb91817302583a826fdab8f7662
<pre>
[WebGPUSwift] fix validation errors in copyBufferToTexture swift implementation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286296">https://bugs.webkit.org/show_bug.cgi?id=286296</a>
<a href="https://rdar.apple.com/143319048">rdar://143319048</a>

Reviewed by Mike Wyrzykowski.

totalBytesUsed(66848768) must be &lt;= [sourceBuffer length](262144).
Fix a validation error with min check and also correct an checked overflow arithmetic operation
which was wrongly added as addition to multiplication.

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.copyBufferToTexture(_:destination:copySize:)):

Co-authored-by: Mike Wyrzykowski &lt;mwyrzykowski@apple.com&gt;
Canonical link: <a href="https://commits.webkit.org/289194@main">https://commits.webkit.org/289194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb6836daaacd6677b339abb709b9d792946c52e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66576 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24385 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4161 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32916 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9544 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75342 "36 flakes 104 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74469 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5112 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13356 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18392 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->