### PR TITLE
[scroll-animations] CSS Animations should update their timeline if another element creates a timeline for that name

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Animation.timeline returns attached timeline
 FAIL Animation.timeline returns null for inactive deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
-FAIL Animation.timeline returns null for inactive (overattached) deferred timeline assert_equals: expected null but got object "[object ScrollTimeline]"
+FAIL Animation.timeline returns null for inactive (overattached) deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -5,7 +5,7 @@ FAIL scroll-timeline-name is not referenceable in animation-timeline on that ele
 PASS scroll-timeline-name on an element which is not a scroll-container
 FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected null but got object "[object DocumentTimeline]"
 FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: Failed to remove timeline expected null but got object "[object ScrollTimeline]"
-FAIL Timeline lookup updates candidate when closer match available. assert_equals: Timeline not updated expected "B" but got "A"
+PASS Timeline lookup updates candidate when closer match available.
 PASS Timeline lookup updates candidate when match becomes available.
 PASS scroll-timeline-axis is block
 PASS scroll-timeline-axis is inline

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -2,9 +2,9 @@
 PASS Descendant can attach to deferred timeline
 PASS Deferred timeline with no attachments
 PASS Inner timeline does not interfere with outer timeline
-FAIL Deferred timeline with two attachments assert_equals: expected "0px" but got "100px"
+PASS Deferred timeline with two attachments
 PASS Dynamically re-attaching
-FAIL Dynamically detaching assert_equals: expected "0px" but got "100px"
+FAIL Dynamically detaching assert_equals: expected "100px" but got "0px"
 FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
 PASS Ancestor attached element becoming display:none/block
 FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -103,6 +103,7 @@ private:
     Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> relatedTimelineScopeElements(const AtomString&);
     void attachPendingOperations();
     bool isPendingTimelineAttachment(const WebAnimation&) const;
+    void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
 
     Ref<Document> protectedDocument() const { return m_document.get(); }
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -122,28 +122,7 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
             keyframeEffect->setComposite(animation.compositeOperation());
     }
 
-    if (!m_overriddenProperties.contains(Property::Timeline)) {
-        ASSERT(owningElement());
-        Ref target = owningElement()->element;
-        Ref document = owningElement()->element.document();
-        WTF::switchOn(animation.timeline(),
-            [&] (Animation::TimelineKeyword keyword) {
-                setTimeline(keyword == Animation::TimelineKeyword::None ? nullptr : RefPtr { document->existingTimeline() });
-            }, [&] (const AtomString& name) {
-                CheckedRef timelinesController = document->ensureTimelinesController();
-                timelinesController->setTimelineForName(name, target, *this);
-            }, [&] (const Animation::AnonymousScrollTimeline& anonymousScrollTimeline) {
-                auto scrollTimeline = ScrollTimeline::create(anonymousScrollTimeline.scroller, anonymousScrollTimeline.axis);
-                scrollTimeline->setSource(target.ptr());
-                setTimeline(WTFMove(scrollTimeline));
-            }, [&] (const Animation::AnonymousViewTimeline& anonymousViewTimeline) {
-                auto insets = anonymousViewTimeline.insets;
-                auto viewTimeline = ViewTimeline::create(nullAtom(), anonymousViewTimeline.axis, WTFMove(insets));
-                viewTimeline->setSubject(target.ptr());
-                setTimeline(WTFMove(viewTimeline));
-            }
-        );
-    }
+    syncStyleOriginatedTimeline();
 
     if (!m_overriddenProperties.contains(Property::RangeStart))
         setRangeStart(animation.range().start);
@@ -159,6 +138,37 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
         else if (animation.playState() == AnimationPlayState::Paused && playState() == WebAnimation::PlayState::Running)
             pause();
     }
+
+    unsuspendEffectInvalidation();
+}
+
+void CSSAnimation::syncStyleOriginatedTimeline()
+{
+    if (m_overriddenProperties.contains(Property::Timeline) || !effect())
+        return;
+
+    suspendEffectInvalidation();
+
+    ASSERT(owningElement());
+    Ref target = owningElement()->element;
+    Ref document = owningElement()->element.document();
+    WTF::switchOn(backingAnimation().timeline(),
+        [&] (Animation::TimelineKeyword keyword) {
+            setTimeline(keyword == Animation::TimelineKeyword::None ? nullptr : RefPtr { document->existingTimeline() });
+        }, [&] (const AtomString& name) {
+            CheckedRef timelinesController = document->ensureTimelinesController();
+            timelinesController->setTimelineForName(name, target, *this);
+        }, [&] (const Animation::AnonymousScrollTimeline& anonymousScrollTimeline) {
+            auto scrollTimeline = ScrollTimeline::create(anonymousScrollTimeline.scroller, anonymousScrollTimeline.axis);
+            scrollTimeline->setSource(target.ptr());
+            setTimeline(WTFMove(scrollTimeline));
+        }, [&] (const Animation::AnonymousViewTimeline& anonymousViewTimeline) {
+            auto insets = anonymousViewTimeline.insets;
+            auto viewTimeline = ViewTimeline::create(nullAtom(), anonymousViewTimeline.axis, WTFMove(insets));
+            viewTimeline->setSubject(target.ptr());
+            setTimeline(WTFMove(viewTimeline));
+        }
+    );
 
     unsuspendEffectInvalidation();
 }

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -50,6 +50,8 @@ public:
     void keyframesRuleDidChange();
     void updateKeyframesIfNeeded(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
 
+    void syncStyleOriginatedTimeline();
+
 private:
     CSSAnimation(const Styleable&, const Animation&);
 


### PR DESCRIPTION
#### 4e5c6a773a47c29137395c835b78b69740529a7f
<pre>
[scroll-animations] CSS Animations should update their timeline if another element creates a timeline for that name
<a href="https://bugs.webkit.org/show_bug.cgi?id=286301">https://bugs.webkit.org/show_bug.cgi?id=286301</a>
<a href="https://rdar.apple.com/problem/143322856">rdar://problem/143322856</a>

Reviewed by Tim Nguyen.

In the case where an element sets a new `scroll-timeline-name` or `view-timeline-name` property to a value that
had previously been set on another element, we should make sure to update any CSS Animation that was created
with an `animation-timeline` value set to that very name.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::updateCSSAnimationsAssociatedWithNamedTimeline):
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
* Source/WebCore/animation/CSSAnimation.h:

Canonical link: <a href="https://commits.webkit.org/289226@main">https://commits.webkit.org/289226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3caba5430ee19437822f04507b53c37e64967fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36685 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66597 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32067 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92600 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13013 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9563 "Found 1 new test failure: swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75401 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74546 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5124 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13380 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18408 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->