### PR TITLE
Reduce use of atoi() in the codebase

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -143,6 +143,7 @@
 #include <wtf/SystemTracing.h>
 #include <wtf/Threading.h>
 #include <wtf/text/AtomStringTable.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 #if ENABLE(C_LOOP)
 #include "CLoopStackInlines.h"
@@ -174,11 +175,9 @@ static bool enableAssembler()
     if (!Options::useJIT())
         return false;
 
-    char* canUseJITString = getenv("JavaScriptCoreUseJIT");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (canUseJITString && !atoi(canUseJITString))
+    auto canUseJITString = span(getenv("JavaScriptCoreUseJIT"));
+    if (canUseJITString.data() && !parseInteger<int>(canUseJITString).value_or(0))
         return false;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     ExecutableAllocator::initializeUnderlyingAllocator();
     if (!ExecutableAllocator::singleton().isValid()) {

--- a/Source/JavaScriptCore/testmem/testmem.cpp
+++ b/Source/JavaScriptCore/testmem/testmem.cpp
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include <vector>
 #include <wtf/MonotonicTime.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 #if PLATFORM(PLAYSTATION)
 #include <memory-extra/showmap.h>
@@ -91,7 +92,7 @@ int main(int argc, char* argv[])
 
     size_t iterations = 20;
     if (argc >= 3) {
-        int iters = atoi(argv[2]);
+        int iters = parseInteger<int>(span(argv[2])).value_or(0);
         if (iters < 0) {
             printf("Iterations argument must be >= 0");
             exit(1);

--- a/Source/JavaScriptCore/testmem/testmem.mm
+++ b/Source/JavaScriptCore/testmem/testmem.mm
@@ -28,6 +28,7 @@
 #import <inttypes.h>
 #import <stdio.h>
 #import <wtf/Compiler.h>
+#import <wtf/text/StringToIntegerConversion.h>
 
 #if __has_include(<libproc.h>)
 #define HAS_LIBPROC 1
@@ -69,7 +70,7 @@ int main(int argc, char* argv[])
 
     size_t iterations = 20;
     if (argc >= 3) {
-        int iters = atoi(argv[2]);
+        int iters = parseInteger<int>(span(argv[2])).value_or(0);
         if (iters < 0) {
             printf("Iterations argument must be >= 0");
             exit(1);

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3493,6 +3493,10 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_deprecated_timer_smart_pointer_exception:
         error(line_number, 'safercpp/timer_exception', 4, "Do not add IsDeprecatedTimerSmartPointerException.")
 
+    uses_atoi = search(r'atoi\(', line)
+    if uses_atoi:
+        error(line_number, 'safercpp/atoi', 4, "Use parseInteger<int>() instead of atoi().")
+
     uses_memset = search(r'memset\(', line)
     if uses_memset:
         error(line_number, 'safercpp/memset', 4, "Use memsetSpan() / zeroSpan() instead of memset().")
@@ -4864,6 +4868,7 @@ class CppChecker(object):
         'runtime/wtf_make_unique',
         'runtime/wtf_move',
         'runtime/wtf_never_destroyed',
+        'safercpp/atoi',
         'safercpp/memchr',
         'safercpp/memcmp',
         'safercpp/memcpy',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6269,6 +6269,11 @@ class WebKitStyleTest(CppStyleTestBase):
             'foo.cpp')
 
         self.assert_lint(
+            'int number = atoi(foo);',
+            'Use parseInteger<int>() instead of atoi().  [safercpp/atoi] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
             'memset(foo, 0);',
             'Use memsetSpan() / zeroSpan() instead of memset().  [safercpp/memset] [4]',
             'foo.cpp')

--- a/Tools/TestRunnerShared/IOSLayoutTestCommunication.cpp
+++ b/Tools/TestRunnerShared/IOSLayoutTestCommunication.cpp
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <wtf/Assertions.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 static int stdinSocket;
 static int stdoutSocket;
@@ -49,10 +50,10 @@ static int connectToServer(sockaddr_in& serverAddress)
 
 void setUpIOSLayoutTestCommunication()
 {
-    char* portFromEnvironment = getenv("PORT");
-    if (!portFromEnvironment)
+    auto portFromEnvironment = span(getenv("PORT"));
+    if (!portFromEnvironment.data())
         return;
-    int port = atoi(portFromEnvironment);
+    int port = parseInteger<int>(portFromEnvironment).value_or(0);
     RELEASE_ASSERT(port > 0);
     isUsingTCP = true;
 

--- a/Tools/TestRunnerShared/TestCommand.cpp
+++ b/Tools/TestRunnerShared/TestCommand.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "TestCommand.h"
 
+#include <wtf/text/StringToIntegerConversion.h>
+
 namespace WTR {
 
 class CommandTokenizer {
@@ -93,7 +95,7 @@ TestCommand parseInputLine(const std::string& inputLine)
         arg = tokenizer.next();
         if (arg == "--timeout") {
             auto timeoutToken = tokenizer.next();
-            result.timeout = Seconds::fromMilliseconds(atoi(timeoutToken.c_str()));
+            result.timeout = Seconds::fromMilliseconds(parseInteger<int>(std::span<const char> { timeoutToken }).value_or(0));
         } else if (arg == "-p" || arg == "--pixel-test") {
             result.shouldDumpPixels = true;
             if (tokenizer.hasNext())

--- a/Tools/TestWebKitAPI/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/NetworkConnection.mm
@@ -32,6 +32,7 @@
 #import <wtf/SHA1.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/Base64.h>
+#import <wtf/text/StringToIntegerConversion.h>
 
 namespace TestWebKitAPI {
 
@@ -71,7 +72,7 @@ void Connection::receiveHTTPRequest(CompletionHandler<void(Vector<char>&&)>&& co
         buffer.appendVector(WTFMove(bytes));
         if (auto* doubleNewline = strnstr(buffer.data(), "\r\n\r\n", buffer.size())) {
             if (auto* contentLengthBegin = strnstr(buffer.data(), "Content-Length", buffer.size())) {
-                size_t contentLength = atoi(contentLengthBegin + strlen("Content-Length: "));
+                size_t contentLength = parseInteger<int>(buffer.span().subspan(contentLengthBegin - buffer.data() + strlen("Content-Length: "))).value_or(0);
                 size_t headerLength = doubleNewline - buffer.data() + strlen("\r\n\r\n");
                 if (buffer.size() - headerLength < contentLength)
                     return connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));


### PR DESCRIPTION
#### b7a414ec0e71197b82ee184f048300aeea5e4630
<pre>
Reduce use of atoi() in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=286335">https://bugs.webkit.org/show_bug.cgi?id=286335</a>

Reviewed by Darin Adler.

Reduce use of atoi() in the codebase as it is considered unsafe.
Use the pre-existing parseInteger&lt;int&gt;() function instead which takes in
a span.

* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::enableAssembler):
* Source/JavaScriptCore/testmem/testmem.cpp:
(main):
* Source/JavaScriptCore/testmem/testmem.mm:
(main):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
* Tools/TestRunnerShared/IOSLayoutTestCommunication.cpp:
(setUpIOSLayoutTestCommunication):
* Tools/TestRunnerShared/TestCommand.cpp:
(WTR::parseInputLine):
* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::Connection::receiveHTTPRequest const):

Canonical link: <a href="https://commits.webkit.org/289357@main">https://commits.webkit.org/289357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdda5addcdaa1d2b27751259a89d940a631fd370

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40968 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67006 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24791 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4874 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78447 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47330 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/86134 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32779 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36486 "Built successfully") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79418 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93349 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85407 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75803 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74990 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6572 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13468 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13812 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107901 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13550 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25962 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/16994 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->