### PR TITLE
[CSS] Fix error recovery of invalid content in block

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-error-recovery-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-error-recovery-expected.txt
@@ -1,0 +1,6 @@
+
+PASS CSS Nesting: Error recovery
+PASS CSS Nesting: Error recovery 1
+PASS CSS Nesting: Error recovery 2
+PASS CSS Nesting: Error recovery 3
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-error-recovery.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-error-recovery.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<title>CSS Nesting: Error recovery</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  html {
+    z-index: 0;
+
+    error3234 {**** ::}
+    
+    #test1 {
+      @media screen {
+        z-index: 1;
+      }
+    }
+
+    { whatever }
+
+    :doesntexist {z-index: 9;}
+
+    #test2 {
+      z-index: 2;   
+    }   
+
+    #test3 {
+      z-index: 3;
+      @media screen {
+        error3234;
+        { foo }
+        z-index:4;
+      }
+      { foo }
+      z-index: 5;
+    }
+
+  }
+</style>
+
+<div id=test1></div>
+<div id=test2></div>
+<div id=test3></div>
+
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(document.documentElement).zIndex, '0');
+  });
+  test(() => {
+    assert_equals(getComputedStyle(document.getElementById("test1")).zIndex, '1');
+  });
+  test(() => {
+    assert_equals(getComputedStyle(document.getElementById("test2")).zIndex, '2');
+  });
+  test(() => {
+    assert_equals(getComputedStyle(document.getElementById("test3")).zIndex, '5');
+  });
+</script>


### PR DESCRIPTION
#### ae311f82a32c766b6cc28a4761a7a6e9a153bca9
<pre>
[CSS] Fix error recovery of invalid content in block
<a href="https://bugs.webkit.org/show_bug.cgi?id=285114">https://bugs.webkit.org/show_bug.cgi?id=285114</a>
<a href="https://rdar.apple.com/142187930">rdar://142187930</a>

Reviewed by Antti Koivisto.

<a href="https://drafts.csswg.org/css-syntax/#block-contents">https://drafts.csswg.org/css-syntax/#block-contents</a>

While parsing invalid content inside a block,
we use qualified rule error recovery.
For the more specific case that the block is a &lt;declaration-list&gt;,
we use the &quot;consume until semicolon&quot; error recovery.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-error-recovery-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nested-error-recovery.html: Added.
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeBlockContent):

Canonical link: <a href="https://commits.webkit.org/289429@main">https://commits.webkit.org/289429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d9900cd69b7668b7f38b81881aa0a571c11d9da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66784 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24578 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89120 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4560 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32381 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93003 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13361 "Failed to compile WebKit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75622 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13578 "Failed to compile WebKit") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74798 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13394 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18722 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13162 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16594 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->