### PR TITLE
[Site Isolation] Creating an iframe while updating the history state of its parent causes a new back/forward item to be created

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/add-iframe-while-changing-document-title-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframe-while-changing-document-title-expected.txt
@@ -1,0 +1,11 @@
+Verifies that adding an iframe while changing the document title does not increase history.length
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'onload'
+PASS history.length is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/add-iframe-while-changing-document-title.html
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframe-while-changing-document-title.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that adding an iframe while changing the document title does not increase history.length");
+jsTestIsAsync = true;
+
+let title = true;
+function changeTitle() {
+    document.title = title ? "a" : "b";
+    title = !title;
+}
+
+onmessage = (event) => {
+    shouldBe("event.data", "'onload'");
+    shouldBe("history.length", "1");
+    finishJSTest();
+}
+
+onload = async () => {
+    await testRunner?.clearBackForwardList();
+
+    setInterval(changeTitle, 10);
+
+    const iframe = document.createElement('iframe');
+    iframe.src = 'http://localhost:8000/site-isolation/resources/post-message-from-child-to-parent.html';
+    document.body.appendChild(iframe);
+}
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-from-child-to-parent.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-from-child-to-parent.html
@@ -1,0 +1,6 @@
+<script>
+onmessage = (event) => {
+    window.parent.postMessage(event.data, "*");
+}
+</script>
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/green-background.html"></iframe>

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -354,7 +354,7 @@ const Vector<Ref<HistoryItem>>& HistoryItem::children() const
 void HistoryItem::clearChildren()
 {
     m_children.clear();
-    notifyChanged();
+    m_client->clearChildren(*this);
 }
 
 // We do same-document navigation if going to a different item and if either of the following is true:

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -66,6 +66,7 @@ class HistoryItemClient : public RefCounted<HistoryItemClient> {
 public:
     virtual ~HistoryItemClient() = default;
     virtual void historyItemChanged(const HistoryItem&) = 0;
+    virtual void clearChildren(const HistoryItem&) const = 0;
 protected:
     HistoryItemClient() = default;
 };

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1166,6 +1166,7 @@ public:
     static Ref<EmptyHistoryItemClient> create() { return adoptRef(*new EmptyHistoryItemClient); }
 private:
     void historyItemChanged(const HistoryItem&) { }
+    void clearChildren(const HistoryItem&) const { }
 };
 
 PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier> identifier, PAL::SessionID sessionID)

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -141,12 +141,8 @@ void WebBackForwardListFrameItem::setWasRestoredFromSession()
 
 void WebBackForwardListFrameItem::setFrameState(Ref<FrameState>&& frameState)
 {
-    m_children.clear();
     m_frameState = WTFMove(frameState);
-
-    ASSERT(m_backForwardListItem);
-    for (auto& childFrameState : std::exchange(m_frameState->children, { }))
-        m_children.append(WebBackForwardListFrameItem::create(*protectedBackForwardListItem(), this, WTFMove(childFrameState)));
+    m_frameState->children.clear();
 }
 
 Ref<FrameState> WebBackForwardListFrameItem::copyFrameStateWithChildren()

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -66,6 +66,7 @@ public:
     RefPtr<WebBackForwardListItem> protectedBackForwardListItem() const;
 
     void setChild(Ref<FrameState>&&);
+    void clearChildren() { m_children.clear(); }
 
     void setWasRestoredFromSession();
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9424,6 +9424,12 @@ void WebPageProxy::backForwardSetChildItem(BackForwardFrameItemIdentifier frameI
         frameItem->setChild(WTFMove(frameState));
 }
 
+void WebPageProxy::backForwardClearChildren(BackForwardItemIdentifier itemID, BackForwardFrameItemIdentifier frameItemID)
+{
+    if (RefPtr frameItem = WebBackForwardListFrameItem::itemForID(itemID, frameItemID))
+        frameItem->clearChildren();
+}
+
 void WebPageProxy::backForwardUpdateItem(IPC::Connection& connection, Ref<FrameState>&& frameState)
 {
     RefPtr frameItem = frameState->itemID && frameState->frameItemID ? WebBackForwardListFrameItem::itemForID(*frameState->itemID, *frameState->frameItemID) : nullptr;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2862,6 +2862,7 @@ private:
     // Back/Forward list management
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);
     void backForwardSetChildItem(WebCore::BackForwardFrameItemIdentifier, Ref<FrameState>&&);
+    void backForwardClearChildren(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
     void backForwardGoToItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardListContainsItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(bool)>&&);
     void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(RefPtr<FrameState>&&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -207,6 +207,7 @@ messages -> WebPageProxy {
     # BackForward messages
     BackForwardAddItem(Ref<WebKit::FrameState> navigatedFrameState)
     BackForwardSetChildItem(WebCore::BackForwardFrameItemIdentifier frameItemID, Ref<WebKit::FrameState> frameState)
+    BackForwardClearChildren(WebCore::BackForwardItemIdentifier itemID, WebCore::BackForwardFrameItemIdentifier frameItemID)
     BackForwardUpdateItem(Ref<WebKit::FrameState> frameState)
     BackForwardGoToItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardItemAtIndex(int32_t itemIndex, WebCore::FrameIdentifier frameID) -> (RefPtr<WebKit::FrameState> frameState) Synchronous

--- a/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp
@@ -55,4 +55,11 @@ void WebHistoryItemClient::historyItemChanged(const WebCore::HistoryItem& item)
     m_page->send(Messages::WebPageProxy::BackForwardUpdateItem(toFrameState(item)));
 }
 
+void WebHistoryItemClient::clearChildren(const WebCore::HistoryItem& item) const
+{
+    if (m_shouldIgnoreChanges)
+        return;
+    m_page->send(Messages::WebPageProxy::BackForwardClearChildren(item.itemID(), item.frameItemID()));
+}
+
 }

--- a/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h
+++ b/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h
@@ -41,6 +41,7 @@ public:
 private:
     explicit WebHistoryItemClient(WebPage&);
     void historyItemChanged(const WebCore::HistoryItem&) final;
+    void clearChildren(const WebCore::HistoryItem&) const final;
 
     const WeakRef<WebPage> m_page;
     bool m_shouldIgnoreChanges { false };

--- a/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.h
@@ -33,4 +33,5 @@ public:
 private:
     LegacyHistoryItemClient() = default;
     void historyItemChanged(const WebCore::HistoryItem&) final;
+    void clearChildren(const WebCore::HistoryItem&) const final;
 };

--- a/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.mm
@@ -37,3 +37,8 @@ void LegacyHistoryItemClient::historyItemChanged(const WebCore::HistoryItem&)
 {
     WKNotifyHistoryItemChanged();
 }
+
+void LegacyHistoryItemClient::clearChildren(const WebCore::HistoryItem&) const
+{
+    WKNotifyHistoryItemChanged();
+}


### PR DESCRIPTION
#### cbb8b220c0f1f1ceaf9bac84eafc71dc87f2fc46
<pre>
[Site Isolation] Creating an iframe while updating the history state of its parent causes a new back/forward item to be created
<a href="https://bugs.webkit.org/show_bug.cgi?id=286334">https://bugs.webkit.org/show_bug.cgi?id=286334</a>
<a href="https://rdar.apple.com/143359188">rdar://143359188</a>

Reviewed by Alex Christensen.

When a root child frame expects its initial history state to be committed, we store a
WebBackForwardListFrameItem on its WebFrameProxy and add a child to it when the history item is
committed. If the WebBackForwardListFrameItem is destroyed before the item is committed, a new item is
added to the back-forward list instead of adding a frame to the existing item.

To fix this, we should stop destroying children in WebBackForwardListFrameItem::setFrameState.
BackForwardUpdateItem should update only its own state, and there should be a separate, explicit message
for clearing history item children.

* LayoutTests/http/tests/site-isolation/history/add-iframe-while-changing-document-title-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/add-iframe-while-changing-document-title.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-from-child-to-parent.html: Added.
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::clearChildren):
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::setFrameState):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::clearChildren):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardClearChildren):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp:
(WebKit::WebHistoryItemClient::clearChildren const):
* Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/LegacyHistoryItemClient.mm:
(LegacyHistoryItemClient::clearChildren const):

Canonical link: <a href="https://commits.webkit.org/289228@main">https://commits.webkit.org/289228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd5672e07fbb296bf39d9d7d7c9f12151d368ff3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66668 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32191 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35893 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92671 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13151 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74592 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18788 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17228 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13381 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13182 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/12959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/16392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/14746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->