### PR TITLE
AX: Add origin field in text marker for debugging

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -27,6 +27,19 @@
 #include "AccessibilityObject.h"
 #include <wtf/StdLibExtras.h>
 
+#define TEXT_MARKER_ASSERT(assertion) do { \
+    std::string debugString = "Text marker origin: " + originToString(origin()).utf8().toStdString(); \
+    RELEASE_ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
+} while (0)
+#define TEXT_MARKER_ASSERT_SINGLE(assertion, marker) do { \
+    std::string debugString = "Text marker origin: " + originToString(marker.origin()).utf8().toStdString(); \
+    RELEASE_ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
+} while (0)
+#define TEXT_MARKER_ASSERT_DOBULE(assertion, marker1, marker2) do { \
+    std::string debugString = "Text marker origins: " + originToString(marker1.origin()).utf8().toStdString() + ", " + originToString(marker2.origin()).utf8().data(); \
+    RELEASE_ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
+} while (0)
+
 namespace WebCore {
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -60,6 +73,62 @@ enum class SentenceRangeType : uint8_t {
     Right,
 };
 
+enum class TextMarkerOrigin : uint16_t {
+    Unknown, // 0
+    PreviousLineStart,
+    NextLineEnd,
+    NextWordStart,
+    NextWordEnd,
+    PreviousWordStart,
+    PreviousWordEnd,
+    PreviousSentenceStart,
+    NextSentenceEnd,
+    PreviousParagraphStart,
+    NextParagraphEnd // 10
+};
+
+inline String originToString(TextMarkerOrigin origin)
+{
+    String result;
+    switch (origin) {
+    case TextMarkerOrigin::PreviousLineStart:
+        result = "PreviousLineStart"_s;
+        break;
+    case TextMarkerOrigin::NextLineEnd:
+        result = "NextLineEnd"_s;
+        break;
+    case TextMarkerOrigin::NextWordStart:
+        result = "NextWordStart"_s;
+        break;
+    case TextMarkerOrigin::NextWordEnd:
+        result = "NextWordEnd"_s;
+        break;
+    case TextMarkerOrigin::PreviousWordStart:
+        result = "PreviousWordStart"_s;
+        break;
+    case TextMarkerOrigin::PreviousWordEnd:
+        result = "PreviousWordEnd"_s;
+        break;
+    case TextMarkerOrigin::PreviousSentenceStart:
+        result = "PreviousSentenceStart"_s;
+        break;
+    case TextMarkerOrigin::NextSentenceEnd:
+        result = "NextSentenceEnd"_s;
+        break;
+    case TextMarkerOrigin::PreviousParagraphStart:
+        result = "PreviousParagraphStart"_s;
+        break;
+    case TextMarkerOrigin::NextParagraphEnd:
+        result = "NextParagraphEnd"_s;
+        break;
+    default:
+        result = "Unknown"_s;
+        break;
+    }
+
+    return result;
+}
+
 // Options for findMarker
 enum class CoalesceObjectBreaks : bool { No, Yes };
 enum class IgnoreBRs : bool { No, Yes };
@@ -78,6 +147,8 @@ struct TextMarkerData {
     unsigned characterOffset;
     bool ignored;
 
+    TextMarkerOrigin origin;
+
     // Constructors of TextMarkerData must zero the struct's block of memory because platform client code may rely on a byte-comparison to determine instances equality.
     // Members initialization alone is not enough to guaranty that all bytes in the struct memeory are initialized, and may cause random inequalities when doing byte-comparisons.
     // For an example of such byte-comparison, see the TestRunner WTR::AccessibilityTextMarker::isEqual.
@@ -90,7 +161,7 @@ struct TextMarkerData {
         unsigned offsetParam = 0,
         Position::AnchorType anchorTypeParam = Position::PositionIsOffsetInAnchor,
         Affinity affinityParam = Affinity::Downstream,
-        unsigned charStart = 0, unsigned charOffset = 0, bool ignoredParam = false)
+        unsigned charStart = 0, unsigned charOffset = 0, bool ignoredParam = false, TextMarkerOrigin originParam = TextMarkerOrigin::Unknown)
     {
         zeroBytes(*this);
         treeID = axTreeID ? axTreeID->toUInt64() : 0;
@@ -101,6 +172,7 @@ struct TextMarkerData {
         characterStart = charStart;
         characterOffset = charOffset;
         ignored = ignoredParam;
+        origin = originParam;
     }
 
     TextMarkerData(AXObjectCache&, const VisiblePosition&, int charStart = 0, int charOffset = 0, bool ignoredParam = false);
@@ -143,11 +215,11 @@ public:
 #if PLATFORM(COCOA)
     AXTextMarker(PlatformTextMarkerData);
 #endif
-    AXTextMarker(std::optional<AXID> treeID, std::optional<AXID> objectID, unsigned offset)
-        : m_data({ treeID, objectID, offset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, offset })
+    AXTextMarker(std::optional<AXID> treeID, std::optional<AXID> objectID, unsigned offset, TextMarkerOrigin origin = TextMarkerOrigin::Unknown)
+        : m_data({ treeID, objectID, offset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, offset, false, origin })
     { }
-    AXTextMarker(const AXCoreObject& object, unsigned offset)
-        : m_data({ object.treeID(), object.objectID(), offset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, offset })
+    AXTextMarker(const AXCoreObject& object, unsigned offset, TextMarkerOrigin origin = TextMarkerOrigin::Unknown)
+        : m_data({ object.treeID(), object.objectID(), offset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, offset, false, origin })
     { }
 
     AXTextMarker() = default;
@@ -177,6 +249,7 @@ public:
     bool isIgnored() const { return m_data.ignored; }
 
     String debugDescription() const;
+    TextMarkerOrigin origin() const { return m_data.origin; }
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     AXTextMarker toTextRunMarker(std::optional<AXID> stopAtID = std::nullopt) const;


### PR DESCRIPTION
#### e951a24c3c217915c3e7bd28f931ab1e495873b6
<pre>
AX: Add origin field in text marker for debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=286308">https://bugs.webkit.org/show_bug.cgi?id=286308</a>
<a href="https://rdar.apple.com/problem/143331453">rdar://problem/143331453</a>

Reviewed by Chris Fleizach.

Accessibility text markers, which are produced by WebKit, are sent back
as parameters from AT when performing text operations. But, when we crash
with these passed-in parameters, it can be hard to discern where the issue
stems from, as we don&apos;t get information about what API generated a given
text marker.

To solve this, when we make text markers, let&apos;s store an origin, which can
be printed out in crashes and in debugging information.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineIndex const):
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::markerRangeForLineIndex const):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarker::findLine const):
(WebCore::AXTextMarker::findParagraph const):
(WebCore::AXTextMarker::findWordOrSentence const):
(WebCore::AXTextMarker::toTextRunMarker const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::originToString):
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::origin const):

Canonical link: <a href="https://commits.webkit.org/289223@main">https://commits.webkit.org/289223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4725747b2192a51720eb21fd758263c9ea320f36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66625 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24421 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46910 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35806 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92531 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75366 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18727 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17159 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/5491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18460 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->