### PR TITLE
[scroll-animations] Add logging for named timelines

### DIFF
--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -425,6 +425,8 @@ void AnimationTimelinesController::updateTimelineForTimelineScope(const Ref<Scro
 
 void AnimationTimelinesController::registerNamedScrollTimeline(const AtomString& name, const Element& source, ScrollAxis axis)
 {
+    LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::registerNamedScrollTimeline: " << name << " source: " << source);
+
     auto& timelines = timelinesForName(name);
 
     auto existingTimelineIndex = timelines.findIf([&](auto& timeline) {
@@ -484,6 +486,8 @@ void AnimationTimelinesController::attachPendingOperations()
 
 void AnimationTimelinesController::registerNamedViewTimeline(const AtomString& name, const Element& subject, ScrollAxis axis, ViewTimelineInsets&& insets)
 {
+    LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::registerNamedViewTimeline: " << name << " subject: " << subject);
+
     auto& timelines = timelinesForName(name);
 
     auto existingTimelineIndex = timelines.findIf([&](auto& timeline) {
@@ -512,6 +516,8 @@ void AnimationTimelinesController::registerNamedViewTimeline(const AtomString& n
 
 void AnimationTimelinesController::unregisterNamedTimeline(const AtomString& name, const Element& element)
 {
+    LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::unregisterNamedTimeline: " << name << " element: " << element);
+
     auto it = m_nameToTimelineMap.find(name);
     if (it == m_nameToTimelineMap.end())
         return;
@@ -540,6 +546,8 @@ void AnimationTimelinesController::unregisterNamedTimeline(const AtomString& nam
 
 void AnimationTimelinesController::setTimelineForName(const AtomString& name, const Element& element, WebAnimation& animation)
 {
+    LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::setTimelineForName: " << name << " element: " << element);
+
     auto it = m_nameToTimelineMap.find(name);
     if (it == m_nameToTimelineMap.end()) {
         m_pendingAttachOperations.append({ element, name, animation });
@@ -548,6 +556,7 @@ void AnimationTimelinesController::setTimelineForName(const AtomString& name, co
 
     auto& timelines = it->value;
     if (RefPtr timeline = determineTimelineForElement(timelines, element, relatedTimelineScopeElements(name))) {
+        LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::setTimelineForName: " << name << " element: " << element << " attaching to timeline of element: " << *originatingElement(*timeline));
         animation.setTimeline(WTFMove(timeline));
         return;
     }
@@ -610,6 +619,8 @@ bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimatio
 
 void AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement(const Element& element)
 {
+    LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement element: " << element);
+
     UncheckedKeyHashSet<AtomString> namesToClear;
 
     for (auto& entry : m_nameToTimelineMap) {


### PR DESCRIPTION
#### 46cc61dd8e4229a2341e38098d40f2b904f6d0de
<pre>
[scroll-animations] Add logging for named timelines
<a href="https://bugs.webkit.org/show_bug.cgi?id=286331">https://bugs.webkit.org/show_bug.cgi?id=286331</a>
<a href="https://rdar.apple.com/143355658">rdar://143355658</a>

Reviewed by Antoine Quint.

Add logging around named scroll/view timelines.

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
(WebCore::AnimationTimelinesController::unregisterNamedTimeline):
(WebCore::AnimationTimelinesController::setTimelineForName):
(WebCore::AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement):

Canonical link: <a href="https://commits.webkit.org/289242@main">https://commits.webkit.org/289242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b7341f40101da94e8a9cc6e028ccd3d23cf8787

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66658 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24455 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4389 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46948 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32175 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92686 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9640 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75452 "Found 58 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html fast/multicol/columns-on-body.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74604 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18776 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13389 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18522 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->