### PR TITLE
Crash under WorkerWorkerAgent::connectToAllWorkerInspectorProxies() on the bots

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
@@ -73,7 +73,7 @@ private:
     std::unique_ptr<Inspector::WorkerFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::WorkerBackendDispatcher> m_backendDispatcher;
 
-    MemoryCompactRobinHoodHashMap<String, WeakPtr<WorkerInspectorProxy>> m_connectedProxies;
+    MemoryCompactRobinHoodHashMap<String, ThreadSafeWeakPtr<WorkerInspectorProxy>> m_connectedProxies;
     bool m_enabled { false };
 };
 

--- a/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
@@ -44,7 +44,7 @@ PageWorkerAgent::~PageWorkerAgent() = default;
 
 void PageWorkerAgent::connectToAllWorkerInspectorProxies()
 {
-    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxiesCopy()) {
+    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxies()) {
         if (auto* document = dynamicDowncast<Document>(proxy->scriptExecutionContext())) {
             if (document->page() == &m_page)
                 connectToWorkerInspectorProxy(proxy);

--- a/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
@@ -44,7 +44,7 @@ WorkerWorkerAgent::~WorkerWorkerAgent() = default;
 
 void WorkerWorkerAgent::connectToAllWorkerInspectorProxies()
 {
-    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxiesCopy()) {
+    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxies()) {
         if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(proxy->scriptExecutionContext())) {
             if (globalScope == &m_globalScope)
                 connectToWorkerInspectorProxy(proxy);

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -42,16 +42,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerInspectorProxy);
 
 using namespace Inspector;
 
-static Lock proxiesLock;
-static WeakHashSet<WorkerInspectorProxy>& proxies() WTF_REQUIRES_LOCK(proxiesLock)
+static ThreadSafeWeakHashSet<WorkerInspectorProxy>& proxies()
 {
-    static NeverDestroyed<WeakHashSet<WorkerInspectorProxy>> proxies;
+    static NeverDestroyed<ThreadSafeWeakHashSet<WorkerInspectorProxy>> proxies;
     return proxies;
 }
 
-WeakHashSet<WorkerInspectorProxy> WorkerInspectorProxy::allWorkerInspectorProxiesCopy()
+const ThreadSafeWeakHashSet<WorkerInspectorProxy>& WorkerInspectorProxy::allWorkerInspectorProxies()
 {
-    Locker lock { proxiesLock };
     return proxies();
 }
 
@@ -79,10 +77,7 @@ void WorkerInspectorProxy::workerStarted(ScriptExecutionContext* scriptExecution
     m_workerThread = thread;
     m_url = url;
     m_name = name;
-    {
-        Locker lock { proxiesLock };
-        proxies().add(*this);
-    }
+    proxies().add(*this);
 
     InspectorInstrumentation::workerStarted(*this);
 }
@@ -93,10 +88,7 @@ void WorkerInspectorProxy::workerTerminated()
         return;
 
     InspectorInstrumentation::workerTerminated(*this);
-    {
-        Locker lock { proxiesLock };
-        proxies().remove(*this);
-    }
+    proxies().remove(*this);
 
     m_scriptExecutionContext = nullptr;
     m_workerThread = nullptr;

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URL.h>
-#include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
 // All of these methods should be called on the Main Thread.
@@ -42,7 +42,7 @@ class WorkerThread;
 
 enum class WorkerThreadStartMode;
 
-class WorkerInspectorProxy : public RefCounted<WorkerInspectorProxy>, public CanMakeWeakPtr<WorkerInspectorProxy, WeakPtrFactoryInitialization::Eager> {
+class WorkerInspectorProxy : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WorkerInspectorProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerInspectorProxy);
     WTF_MAKE_NONCOPYABLE(WorkerInspectorProxy);
 public:
@@ -60,7 +60,7 @@ public:
         virtual void sendMessageFromWorkerToFrontend(WorkerInspectorProxy&, String&&) = 0;
     };
 
-    static WeakHashSet<WorkerInspectorProxy> allWorkerInspectorProxiesCopy();
+    static const ThreadSafeWeakHashSet<WorkerInspectorProxy>& allWorkerInspectorProxies();
 
     const URL& url() const { return m_url; }
     const String& name() const { return m_name; }


### PR DESCRIPTION
#### cdc3afcab7cc707ed17c26ceb77c2e61a5fd5964
<pre>
Crash under WorkerWorkerAgent::connectToAllWorkerInspectorProxies() on the bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=286300">https://bugs.webkit.org/show_bug.cgi?id=286300</a>

Reviewed by NOBODY (OOPS!).

Have WorkerInspectorProxy subclass ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr as
it can get ref&apos;d / deref&apos;d from multiple threads.

* Source/WebCore/inspector/agents/InspectorWorkerAgent.h:
* Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp:
(WebCore::PageWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp:
(WebCore::WorkerWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
(WebCore::proxies):
(WebCore::WorkerInspectorProxy::allWorkerInspectorProxies):
(WebCore::WorkerInspectorProxy::workerStarted):
(WebCore::WorkerInspectorProxy::workerTerminated):
(WebCore::WTF_REQUIRES_LOCK): Deleted.
(WebCore::WorkerInspectorProxy::allWorkerInspectorProxiesCopy): Deleted.
* Source/WebCore/workers/WorkerInspectorProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdc3afcab7cc707ed17c26ceb77c2e61a5fd5964

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66581 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24390 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77799 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46866 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92462 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75329 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74466 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18682 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5120 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->