### PR TITLE
[GStreamer][WebRTC] Handle GObject unsigned pt properties in RTP payloaders

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.h
@@ -31,7 +31,7 @@ public:
     static RefPtr<GStreamerAudioRTPPacketizer> create(RefPtr<UniqueSSRCGenerator>, const GstStructure* codecParameters, GUniquePtr<GstStructure>&& encodingParameters);
 
 private:
-    explicit GStreamerAudioRTPPacketizer(GRefPtr<GstCaps>&& inputCaps, GRefPtr<GstElement>&& encoder, GRefPtr<GstElement>&& payloader, GUniquePtr<GstStructure>&& encodingParameters, GRefPtr<GstCaps>&& rtpCaps);
+    explicit GStreamerAudioRTPPacketizer(GRefPtr<GstCaps>&& inputCaps, GRefPtr<GstElement>&& encoder, GRefPtr<GstElement>&& payloader, GUniquePtr<GstStructure>&& encodingParameters, GRefPtr<GstCaps>&& rtpCaps, std::optional<int>&& payloadType);
 
     GRefPtr<GstElement> m_audioconvert;
     GRefPtr<GstElement> m_audioresample;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
@@ -32,7 +32,7 @@ class GStreamerRTPPacketizer : public ThreadSafeRefCounted<GStreamerRTPPacketize
     WTF_MAKE_NONCOPYABLE(GStreamerRTPPacketizer);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit GStreamerRTPPacketizer(GRefPtr<GstElement>&& encoder, GRefPtr<GstElement>&& payloader, GUniquePtr<GstStructure>&& encodingParameters);
+    explicit GStreamerRTPPacketizer(GRefPtr<GstElement>&& encoder, GRefPtr<GstElement>&& payloader, GUniquePtr<GstStructure>&& encodingParameters, std::optional<int>&&);
     virtual ~GStreamerRTPPacketizer();
 
     GstElement* bin() const { return m_bin.get(); }
@@ -44,7 +44,7 @@ public:
     void ensureMidExtension(const String&);
 
     String rtpStreamId() const;
-    int payloadType() const;
+    std::optional<int> payloadType() const;
     unsigned currentSequenceNumberOffset() const;
     void setSequenceNumberOffset(unsigned);
 
@@ -68,10 +68,10 @@ protected:
     GRefPtr<GstElement> m_valve;
 
     GUniquePtr<GstStructure> m_encodingParameters;
-    int m_payloadType;
     GUniquePtr<GstStructure> m_stats;
 
 private:
+    void setPayloadType(int);
     void updateStatsFromRTPExtensions();
     void applyEncodingParameters(const GstStructure*) const;
     virtual void configure(const GstStructure*) const { };
@@ -85,6 +85,7 @@ private:
 
     String m_mid;
     String m_rid;
+    std::optional<int> m_payloadType;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.h
@@ -33,7 +33,7 @@ public:
     void updateStats() final;
 
 private:
-    explicit GStreamerVideoRTPPacketizer(GRefPtr<GstElement>&& encoder, GRefPtr<GstElement>&& payloader, GUniquePtr<GstStructure>&& encodingParameters, GRefPtr<GstCaps>&& rtpCaps);
+    explicit GStreamerVideoRTPPacketizer(GRefPtr<GstElement>&& encoder, GRefPtr<GstElement>&& payloader, GUniquePtr<GstStructure>&& encodingParameters, GRefPtr<GstCaps>&& rtpCaps, std::optional<int>&& payloadType);
 
     void configure(const GstStructure*) const final;
 


### PR DESCRIPTION
#### 84c90a1cdcd4d11f253d1f1c5a2ad483efa58c77
<pre>
[GStreamer][WebRTC] Handle GObject unsigned pt properties in RTP payloaders
<a href="https://bugs.webkit.org/show_bug.cgi?id=286346">https://bugs.webkit.org/show_bug.cgi?id=286346</a>

Reviewed by Xabier Rodriguez-Calvar.

The GStreamer rtp*pay2 payloaders&apos; &quot;pt&quot; property is an unsigned int while on the legacy payloaders
it is an int, so both cases need to be handled. We also now emit an error early on if an attempt to
set an out-of-range value is made.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp:
(WebCore::GStreamerAudioRTPPacketizer::create):
(WebCore::GStreamerAudioRTPPacketizer::GStreamerAudioRTPPacketizer):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::GStreamerRTPPacketizer):
(WebCore::GStreamerRTPPacketizer::setPayloadType):
(WebCore::GStreamerRTPPacketizer::payloadType const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):
(WebCore::GStreamerVideoRTPPacketizer::GStreamerVideoRTPPacketizer):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.h:

Canonical link: <a href="https://commits.webkit.org/289286@main">https://commits.webkit.org/289286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf8d86682e0dc17ee08427f8050f782cde679aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66866 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/24660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89352 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/4671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32532 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36248 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93077 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9839 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13757 "Failed to checkout and rebase branch from PR 39371") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/74097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19095 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17487 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13573 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->