### PR TITLE
Reduce use of memchr() in the codebase

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1011,6 +1011,8 @@ int compareSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 size_t find(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
 {
+    static_assert(sizeof(T) == 1);
+    static_assert(sizeof(T) == sizeof(U));
     auto* result = static_cast<T*>(memmem(haystack.data(), haystack.size(), needle.data(), needle.size())); // NOLINT
     if (!result)
         return notFound;
@@ -1020,6 +1022,8 @@ size_t find(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 size_t contains(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
 {
+    static_assert(sizeof(T) == 1);
+    static_assert(sizeof(T) == sizeof(U));
     return !!memmem(haystack.data(), haystack.size(), needle.data(), needle.size()); // NOLINT
 }
 

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -105,19 +105,17 @@ static SubtagComparison subtagCompare(std::span<const char> key, std::span<const
 
     result.keyLength = key.size();
     result.keyContinue = result.keyLength;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (auto* hyphenPointer = memchr(key.data(), '-', key.size())) {
-        result.keyLength = static_cast<const char*>(hyphenPointer) - key.data();
+    if (size_t hyphenIndex = find(key, '-'); hyphenIndex != notFound) {
+        result.keyLength = hyphenIndex;
         result.keyContinue = result.keyLength + 1;
     }
 
     result.rangeLength = range.size();
     result.rangeContinue = result.rangeLength;
-    if (auto* hyphenPointer = memchr(range.data(), '-', range.size())) {
-        result.rangeLength = static_cast<const char*>(hyphenPointer) - range.data();
+    if (size_t hyphenIndex = find(range, '-'); hyphenIndex != notFound) {
+        result.rangeLength = hyphenIndex;
         result.rangeContinue = result.rangeLength + 1;
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (result.keyLength == result.rangeLength)
         result.comparison = compareSpans(key.first(result.keyLength), range.first(result.keyLength));

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3517,6 +3517,10 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_memmem:
         error(line_number, 'safercpp/memmem', 4, "Use WTF::find() or WTF::contains() instead of memmem().")
 
+    uses_memchr = search(r'memchr\(', line)
+    if uses_memchr:
+        error(line_number, 'safercpp/memchr', 4, "Use WTF::find() instead of memchr().")
+
     uses_strstr = search(r'strstr\(', line)
     if uses_strstr:
         error(line_number, 'safercpp/strstr', 4, "Use WTF::find() or WTF::contains() instead of strstr().")
@@ -4860,6 +4864,7 @@ class CppChecker(object):
         'runtime/wtf_make_unique',
         'runtime/wtf_move',
         'runtime/wtf_never_destroyed',
+        'safercpp/memchr',
         'safercpp/memcmp',
         'safercpp/memcpy',
         'safercpp/memmem',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6299,6 +6299,11 @@ class WebKitStyleTest(CppStyleTestBase):
             'foo.cpp')
 
         self.assert_lint(
+            'char* result = memchr(haystack, c, strlen(haystack));',
+            'Use WTF::find() instead of memchr().  [safercpp/memchr] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
             'char* result = strstr(haystack, needle);',
             'Use WTF::find() or WTF::contains() instead of strstr().  [safercpp/strstr] [4]',
             'foo.cpp')

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -47,9 +47,10 @@ static const char* dataAsString(NSData *data)
     static std::array<char, 1000> buffer;
     if ([data length] > buffer.size() - 1)
         return "ERROR";
-    if (memchr([data bytes], 0, [data length]))
+    auto dataSpan = span(data);
+    if (contains(dataSpan, 0))
         return "ERROR";
-    memcpySpan(std::span { buffer }, span(data));
+    memcpySpan(std::span { buffer }, dataSpan);
     buffer[[data length]] = '\0';
     return buffer.data();
 }


### PR DESCRIPTION
#### 0e64aee2e3700b102c9a400f2b4b1849b9778334
<pre>
Reduce use of memchr() in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=286337">https://bugs.webkit.org/show_bug.cgi?id=286337</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::find):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::spanHasPrefixIgnoringASCIICase):
(WTF::sizeof):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::subtagCompare):
* Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm:
(-[NSData _webkit_guessedMIMETypeForXML]):
(-[NSData _webkit_guessedMIMEType]):
(-[NSData _web_isCaseInsensitiveEqualToCString:]):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::dataAsString):

Canonical link: <a href="https://commits.webkit.org/289326@main">https://commits.webkit.org/289326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9967ab56be72950db92ca92477d745e2476f7468

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91335 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66914 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24699 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47234 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/85926 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32601 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36344 "Failed to checkout and rebase branch from PR 39363") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79272 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93179 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85260 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75703 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74885 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17541 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13451 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13650 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18926 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107726 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13403 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25927 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->