### PR TITLE
[iOS] Text may become unselected when moving selection handles past bidi text boundaries

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-4-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-4-expected.txt
@@ -1,0 +1,14 @@
+WebKit النص العربي يُكتب من اليمين إلى.
+
+Verifies that LTR text is not unselected when dragging a selection handle across a bidi boundary.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS isVisuallyContiguous is true
+PASS textRange.toString() is getSelection().toString()
+PASS selectionRects.length is 1
+PASS Math.abs(textWidth - selectionRects[0].width) is <= 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-4.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-4.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 18px;
+    font-family: system-ui;
+}
+
+.start {
+    color: tomato;
+}
+
+.paragraph {
+    direction: rtl;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that LTR text is not unselected when dragging a selection handle across a bidi boundary.");
+
+    const paragraph = document.querySelector(".paragraph");
+    textRange = document.createRange();
+    textRange.selectNodeContents(paragraph);
+    textWidth = textRange.getBoundingClientRect().width;
+
+    await UIHelper.longPressElement(document.querySelector(".start"));
+    await UIHelper.waitForSelectionToAppear();
+
+    const start = UIHelper.midPointOfRect(await UIHelper.getSelectionStartGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(start.x, start.y)
+        .move(start.x - textWidth, start.y, 0.8)
+        .end()
+        .takeResult());
+
+    selectionRects = await UIHelper.getUISelectionViewRects();
+    isVisuallyContiguous = await UIHelper.isSelectionVisuallyContiguous();
+
+    shouldBeTrue("isVisuallyContiguous");
+    shouldBe("textRange.toString()", "getSelection().toString()");
+    shouldBe("selectionRects.length", "1");
+    shouldBeLessThanOrEqual("Math.abs(textWidth - selectionRects[0].width)", "1");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p class="paragraph"><span class="start">WebKit</span> النص العربي يُكتب من اليمين إلى.</p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -167,6 +167,7 @@ enum class SelectionExtentMovement : uint8_t {
     Right,
 };
 void adjustVisibleExtentPreservingVisualContiguity(const VisiblePosition& base, VisiblePosition& extent, SelectionExtentMovement);
+WEBCORE_EXPORT bool crossesBidiTextBoundaryInSameLine(const VisiblePosition&, const VisiblePosition& other);
 
 // -------------------------------------------------------------------------
 // HTMLElement

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -284,6 +284,8 @@ void DragCaretController::setCaretPosition(const VisiblePosition& position)
 
 static void adjustEndpointsAtBidiBoundary(VisiblePosition& visibleBase, VisiblePosition& visibleExtent)
 {
+    // FIXME: Consider unifying with the logic in `adjustVisibleExtentPreservingVisualContiguity`, so that we
+    // expand the selection to the nearest range that maintains logical and visual contiguity.
     RenderedPosition base(visibleBase);
     RenderedPosition extent(visibleExtent);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7839,6 +7839,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_shouldRevealCurrentSelectionAfterInsertion = true;
     m_internals->lastLayerTreeTransactionIdAndPageScaleBeforeScalingPage = std::nullopt;
     m_lastSelectedReplacementRange = { };
+    m_bidiSelectionFlippingState = BidiSelectionFlippingState::NotFlipping;
 
     invokePendingSyntheticClickCallback(SyntheticClickResult::PageInvalid);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2793,8 +2793,15 @@ private:
     bool m_completingSyntheticClick { false };
     bool m_hasHandledSyntheticClick { false };
 
-    enum SelectionAnchor { Start, End };
-    SelectionAnchor m_selectionAnchor { Start };
+    enum class SelectionAnchor : bool { Start, End };
+    SelectionAnchor m_selectionAnchor { SelectionAnchor::Start };
+
+    enum class BidiSelectionFlippingState : uint8_t {
+        NotFlipping,
+        FlippingToStart,
+        FlippingToEnd
+    };
+    BidiSelectionFlippingState m_bidiSelectionFlippingState { BidiSelectionFlippingState::NotFlipping };
 
     RefPtr<WebCore::Node> m_potentialTapNode;
     WebCore::FloatPoint m_potentialTapLocation;


### PR DESCRIPTION
#### 6043720e6a29fb98f7a8d41967c9350ca803ec07
<pre>
[iOS] Text may become unselected when moving selection handles past bidi text boundaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=286313">https://bugs.webkit.org/show_bug.cgi?id=286313</a>
<a href="https://rdar.apple.com/143267253">rdar://143267253</a>

Reviewed by Abrar Rahman Protyasha, Megan Gardner, and Ryosuke Niwa.

Fix a bug when extending selection range endpoints across bidi text boundaries, which arises in the
following scenario:

-   The initial selection is fully contained inside bidi text (e.g. LTR text in an RTL paragraph or
    vice versa).

-   The user moves one of the range endpoints out of the bidi text run, such that it flips (i.e. the
    selection base and extent swap, in terms of logical order).

-   After the endpoints swap, the new selection base leaves the bidi text run, and previously
    selected bidi text becomes unselected.

This is due to a combination of two issues:

1.  When the selection flips, any in-flight calls to `WebPage::updateSelectionWithTouches` will
    still have the stale value of `baseIsStart`, which (often) causes us to adjust the new selection
    base instead of the new extent after the selection flips. To mitigate this, keep track of
    whether the selection is in the process of flipping with a new selection flipping state enum,
    and ignore calls to `WebPage::updateSelectionWithTouches` that arrive with an unexpected value
    for `baseIsStart`.

2.  When the selection flips due to crossing a bidi text boundary, we need to use the old selection
    extent as the new base rather than maintaining the previous selection base. This ensures that we
    update the selection to include all of the bidi text that&apos;s both logically and visually between
    the old base and the new extent.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-4-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-4.html: Added.

Add a layout test to exercise this corner case.

* Source/WebCore/editing/Editing.cpp:
(WebCore::forEachRenderedBoxBetween):

Adjust this helper, so that the callback returns an enum indicating whether iteration should end
early (see below).

(WebCore::boxWithMinimumBidiLevelBetween):
(WebCore::crossesBidiTextBoundaryInSameLine):

Add a helper to compute whether or not a bidi text boundary exists between two visible positions.
This is used below to determine whether the selection extent is flipping due to crossing a bidi text
boundary.

* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::adjustEndpointsAtBidiBoundary):

Add a FIXME here about unifying existing behavior to adjust the selection at bidi endpoints on
macOS, with this new (currently iOS-only) behavior of expanding the range to the nearest visually-
and logically-contiguous range.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Drive-by refactoring: make `SelectionAnchor` an 8-bit enum class.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::rangeForPointInRootViewCoordinates):

Implement the main fixes here. See description above for more details.

(WebKit::WebPage::updateSelectionWithTouches):
(WebKit::WebPage::setSelectionRange):
(WebKit::WebPage::beginSelectionInDirection):
(WebKit::WebPage::updateSelectionWithExtentPoint):

Canonical link: <a href="https://commits.webkit.org/289217@main">https://commits.webkit.org/289217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b64d2d44f320d03ebacd582ab674f90bc806439e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90886 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/36790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13496 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/36790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88870 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46942 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32177 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35867 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92606 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13127 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18378 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17212 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13158 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/12938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/16363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/14725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->