### PR TITLE
[scroll-animations] Removing element should null out related timelines on existing animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -5,8 +5,8 @@ PASS Inner timeline does not interfere with outer timeline
 FAIL Deferred timeline with two attachments assert_equals: expected "0px" but got "100px"
 PASS Dynamically re-attaching
 FAIL Dynamically detaching assert_equals: expected "0px" but got "100px"
-FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
-PASS Ancestor attached element becoming display:none/block
+FAIL Removing/inserting element with attaching timeline assert_equals: expected "100px" but got "0px"
+FAIL Ancestor attached element becoming display:none/block assert_equals: expected "0px" but got "100px"
 FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
 PASS Animations prefer non-deferred timelines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
@@ -2,5 +2,5 @@
 FAIL Dynamically changing view-timeline attachment assert_equals: ambiguous expected "-1" but got "75"
 FAIL Dynamically changing view-timeline-axis assert_equals: horizontal expected "10" but got "25"
 FAIL Dynamically changing view-timeline-inset assert_equals: with inset expected "0" but got "25"
-PASS Element with scoped view-timeline becoming display:none
+FAIL Element with scoped view-timeline becoming display:none assert_equals: display:none expected "-1" but got "25"
 


### PR DESCRIPTION
#### cb340c6cddd727e2eabf365bb50c19c9df8bf490
<pre>
[scroll-animations] Removing element should null out related timelines on existing animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=286328">https://bugs.webkit.org/show_bug.cgi?id=286328</a>
<a href="https://rdar.apple.com/143352487">rdar://143352487</a>

Reviewed by NOBODY (OOPS!).

For the &quot;Removing/inserting element with attaching timeline&quot; subtest of css/timeline-scope.html,
an element with an associated named timeline is removed from the dom, which should result in the
animation attached to the associated timeline to become null. This progresses one part of the subtest,
but is still failing due to an issue where attaching to a new timeline doesn&apos;t add the associated effect
to the KeyframeEffectStack because the animation isn&apos;t considered relevant (this affects another subtest
as well).

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb340c6cddd727e2eabf365bb50c19c9df8bf490

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66671 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88914 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4415 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77928 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46961 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35900 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92645 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75427 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74575 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17238 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6042 "Failed to checkout and rebase branch from PR 39352") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13193 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18541 "Failed to checkout and rebase branch from PR 39352") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12966 "Failed to checkout and rebase branch from PR 39352") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16399 "Failed to checkout and rebase branch from PR 39352") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14753 "Failed to checkout and rebase branch from PR 39352") | | | 
<!--EWS-Status-Bubble-End-->