### PR TITLE
Introduce WTF::print()

### DIFF
--- a/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
+++ b/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
@@ -30,6 +30,7 @@
 #include "InitializeThreading.h"
 #include "JavaScript.h"
 #include "Options.h"
+#include <wtf/Print.h>
 
 using JSC::Options;
 
@@ -83,9 +84,7 @@ int testFunctionOverrides()
     JSC::Options::functionOverrides() = oldFunctionOverrides;
     JSC::FunctionOverrides::reinstallOverrides();
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("%s: function override tests.\n", failed ? "FAIL" : "PASS");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    print("{}: function override tests.\n", failed ? "FAIL" : "PASS");
 
     return failed;
 }

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1470EAF32BD6F6D900E26254 /* WeakPtrImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF22BD6F6D900E26254 /* WeakPtrImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1470EAF52BD6F8AF00E26254 /* WeakPtrFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF42BD6F8AF00E26254 /* WeakPtrFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1470EAF72BD6FB3F00E26254 /* CanMakeWeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 1470EAF62BD6FB3F00E26254 /* CanMakeWeakPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		14E9EB432D3F09B3006D6706 /* Print.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E9EB422D3F09B3006D6706 /* Print.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A1D8B9E1731879800141DA4 /* FunctionDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A1D8B9D1731879800141DA4 /* FunctionDispatcher.cpp */; };
 		1C08E3682985D8F300CAE594 /* IOReturnSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C08E3662985D7D300CAE594 /* IOReturnSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C08E3692985D8F800CAE594 /* IOTypesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C08E3672985D7D400CAE594 /* IOTypesSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1157,6 +1158,7 @@
 		1470EAF62BD6FB3F00E26254 /* CanMakeWeakPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanMakeWeakPtr.h; sourceTree = "<group>"; };
 		149EF16216BBFE0D000A4331 /* TriState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TriState.h; sourceTree = "<group>"; };
 		14E785E71DFB330100209BD1 /* OrdinalNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrdinalNumber.h; sourceTree = "<group>"; };
+		14E9EB422D3F09B3006D6706 /* Print.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Print.h; path = wtf/Print.h; sourceTree = "<group>"; };
 		14F3B0F615E45E4600210069 /* SaturatedArithmetic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SaturatedArithmetic.h; sourceTree = "<group>"; };
 		1A1D8B9B173186CE00141DA4 /* FunctionDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FunctionDispatcher.h; sourceTree = "<group>"; };
 		1A1D8B9D1731879800141DA4 /* FunctionDispatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FunctionDispatcher.cpp; sourceTree = "<group>"; };
@@ -2048,6 +2050,7 @@
 				1404B3E42CBC954D00A7471C /* AbstractRefCountedAndCanMakeWeakPtr.h */,
 				144EB7452CBC94B100926E1B /* AbstractRefCounted.h */,
 				140ECC352C9906DF00473E19 /* RefCountedAndCanMakeWeakPtr.h */,
+				14E9EB422D3F09B3006D6706 /* Print.h */,
 				5D247B6D14689C4700E78B76 /* Configurations */,
 				DDE9931F278D0FAA00F60D26 /* Frameworks */,
 				5D247B6314689B8600E78B76 /* Products */,
@@ -3548,6 +3551,7 @@
 				FFE39CAC2B1D7472004972B0 /* policy.h in Headers */,
 				FFE39CB22B1D7472004972B0 /* policy_holder.h in Headers */,
 				8AB05DFC2C99482E00738BDD /* PreciseSum.h in Headers */,
+				14E9EB432D3F09B3006D6706 /* Print.h in Headers */,
 				DD3DC93227A4BF8E007E5B61 /* PrintStream.h in Headers */,
 				DD3DC95027A4BF8E007E5B61 /* PriorityQueue.h in Headers */,
 				DD3DC89927A4BF8E007E5B61 /* ProcessID.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -229,6 +229,7 @@ set(WTF_PUBLIC_HEADERS
     PointerComparison.h
     PointerPreparations.h
     PreciseSum.h
+    Print.h
     PrintStream.h
     PriorityQueue.h
     ProcessID.h

--- a/Source/WTF/wtf/Print.h
+++ b/Source/WTF/wtf/Print.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include <format>
+#include <iostream>
+
+template <size_t Extent>
+struct std::formatter<std::span<const LChar, Extent>> : std::formatter<std::string_view> {
+    auto format(const std::span<const LChar, Extent>& span, std::format_context& ctx) const
+    {
+        auto charSpan = spanReinterpretCast<const char>(span);
+        return std::formatter<string_view>::format(std::string_view(charSpan.begin(), charSpan.end()), ctx);
+    }
+};
+
+namespace WTF {
+
+inline constexpr void checkForCharPointers()
+{
+}
+
+template<typename Arg>
+inline constexpr void checkForCharPointers(Arg&&)
+{
+    static_assert(!std::is_pointer_v<Arg> || !std::is_same_v<std::remove_cv_t<std::remove_pointer_t<Arg>>, char>, "char* is not bounds safe");
+}
+
+template<typename Arg, typename... Args>
+inline constexpr void checkForCharPointers(Arg&& arg, Args&&...args)
+{
+    checkForCharPointers(arg);
+    checkForCharPointers(std::forward<Args>(args)...);
+}
+
+template<typename... Args>
+void print(const std::format_string<Args...> message, Args&&...args)
+{
+    checkForCharPointers(args...);
+    std::cout << std::format(message, std::forward<Args>(args)...);
+}
+
+} // namespace WTF
+
+using WTF::print;

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -35,6 +35,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/Print.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UUID.h>
@@ -900,9 +901,7 @@ bool protocolIs(StringView string, ASCIILiteral protocol)
 
 void URL::print() const
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("%s\n", m_string.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    WTF::print("{}\n", m_string.utf8().span());
 }
 
 #endif


### PR DESCRIPTION
#### 11d1fa64dfb4bb8f0179bbe8fb2eb55096f76553
<pre>
Introduce WTF::print()
<a href="https://bugs.webkit.org/show_bug.cgi?id=286323">https://bugs.webkit.org/show_bug.cgi?id=286323</a>
<a href="https://rdar.apple.com/143346641">rdar://143346641</a>

Reviewed by NOBODY (OOPS!).

printf() is not bounds safe because:
* printf() assumes %s arguments are null-terminated, but there’s no way to
  verify that;
* when a wrapper function invokes printf(), there’s no way to check whether the
  arguments match the format string. [1]

This patch introduces WTF::print(), a bounds-safe alternative to printf(), based
on std::format() [2].

A future patch will add WTF::printTo(), a bounds-safe alternative to sprintf().

This patch includes support for string literals and span&lt;LChar&gt;. We can add
CString, String, etc. in future patches if we like -- but note that existing
printf code does not pass through those types because printf never supported them.

[1] Even if you follow best practices and use the __format__(printf) attribute,
the compiler can only check the arguments + format string passed to the
wrapper. It can’t check the arguments + format string after the wrapper
transforms them. We have 53 such wrappers in WebKit today, including some that
use inheritance.

[2] Though it was designed for compile-time safety checking, std::format bizarrely
assumes without verification that char* is null-terminated. WTF::print() closes
that hole by treating char* as an error. In contrast, string literals are safe
because their type before decay is char[size_t], not char*, and the stdlib
rejects char[0], avoiding buffer underflow when subtracting out the null terminator.

* Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp:
(testFunctionOverrides):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/URL.cpp:
(WTF::URL::print const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11d1fa64dfb4bb8f0179bbe8fb2eb55096f76553

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85829 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5470 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40210 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36768 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5701 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13472 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4363 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/40210 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4223 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/40210 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35845 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78794 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74870 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/40210 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92580 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84778 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13105 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/13472 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75395 "Found 66 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/hidpi/filters-drop-shadow.html fast/hidpi/hidpi-form-controls-drawing-size.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13315 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/40210 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74540 "Found 102 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.Find, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/image, /TestWebKit:WebKit.UserMediaBasic ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18754 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/40210 "Hash 11d1fa64 for PR 39343 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6002 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18485 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107186 "Hash 11d1fa64 for PR 39343 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12913 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/107186 "Hash 11d1fa64 for PR 39343 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->