### PR TITLE
Annotate RemoteMediaResourceManager endpoints

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1313,6 +1313,9 @@ void GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPrefe
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     protectedSampleBufferDisplayLayerManager()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
 #endif
+#if ENABLE(VIDEO)
+    protectedRemoteMediaResourceManager()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
+#endif
 
     enableMediaPlaybackIfNecessary();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -175,6 +175,16 @@ void RemoteMediaResourceManager::loadFinished(RemoteMediaResourceIdentifier iden
         resource->loadFinished(metrics);
 }
 
+void RemoteMediaResourceManager::updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess sharedPreferencesForWebProcess)
+{
+    assertIsMainThread();
+
+    Ref queue = RemoteMediaResourceLoader::defaultQueue();
+    queue->dispatch([this, protectedThis = Ref { *this }, sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess)] {
+        m_sharedPreferencesForWebProcess = sharedPreferencesForWebProcess;
+    });
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
@@ -29,6 +29,7 @@
 
 #include "Connection.h"
 #include "RemoteMediaResourceIdentifier.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/SharedMemory.h>
@@ -70,6 +71,8 @@ public:
 
     // IPC::Connection::WorkQueueMessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
+    void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess);
 
 private:
     RemoteMediaResourceManager();
@@ -87,6 +90,7 @@ private:
     HashMap<RemoteMediaResourceIdentifier, ThreadSafeWeakPtr<RemoteMediaResource>> m_remoteMediaResources WTF_GUARDED_BY_LOCK(m_lock);
 
     RefPtr<IPC::Connection> m_connection;
+    SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=UseGPUProcessForMediaEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=GPU
 ]


### PR DESCRIPTION
#### 5a672fb05f1805616f65bfa36a3d540f17d37e6f
<pre>
Annotate RemoteMediaResourceManager endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=286357">https://bugs.webkit.org/show_bug.cgi?id=286357</a>
<a href="https://rdar.apple.com/143392618">rdar://143392618</a>

Reviewed by NOBODY (OOPS!).

Annotate RemoteMediaResourceManager endpoints with UseGPUProcessForMediaEnabled

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp:
(WebKit::RemoteMediaResourceManager::updateSharedPreferencesForWebProcess):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h:
(WebKit::RemoteMediaResourceManager::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a672fb05f1805616f65bfa36a3d540f17d37e6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1998 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97902 "Hash 5a672fb0 for PR 39379 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43317 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20809 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71014 "39 flakes 221 failures") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95808 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9544 "Found 60 new test failures: compositing/contents-format/deep-color-backing-store.html editing/caret/caret-position-vertical-rl.html fast/events/onunload-not-on-body.html fast/forms/form-associated-element-crash3.html fast/mediastream/microphone-interruption-and-audio-session.html http/tests/app-privacy-report/app-attribution-media-redirect.html http/tests/app-privacy-report/user-attribution-media-redirect.html http/tests/cache/memory-cache-pruning.html http/tests/media/audio-load-loadeddata.html http/tests/misc/delete-frame-during-readystatechange-with-gc-after-video-removal.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83979 "Found 12 new API test failures: TestWebKitAPI.URLSchemeHandler.Ranges, TestWebKitAPI.WKWebExtensionAPIMenus.MacAudioContextMenuItems, TestWebKitAPI.MediaLoading.RangeRequestSynthesisWithContentLength, TestWebKitAPI.SiteIsolation.MutesAndSetsAudioInMultipleFrames, TestWebKitAPI.SiteIsolation.PlayAudioInRemoteFrameThenRemove, TestWebKitAPI.SiteIsolation.PlayAudioInMultipleFrames, TestWebKitAPI.WKWebExtensionAPIMenus.MacVideoContextMenuItems, TestWebKitAPI.MediaLoading.RangeRequestSynthesisWithoutContentLength, TestWebKitAPI.WebpagePreferences.WebsitePoliciesDuringRedirect, TestWebKitAPI.MediaLoading.LockdownModeHLS ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51343 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9234 "Found 60 new test failures: imported/w3c/web-platform-tests/accessibility/crashtests/removed-from-flat-tree.html imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-video-sibling.html imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-video.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-for-cue.html imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-replaced.html imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003a.html imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003b.html imported/w3c/web-platform-tests/css/css-contain/contain-size-replaced-003c.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42645 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79541 "Found 9 new API test failures: TestWebKitAPI.URLSchemeHandler.Ranges, TestWebKitAPI.MediaLoading.RangeRequestSynthesisWithContentLength, TestWebKitAPI.SiteIsolation.MutesAndSetsAudioInMultipleFrames, TestWebKitAPI.SiteIsolation.PlayAudioInRemoteFrameThenRemove, TestWebKitAPI.MediaLoading.RangeRequestSynthesisWithoutContentLength, TestWebKitAPI.SiteIsolation.PlayAudioInMultipleFrames, TestWebKitAPI.MediaLoading.LockdownModeHLS, TestWebKitAPI.MediaLoading.UserAgentStringHLS, TestWebKitAPI.WebKit.MediaCache (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1583 "Found 60 new test failures: fast/css-grid-layout/grid-simplified-layout-positioned.html fast/css/aspect-ratio-min-height-replaced.html fast/forms/form-associated-element-crash3.html fast/multicol/column-rules-fixed-height.html fast/text/word-spacing-rtl.html http/tests/cache/disk-cache/disk-cache-media-small.html http/tests/cache/memory-cache-pruning.html http/tests/canvas/webgl/origin-clean-conformance.html http/tests/contentextensions/text-track-blocked.html http/tests/contentextensions/video-element-resource-type.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99824 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19858 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14587 "Found 60 new test failures: fast/forms/form-associated-element-crash3.html http/tests/cache/disk-cache/disk-cache-media-small.html http/tests/cache/memory-cache-pruning.html http/tests/canvas/webgl/origin-clean-conformance.html http/tests/contentextensions/text-track-blocked.html http/tests/contentextensions/video-element-resource-type.html http/tests/inspector/dom/didFireEvent.html http/tests/inspector/network/resource-initiatorNode.html http/tests/media/audio-load-loadeddata.html http/tests/media/audio-volume-zero.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80030 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79332 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23863 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1130 "Found 60 new test failures: compositing/transforms/clipping-layer-and-flattening-layer.html css3/masking/clip-path-with-path.html fast/forms/form-associated-element-crash3.html http/tests/cache/disk-cache/disk-cache-media-small.html http/tests/cache/memory-cache-pruning.html http/tests/canvas/webgl/origin-clean-conformance.html http/tests/contentextensions/text-track-blocked.html http/tests/contentextensions/video-element-resource-type.html http/tests/inspector/dom/didFireEvent.html http/tests/inspector/network/resource-initiatorNode.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12894 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25018 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->