### PR TITLE
Overlay Regions should support Event Regions with multiple rects

### DIFF
--- a/LayoutTests/overlay-region/multi-rects-fixed-node-expected.txt
+++ b/LayoutTests/overlay-region/multi-rects-fixed-node-expected.txt
@@ -1,0 +1,104 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 0 y: 0 width: 800 height: 50])
+      (overlay region [x: 160 y: 50 width: 480 height: 40])
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 5013])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 5013])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 5013])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 5013])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 5013])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 5013])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 90])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (layer position [x: 400 y: 400]))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/multi-rects-fixed-node.html
+++ b/LayoutTests/overlay-region/multi-rects-fixed-node.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .fixed {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            pointer-events: none;
+        }
+
+        #menu {
+            width: 100%;
+            height: 50px;
+            pointer-events: auto;
+            background: #F67280;
+        }
+        #other {
+            width: 60%;
+            height: 40px;
+            margin: auto;
+            pointer-events: auto;
+            background: #F67280;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+        <div id="menu">This is a fixed menu</div>
+        <div id="other">Also fixed</div>
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.animationFrame();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1282,23 +1282,25 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
 
         // Overlay regions are positioned relative to the viewport of the scrollview,
         // not the frame (external) nor the bounds (origin moves while scrolling).
-        CGRect rect = [overlayView convertRect:node->eventRegion().region().bounds() toView:scrollView.superview];
-        CGRect offsetRect = CGRectOffset(rect, -scrollView.frame.origin.x, -scrollView.frame.origin.y);
-        CGRect snappedRect = snapRectToScrollViewEdges(offsetRect, viewport);
+        for (auto regionRect : node->eventRegion().region().rects()) {
+            CGRect rect = [overlayView convertRect:regionRect toView:scrollView.superview];
+            CGRect offsetRect = CGRectOffset(rect, -scrollView.frame.origin.x, -scrollView.frame.origin.y);
+            CGRect snappedRect = snapRectToScrollViewEdges(offsetRect, viewport);
 
-        if (CGRectIsEmpty(snappedRect))
-            continue;
+            if (CGRectIsEmpty(snappedRect))
+                continue;
 
-        auto rectToAdd = WebCore::enclosingIntRect(snappedRect);
-        if (!isValidOverlayRegionRect(rectToAdd))
-            continue;
+            auto rectToAdd = WebCore::enclosingIntRect(snappedRect);
+            if (!isValidOverlayRegionRect(rectToAdd))
+                continue;
 
-        if (std::abs(CGRectGetWidth(snappedRect) - CGRectGetWidth(viewport)) <= rectCandidateEpsilon)
-            fullWidthRects.append(rectToAdd);
-        else if (std::abs(CGRectGetHeight(snappedRect) - CGRectGetHeight(viewport)) <= rectCandidateEpsilon)
-            fullHeightRects.append(rectToAdd);
-        else
-            addOverlayRegionRect(rectToAdd);
+            if (std::abs(CGRectGetWidth(snappedRect) - CGRectGetWidth(viewport)) <= rectCandidateEpsilon)
+                fullWidthRects.append(rectToAdd);
+            else if (std::abs(CGRectGetHeight(snappedRect) - CGRectGetHeight(viewport)) <= rectCandidateEpsilon)
+                fullHeightRects.append(rectToAdd);
+            else
+                addOverlayRegionRect(rectToAdd);
+        }
     }
 
     auto mergeAndAdd = [&](auto& vec, const auto& sort, const auto& shouldMerge) {


### PR DESCRIPTION
#### 0cc94ed978bc5d6b87529ba053504cfc97124d92
<pre>
Overlay Regions should support Event Regions with multiple rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=286299">https://bugs.webkit.org/show_bug.cgi?id=286299</a>
&lt;<a href="https://rdar.apple.com/141300961">rdar://141300961</a>&gt;

Reviewed by Wenson Hsieh.

Use `Region#rects()` instead of looking at the bounds when building
the Overlay Regions lists.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(configureScrollViewWithOverlayRegionsIDs):
Iterate over each of the EventRegion&apos;s Region rects.

* LayoutTests/overlay-region/multi-rects-fixed-node-expected.txt: Added.
* LayoutTests/overlay-region/multi-rects-fixed-node.html: Added.
Add a new test for this case.

Canonical link: <a href="https://commits.webkit.org/289206@main">https://commits.webkit.org/289206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7feb34236c8deaa12f5a1eb713a38b7358f79e02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66578 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24386 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32054 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9546 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74508 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18373 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5114 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18394 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->