### PR TITLE
Track opt-in cookie partitioning state in WebCookieCache instead of WebProcess

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1934,7 +1934,7 @@ void WebsiteDataStore::propagateSettingUpdates()
             webProcess->setOptInCookiePartitioningEnabled(enabled);
 
         if (m_isOptInCookiePartitioningEnabled && m_thirdPartyCookieBlockingMode == WebCore::ThirdPartyCookieBlockingMode::All) {
-            RELEASE_LOG(Storage, "WebsiteDataStore::propagateSettingUpdates (%p) sessionID=%" PRIu64 ", OptInCookiePartitioning enabled, setting ThirdPartyCookieBlockingMode::AllExceptPartitioned" PRIu64, this, m_sessionID.toUInt64());
+            RELEASE_LOG(Storage, "WebsiteDataStore::propagateSettingUpdates (%p) sessionID=%" PRIu64 ", OptInCookiePartitioning enabled, setting ThirdPartyCookieBlockingMode::AllExceptPartitioned", this, m_sessionID.toUInt64());
             setThirdPartyCookieBlockingMode(WebCore::ThirdPartyCookieBlockingMode::AllExceptPartitioned, []() { });
         } else if (!m_isOptInCookiePartitioningEnabled && m_thirdPartyCookieBlockingMode == WebCore::ThirdPartyCookieBlockingMode::AllExceptPartitioned) {
             RELEASE_LOG(Storage, "WebsiteDataStore::propagateSettingUpdates (%p) sessionID=%" PRIu64 ", OptInCookiePartitioning disabled, setting ThirdPartyCookieBlockingMode::All", this, m_sessionID.toUInt64());

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
@@ -44,7 +44,7 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
         auto cookieStorage = adoptCF(_CFURLStorageSessionCopyCookieStorage(kCFAllocatorDefault, storageSession.get()));
         m_inMemoryStorageSession = makeUnique<NetworkStorageSession>(WebProcess::singleton().sessionID(), WTFMove(storageSession), WTFMove(cookieStorage), NetworkStorageSession::IsInMemoryCookieStore::Yes);
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
-        setOptInCookiePartitioningEnabled(WebProcess::singleton().isOptInCookiePartitioningEnabled());
+        m_inMemoryStorageSession->setOptInCookiePartitioningEnabled(m_optInCookiePartitioningEnabled);
 #endif
     }
     return *m_inMemoryStorageSession;
@@ -53,7 +53,9 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
 void WebCookieCache::setOptInCookiePartitioningEnabled(bool enabled)
 {
-    inMemoryStorageSession().setOptInCookiePartitioningEnabled(enabled);
+    m_optInCookiePartitioningEnabled = enabled;
+    if (m_inMemoryStorageSession)
+        m_inMemoryStorageSession->setOptInCookiePartitioningEnabled(enabled);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -74,6 +74,9 @@ private:
 
     HashSet<String> m_hostsWithInMemoryStorage;
     std::unique_ptr<WebCore::NetworkStorageSession> m_inMemoryStorageSession;
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    bool m_optInCookiePartitioningEnabled { false };
+#endif
 
     PendingCookieUpdateCounter m_pendingCookieUpdateCounter;
 };

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -706,7 +706,7 @@ void WebProcess::setWebsiteDataStoreParameters(WebProcessDataStoreParameters&& p
     ensureNetworkProcessConnection();
 
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
-    m_cookieJar->setOptInCookiePartitioningEnabled(parameters.isOptInCookiePartitioningEnabled);
+    setOptInCookiePartitioningEnabled(parameters.isOptInCookiePartitioningEnabled);
 #endif
 }
 
@@ -2011,7 +2011,6 @@ void WebProcess::setEnabledServices(bool hasImageServices, bool hasSelectionServ
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
 void WebProcess::setOptInCookiePartitioningEnabled(bool enabled)
 {
-    m_isOptInCookiePartitioningEnabled = enabled;
     m_cookieJar->setOptInCookiePartitioningEnabled(enabled);
 }
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -491,10 +491,6 @@ public:
     void registerAdditionalFonts(AdditionalFonts&&);
 #endif
 
-#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
-    bool isOptInCookiePartitioningEnabled() { return m_isOptInCookiePartitioningEnabled; }
-#endif
-
 private:
     WebProcess();
     ~WebProcess();
@@ -900,9 +896,6 @@ private:
     bool m_isWebTransportEnabled { false };
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
     bool m_prefersNonBlinkingCursor { false };
-#endif
-#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
-    bool m_isOptInCookiePartitioningEnabled { false };
 #endif
 
     String m_mediaKeysStorageDirectory;


### PR DESCRIPTION
#### bf6f72a73c90287ceff2d5db7f5efe025f82a6b9
<pre>
Track opt-in cookie partitioning state in WebCookieCache instead of WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=286316">https://bugs.webkit.org/show_bug.cgi?id=286316</a>
<a href="https://rdar.apple.com/143052569">rdar://143052569</a>

Reviewed by Alex Christensen.

This is a bit of clean up and improvement for how the opt-in cookie
partitioniong state is tracked. This patch moves the state from the WebProcess
into the WebCookieCache. If the cache does not currently exist, then we simply
save it but we don&apos;t instatiate the cache.

This patch also fixes a small format string bug in a log entry.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::propagateSettingUpdates):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm:
(WebKit::WebCookieCache::inMemoryStorageSession):
(WebKit::WebCookieCache::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setWebsiteDataStoreParameters):
(WebKit::WebProcess::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/289310@main">https://commits.webkit.org/289310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4fc6e7da26807a71ceaba2732d5199d4b3065de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37162 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24666 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4491 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93097 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75668 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74848 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19104 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17497 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13440 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18876 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16783 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->