### PR TITLE
Rename `span(const char*)` to `unsafeSpan(const char*)`

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -45,7 +45,7 @@ JSStringRef JSStringCreateWithUTF8CString(const char* string)
 {
     JSC::initialize();
     if (string) {
-        auto stringSpan = span8(string);
+        auto stringSpan = unsafeSpan8(string);
         Vector<UChar, 1024> buffer(stringSpan.size());
         auto result = WTF::Unicode::convert(spanReinterpretCast<const char8_t>(stringSpan), buffer.mutableSpan());
         if (result.code == WTF::Unicode::ConversionResultCode::Success) {

--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1262,7 +1262,7 @@ static StructHandlers* createStructHandlerMap()
     // Step 1: find all valueWith<Foo>:inContext: class methods in JSValue.
     forEachMethodInClass(object_getClass([JSValue class]), ^(Method method){
         SEL selector = method_getName(method);
-        auto name = span(sel_getName(selector));
+        auto name = unsafeSpan(sel_getName(selector));
         // Check for valueWith<Foo>:context:
         if (name.size() < valueWithXinContextLength || !spanHasPrefix(name, "valueWith"_span) || !spanHasSuffix(name, ":inContext:"_span))
             return;
@@ -1289,7 +1289,7 @@ static StructHandlers* createStructHandlerMap()
     // Step 2: find all to<Foo> instance methods in JSValue.
     forEachMethodInClass([JSValue class], ^(Method method){
         SEL selector = method_getName(method);
-        auto name = span(sel_getName(selector));
+        auto name = unsafeSpan(sel_getName(selector));
         // Check for to<Foo>
         if (name.size() < toXLength || !spanHasPrefix(name, "to"_span))
             return;
@@ -1304,7 +1304,7 @@ static StructHandlers* createStructHandlerMap()
         StructTagHandler& handler = iter->value;
 
         // check that strlen(<foo>) == strlen(<Foo>)
-        auto valueWithName = span(sel_getName(handler.typeToValueSEL));
+        auto valueWithName = unsafeSpan(sel_getName(handler.typeToValueSEL));
         if (valueWithName.size() - valueWithXinContextLength != name.size() - toXLength)
             return;
         // Check that <Foo> == <Foo>

--- a/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCCallbackFunction.cpp
@@ -228,7 +228,7 @@ JSObjectRef JSCCallbackFunction::construct(JSContextRef callerContext, size_t ar
         *exception = toRef(JSC::createTypeError(toJS(jsContext), "constructor returned null"_s));
         break;
     default:
-        *exception = toRef(JSC::createTypeError(toJS(jsContext), makeString("invalid type "_s, span(g_type_name(G_VALUE_TYPE(&returnValue))), " returned by constructor"_s)));
+        *exception = toRef(JSC::createTypeError(toJS(jsContext), makeString("invalid type "_s, unsafeSpan(g_type_name(G_VALUE_TYPE(&returnValue))), " returned by constructor"_s)));
         break;
     }
     g_value_unset(&returnValue);

--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -467,7 +467,7 @@ JSValueRef jscContextGValueToJSValue(JSCContext* context, const GValue* value, J
         break;
     }
 
-    *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type "_s, span(g_type_name(G_VALUE_TYPE(value))))));
+    *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type "_s, unsafeSpan(g_type_name(G_VALUE_TYPE(value))))));
     return JSValueMakeUndefined(priv->jsContext.get());
 }
 
@@ -587,7 +587,7 @@ void jscContextJSValueToGValue(JSCContext* context, JSValueRef jsValue, GType ty
     case G_TYPE_INTERFACE:
     case G_TYPE_VARIANT:
     default:
-        *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type "_s, span(g_type_name(G_VALUE_TYPE(value))))));
+        *exception = toRef(JSC::createTypeError(globalObject, makeString("unsupported type "_s, unsafeSpan(g_type_name(G_VALUE_TYPE(value))))));
         break;
     }
 }

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -168,7 +168,7 @@ RegisterID* RegExpNode::emitBytecode(BytecodeGenerator& generator, RegisterID* d
     if (regExp->isValid())
         return generator.emitNewRegExp(generator.finalDestination(dst), regExp);
 
-    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), span8(regExp->errorMessage()));
+    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), unsafeSpan8(regExp->errorMessage()));
     generator.emitThrowStaticError(ErrorTypeWithExtension::SyntaxError, message);
     return generator.emitLoad(generator.finalDestination(dst), jsUndefined());
 }

--- a/Source/JavaScriptCore/runtime/Error.cpp
+++ b/Source/JavaScriptCore/runtime/Error.cpp
@@ -291,13 +291,13 @@ JSObject* createTypeErrorCopy(JSGlobalObject* globalObject, JSValue error)
 
 String makeDOMAttributeGetterTypeErrorMessage(const char* interfaceName, const String& attributeName)
 {
-    auto interfaceNameSpan = span(interfaceName);
+    auto interfaceNameSpan = unsafeSpan(interfaceName);
     return makeString("The "_s, interfaceNameSpan, '.', attributeName, " getter can only be used on instances of "_s, interfaceNameSpan);
 }
 
 String makeDOMAttributeSetterTypeErrorMessage(const char* interfaceName, const String& attributeName)
 {
-    auto interfaceNameSpan = span(interfaceName);
+    auto interfaceNameSpan = unsafeSpan(interfaceName);
     return makeString("The "_s, interfaceNameSpan, '.', attributeName, " setter can only be used on instances of "_s, interfaceNameSpan);
 }
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -207,7 +207,7 @@ std::optional<T> parse(const char* string);
 template<>
 std::optional<OptionsStorage::Bool> parse(const char* string)
 {
-    auto span = WTF::span(string);
+    auto span = unsafeSpan(string);
     if (equalLettersIgnoringASCIICase(span, "true"_s) || equalLettersIgnoringASCIICase(span, "yes"_s) || !strcmp(string, "1"))
         return true;
     if (equalLettersIgnoringASCIICase(span, "false"_s) || equalLettersIgnoringASCIICase(span, "no"_s) || !strcmp(string, "0"))
@@ -278,7 +278,7 @@ std::optional<OptionsStorage::OptionString> parse(const char* string)
 template<>
 std::optional<OptionsStorage::GCLogLevel> parse(const char* string)
 {
-    auto span = WTF::span(string);
+    auto span = unsafeSpan(string);
     if (equalLettersIgnoringASCIICase(span, "none"_s) || equalLettersIgnoringASCIICase(span, "no"_s) || equalLettersIgnoringASCIICase(span, "false"_s) || !strcmp(string, "0"))
         return GCLogging::None;
 
@@ -296,7 +296,7 @@ std::optional<OptionsStorage::OSLogType> parse(const char* string)
 {
     std::optional<OptionsStorage::OSLogType> result;
 
-    auto span = WTF::span(string);
+    auto span = unsafeSpan(string);
     if (equalLettersIgnoringASCIICase(span, "none"_s) || equalLettersIgnoringASCIICase(span, "false"_s) || !strcmp(string, "0"))
         result = OSLogType::None;
     else if (equalLettersIgnoringASCIICase(span, "true"_s) || !strcmp(string, "1"))
@@ -428,7 +428,7 @@ bool Options::overrideAliasedOptionWithHeuristic(const char* name)
     if (!stringValue)
         return false;
 
-    auto aliasedOption = makeString(span(&name[4]), '=', span(stringValue));
+    auto aliasedOption = makeString(unsafeSpan(&name[4]), '=', unsafeSpan(stringValue));
     if (Options::setOption(aliasedOption.utf8().data()))
         return true;
 
@@ -1262,7 +1262,7 @@ bool Options::setAliasedOption(const char* arg, bool verify)
         && !strncasecmp(arg, #aliasedName_, equalStr - arg)) {          \
         auto unaliasedOption = String::fromLatin1(#unaliasedName_);     \
         if (equivalence == SameOption)                                  \
-            unaliasedOption = makeString(unaliasedOption, span(equalStr)); \
+            unaliasedOption = makeString(unaliasedOption, unsafeSpan(equalStr)); \
         else {                                                          \
             ASSERT(equivalence == InvertedOption);                      \
             auto invertedValueStr = invertBoolOptionValue(equalStr + 1); \
@@ -1439,10 +1439,10 @@ void Option::dump(StringBuilder& builder) const
         builder.append(m_int32);
         break;
     case Options::Type::OptionRange:
-        builder.append(span(m_optionRange.rangeString()));
+        builder.append(unsafeSpan(m_optionRange.rangeString()));
         break;
     case Options::Type::OptionString:
-        builder.append('"', m_optionString ? span8(m_optionString) : ""_span, '"');
+        builder.append('"', m_optionString ? unsafeSpan8(m_optionString) : ""_span, '"');
         break;
     case Options::Type::GCLogLevel:
         builder.append(m_gcLogLevel);

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -683,7 +683,7 @@ String RegExp::escapedPattern() const
 
 String RegExp::toSourceString() const
 {
-    return makeString('/', escapedPattern(), '/', span(Yarr::flagsString(flags()).data()));
+    return makeString('/', escapedPattern(), '/', unsafeSpan(Yarr::flagsString(flags()).data()));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1315,7 +1315,7 @@ void SamplingProfiler::reportTopBytecodes(PrintStream& out)
         auto frameDescription = makeString(frame.displayName(m_vm), descriptionForLocation(frame.semanticLocation, frame.wasmCompilationMode, frame.wasmOffset));
         if (std::optional<std::pair<StackFrame::CodeLocation, CodeBlock*>> machineLocation = frame.machineLocation) {
             frameDescription = makeString(frameDescription, " <-- "_s,
-                span(machineLocation->second->inferredName().data()), descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
+                unsafeSpan(machineLocation->second->inferredName().data()), descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
         }
         bytecodeCounts.add(frameDescription, 0).iterator->value++;
 

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -244,7 +244,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             builder.append(std::span { line, p + 1 });
             return builder.toString();
         }
-        builder.append(span(line));
+        builder.append(unsafeSpan(line));
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     } while ((line = fgets(buffer, bufferSize, file)));

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -80,7 +80,7 @@ static void dumpWasmSource(const Vector<uint8_t>& source)
     const char* file = Options::dumpWasmSourceFileName();
     if (!file)
         return;
-    auto fileHandle = FileSystem::openFile(WTF::makeString(span(file), (count++), ".wasm"_s),
+    auto fileHandle = FileSystem::openFile(WTF::makeString(unsafeSpan(file), (count++), ".wasm"_s),
         FileSystem::FileOpenMode::Truncate,
         FileSystem::FileAccessPermission::All,
         /* failIfFileExists = */ true);
@@ -88,7 +88,7 @@ static void dumpWasmSource(const Vector<uint8_t>& source)
         dataLogLn("Error dumping wasm");
         return;
     }
-    dataLogLn("Dumping ", source.size(), " wasm source bytes to ", WTF::makeString(span(file), (count - 1), ".wasm"_s));
+    dataLogLn("Dumping ", source.size(), " wasm source bytes to ", WTF::makeString(unsafeSpan(file), (count - 1), ".wasm"_s));
     FileSystem::writeToFile(fileHandle, source.span());
     FileSystem::closeFile(fileHandle);
 }

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -80,7 +80,7 @@ static String createWithFormatAndArguments(const char* format, va_list args)
 ALLOW_NONLITERAL_FORMAT_BEGIN
 
 #if USE(CF)
-    if (contains(span8(format), "%@"_span)) {
+    if (contains(unsafeSpan(format), "%@"_span)) {
         auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
         auto result = adoptCF(CFStringCreateWithFormatAndArguments(kCFAllocatorDefault, nullptr, cfFormat.get(), args));
         va_end(argsCopy);
@@ -152,7 +152,7 @@ WTF_ATTRIBUTE_PRINTF(2, 0)
 static void vprintf_stderr_common([[maybe_unused]] WTFLogChannel* channel, const char* format, va_list args)
 {
 #if USE(CF)
-    if (contains(span8(format), "%@"_span)) {
+    if (contains(unsafeSpan(format), "%@"_span)) {
         auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, format, kCFStringEncodingUTF8, kCFAllocatorNull));
 
 ALLOW_NONLITERAL_FORMAT_BEGIN
@@ -200,8 +200,8 @@ ALLOW_NONLITERAL_FORMAT_END
 WTF_ATTRIBUTE_PRINTF(2, 0)
 static void vprintf_stderr_with_prefix(const char* rawPrefix, const char* rawFormat, va_list args)
 {
-    auto prefix = span(rawPrefix);
-    auto format = span(rawFormat);
+    auto prefix = unsafeSpan(rawPrefix);
+    auto format = unsafeSpan(rawFormat);
     Vector<char> formatWithPrefix(prefix.size() + format.size() + 1);
     memcpySpan(formatWithPrefix.mutableSpan(), prefix);
     memcpySpan(formatWithPrefix.mutableSpan().subspan(prefix.size()), format);
@@ -215,7 +215,7 @@ ALLOW_NONLITERAL_FORMAT_END
 WTF_ATTRIBUTE_PRINTF(2, 0)
 static void vprintf_stderr_with_trailing_newline(WTFLogChannel* channel, const char* rawFormat, va_list args)
 {
-    auto format = span(rawFormat);
+    auto format = unsafeSpan(rawFormat);
     if (!format.empty() && format.back() == '\n') {
         vprintf_stderr_common(channel, rawFormat, args);
         return;

--- a/Source/WTF/wtf/DataLog.cpp
+++ b/Source/WTF/wtf/DataLog.cpp
@@ -112,7 +112,7 @@ static void initializeLogFileOnce()
 #endif
 #endif // DATA_LOG_TO_FILE
     char actualFilename[maxPathLength + 1];
-    if (filename && !contains(span8(filename), "%pid"_span)) {
+    if (filename && !contains(unsafeSpan(filename), "%pid"_span)) {
         snprintf(actualFilename, sizeof(actualFilename), "%s.%%pid.txt", filename);
         filename = actualFilename;
     }
@@ -138,7 +138,7 @@ void setDataFile(const char* path)
     const char* pathToOpen = path;
 
     if (path) {
-        auto pathSpan = span(path);
+        auto pathSpan = unsafeSpan(path);
         if (size_t pidIndex = find(pathSpan, "%pid"_span); pidIndex != notFound) {
             size_t pathCharactersAvailable = std::min(maxPathLength, pidIndex);
             strncpy(formattedPath, path, pathCharactersAvailable);

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -911,7 +911,7 @@ double parseDate(std::span<const LChar> dateString, bool& isLocalTime)
             for (auto& knownZone : knownZones) {
                 // Since the passed-in length is used for both strings, the following checks that
                 // dateString has the time zone name as a prefix, not that it is equal.
-                auto tzName = span8(knownZone.tzName);
+                auto tzName = unsafeSpan8(knownZone.tzName);
                 if (skipLettersExactlyIgnoringASCIICase(dateString, tzName)) {
                     offset = knownZone.tzOffset;
                     isLocalTime = false;

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -65,7 +65,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 static String fromStdFileSystemPath(const std::filesystem::path& path)
 {
 #if HAVE(MISSING_U8STRING)
-    return String::fromUTF8(span8(path.u8string().c_str()));
+    return String::fromUTF8(unsafeSpan8(path.u8string().c_str()));
 #else
     return String::fromUTF8(span(path.u8string()));
 #endif

--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -39,8 +39,8 @@ Lock messageHandlerLoggerObserverLock;
 String Logger::LogSiteIdentifier::toString() const
 {
     if (className)
-        return makeString(className, "::"_s, span(methodName), '(', hex(objectIdentifier), ") "_s);
-    return makeString(span(methodName), '(', hex(objectIdentifier), ") "_s);
+        return makeString(className, "::"_s, unsafeSpan(methodName), '(', hex(objectIdentifier), ") "_s);
+    return makeString(unsafeSpan(methodName), '(', hex(objectIdentifier), ") "_s);
 }
 
 String LogArgument<const void*>::toString(const void* argument)

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -385,7 +385,7 @@ private:
         UNUSED_PARAM(line);
         UNUSED_PARAM(function);
 #elif ENABLE(JOURNALD_LOG)
-        auto fileString = makeString("CODE_FILE="_s, span(file));
+        auto fileString = makeString("CODE_FILE="_s, unsafeSpan(file));
         auto lineString = makeString("CODE_LINE="_s, line);
         sd_journal_send_with_location(fileString.utf8().data(), lineString.utf8().data(), function, "WEBKIT_SUBSYSTEM=%s", channel.subsystem, "WEBKIT_CHANNEL=%s", channel.name, "MESSAGE=%s", logMessage.utf8().data(), nullptr);
 #else

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -129,7 +129,7 @@ void Config::initialize()
 
     const char* useAllocationProfilingRaw = getenv("JSC_useAllocationProfiling");
     if (useAllocationProfilingRaw) {
-        auto useAllocationProfiling = span(useAllocationProfilingRaw);
+        auto useAllocationProfiling = unsafeSpan(useAllocationProfilingRaw);
         if (equalLettersIgnoringASCIICase(useAllocationProfiling, "true"_s)
             || equalLettersIgnoringASCIICase(useAllocationProfiling, "yes"_s)
             || equal(useAllocationProfiling, "1"_s))

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -151,7 +151,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     
     // Append the file name suffix.
     CString suffixUTF8 = suffix.utf8();
-    temporaryFilePath.append(suffixUTF8.spanIncludingNullTerminator());
+    temporaryFilePath.append(suffixUTF8.unsafeSpanIncludingNullTerminator());
 
     platformFileHandle = mkostemps(temporaryFilePath.data(), suffixUTF8.length(), O_CLOEXEC);
     if (platformFileHandle == invalidPlatformFileHandle)
@@ -170,7 +170,7 @@ NSString *createTemporaryDirectory(NSString *directoryPrefix)
         return nil;
 
     NSString *tempDirectoryComponent = [directoryPrefix stringByAppendingString:@"-XXXXXXXX"];
-    auto tempDirectorySpanIncludingNullTerminator = spanIncludingNullTerminator([[tempDirectory stringByAppendingPathComponent:tempDirectoryComponent] fileSystemRepresentation]);
+    auto tempDirectorySpanIncludingNullTerminator = unsafeSpanIncludingNullTerminator([[tempDirectory stringByAppendingPathComponent:tempDirectoryComponent] fileSystemRepresentation]);
     if (tempDirectorySpanIncludingNullTerminator.empty())
         return nil;
 

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -326,7 +326,7 @@ BOOL isUserVisibleURL(NSString *string)
 
     std::array<char, 1024> buffer;
     auto success = CFStringGetCString(bridge_cast(string), buffer.data(), buffer.size() - 1, kCFStringEncodingUTF8);
-    auto characters = success ? span(buffer.data()) : span([string UTF8String]);
+    auto characters = success ? unsafeSpan(buffer.data()) : unsafeSpan([string UTF8String]);
 
     // Check for control characters, %-escape sequences that are non-ASCII, and xn--: these
     // are the things that might lead the userVisibleString function to actually change the string.

--- a/Source/WTF/wtf/glib/Application.cpp
+++ b/Source/WTF/wtf/glib/Application.cpp
@@ -57,7 +57,7 @@ const CString& applicationID()
         // and won't flood xdg-desktop-portal with new ids.
         if (auto executablePath = FileSystem::currentExecutablePath(); !executablePath.isNull()) {
             GUniquePtr<char> digest(g_compute_checksum_for_data(G_CHECKSUM_SHA256, reinterpret_cast<const uint8_t*>(executablePath.data()), executablePath.length()));
-            id.get() = makeString("org.webkit.app-"_s, span(digest.get())).utf8();
+            id.get() = makeString("org.webkit.app-"_s, unsafeSpan(digest.get())).utf8();
             return;
         }
 

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -158,7 +158,7 @@ public:
         case WebXRCPFrameStartSubmissionStart:
         case WebXRCPFrameEndSubmissionStart:
         case WakeUpAndApplyDisplayListStart:
-            beginMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
+            beginMark(nullptr, tracePointCodeName(code).unsafeSpanIncludingNullTerminator(), "%s", "");
             break;
 
         case VMEntryScopeEnd:
@@ -218,7 +218,7 @@ public:
         case WebXRCPFrameStartSubmissionEnd:
         case WebXRCPFrameEndSubmissionEnd:
         case WakeUpAndApplyDisplayListEnd:
-            endMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
+            endMark(nullptr, tracePointCodeName(code).unsafeSpanIncludingNullTerminator(), "%s", "");
             break;
 
         case DisplayRefreshDispatchingToMainThread:
@@ -228,7 +228,7 @@ public:
         case SyntheticMomentumEvent:
         case RemoteLayerTreeScheduleRenderingUpdate:
         case DisplayLinkUpdate:
-            instantMark(tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
+            instantMark(tracePointCodeName(code).unsafeSpanIncludingNullTerminator(), "%s", "");
             break;
 
         case WTFRange:

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -70,7 +70,7 @@ public:
     constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
     constexpr std::span<const char> span() const { return m_charactersWithNullTerminator.first(length()); }
     std::span<const LChar> span8() const { return byteCast<LChar>(m_charactersWithNullTerminator.first(length())); }
-    std::span<const char> spanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
+    std::span<const char> unsafeSpanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
     size_t isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
     constexpr char operator[](size_t index) const { return m_charactersWithNullTerminator[index]; }

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -282,7 +282,7 @@ inline AtomString AtomString::fromUTF8(const char* characters)
         return nullAtom();
     if (!*characters)
         return emptyAtom();
-    return fromUTF8Internal(span(characters));
+    return fromUTF8Internal(unsafeSpan(characters));
 }
 
 inline AtomString String::toExistingAtomString() const

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -116,7 +116,7 @@ ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(ASCIILiteral literal)
 
 ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addCString(const char* s)
 {
-    return s ? add(WTF::span8(s)) : nullptr;
+    return s ? add(unsafeSpan8(s)) : nullptr;
 }
 
 template<typename StringTableProvider>

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -54,7 +54,7 @@ CString::CString(const char* string)
     if (!string)
         return;
 
-    init(WTF::span(string));
+    init(unsafeSpan(string));
 }
 
 CString::CString(std::span<const char> string)
@@ -107,7 +107,7 @@ void CString::copyBufferIfNeeded()
     RefPtr<CStringBuffer> buffer = WTFMove(m_buffer);
     size_t length = buffer->length();
     m_buffer = CStringBuffer::createUninitialized(length);
-    memcpySpan(m_buffer->mutableSpanIncludingNullTerminator(), buffer->spanIncludingNullTerminator());
+    memcpySpan(m_buffer->mutableSpanIncludingNullTerminator(), buffer->unsafeSpanIncludingNullTerminator());
 }
 
 bool CString::isSafeToSendToAnotherThread() const
@@ -120,7 +120,7 @@ void CString::grow(size_t newLength)
     ASSERT(newLength > length());
 
     auto newBuffer = CStringBuffer::createUninitialized(newLength);
-    memcpySpan(newBuffer->mutableSpanIncludingNullTerminator(), m_buffer->spanIncludingNullTerminator());
+    memcpySpan(newBuffer->mutableSpanIncludingNullTerminator(), m_buffer->unsafeSpanIncludingNullTerminator());
     m_buffer = WTFMove(newBuffer);
 }
 

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -46,7 +46,7 @@ public:
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     std::span<const LChar> span() const LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast_ptr<const LChar*>(this + 1), m_length); }
-    std::span<const char> spanIncludingNullTerminator() const LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast_ptr<const char*>(this + 1), m_length + 1); }
+    std::span<const char> unsafeSpanIncludingNullTerminator() const LIFETIME_BOUND { return unsafeMakeSpan(reinterpret_cast_ptr<const char*>(this + 1), m_length + 1); }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 private:
@@ -79,10 +79,10 @@ public:
 
     const char* data() const LIFETIME_BOUND;
 
-    std::string toStdString() const { return m_buffer ? std::string(m_buffer->spanIncludingNullTerminator().data()) : std::string(); }
+    std::string toStdString() const { return m_buffer ? std::string(m_buffer->unsafeSpanIncludingNullTerminator().data()) : std::string(); }
 
     std::span<const LChar> span() const LIFETIME_BOUND;
-    std::span<const char> spanIncludingNullTerminator() const LIFETIME_BOUND;
+    std::span<const char> unsafeSpanIncludingNullTerminator() const LIFETIME_BOUND;
 
     WTF_EXPORT_PRIVATE std::span<char> mutableSpan() LIFETIME_BOUND;
     WTF_EXPORT_PRIVATE std::span<char> mutableSpanIncludingNullTerminator() LIFETIME_BOUND;
@@ -129,7 +129,7 @@ inline CString::CString(std::span<const LChar> bytes)
 
 inline const char* CString::data() const
 {
-    return m_buffer ? m_buffer->spanIncludingNullTerminator().data() : nullptr;
+    return m_buffer ? m_buffer->unsafeSpanIncludingNullTerminator().data() : nullptr;
 }
 
 inline std::span<const LChar> CString::span() const
@@ -139,10 +139,10 @@ inline std::span<const LChar> CString::span() const
     return { };
 }
 
-inline std::span<const char> CString::spanIncludingNullTerminator() const
+inline std::span<const char> CString::unsafeSpanIncludingNullTerminator() const
 {
     if (m_buffer)
-        return m_buffer->spanIncludingNullTerminator();
+        return m_buffer->unsafeSpanIncludingNullTerminator();
     return { };
 }
 

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -50,35 +50,35 @@ inline std::span<const UChar> span(const UChar& character)
     return unsafeMakeSpan(&character, 1);
 }
 
-inline std::span<const LChar> span8(const char* string)
+inline std::span<const LChar> unsafeSpan8(const char* string)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(byteCast<LChar>(string), string ? strlen(string) : 0);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
-inline std::span<const LChar> span8IncludingNullTerminator(const char* string)
+inline std::span<const LChar> unsafeSpan8IncludingNullTerminator(const char* string)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(byteCast<LChar>(string), string ? strlen(string) + 1 : 0);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
-inline std::span<const char> span(const char* string)
+inline std::span<const char> unsafeSpan(const char* string)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(string, string ? strlen(string) : 0);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
-inline std::span<const char> spanIncludingNullTerminator(const char* string)
+inline std::span<const char> unsafeSpanIncludingNullTerminator(const char* string)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(string, string ? strlen(string) + 1 : 0);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
-inline std::span<const LChar> span(const LChar* string)
+inline std::span<const LChar> unsafeSpan(const LChar* string)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return unsafeMakeSpan(string, string ? strlen(byteCast<char>(string)) : 0);
@@ -86,7 +86,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-inline std::span<const UChar> span(const UChar* string)
+inline std::span<const UChar> unsafeSpan(const UChar* string)
 {
     if (!string)
         return { };
@@ -549,7 +549,7 @@ bool equalIgnoringASCIICaseCommon(const StringClassA& a, const StringClassB& b)
 
 template<typename StringClassA> bool equalIgnoringASCIICaseCommon(const StringClassA& a, const char* b)
 {
-    auto bSpan = span8(b);
+    auto bSpan = unsafeSpan8(b);
     if (a.length() != bSpan.size())
         return false;
     if (a.is8Bit())
@@ -576,8 +576,8 @@ size_t findIgnoringASCIICase(std::span<const SearchCharacterType> source, std::s
 
 inline size_t findIgnoringASCIICaseWithoutLength(const char* source, const char* matchCharacters)
 {
-    auto searchSpan = span(source);
-    auto matchSpan = span(matchCharacters);
+    auto searchSpan = unsafeSpan(source);
+    auto matchSpan = unsafeSpan(matchCharacters);
 
     return matchSpan.size() <= searchSpan.size() ? findIgnoringASCIICase(searchSpan, matchSpan, 0) : notFound;
 }
@@ -926,7 +926,7 @@ template<typename StringClass> inline bool startsWithLettersIgnoringASCIICaseCom
 
 inline bool equalIgnoringASCIICase(const char* a, const char* b)
 {
-    return equalIgnoringASCIICase(span8(a), span8(b));
+    return equalIgnoringASCIICase(unsafeSpan8(a), unsafeSpan8(b));
 }
 
 inline bool equalLettersIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
@@ -936,7 +936,7 @@ inline bool equalLettersIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
 
 inline bool equalIgnoringASCIICase(const char* string, ASCIILiteral literal)
 {
-    return equalIgnoringASCIICase(span8(string), literal.span8());
+    return equalIgnoringASCIICase(unsafeSpan8(string), literal.span8());
 }
 
 inline bool equalIgnoringASCIICase(ASCIILiteral a, ASCIILiteral b)
@@ -1225,13 +1225,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 }
 
+using WTF::charactersContain;
 using WTF::equalIgnoringASCIICase;
 using WTF::equalIgnoringASCIICaseWithLength;
 using WTF::equalLettersIgnoringASCIICase;
 using WTF::equalLettersIgnoringASCIICaseWithLength;
 using WTF::isLatin1;
 using WTF::span;
-using WTF::spanIncludingNullTerminator;
-using WTF::span8;
-using WTF::span8IncludingNullTerminator;
-using WTF::charactersContain;
+using WTF::unsafeSpan;
+using WTF::unsafeSpan8;
+using WTF::unsafeSpanIncludingNullTerminator;
+using WTF::unsafeSpan8IncludingNullTerminator;

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -123,7 +123,7 @@ private:
 template<> class StringTypeAdapter<const LChar*, void> {
 public:
     StringTypeAdapter(const LChar* characters)
-        : m_characters { span(characters) }
+        : m_characters { unsafeSpan(characters) }
     {
         RELEASE_ASSERT(m_characters.size() <= String::MaxLength);
     }
@@ -139,7 +139,7 @@ private:
 template<> class StringTypeAdapter<const UChar*, void> {
 public:
     StringTypeAdapter(const UChar* characters)
-        : m_characters { span(characters) }
+        : m_characters { unsafeSpan(characters) }
     {
         RELEASE_ASSERT(m_characters.size() <= String::MaxLength);
     }

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -257,7 +257,7 @@ public:
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create8BitIfPossible(std::span<const UChar>);
 
     // Not using create() naming to encourage developers to call create(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(WTF::span8(characters)); }
+    ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(unsafeSpan8(characters)); }
 
     static Ref<StringImpl> createSubstringSharingImpl(StringImpl&, unsigned offset, unsigned length);
 

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -404,7 +404,7 @@ inline StringView::StringView(std::span<const UChar> characters)
 
 inline StringView::StringView(const char* characters)
 {
-    initialize(WTF::span8(characters));
+    initialize(unsafeSpan8(characters));
 }
 
 inline StringView::StringView(std::span<const char> characters)
@@ -765,7 +765,7 @@ inline bool equal(StringView a, const LChar* b)
     if (a.isEmpty())
         return !b;
 
-    auto bSpan = span8(byteCast<char>(b));
+    auto bSpan = unsafeSpan8(byteCast<char>(b));
     if (a.length() != bSpan.size())
         return false;
 

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -108,7 +108,7 @@ TextStream& TextStream::operator<<(double d)
 
 TextStream& TextStream::operator<<(const char* string)
 {
-    m_text.append(span(string));
+    m_text.append(unsafeSpan(string));
     return *this;
 }
 

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -623,7 +623,7 @@ Vector<char> asciiDebug(StringImpl* impl)
         }
     }
     CString narrowString = buffer.toString().ascii();
-    return { narrowString.spanIncludingNullTerminator() };
+    return { narrowString.unsafeSpanIncludingNullTerminator() };
 }
 
 Vector<char> asciiDebug(String& string)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -268,7 +268,7 @@ public:
     WTF_EXPORT_PRIVATE static String fromUTF8(std::span<const char8_t>);
     static String fromUTF8(std::span<const LChar> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
     static String fromUTF8(std::span<const char> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
-    static String fromUTF8(const char* string) { return fromUTF8(WTF::span8(string)); }
+    static String fromUTF8(const char* string) { return fromUTF8(unsafeSpan8(string)); }
     static String fromUTF8ReplacingInvalidSequences(std::span<const char8_t>);
     static String fromUTF8ReplacingInvalidSequences(std::span<const LChar> characters) { return fromUTF8ReplacingInvalidSequences(byteCast<char8_t>(characters)); }
 

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -118,7 +118,7 @@ public:
         if (!state->client.alwaysOnLoggingAllowed())
             return;
 
-        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::"_s, span(methodName), ' '), state->contextId.toUInt64(), state->flags, arguments...);
+        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::"_s, unsafeSpan(methodName), ' '), state->contextId.toUInt64(), state->flags, arguments...);
     }
 
     template<typename... Arguments>
@@ -127,7 +127,7 @@ public:
         if (!m_manager->alwaysOnLoggingAllowed())
             return;
 
-        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::"_s, span(methodName), ' '), arguments...);
+        m_logger->logAlways(LogMedia, makeString("WebMediaSessionManager::"_s, unsafeSpan(methodName), ' '), arguments...);
     }
 
 private:

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -256,7 +256,7 @@ static IDBError createOrMigrateRecordsTableIfNecessary(SQLiteDatabase& database)
     String tableStatement = database.tableSQL("Records"_s);
     if (tableStatement.isEmpty()) {
         if (!database.executeCommand(v3RecordsTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating Records table ("_s, database.lastError(), ") - "_s, span(database.lastErrorMsg())) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating Records table ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
 
         return IDBError { };
     }
@@ -276,16 +276,16 @@ static IDBError createOrMigrateRecordsTableIfNecessary(SQLiteDatabase& database)
 
     // Create a temporary table with the correct schema and migrate all existing content over.
     if (!database.executeCommand(v3RecordsTableSchemaTemp()))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary Records table ("_s, database.lastError(), ") - "_s, span(database.lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary Records table ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
 
     if (!database.executeCommand("INSERT INTO _Temp_Records (objectStoreID, key, value) SELECT objectStoreID, CAST(key AS TEXT), value FROM Records"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating Records table ("_s, database.lastError(), ") - "_s, span(database.lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating Records table ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
 
     if (!database.executeCommand("DROP TABLE Records"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping Records table ("_s, database.lastError(), ") - "_s, span(database.lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping Records table ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
 
     if (!database.executeCommand("ALTER TABLE _Temp_Records RENAME TO Records"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary Records table ("_s, database.lastError(), ") - "_s, span(database.lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary Records table ("_s, database.lastError(), ") - "_s, unsafeSpan(database.lastErrorMsg())) };
 
     transaction.commit();
 
@@ -300,7 +300,7 @@ IDBError SQLiteIDBBackingStore::ensureValidBlobTables()
     String recordsTableStatement = m_sqliteDB->tableSQL("BlobRecords"_s);
     if (recordsTableStatement.isEmpty()) {
         if (!m_sqliteDB->executeCommand(blobRecordsTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
         recordsTableStatement = blobRecordsTableSchema();
     }
@@ -310,7 +310,7 @@ IDBError SQLiteIDBBackingStore::ensureValidBlobTables()
     String filesTableStatement = m_sqliteDB->tableSQL("BlobFiles"_s);
     if (filesTableStatement.isEmpty()) {
         if (!m_sqliteDB->executeCommand(blobFilesTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobFiles table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating BlobFiles table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
         filesTableStatement = blobFilesTableSchema();
     }
@@ -331,7 +331,7 @@ IDBError SQLiteIDBBackingStore::ensureValidRecordsTable()
     // Whether the updated records table already existed or if it was just created and the data migrated over,
     // make sure the uniqueness index exists.
     if (!m_sqliteDB->executeCommand("CREATE UNIQUE INDEX IF NOT EXISTS RecordsIndex ON Records (objectStoreID, key);"_s))
-        error = IDBError { ExceptionCode::UnknownError, makeString("Error creating RecordsIndex on Records table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        error = IDBError { ExceptionCode::UnknownError, makeString("Error creating RecordsIndex on Records table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     return error;
 }
@@ -344,7 +344,7 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsTable()
     String tableStatement = m_sqliteDB->tableSQL("IndexRecords"_s);
     if (tableStatement.isEmpty()) {
         if (!m_sqliteDB->executeCommand(v3IndexRecordsTableSchema()))
-            return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
         return IDBError { };
     }
@@ -360,16 +360,16 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsTable()
 
     // Create a temporary table with the correct schema and migrate all existing content over.
     if (!m_sqliteDB->executeCommand(v3IndexRecordsTableSchemaTemp()))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating temporary IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     if (!m_sqliteDB->executeCommand("INSERT INTO _Temp_IndexRecords SELECT IndexRecords.indexID, IndexRecords.objectStoreID, IndexRecords.key, IndexRecords.value, Records.rowid FROM IndexRecords INNER JOIN Records ON Records.key = IndexRecords.value AND Records.objectStoreID = IndexRecords.objectStoreID"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error migrating IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     if (!m_sqliteDB->executeCommand("DROP TABLE IndexRecords"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     if (!m_sqliteDB->executeCommand("ALTER TABLE _Temp_IndexRecords RENAME TO IndexRecords"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error renaming temporary IndexRecords table ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     transaction.commit();
 
@@ -386,10 +386,10 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsIndex()
         return IDBError { };
     
     if (!m_sqliteDB->executeCommand("DROP INDEX IF EXISTS IndexRecordsIndex"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     if (!m_sqliteDB->executeCommand(IndexRecordsIndexSchema))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     return IDBError { };
 }
@@ -404,10 +404,10 @@ IDBError SQLiteIDBBackingStore::ensureValidIndexRecordsRecordIndex()
         return IDBError { };
     
     if (!m_sqliteDB->executeCommand("DROP INDEX IF EXISTS IndexRecordsRecordIndex"_s))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsRecordIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error dropping IndexRecordsRecordIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     if (!m_sqliteDB->executeCommand(v1IndexRecordsRecordIndexSchema))
-        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsRecordIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, span(m_sqliteDB->lastErrorMsg())) };
+        return IDBError { ExceptionCode::UnknownError, makeString("Error creating IndexRecordsRecordIndex index ("_s, m_sqliteDB->lastError(), ") - "_s, unsafeSpan(m_sqliteDB->lastErrorMsg())) };
 
     return IDBError { };
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1943,7 +1943,7 @@ void GStreamerMediaEndpoint::onIceCandidate(guint sdpMLineIndex, gchararray cand
     if (isStopped())
         return;
 
-    String candidateString = span(candidate);
+    String candidateString = unsafeSpan(candidate);
 
     // webrtcbin notifies an empty ICE candidate when gathering is complete.
     if (candidateString.isEmpty())

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -715,7 +715,7 @@ void setSsrcAudioLevelVadOn(GstStructure* structure)
 {
     unsigned totalFields = gst_structure_n_fields(structure);
     for (unsigned i = 0; i < totalFields; i++) {
-        String fieldName = WTF::span(gst_structure_nth_field_name(structure, i));
+        String fieldName = unsafeSpan(gst_structure_nth_field_name(structure, i));
         if (!fieldName.startsWith("extmap-"_s))
             continue;
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -200,7 +200,7 @@ static inline RTCRtpCodecParameters toRTCCodecParameters(const webrtc::RtpCodecP
             sdpFmtpLineBuilder.append(';');
         else
             isFirst = false;
-        sdpFmtpLineBuilder.append(span(keyValue.first.c_str()), '=', span(keyValue.second.c_str()));
+        sdpFmtpLineBuilder.append(std::span { keyValue.first }, '=', std::span { keyValue.second });
     }
     parameters.sdpFmtpLine = sdpFmtpLineBuilder.toString();
 

--- a/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
@@ -268,7 +268,7 @@ std::optional<Vector<uint8_t>> decryptAESGCMPayload(const ClientKeys& clientKeys
      */
     static constexpr auto cekInfoHeader = "Content-Encoding: aesgcm"_s;
     std::array<uint8_t, cekInfoHeader.length() + 1 + sizeof(context)> cekInfo;
-    memcpySpan(std::span { cekInfo }, cekInfoHeader.spanIncludingNullTerminator());
+    memcpySpan(std::span { cekInfo }, cekInfoHeader.unsafeSpanIncludingNullTerminator());
     memcpySpan(std::span { cekInfo }.subspan(cekInfoHeader.length() + 1), asByteSpan(context));
 
     auto cek = hmacSHA256(prk, cekInfo);
@@ -280,7 +280,7 @@ std::optional<Vector<uint8_t>> decryptAESGCMPayload(const ClientKeys& clientKeys
      */
     static constexpr auto nonceInfoHeader = "Content-Encoding: nonce"_s;
     std::array<uint8_t, nonceInfoHeader.length() + 1 + sizeof(context)> nonceInfo;
-    memcpySpan(std::span { nonceInfo }, nonceInfoHeader.spanIncludingNullTerminator());
+    memcpySpan(std::span { nonceInfo }, nonceInfoHeader.unsafeSpanIncludingNullTerminator());
     memcpySpan(std::span { nonceInfo }.subspan(nonceInfoHeader.length() + 1), asByteSpan(context));
 
     auto nonce = hmacSHA256(prk, nonceInfo);

--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -107,7 +107,7 @@ static const String& fullyQualifiedInfoTableName()
 
 static String formatErrorMessage(ASCIILiteral message, int sqliteErrorCode, const char* sqliteErrorMessage)
 {
-    return makeString(message, " ("_s, sqliteErrorCode, ' ', span(sqliteErrorMessage), ')');
+    return makeString(message, " ("_s, sqliteErrorCode, ' ', unsafeSpan(sqliteErrorMessage), ')');
 }
 
 static bool setTextValueInDatabase(SQLiteDatabase& db, StringView query, const String& value)

--- a/Source/WebCore/Modules/webdatabase/SQLError.h
+++ b/Source/WebCore/Modules/webdatabase/SQLError.h
@@ -42,7 +42,7 @@ public:
     }
     static Ref<SQLError> create(unsigned code, ASCIILiteral message, int sqliteCode, const char* sqliteMessage)
     {
-        return create(code, makeString(message, " ("_s, sqliteCode, ' ', span(sqliteMessage), ')'));
+        return create(code, makeString(message, " ("_s, sqliteCode, ' ', unsafeSpan(sqliteMessage), ')'));
     }
 
     unsigned code() const { return m_code; }

--- a/Source/WebCore/PAL/pal/unix/LoggingUnix.cpp
+++ b/Source/WebCore/PAL/pal/unix/LoggingUnix.cpp
@@ -43,7 +43,7 @@ String logLevelString()
 #endif
 
         // To disable logging notImplemented set the DISABLE_NI_WARNING environment variable to 1.
-        return makeString("NotYetImplemented,"_s, span(logEnv));
+        return makeString("NotYetImplemented,"_s, unsafeSpan(logEnv));
     }
 #endif
     return String();

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
@@ -295,8 +295,8 @@ JSC::EncodedJSValue rejectPromiseWithGetterTypeError(JSC::JSGlobalObject& lexica
 
 String makeThisTypeErrorMessage(const char* interfaceName, const char* functionName)
 {
-    auto interfaceNameSpan = span(interfaceName);
-    return makeString("Can only call "_s, interfaceNameSpan, '.', span(functionName), " on instances of "_s, interfaceNameSpan);
+    auto interfaceNameSpan = unsafeSpan(interfaceName);
+    return makeString("Can only call "_s, interfaceNameSpan, '.', unsafeSpan(functionName), " on instances of "_s, interfaceNameSpan);
 }
 
 String makeUnsupportedIndexedSetterErrorMessage(ASCIILiteral interfaceName)

--- a/Source/WebCore/bridge/IdentifierRep.cpp
+++ b/Source/WebCore/bridge/IdentifierRep.cpp
@@ -94,7 +94,7 @@ IdentifierRep* IdentifierRep::get(const char* name)
     if (!name)
         return nullptr;
   
-    String string = String::fromUTF8WithLatin1Fallback(span(name));
+    String string = String::fromUTF8WithLatin1Fallback(unsafeSpan(name));
     StringIdentifierMap::AddResult result = stringIdentifierMap().add(string.impl(), nullptr);
     if (result.isNewEntry) {
         ASSERT(!result.iterator->value);

--- a/Source/WebCore/bridge/objc/objc_class.mm
+++ b/Source/WebCore/bridge/objc/objc_class.mm
@@ -85,7 +85,7 @@ ObjcClass* ObjcClass::classForIsA(ClassStructPtr isa)
 typedef Vector<char, 256> JSNameConversionBuffer;
 static inline void convertJSMethodNameToObjc(const CString& jsName, JSNameConversionBuffer& buffer)
 {
-    auto characters = jsName.spanIncludingNullTerminator();
+    auto characters = jsName.unsafeSpanIncludingNullTerminator();
     buffer.reserveInitialCapacity(characters.size());
     for (size_t i = 0; i < characters.size(); ++i) {
         if (characters[i] == '$') {

--- a/Source/WebCore/bridge/objc/objc_utility.mm
+++ b/Source/WebCore/bridge/objc/objc_utility.mm
@@ -255,7 +255,7 @@ ObjcValueType objcValueTypeForType(const char* rawType)
 {
     ObjcValueType objcValueType = ObjcInvalidType;
 
-    for (char typeChar : span(rawType)) {
+    for (char typeChar : unsafeSpan(rawType)) {
         switch (typeChar) {
             case _C_CONST:
             case _C_BYCOPY:

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10399,7 +10399,7 @@ RefPtr<HTMLAttachmentElement> Document::attachmentForIdentifier(const String& id
 
 static MessageSource messageSourceForWTFLogChannel(const WTFLogChannel& channel)
 {
-    auto channelName = span(channel.name);
+    auto channelName = unsafeSpan(channel.name);
     if (equalLettersIgnoringASCIICase(channelName, "media"_s))
         return MessageSource::Media;
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1769,7 +1769,7 @@ static UStringSearch* createSearcher()
     // but it doesn't matter exactly what it is, since we don't perform any searches
     // without setting both the pattern and the text.
     UErrorCode status = U_ZERO_ERROR;
-    auto searchCollatorName = makeString(span(currentSearchLocaleID()), "@collation=search"_s);
+    auto searchCollatorName = makeString(unsafeSpan(currentSearchLocaleID()), "@collation=search"_s);
     UStringSearch* searcher = usearch_open(&newlineCharacter, 1, &newlineCharacter, 1, searchCollatorName.utf8().data(), 0, &status);
     ASSERT(U_SUCCESS(status) || status == U_USING_FALLBACK_WARNING || status == U_USING_DEFAULT_WARNING);
     return searcher;

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1479,7 +1479,7 @@ static inline BOOL read2DigitNumber(std::span<const char>& p, int8_t& outval)
 
 static inline NSDate *_dateForString(NSString *string)
 {
-    auto p = spanIncludingNullTerminator([string UTF8String]);
+    auto p = unsafeSpanIncludingNullTerminator([string UTF8String]);
     RetainPtr<NSDateComponents> dateComponents = adoptNS([[NSDateComponents alloc] init]);
 
     // Set the time zone to GMT

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -294,7 +294,7 @@ DecodedHTMLEntity consumeHTMLEntity(StringParsingBuffer<UChar>& source)
 DecodedHTMLEntity decodeNamedHTMLEntityForXMLParser(const char* name)
 {
     HTMLEntitySearch search;
-    for (char character : span(name)) {
+    for (char character : unsafeSpan(name)) {
         search.advance(character);
         if (!search.isEntityPrefix())
             return { };

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -75,7 +75,7 @@ static void appendMailtoPostFormDataToURL(URL& url, const FormData& data, const 
         body = PAL::decodeURLEscapeSequences(makeStringByReplacingAll(makeStringByReplacingAll(body, '&', "\r\n"_s), '+', ' '));
     }
 
-    Vector<uint8_t> bodyData("body="_s.span8());
+    Vector<uint8_t> bodyData("body="_span);
     FormDataBuilder::encodeStringAsFormData(bodyData, body.utf8());
     body = makeStringByReplacingAll(bodyData.span(), '+', "%20"_s);
 

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -263,7 +263,7 @@ bool PrivateClickMeasurement::hasHigherPriorityThan(const PrivateClickMeasuremen
 
 static URL makeValidURL(const RegistrableDomain& domain, const char* path)
 {
-    URL validURL { makeString("https://"_s, domain.string(), span(path)) };
+    URL validURL { makeString("https://"_s, domain.string(), unsafeSpan(path)) };
     return validURL.isValid() ? validURL : URL { };
 }
 

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -392,7 +392,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    return makeString("pageProperty() unimplemented for: "_s, span(propertyName));
+    return makeString("pageProperty() unimplemented for: "_s, unsafeSpan(propertyName));
 }
 
 bool PrintContext::isPageBoxVisible(LocalFrame* frame, int pageNumber)

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -62,7 +62,7 @@ void SharedBufferChunkReader::setSeparator(const Vector<char>& separator)
 void SharedBufferChunkReader::setSeparator(const char* separator)
 {
     m_separator.clear();
-    m_separator.append(WTF::span(separator));
+    m_separator.append(unsafeSpan(separator));
 }
 
 bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSeparator)

--- a/Source/WebCore/platform/graphics/ColorSerialization.cpp
+++ b/Source/WebCore/platform/graphics/ColorSerialization.cpp
@@ -595,7 +595,7 @@ String serializationForCSS(SRGBA<uint8_t> color, bool useColorFunctionSerializat
     case 0xFF:
         return makeString("rgb("_s, red, ", "_s, green, ", "_s, blue, ')');
     default:
-        return makeString("rgba("_s, red, ", "_s, green, ", "_s, blue, ", 0."_s, span(fractionDigitsForFractionalAlphaValue(alpha).data()), ')');
+        return makeString("rgba("_s, red, ", "_s, green, ", "_s, blue, ", 0."_s, unsafeSpan(fractionDigitsForFractionalAlphaValue(alpha).data()), ')');
     }
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -105,7 +105,7 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     }
 
 #if ASSERT_ENABLED
-    auto clientExtensions = span8(EGL_QueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS));
+    auto clientExtensions = unsafeSpan8(EGL_QueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS));
     ASSERT(clientExtensions.data());
 #endif
 
@@ -151,7 +151,7 @@ static EGLDisplay initializeEGLDisplay(const GraphicsContextGLAttributes& attrs)
     LOG(WebGL, "ANGLE initialised Major: %d Minor: %d", majorVersion, minorVersion);
 
 #if ASSERT_ENABLED && ENABLE(WEBXR)
-    auto displayExtensions = span8(EGL_QueryString(display, EGL_EXTENSIONS));
+    auto displayExtensions = unsafeSpan8(EGL_QueryString(display, EGL_EXTENSIONS));
     ASSERT(WTF::contains(displayExtensions, "EGL_ANGLE_metal_shared_event_sync"_span));
 #endif
 
@@ -260,7 +260,7 @@ bool GraphicsContextGLCocoa::platformInitializeContext()
     eglContextAttributes.append(EGL_FALSE);
 
 #if HAVE(TASK_IDENTITY_TOKEN)
-    auto displayExtensions = span8(EGL_QueryString(m_displayObj, EGL_EXTENSIONS));
+    auto displayExtensions = unsafeSpan8(EGL_QueryString(m_displayObj, EGL_EXTENSIONS));
     bool supportsOwnershipIdentity = WTF::contains(displayExtensions, "EGL_ANGLE_metal_create_context_ownership_identity"_span);
     if (m_resourceOwner && supportsOwnershipIdentity) {
         eglContextAttributes.append(EGL_CONTEXT_METAL_OWNERSHIP_IDENTITY_ANGLE);

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -70,7 +70,7 @@ static void initializeDMABufAvailability()
         if (!webkitGstCheckVersion(1, 20, 0))
             return;
 
-        auto value = WTF::span(g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED"));
+        auto value = unsafeSpan(g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED"));
         s_isDMABufDisabled = value.data() && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
         if (!s_isDMABufDisabled && !DRMDeviceManager::singleton().mainGBMDeviceNode(DRMDeviceManager::NodeType::Render))
             s_isDMABufDisabled = true;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -308,7 +308,7 @@ bool doCapsHaveType(const GstCaps* caps, const char* type)
         GST_WARNING("Failed to get MediaType");
         return false;
     }
-    return mediaType.startsWith(span(type));
+    return mediaType.startsWith(unsafeSpan(type));
 }
 
 bool areEncryptedCaps(const GstCaps* caps)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1041,7 +1041,7 @@ static inline Vector<RTCRtpCapabilities::HeaderExtensionCapability> probeRtpExte
     Vector<RTCRtpCapabilities::HeaderExtensionCapability> extensions;
     for (const auto& uri : candidates) {
         if (auto extension = adoptGRef(gst_rtp_header_extension_create_from_uri(uri.characters())))
-            extensions.append(makeString(span(uri)));
+            extensions.append(makeString(unsafeSpan(uri)));
     }
     return extensions;
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2453,7 +2453,7 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
     configureElementPlatformQuirks(element);
 
     GUniquePtr<char> elementName(gst_element_get_name(element));
-    String elementClass = WTF::span(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+    String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
     auto classifiers = elementClass.split('/');
 
     // In GStreamer 1.20 and older urisourcebin mishandles source elements with dynamic pads. This

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -351,7 +351,7 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
         format = GST_VIDEO_FORMAT_BGRA;
         break;
     }
-    auto formatName = WTF::span(gst_video_format_to_string(format));
+    auto formatName = unsafeSpan(gst_video_format_to_string(format));
     GST_TRACE("Creating %s VideoFrame from pixel buffer", formatName.data());
 
     int frameRateNumerator, frameRateDenominator;
@@ -616,7 +616,7 @@ GRefPtr<GstSample> VideoFrameGStreamer::convert(GstVideoFormat format, const Int
 
     auto width = destinationSize.width();
     auto height = destinationSize.height();
-    auto formatName = WTF::span(gst_video_format_to_string(format));
+    auto formatName = unsafeSpan(gst_video_format_to_string(format));
     auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.data(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
 
     if (gst_caps_is_equal(caps, outputCaps.get()))

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -301,7 +301,7 @@ CDMInstanceSessionThunder::CDMInstanceSessionThunder(CDMInstanceThunder& instanc
     };
     m_thunderSessionCallbacks.error_message_callback = [](OpenCDMSession*, void* userData, const char message[]) {
         GST_ERROR("Got 'error' OCDM notification: %s", message);
-        callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(span(message))]() mutable {
+        callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(unsafeSpan(message))]() mutable {
             if (!session)
                 return;
             session->errorCallback(WTFMove(buffer));

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -192,7 +192,7 @@ static Vector<hb_feature_t, 4> fontFeatures(const FontCascade& font, const FontP
     auto* fcPattern = fontPlatformData.fcPattern();
     FcChar8* fcFontFeature;
     for (int i = 0; FcPatternGetString(fcPattern, FC_FONT_FEATURES, i, &fcFontFeature) == FcResultMatch; ++i) {
-        auto fcFontFeatureSpan = spanIncludingNullTerminator(reinterpret_cast<char*>(fcFontFeature)).subspan<0, 5>();
+        auto fcFontFeatureSpan = unsafeSpanIncludingNullTerminator(reinterpret_cast<char*>(fcFontFeature)).subspan<0, 5>();
         featuresToBeApplied.set(fontFeatureTag(fcFontFeatureSpan), 1);
     }
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -276,7 +276,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitializeContext()
     eglContextAttributes.append(0);
 #endif
 
-    if (contains(span8(displayExtensions), "EGL_ANGLE_power_preference"_span)) {
+    if (contains(unsafeSpan(displayExtensions), "EGL_ANGLE_power_preference"_span)) {
         eglContextAttributes.append(EGL_POWER_PREFERENCE_ANGLE);
         // EGL_LOW_POWER_ANGLE is the default. Change to
         // EGL_HIGH_POWER_ANGLE if desired.

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -78,7 +78,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     const char* quirksList = g_getenv("WEBKIT_GST_QUIRKS");
     GST_DEBUG("Attempting to parse requested quirks: %s", GST_STR_NULL(quirksList));
     if (quirksList) {
-        StringView quirks { span(quirksList) };
+        StringView quirks { unsafeSpan(quirksList) };
         if (WTF::equalLettersIgnoringASCIICase(quirks, "help"_s)) {
             gst_printerrln("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, openmax, realtek, westeros");
             return;
@@ -118,7 +118,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     if (!holePunchQuirk)
         return;
 
-    StringView identifier { span(holePunchQuirk) };
+    StringView identifier { unsafeSpan(holePunchQuirk) };
     if (WTF::equalLettersIgnoringASCIICase(identifier, "help"_s)) {
         WTFLogAlways("Supported quirks for WEBKIT_GST_HOLE_PUNCH_QUIRK are: fake, westeros, bcmnexus");
         return;

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
@@ -565,7 +565,7 @@ void PNGImageDecoder::decode(bool onlySize, unsigned haltAtFrame, bool allDataRe
 
 void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
 {
-    if (chunk->size == 8 && spanHasPrefix(span(chunk->name), "acTL"_span)) {
+    if (chunk->size == 8 && spanHasPrefix(unsafeSpan(chunk->name), "acTL"_span)) {
         if (m_hasInfo || m_isAnimated)
             return;
 
@@ -585,7 +585,7 @@ void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
             return;
 
         m_frameBufferCache.resize(m_frameCount);
-    } else if (chunk->size == 26 && spanHasPrefix(span(chunk->name), "fcTL"_span)) {
+    } else if (chunk->size == 26 && spanHasPrefix(unsafeSpan(chunk->name), "fcTL"_span)) {
         if (m_hasInfo && !m_isAnimated)
             return;
 
@@ -652,7 +652,7 @@ void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
             fallbackNotAnimated();
             return;
         }
-    } else if (chunk->size >= 4 && spanHasPrefix(span(chunk->name), "fdAT"_span)) {
+    } else if (chunk->size >= 4 && spanHasPrefix(unsafeSpan(chunk->name), "fdAT"_span)) {
         if (!m_frameInfo || !m_isAnimated)
             return;
 

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -465,7 +465,7 @@ bool MediaRecorderPrivateBackend::preparePipeline()
             return;
         }
 
-        String elementClass = WTF::span(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
         if (classifiers.contains("Audio"_s) && classifiers.contains("Codec"_s) && classifiers.contains("Encoder"_s))
             recorder->configureAudioEncoder(element);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -152,7 +152,7 @@ GstElement* GStreamerCapturer::createSource()
         }
     } else {
         ASSERT(m_device);
-        auto sourceName = makeString(WTF::span(name()), hex(reinterpret_cast<uintptr_t>(this)));
+        auto sourceName = makeString(unsafeSpan(name()), hex(reinterpret_cast<uintptr_t>(this)));
         m_src = gst_device_create_element(m_device->device(), sourceName.ascii().data());
         ASSERT(m_src);
         g_object_set(m_src.get(), "do-timestamp", TRUE, nullptr);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -206,7 +206,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
     m_isDecoding = true;
 
     g_signal_connect(decodebin.get(), "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer userData) {
-        String elementClass = WTF::span(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
         if (!classifiers.contains("Depayloader"_s))
             return;
@@ -218,7 +218,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
     }), this);
 
     g_signal_connect(decodebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
-        String elementClass = WTF::span(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
         if (!classifiers.contains("Decoder"_s) || !classifiers.contains("Video"_s))
             return;
@@ -255,7 +255,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
 {
     GRefPtr<GstElement> parsebin = makeGStreamerElement("parsebin", nullptr);
     g_signal_connect(parsebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
-        String elementClass = WTF::span(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        String elementClass = unsafeSpan(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
         auto classifiers = elementClass.split('/');
         if (!classifiers.contains("Depayloader"_s))
             return;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -503,8 +503,8 @@ bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>
     }
 
     StringBuilder simulcastBuilder;
-    const char* direction = "send";
-    simulcastBuilder.append(span(direction));
+    auto direction = "send"_s;
+    simulcastBuilder.append(direction);
     simulcastBuilder.append(' ');
     unsigned totalStreams = 0;
     for (auto& packetizer : m_packetizers) {
@@ -515,7 +515,7 @@ bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>
         if (totalStreams > 0)
             simulcastBuilder.append(';');
         simulcastBuilder.append(rtpStreamId);
-        gst_structure_set(structure, makeString("rid-"_s, rtpStreamId).ascii().data(), G_TYPE_STRING, direction, nullptr);
+        gst_structure_set(structure, makeString("rid-"_s, rtpStreamId).ascii().data(), G_TYPE_STRING, direction.characters(), nullptr);
         packetizer->configureExtensions();
         totalStreams++;
     }

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -121,7 +121,7 @@ public:
     GstElement* makeElement(const gchar* factoryName)
     {
         static Atomic<uint32_t> elementId;
-        auto name = makeString(span(Name()), "-enc-"_s, span(factoryName), "-"_s, elementId.exchangeAdd(1));
+        auto name = makeString(span(Name()), "-enc-"_s, unsafeSpan(factoryName), "-"_s, elementId.exchangeAdd(1));
         auto* elem = makeGStreamerElement(factoryName, name.utf8().data());
         return elem;
     }

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -50,7 +50,7 @@ static inline void append(Vector<uint8_t>& buffer, std::span<const uint8_t> byte
 
 static inline void append(Vector<uint8_t>& buffer, const char* string)
 {
-    buffer.append(span8(string));
+    buffer.append(unsafeSpan8(string));
 }
 
 static inline void append(Vector<uint8_t>& buffer, const CString& string)

--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -904,7 +904,7 @@ void CurlHandle::addExtraNetworkLoadMetrics(NetworkLoadMetrics& networkLoadMetri
     additionalMetrics->responseHeaderBytesReceived = responseHeaderSize;
 
     if (ip)
-        additionalMetrics->remoteAddress = port ? makeString(span(ip), ':', port) : String::fromLatin1(ip);
+        additionalMetrics->remoteAddress = port ? makeString(unsafeSpan(ip), ':', port) : String::fromLatin1(ip);
 
     if (m_tlsConnectionInfo) {
         additionalMetrics->tlsProtocol = m_tlsConnectionInfo->protocol;

--- a/Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp
+++ b/Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp
@@ -68,7 +68,7 @@ static ProtectionSpace protectionSpaceFromSoupAuthAndURL(SoupAuth* soupAuth, con
     if (!port)
         port = defaultPortForProtocol(url.protocol());
 #else
-    URL authURL({ }, makeString("http://"_s, WTF::span(soup_auth_get_authority(soupAuth))));
+    URL authURL({ }, makeString("http://"_s, unsafeSpan(soup_auth_get_authority(soupAuth))));
     auto host = authURL.host();
     auto port = authURL.port();
 #endif

--- a/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
+++ b/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
@@ -166,7 +166,7 @@ Vector<RefPtr<PlatformSpeechSynthesisVoice>> SpielSpeechWrapper::initializeVoice
         auto isDefault = true;
         const auto languages = span(const_cast<char**>(spiel_voice_get_languages(voice)));
         for (const auto language : languages) {
-            auto languageString = makeString(span(language));
+            auto languageString = makeString(unsafeSpan(language));
             auto uri = generateVoiceURI(voice, languageString);
             platformVoices.append(PlatformSpeechSynthesisVoice::create(uri, name, languageString, false, isDefault));
             m_voices.add(uri, GRefPtr(voice));

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -58,7 +58,7 @@ static constexpr auto notOpenErrorMessage = "database is not open"_s;
 static void unauthorizedSQLFunction(sqlite3_context *context, int, sqlite3_value **)
 {
     auto* functionName = static_cast<const char*>(sqlite3_user_data(context));
-    sqlite3_result_error(context, makeString("Function "_s, span(functionName), " is unauthorized"_s).utf8().data(), -1);
+    sqlite3_result_error(context, makeString("Function "_s, unsafeSpan(functionName), " is unauthorized"_s).utf8().data(), -1);
 }
 
 static void initializeSQLiteIfNecessary()
@@ -779,7 +779,7 @@ static Expected<sqlite3_stmt*, int> constructAndPrepareStatement(SQLiteDatabase&
 Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatementSlow(StringView queryString)
 {
     auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
-    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
         return makeUnexpected(sqlStatement.error());
@@ -789,7 +789,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatementSlow(StringView q
 
 Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral query)
 {
-    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.characters());
         return makeUnexpected(sqlStatement.error());
@@ -800,7 +800,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral que
 Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatementSlow(StringView queryString)
 {
     auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
-    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareHeapStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
         return makeUnexpected(sqlStatement.error());
@@ -810,7 +810,7 @@ Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatementSl
 
 Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatement(ASCIILiteral query)
 {
-    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareHeapStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.characters());
         return makeUnexpected(sqlStatement.error());

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -214,7 +214,7 @@ static String getFullCFHTML(IDataObject* data)
 
 static void append(Vector<char>& vector, const char* string)
 {
-    vector.append(span(string));
+    vector.append(unsafeSpan(string));
 }
 
 static void append(Vector<char>& vector, const CString& string)

--- a/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
@@ -67,7 +67,7 @@ Instance::Impl::Impl()
 
         auto createInfo = createStructure<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO>();
         createInfo.createFlags = 0;
-        memcpySpan(std::span { createInfo.applicationInfo.applicationName }, s_applicationName.spanIncludingNullTerminator());
+        memcpySpan(std::span { createInfo.applicationInfo.applicationName }, s_applicationName.unsafeSpanIncludingNullTerminator());
         createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
         createInfo.applicationInfo.applicationVersion = s_applicationVersion;
         createInfo.enabledApiLayerCount = 0;

--- a/Source/WebCore/xml/XMLErrors.cpp
+++ b/Source/WebCore/xml/XMLErrors.cpp
@@ -81,7 +81,7 @@ void XMLErrors::handleError(Type type, const char* message, TextPosition positio
 void XMLErrors::appendErrorMessage(ASCIILiteral typeString, TextPosition position, const char* message)
 {
     // <typeString> on line <lineNumber> at column <columnNumber>: <message>
-    m_errorMessages.append(typeString, " on line "_s, position.m_line.oneBasedInt(), " at column "_s, position.m_column.oneBasedInt(), ": "_s, span(message));
+    m_errorMessages.append(typeString, " on line "_s, position.m_line.oneBasedInt(), " at column "_s, position.m_column.oneBasedInt(), ": "_s, unsafeSpan(message));
 }
 
 static inline Ref<Element> createXHTMLParserErrorHeader(Document& document, String&& errorMessages)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -210,7 +210,7 @@ static HashMap<String, RTCNetwork> gatherNetworkMap()
 
         auto prefixLength = rtc::CountIPMaskBits(address->second.rtcAddress());
 
-        auto name = span(iterator->ifa_name);
+        auto name = unsafeSpan(iterator->ifa_name);
         auto prefixString = address->second.rtcAddress().ToString();
         auto networkKey = makeString(name, "-"_s, prefixLength, "-"_s, std::span { prefixString });
 

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectInterface.mm
@@ -88,7 +88,7 @@ static void initializeMethod(MethodInfo& methodInfo, Protocol *protocol, SEL sel
 
     bool foundBlock = false;
     for (NSUInteger i = firstArgument; i < argumentCount; ++i) {
-        auto argumentType = span([methodSignature getArgumentTypeAtIndex:i]);
+        auto argumentType = unsafeSpan([methodSignature getArgumentTypeAtIndex:i]);
 
         if (argumentType.empty() || argumentType.front() != '@') {
             // This is a non-object type; we won't allow any classes to be decoded for it.

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -94,7 +94,7 @@ std::span<const uint8_t> SandboxExtensionImpl::getSerializedFormat()
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ASSERT(strlen(m_token));
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    return span8(m_token);
+    return unsafeSpan8(m_token);
 }
 
 char* SandboxExtensionImpl::sandboxExtensionForType(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -240,7 +240,7 @@ static std::optional<CString> setAndSerializeSandboxParameters(const SandboxInit
             WTFLogAlways("%s: Could not set sandbox parameter: %s\n", getprogname(), safeStrerror(errno).data());
             CRASH();
         }
-        builder.append(span(name), ':', span(value), ':');
+        builder.append(unsafeSpan(name), ':', unsafeSpan(value), ':');
     }
     if (isProfilePath) {
         auto contents = fileContents(profileOrProfilePath);

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -422,7 +422,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 
     startTable("Version Information"_s);
     auto versionObject = JSON::Object::create();
-    addTableRow(versionObject, "WebKit version"_s, makeString(webkitPortName(), ' ', WEBKIT_MAJOR_VERSION, '.', WEBKIT_MINOR_VERSION, '.', WEBKIT_MICRO_VERSION, " ("_s, WTF::span(BUILD_REVISION), ')'));
+    addTableRow(versionObject, "WebKit version"_s, makeString(webkitPortName(), ' ', WEBKIT_MAJOR_VERSION, '.', WEBKIT_MINOR_VERSION, '.', WEBKIT_MICRO_VERSION, " ("_s, unsafeSpan(BUILD_REVISION), ')'));
 
 #if OS(UNIX)
     struct utsname osName;
@@ -434,7 +434,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     addTableRow(versionObject, "Desktop"_s, (desktopName && *desktopName) ? String::fromUTF8(desktopName) : "Unknown"_s);
 
 #if USE(CAIRO)
-    addTableRow(versionObject, "Cairo version"_s, makeString(WTF::span(CAIRO_VERSION_STRING), " (build) "_s, WTF::span(cairo_version_string()), " (runtime)"_s));
+    addTableRow(versionObject, "Cairo version"_s, makeString(unsafeSpan(CAIRO_VERSION_STRING), " (build) "_s, unsafeSpan(cairo_version_string()), " (runtime)"_s));
 #endif
 
 #if USE(GSTREAMER)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3433,7 +3433,7 @@ void webkit_web_view_load_plain_text(WebKitWebView* webView, const gchar* plainT
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
     g_return_if_fail(plainText);
 
-    getPage(webView).loadData(WebCore::SharedBuffer::create(span8(plainText)), "text/plain"_s, "UTF-8"_s, aboutBlankURL().string());
+    getPage(webView).loadData(WebCore::SharedBuffer::create(unsafeSpan8(plainText)), "text/plain"_s, "UTF-8"_s, aboutBlankURL().string());
 }
 
 /**

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -76,7 +76,7 @@ void SubFrameSOAuthorizationSession::fallBackToWebPathInternal()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPathInternal: navigationAction=%p", navigationAction());
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(span8(soAuthorizationPostDidCancelMessageToParent)));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(unsafeSpan8(soAuthorizationPostDidCancelMessageToParent)));
     appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
 }
 
@@ -102,7 +102,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
     // Cancelled the current load before loading the data to post SOAuthorizationDidStart to the parent frame.
     invokeCallback(true);
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(span8(soAuthorizationPostDidStartMessageToParent)));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(unsafeSpan8(soAuthorizationPostDidStartMessageToParent)));
 }
 
 void SubFrameSOAuthorizationSession::didFinishLoad(IsMainFrame, const URL&)

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
@@ -214,7 +214,7 @@ void RemoteInspectorClient::setBackendCommands(const char* backendCommands)
         return;
     }
 
-    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(span8(backendCommands)));
+    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(unsafeSpan8(backendCommands)));
 }
 
 void RemoteInspectorClient::connectionDidClose()

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -213,7 +213,7 @@ void ProcessLauncher::launchProcess()
     UnixFileDescriptor sysprofFd;
 
     if (const char* sysprofFdStr = getenv("SYSPROF_CONTROL_FD"))
-        sysprofFd = UnixFileDescriptor(parseInteger<int>(StringView(span(sysprofFdStr))).value_or(-1), UnixFileDescriptor::Duplicate);
+        sysprofFd = UnixFileDescriptor(parseInteger<int>(StringView(unsafeSpan(sysprofFdStr))).value_or(-1), UnixFileDescriptor::Duplicate);
 
     if (sysprofFd) {
         int fd = sysprofFd.release();

--- a/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/ResponsivenessTimer.cpp
@@ -119,7 +119,7 @@ bool ResponsivenessTimer::mayBecomeUnresponsive() const
         char* variable = getenv("DYLD_INSERT_LIBRARIES");
         if (!variable)
             return false;
-        if (!contains(span8(variable), "libgmalloc"_span))
+        if (!contains(unsafeSpan(variable), "libgmalloc"_span))
             return false;
         return true;
     }();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2665,7 +2665,7 @@ static String commandNameForSelector(SEL selector)
     // Remove the trailing colon.
     // No need to capitalize the command name since Editor command names are
     // not case sensitive.
-    auto selectorName = span(sel_getName(selector));
+    auto selectorName = unsafeSpan(sel_getName(selector));
     if (selectorName.size() < 2 || selectorName[selectorName.size() - 1] != ':')
         return String();
     return String(selectorName.first(selectorName.size() - 1));

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -828,14 +828,14 @@ void WebProcess::registerLogHook()
             return;
 #endif
 
-        auto logChannel = span8IncludingNullTerminator(msg->subsystem);
-        auto logCategory = span8IncludingNullTerminator(msg->category);
+        auto logChannel = unsafeSpan8IncludingNullTerminator(msg->subsystem);
+        auto logCategory = unsafeSpan8IncludingNullTerminator(msg->category);
 
         if (type == OS_LOG_TYPE_FAULT)
             type = OS_LOG_TYPE_ERROR;
 
         if (char* messageString = os_log_copy_message_string(msg)) {
-            auto logString = span8IncludingNullTerminator(messageString);
+            auto logString = unsafeSpan8IncludingNullTerminator(messageString);
             WebProcess::singleton().sendLogOnStream(logChannel, logCategory, logString, type);
             free(messageString);
         }

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -660,7 +660,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (CFEqual(CFErrorGetDomain(error), kCFErrorDomainOSStatus)) {
         const char* descriptionOSStatus = GetMacOSStatusCommentString(static_cast<OSStatus>(errorCode));
         if (descriptionOSStatus && descriptionOSStatus[0] != '\0')
-            description = makeString("OSStatus Error "_s, errorCode, ": "_s, span(descriptionOSStatus));
+            description = makeString("OSStatus Error "_s, errorCode, ": "_s, unsafeSpan(descriptionOSStatus));
     }
 
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
@@ -36,13 +36,13 @@ TEST(Base64, Encode)
 {
     static constexpr OptionSet<Base64EncodeOption> options;
 
-    EXPECT_ENCODE("", ""_s.span8());
-    EXPECT_ENCODE("Zg==", "f"_s.span8());
-    EXPECT_ENCODE("Zm8=", "fo"_s.span8());
-    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
-    EXPECT_ENCODE("Zm9vYg==", "foob"_s.span8());
-    EXPECT_ENCODE("Zm9vYmE=", "fooba"_s.span8());
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+    EXPECT_ENCODE("", ""_span);
+    EXPECT_ENCODE("Zg==", "f"_span);
+    EXPECT_ENCODE("Zm8=", "fo"_span);
+    EXPECT_ENCODE("Zm9v", "foo"_span);
+    EXPECT_ENCODE("Zm9vYg==", "foob"_span);
+    EXPECT_ENCODE("Zm9vYmE=", "fooba"_span);
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span);
 
     EXPECT_ENCODE("AA==", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ==", Vector<uint8_t>({ 1 }));
@@ -58,13 +58,13 @@ TEST(Base64, EncodeOmitPadding)
 {
     static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::OmitPadding };
 
-    EXPECT_ENCODE("", ""_s.span8());
-    EXPECT_ENCODE("Zg", "f"_s.span8());
-    EXPECT_ENCODE("Zm8", "fo"_s.span8());
-    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
-    EXPECT_ENCODE("Zm9vYg", "foob"_s.span8());
-    EXPECT_ENCODE("Zm9vYmE", "fooba"_s.span8());
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+    EXPECT_ENCODE("", ""_span);
+    EXPECT_ENCODE("Zg", "f"_span);
+    EXPECT_ENCODE("Zm8", "fo"_span);
+    EXPECT_ENCODE("Zm9v", "foo"_span);
+    EXPECT_ENCODE("Zm9vYg", "foob"_span);
+    EXPECT_ENCODE("Zm9vYmE", "fooba"_span);
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span);
 
     EXPECT_ENCODE("AA", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ", Vector<uint8_t>({ 1 }));
@@ -80,13 +80,13 @@ TEST(Base64, EncodeURL)
 {
     static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::URL };
 
-    EXPECT_ENCODE("", ""_s.span8());
-    EXPECT_ENCODE("Zg==", "f"_s.span8());
-    EXPECT_ENCODE("Zm8=", "fo"_s.span8());
-    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
-    EXPECT_ENCODE("Zm9vYg==", "foob"_s.span8());
-    EXPECT_ENCODE("Zm9vYmE=", "fooba"_s.span8());
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+    EXPECT_ENCODE("", ""_span);
+    EXPECT_ENCODE("Zg==", "f"_span);
+    EXPECT_ENCODE("Zm8=", "fo"_span);
+    EXPECT_ENCODE("Zm9v", "foo"_span);
+    EXPECT_ENCODE("Zm9vYg==", "foob"_span);
+    EXPECT_ENCODE("Zm9vYmE=", "fooba"_span);
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span);
 
     EXPECT_ENCODE("AA==", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ==", Vector<uint8_t>({ 1 }));
@@ -102,13 +102,13 @@ TEST(Base64, EncodeURLOmitPadding)
 {
     static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding };
 
-    EXPECT_ENCODE("", ""_s.span8());
-    EXPECT_ENCODE("Zg", "f"_s.span8());
-    EXPECT_ENCODE("Zm8", "fo"_s.span8());
-    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
-    EXPECT_ENCODE("Zm9vYg", "foob"_s.span8());
-    EXPECT_ENCODE("Zm9vYmE", "fooba"_s.span8());
-    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+    EXPECT_ENCODE("", ""_span);
+    EXPECT_ENCODE("Zg", "f"_span);
+    EXPECT_ENCODE("Zm8", "fo"_span);
+    EXPECT_ENCODE("Zm9v", "foo"_span);
+    EXPECT_ENCODE("Zm9vYg", "foob"_span);
+    EXPECT_ENCODE("Zm9vYmE", "fooba"_span);
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_span);
 
     EXPECT_ENCODE("AA", Vector<uint8_t>({ 0 }));
     EXPECT_ENCODE("AQ", Vector<uint8_t>({ 1 }));

--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -738,7 +738,7 @@ TEST(JSONValue, MemoryCost)
 
     {
         Ref<JSON::Value> valueA = JSON::Value::create(makeString("t"_s));
-        Ref<JSON::Value> valueB = JSON::Value::create(makeString(span("😀")));
+        Ref<JSON::Value> valueB = JSON::Value::create(makeString(unsafeSpan("😀")));
         EXPECT_LT(valueA->memoryCost(), valueB->memoryCost());
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -43,7 +43,7 @@ TEST(WTF, StringImplCreationFromLiteral)
 
     // Constructor taking the size explicitly.
     const char* programmaticStringData = "Explicit Size Literal";
-    auto programmaticString = StringImpl::createWithoutCopying(span(programmaticStringData));
+    auto programmaticString = StringImpl::createWithoutCopying(unsafeSpan(programmaticStringData));
     ASSERT_EQ(strlen(programmaticStringData), programmaticString->length());
     ASSERT_TRUE(equal(programmaticString.get(), StringView::fromLatin1(programmaticStringData)));
     ASSERT_EQ(programmaticStringData, reinterpret_cast<const char*>(programmaticString->span8().data()));

--- a/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
@@ -96,7 +96,7 @@ public:
         char* line;
 
         while ((line = fgets(buffer, sizeof(buffer), m_stderr)))
-            result.append(span(line));
+            result.append(unsafeSpan(line));
 
         return result.toString();
     }

--- a/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
@@ -94,7 +94,7 @@ static const char* testDecode(ASCIILiteral encodingName, std::initializer_list<c
         auto vector = decodeHexTestBytes(inputs.begin()[i]);
         bool last = i == size - 1;
         bool sawError = false;
-        resultBuilder.append(span(escapeNonASCIIPrintableCharacters(codec->decode(vector.span(), last, false, sawError))));
+        resultBuilder.append(unsafeSpan(escapeNonASCIIPrintableCharacters(codec->decode(vector.span(), last, false, sawError))));
         if (sawError)
             resultBuilder.append(" ERROR"_s);
     }

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -146,14 +146,14 @@ TEST(CurlMultipartHandleTests, SimpleMessage)
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--\r\n This is the epilogue."_s;
+        "\r\n--boundary--\r\n This is the epilogue."_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -177,14 +177,14 @@ TEST(CurlMultipartHandleTests, NoHeader)
     auto data =
         "--boundary\r\n\r\n\r\n"
         "ABCDEF"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 0);
 
     handle->completeHeaderProcessing();
@@ -199,14 +199,14 @@ TEST(CurlMultipartHandleTests, NoBody)
     auto data =
         "--boundary\r\nContent-type: text/plain\r\n\r\n"
         "\r\n--boundary  \r\nContent-type: text/html\r\n\r\n"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -232,14 +232,14 @@ TEST(CurlMultipartHandleTests, TransportPadding)
         "ABCDEF"
         "\r\n--boundary  \r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--\r\n This is the epilogue."_s;
+        "\r\n--boundary--\r\n This is the epilogue."_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -264,14 +264,14 @@ TEST(CurlMultipartHandleTests, NoEndOfBoundary)
         "--boundary\r\nContent-type: text/plain\r\n\r\n"
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
-        "<html></html>"_s;
+        "<html></html>"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -298,14 +298,14 @@ TEST(CurlMultipartHandleTests, NoEndOfBoundaryAfterCompleted)
         "--boundary\r\nContent-type: text/plain\r\n\r\n"
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
-        "<html></html>"_s;
+        "<html></html>"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -332,14 +332,14 @@ TEST(CurlMultipartHandleTests, NoCloseDelimiter)
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary\r\n"_s;
+        "\r\n--boundary\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -367,14 +367,14 @@ TEST(CurlMultipartHandleTests, NoCloseDelimiterAfterCompleted)
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary\r\n"_s;
+        "\r\n--boundary\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -401,14 +401,14 @@ TEST(CurlMultipartHandleTests, CloseDelimiter)
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -434,14 +434,14 @@ TEST(CurlMultipartHandleTests, CloseDelimiterAfterCompleted)
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -463,20 +463,20 @@ TEST(CurlMultipartHandleTests, CloseDelimiterAfterCompleted)
 
 TEST(CurlMultipartHandleTests, DivideFirstDelimiter)
 {
-    auto data = "--bound"_s;
+    auto data = "--bound"_span;
 
     auto nextData = "ary\r\nContent-type: text/plain\r\n\r\n"
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 0);
 
     handle->didReceiveMessage(span(nextData));
@@ -502,18 +502,18 @@ TEST(CurlMultipartHandleTests, DivideSecondDelimiter)
 {
     auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
         "ABCDEF"
-        "\r\n--b"_s;
+        "\r\n--b"_span;
 
     auto nextData = "oundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -541,16 +541,16 @@ TEST(CurlMultipartHandleTests, DivideLastDelimiter)
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundar"_s;
+        "\r\n--boundar"_span;
 
-    auto nextData = "y--\r\n"_s;
+    auto nextData = "y--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -579,16 +579,16 @@ TEST(CurlMultipartHandleTests, DivideCloseDelimiter)
         "ABCDEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary"_s;
+        "\r\n--boundary"_span;
 
-    auto nextData = "--\r\n"_s;
+    auto nextData = "--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -615,19 +615,19 @@ TEST(CurlMultipartHandleTests, DivideTransportPadding)
 {
     auto data = "--boundary  \r\nContent-type: text/plain\r\n\r\n"
         "ABCDEF"
-        "\r\n--boundary      "_s;
+        "\r\n--boundary      "_span;
 
     auto nextData =
         "  \r\nContent-type: text/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--        \r\n"_s;
+        "\r\n--boundary--        \r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -653,18 +653,18 @@ TEST(CurlMultipartHandleTests, DivideHeader)
 {
     auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
         "ABCDEF"
-        "\r\n--boundary\r\nContent-type: t"_s;
+        "\r\n--boundary\r\nContent-type: t"_span;
 
     auto nextData = "ext/html\r\n\r\n"
         "<html></html>"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -689,21 +689,21 @@ TEST(CurlMultipartHandleTests, DivideHeader)
 TEST(CurlMultipartHandleTests, DivideBody)
 {
     auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
-        "ABC"_s;
+        "ABC"_span;
 
     auto secondData = "DEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
-        "<h"_s;
+        "<h"_span;
 
     auto lastData = "tml></html>"
-        "\r\n--boundary--\r\n"_s;
+        "\r\n--boundary--\r\n"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -731,20 +731,20 @@ TEST(CurlMultipartHandleTests, DivideBody)
 TEST(CurlMultipartHandleTests, CompleteWhileHeaderProcessing)
 {
     auto data = "--boundary\r\nContent-type: text/plain\r\n\r\n"
-        "ABC"_s;
+        "ABC"_span;
 
     auto secondData = "DEF"
         "\r\n--boundary\r\nContent-type: text/html\r\n\r\n"
-        "<h"_s;
+        "<h"_span;
 
-    auto lastData = "tml></html>"_s;
+    auto lastData = "tml></html>"_span;
 
     MultipartHandleClient client;
 
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(span(data));
+    handle->didReceiveMessage(data);
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     EXPECT_EQ(client.data().size(), 0);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm
@@ -74,7 +74,7 @@ TEST(WebKit, HTTPReferer)
         HTTPServer server([&] (Connection connection) {
             connection.receiveHTTPRequest([connection, expectedReferer, &done] (Vector<char>&& request) {
                 if (expectedReferer) {
-                    auto expectedHeaderField = makeString("Referer: "_s, span(expectedReferer), "\r\n"_s);
+                    auto expectedHeaderField = makeString("Referer: "_s, unsafeSpan(expectedReferer), "\r\n"_s);
                     EXPECT_TRUE(strnstr(request.data(), expectedHeaderField.utf8().data(), request.size()));
                 } else
                     EXPECT_FALSE(strnstr(request.data(), "Referer:"_s, request.size()));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -2403,7 +2403,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
 
     RetainPtr<NSURL> baseURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     URL testURL { "http://www.example.com"_str };
-    auto testHtml = generateHtml(openerTemplate, testURL.string(), makeString("newWindow.location = '"_s, span(baseURL.get().absoluteString.UTF8String), "';"_s)); // Starts a new navigation on the new window.
+    auto testHtml = generateHtml(openerTemplate, testURL.string(), makeString("newWindow.location = '"_s, unsafeSpan(baseURL.get().absoluteString.UTF8String), "';"_s)); // Starts a new navigation on the new window.
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto messageHandler = adoptNS([[TestSOAuthorizationScriptMessageHandler alloc] initWithExpectation:@[@"Hello.", @"WindowClosed."]]);

--- a/Tools/TestWebKitAPI/win/PlatformUtilitiesWin.cpp
+++ b/Tools/TestWebKitAPI/win/PlatformUtilitiesWin.cpp
@@ -51,7 +51,7 @@ WKStringRef createInjectedBundlePath()
 
 WKURLRef createURLForResource(const char* resource, const char* extension)
 {
-    String filename = makeString("..\\..\\..\\Tools\\TestWebKitAPI\\Tests\\WebKit\\"_s, span(resource), '.', span(extension));
+    String filename = makeString("..\\..\\..\\Tools\\TestWebKitAPI\\Tests\\WebKit\\"_s, unsafeSpan(resource), '.', unsafeSpan(extension));
     auto url = URL::fileURLWithFileSystemPath(FileSystem::pathByAppendingComponent(moduleDirectory(), filename));
     return WKURLCreateWithUTF8CString(url.string().utf8().data());
 }


### PR DESCRIPTION
#### 2b5cd73b19cc1c159edec291d87702bad336ace5
<pre>
Rename `span(const char*)` to `unsafeSpan(const char*)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=286317">https://bugs.webkit.org/show_bug.cgi?id=286317</a>

Reviewed by NOBODY (OOPS!).

Rename `span(const char*)` to `unsafeSpan(const char*)` since it assumes a null-terminated string.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringCreateWithUTF8CString):
* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::RegExpNode::emitBytecode):
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::makeDOMAttributeGetterTypeErrorMessage):
(JSC::makeDOMAttributeSetterTypeErrorMessage):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::parse):
(JSC::Options::overrideAliasedOptionWithHeuristic):
(JSC::Options::setAliasedOption):
(JSC::OptionsHelper::Option::dump const):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::toSourceString const):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::reportTopBytecodes):
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::parseClause):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::dumpWasmSource):
* Source/WTF/wtf/Assertions.cpp:
(WTF::createWithFormatAndArguments):
* Source/WTF/wtf/DataLog.cpp:
(WTF::initializeLogFileOnce):
(WTF::setDataFile):
* Source/WTF/wtf/DateMath.cpp:
(WTF::parseDate):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::fromStdFileSystemPath):
* Source/WTF/wtf/Logger.cpp:
(WTF::Logger::LogSiteIdentifier::toString const):
* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::initialize):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
(WTF::FileSystemImpl::createTemporaryDirectory):
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::isUserVisibleURL):
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WTF/wtf/text/AtomString.h:
(WTF::AtomString::fromUTF8):
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::addCString):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::CString):
(WTF::CString::copyBufferIfNeeded):
(WTF::CString::grow):
* Source/WTF/wtf/text/CString.h:
(WTF::CString::data const):
(WTF::CString::unsafeSpanIncludingNullTerminator const):
(WTF::CString::spanIncludingNullTerminator const): Deleted.
* Source/WTF/wtf/text/StringCommon.h:
(WTF::unsafeSpan8):
(WTF::unsafeSpan8IncludingNullTerminator):
(WTF::unsafeSpan):
(WTF::unsafeSpanIncludingNullTerminator):
(WTF::equalIgnoringASCIICaseCommon):
(WTF::findIgnoringASCIICaseWithoutLength):
(WTF::equalIgnoringASCIICase):
(WTF::span8): Deleted.
(WTF::span8IncludingNullTerminator): Deleted.
(WTF::spanIncludingNullTerminator): Deleted.
* Source/WTF/wtf/text/StringConcatenate.h:
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::createFromCString):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
(WTF::equal):
* Source/WTF/wtf/text/TextStream.cpp:
(WTF::TextStream::operator&lt;&lt;):
* Source/WTF/wtf/text/WTFString.cpp:
(asciiDebug):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::WebMediaSessionLogger::logAlways const):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::createOrMigrateRecordsTableIfNecessary):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidBlobTables):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidRecordsTable):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsTable):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::ensureValidIndexRecordsRecordIndex):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::onIceCandidate):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::setSsrcAudioLevelVadOn):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::toRTCCodecParameters):
* Source/WebCore/Modules/push-api/PushMessageCrypto.cpp:
(WebCore::PushCrypto::decryptAESGCMPayload):
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::formatErrorMessage):
* Source/WebCore/Modules/webdatabase/SQLError.h:
(WebCore::SQLError::create):
* Source/WebCore/PAL/pal/unix/LoggingUnix.cpp:
(PAL::logLevelString):
* Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp:
(WebCore::makeThisTypeErrorMessage):
* Source/WebCore/bridge/IdentifierRep.cpp:
(WebCore::IdentifierRep::get):
* Source/WebCore/bridge/objc/objc_class.mm:
(JSC::Bindings::convertJSMethodNameToObjc):
* Source/WebCore/bridge/objc/objc_utility.mm:
(JSC::Bindings::objcValueTypeForType):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(_dateForString):
* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::decodeNamedHTMLEntityForXMLParser):
* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::appendMailtoPostFormDataToURL):
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
(WebCore::makeValidURL):
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::pageProperty):
* Source/WebCore/platform/SharedBufferChunkReader.cpp:
(WebCore::SharedBufferChunkReader::setSeparator):
* Source/WebCore/platform/graphics/ColorSerialization.cpp:
(WebCore::serializationForCSS):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(initializeDMABufAvailability):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::doCapsHaveType):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::probeRtpExtensions):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureElement):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::convert):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMInstanceSessionThunder::CDMInstanceSessionThunder):
* Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp:
(WebCore::fontFeatures):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::start):
(WebCore::MermaidBuilder::generatePadId):
(WebCore::MermaidBuilder::process):
(WebCore::MermaidBuilder::dumpPad):
(WebCore::MermaidBuilder::dumpElement):
(WebCore::MermaidBuilder::describeCaps):
(WebCore::GStreamerElementHarness::dumpGraph):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::GStreamerQuirksManager):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::preparePipeline):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::createSource):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::createParser):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::configurePacketizers):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp:
(WebCore::GStreamerVideoEncoder::makeElement):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::append):
* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::addExtraNetworkLoadMetrics):
* Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp:
(WebCore::protectionSpaceFromSoupAuthAndURL):
* Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp:
(WebCore::SpielSpeechWrapper::initializeVoiceList):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::unauthorizedSQLFunction):
(WebCore::SQLiteDatabase::prepareStatementSlow):
(WebCore::SQLiteDatabase::prepareStatement):
(WebCore::SQLiteDatabase::prepareHeapStatementSlow):
(WebCore::SQLiteDatabase::prepareHeapStatement):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::append):
* Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp:
(PlatformXR::Instance::Impl::Impl):
* Source/WebCore/xml/XMLErrors.cpp:
(WebCore::XMLErrors::appendErrorMessage):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::setAndSerializeSandboxParameters):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp:
(WebCore::SocketStreamHandleImpl::reportErrorToClient):
* Tools/TestWebKitAPI/Tests/WTF/Base64.cpp:
(TestWebKitAPI::TEST(Base64, Encode)):
(TestWebKitAPI::TEST(Base64, EncodeOmitPadding)):
(TestWebKitAPI::TEST(Base64, EncodeURL)):
(TestWebKitAPI::TEST(Base64, EncodeURLOmitPadding)):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, StringImplCreationFromLiteral)):
* Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp:
(TestWebKitAPI::LoggingTest::output):
* Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp:
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, SimpleMessage)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoHeader)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoBody)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, TransportPadding)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoEndOfBoundary)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoEndOfBoundaryAfterCompleted)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoCloseDelimiter)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, NoCloseDelimiterAfterCompleted)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, CloseDelimiter)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, CloseDelimiterAfterCompleted)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideFirstDelimiter)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideSecondDelimiter)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideLastDelimiter)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideCloseDelimiter)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideTransportPadding)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideHeader)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, DivideBody)):
(TestWebKitAPI::Curl::TEST(CurlMultipartHandleTests, CompleteWhileHeaderProcessing)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NetworkProcess.mm:
(TEST(WebKit, HTTPReferer)):
* Tools/TestWebKitAPI/win/PlatformUtilitiesWin.cpp:
(TestWebKitAPI::Util::createURLForResource):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b5cd73b19cc1c159edec291d87702bad336ace5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40284 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90928 "Hash 2b5cd73b for PR 39362 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36827 "Hash 2b5cd73b for PR 39362 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13541 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/90928 "Hash 2b5cd73b for PR 39362 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/36827 "Hash 2b5cd73b for PR 39362 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77927 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/90928 "Hash 2b5cd73b for PR 39362 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32213 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35909 "Hash 2b5cd73b for PR 39362 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78851 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33074 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92661 "Hash 2b5cd73b for PR 39362 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84835 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13165 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9657 "Found 1 new test failure: fast/webgpu/type-checker-array-without-argument.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/92661 "Hash 2b5cd73b for PR 39362 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73778 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/92661 "Hash 2b5cd73b for PR 39362 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17237 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18546 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107263 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12971 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25833 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->