### PR TITLE
nullptr crash | WebCore::isScriptElement; WebCore::SVGAnimatedString::setBaseVal;

### DIFF
--- a/LayoutTests/svg/dom/SVGAnimatedString-detached-set-baseVal-expected.txt
+++ b/LayoutTests/svg/dom/SVGAnimatedString-detached-set-baseVal-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+PASS

--- a/LayoutTests/svg/dom/SVGAnimatedString-detached-set-baseVal.html
+++ b/LayoutTests/svg/dom/SVGAnimatedString-detached-set-baseVal.html
@@ -1,0 +1,17 @@
+<p>This test passes if it doesn't crash.</p>
+<script>
+if (testRunner)
+    testRunner.dumpAsText();
+
+let animatedString = (() => {
+    return (new Document).createElementNS('http://www.w3.org/2000/svg', 'text').className;
+})();
+
+if (window.GCController)
+    GCController.collect();
+
+animatedString.baseVal = 'foo';
+let newValue = animatedString.baseVal;
+document.write(newValue == 'foo' ? 'PASS' : `FAIL - ${newValue}`);
+
+</script>

--- a/Source/WebCore/svg/properties/SVGAnimatedString.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimatedString.cpp
@@ -37,7 +37,7 @@ ExceptionOr<void> SVGAnimatedString::setBaseVal(const StringOrTrustedScriptURL& 
     auto stringValueHolder = WTF::switchOn(baseVal,
         [&](const String& str) -> ExceptionOr<String> {
             SVGElement* el = contextElement();
-            if (isScriptElement(*el) && m_isHrefProperty == IsHrefProperty::Yes)
+            if (el && isScriptElement(*el) && m_isHrefProperty == IsHrefProperty::Yes)
                 return trustedTypeCompliantString(TrustedType::TrustedScriptURL, *(contextElement()->document().scriptExecutionContext()), str, "SVGScriptElement href"_s);
             return String(str);
         },


### PR DESCRIPTION
#### a722b348044c8a77e81521b47bbd72b1b87a5410
<pre>
nullptr crash | WebCore::isScriptElement; WebCore::SVGAnimatedString::setBaseVal;
<a href="https://bugs.webkit.org/show_bug.cgi?id=286307">https://bugs.webkit.org/show_bug.cgi?id=286307</a>
<a href="https://rdar.apple.com/141021945">rdar://141021945</a>

Reviewed by Ryosuke Niwa.

Adding a null check on the element before passing it in isScriptElement in SVGAnimatedString::setBaseVal().

* Source/WebCore/svg/properties/SVGAnimatedString.cpp:
(WebCore::SVGAnimatedString::setBaseVal):

Canonical link: <a href="https://commits.webkit.org/289221@main">https://commits.webkit.org/289221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d458d1259c6003722e8858b2aa058974681408b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36780 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66648 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35857 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92593 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9616 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75398 "Found 63 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html fast/multicol/columns-on-body.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74543 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18758 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17196 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18507 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14712 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->