### PR TITLE
Convert import-w3c-tests to use webkitscmpy

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -71,22 +71,18 @@ import itertools
 import json
 import logging
 import mimetypes
+from pathlib import Path
 
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
+from webkitscmpy.local.git import Git
 
 from webkitpy.common.host import Host
 from webkitpy.common.system.filesystem import FileSystem
-from webkitpy.common.system.executive import ScriptError
 from webkitpy.common.webkit_finder import WebKitFinder
-from webkitpy.port.factory import PortFactory
 from webkitpy.layout_tests.controllers.layout_test_finder_legacy import LayoutTestFinder
 from webkitpy.w3c.common import TEMPLATED_TEST_HEADER, WPT_GH_URL, WPTPaths
-from webkitpy.w3c.test_parser import TestParser
 from webkitpy.w3c.test_converter import convert_for_webkit
 from webkitpy.w3c.test_downloader import TestDownloader
+from webkitpy.w3c.test_parser import TestParser
 
 _log = logging.getLogger(__name__)
 
@@ -213,10 +209,9 @@ class TestImporter(object):
         if self.source_directory:
             source_path = str(Path(self.source_directory) / 'web-platform-tests')
             try:
-                git = self.test_downloader().git(source_path)
-                self.upstream_revision = git.rev_parse('HEAD')
-            except (OSError, ScriptError):
-                pass
+                self.upstream_revision = Git(source_path).find('HEAD').hash
+            except OSError:
+                self.upstream_revision = None
         else:
             _log.info('Downloading W3C test repositories')
             self.filesystem.maybe_make_directory(self.tests_download_path)


### PR DESCRIPTION
#### ef30fc3c07da4a6565b140d317f2cafe3fc4be0f
<pre>
Convert import-w3c-tests to use webkitscmpy
<a href="https://bugs.webkit.org/show_bug.cgi?id=286305">https://bugs.webkit.org/show_bug.cgi?id=286305</a>
<a href="https://rdar.apple.com/143329667">rdar://143329667</a>

Reviewed by Brianna Fan.

This gets us away from the largely unmaintained/deprecated
webkitpy.common.checkout.scm.

* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader.checkout_test_repository):
(TestDownloader.git): Deleted.
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.do_import):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
(TestImporterTest.import_directory):
This is now near identical to import_downloaded_tests, so just make it call that.
(TestImporterTest.import_downloaded_tests):
Use webkitscmpy mock to make everything work.

Canonical link: <a href="https://commits.webkit.org/294355@main">https://commits.webkit.org/294355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/277cc34d898837679a3fbb7b037c8a250e1cae02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75236 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32370 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55596 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/98312 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7222 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106323 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84201 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83699 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28348 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19636 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16525 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25878 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->