### PR TITLE
<input type=color alpha> swatch does not have a background that reflects the transparency

### DIFF
--- a/LayoutTests/fast/forms/color/color-input-swatch-expected.txt
+++ b/LayoutTests/fast/forms/color/color-input-swatch-expected.txt
@@ -1,0 +1,102 @@
+initial state
+
+getComputedStyle(swatch).backgroundColor is rgb(0, 0, 0)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: limited-srgb, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is rgb(255, 239, 213)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: limited-srgb, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is color(srgb 1 0.937255 0.835294)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: display-p3, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: display-p3, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: limited-srgb, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is rgb(68, 68, 68)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: limited-srgb, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: display-p3, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.266667 0.266667 0.266667)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: display-p3, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is rgb(255, 0, 104)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 2 0 0.5)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is rgb(40, 40, 40)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: display-p3, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.156863 0.156863 0.156863)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: display-p3, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+

--- a/LayoutTests/fast/forms/color/color-input-swatch.html
+++ b/LayoutTests/fast/forms/color/color-input-swatch.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<script src="../../../resources/js-test-pre.js"></script>
+<input type=color>
+<script>
+function log(swatch) {
+  evalAndLogResult("getComputedStyle(swatch).backgroundColor");
+  evalAndLogResult("getComputedStyle(swatch).backgroundImage");
+  evalAndLogResult("getComputedStyle(swatch).backgroundSize");
+}
+
+const control = document.querySelector("input");
+const swatch = internals.shadowRoot(control).firstChild.firstChild;
+
+debug(`initial state\n`);
+log(swatch);
+
+for (const value of [ "papayawhip", "#44444444", "color(display-p3 2 none .5 / .7)", "rgba(40,40,40,.6)" ]) {
+  for (const colorSpace of ["limited-srgb", "display-p3"]) {
+    for (const alpha of [false, true]) {
+      control.alpha = alpha;
+      control.colorSpace = colorSpace;
+      control.value = value;
+
+      debug(`\nalpha: ${alpha}, colorSpace: ${colorSpace}, value: ${value}\n`);
+      log(swatch);
+    }
+  }
+}
+</script>

--- a/LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt
@@ -1,0 +1,102 @@
+initial state
+
+getComputedStyle(swatch).backgroundColor is rgb(0, 0, 0)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: limited-srgb, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is rgb(255, 239, 213)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: limited-srgb, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is color(srgb 1 0.937255 0.835294)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: display-p3, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: display-p3, value: papayawhip
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: false, colorSpace: limited-srgb, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is rgb(68, 68, 68)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is auto
+
+alpha: true, colorSpace: limited-srgb, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
+getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23121212'/><polygon points='1,0 1,1 0,1' fill='%23cdcdcd'/></svg>")
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: false, colorSpace: display-p3, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.266667 0.266667 0.266667)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: true, colorSpace: display-p3, value: #44444444
+
+getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
+getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23121212'/><polygon points='1,0 1,1 0,1' fill='%23cdcdcd'/></svg>")
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: false, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is rgb(255, 0, 104)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: true, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
+getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23b30049'/><polygon points='1,0 1,1 0,1' fill='%23ff4c95'/></svg>")
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: false, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 2 0 0.5)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: true, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
+
+getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
+getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23b30049'/><polygon points='1,0 1,1 0,1' fill='%23ff4c95'/></svg>")
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: false, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is rgb(40, 40, 40)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: true, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
+getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23181818'/><polygon points='1,0 1,1 0,1' fill='%237e7e7e'/></svg>")
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: false, colorSpace: display-p3, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is color(display-p3 0.156863 0.156863 0.156863)
+getComputedStyle(swatch).backgroundImage is none
+getComputedStyle(swatch).backgroundSize is 100% 100%
+
+alpha: true, colorSpace: display-p3, value: rgba(40,40,40,.6)
+
+getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
+getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23181818'/><polygon points='1,0 1,1 0,1' fill='%237e7e7e'/></svg>")
+getComputedStyle(swatch).backgroundSize is 100% 100%
+

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -33,7 +33,6 @@
 #include "ColorInputType.h"
 
 #include "AXObjectCache.h"
-#include "CSSPropertyNames.h"
 #include "CSSPropertyParserConsumer+Color.h"
 #include "Chrome.h"
 #include "Color.h"
@@ -336,8 +335,7 @@ void ColorInputType::updateColorSwatch()
     if (!colorSwatch)
         return;
 
-    ASSERT(element());
-    colorSwatch->setInlineStyleProperty(CSSPropertyBackgroundColor, element()->value());
+    RenderTheme::singleton().setColorWellSwatchBackground(*colorSwatch, valueAsColor());
 }
 
 HTMLElement* ColorInputType::shadowColorSwatch() const

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -23,9 +23,11 @@
 
 #include "BorderShape.h"
 #include "ButtonPart.h"
+#include "CSSPropertyNames.h"
 #include "CSSValueKeywords.h"
 #include "ColorBlending.h"
 #include "ColorLuminance.h"
+#include "ColorSerialization.h"
 #include "ColorWellPart.h"
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
@@ -1445,6 +1447,13 @@ void RenderTheme::paintSliderTicks(const RenderObject& renderer, const PaintInfo
 bool RenderTheme::shouldHaveSpinButton(const HTMLInputElement& inputElement) const
 {
     return inputElement.isSteppable() && !inputElement.isRangeControl();
+}
+
+void RenderTheme::setColorWellSwatchBackground(HTMLElement& swatch, Color color)
+{
+    if (!color.isOpaque())
+        color = blendSourceOver(Color::white, color);
+    swatch.setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForHTML(color));
 }
 
 void RenderTheme::adjustSliderThumbStyle(RenderStyle& style, const Element* element) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -208,6 +208,8 @@ public:
     virtual bool shouldHaveSpinButton(const HTMLInputElement&) const;
     virtual bool shouldHaveCapsLockIndicator(const HTMLInputElement&) const { return false; }
 
+    virtual void setColorWellSwatchBackground(HTMLElement&, Color);
+
     // Functions for <select> elements.
     virtual bool delegatesMenuListRendering() const { return false; }
     virtual bool popsMenuByArrowKeys() const { return false; }

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -80,6 +80,8 @@ public:
 
     FloatSize meterSizeForBounds(const RenderMeter&, const FloatRect&) const final;
     bool supportsMeter(StyleAppearance) const final;
+
+    void setColorWellSwatchBackground(HTMLElement&, Color) final;
 
     IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const final;
 


### PR DESCRIPTION
#### 3d975165870fdedf358571e31742bfa93eab1fd3
<pre>
&lt;input type=color alpha&gt; swatch does not have a background that reflects the transparency
<a href="https://bugs.webkit.org/show_bug.cgi?id=286212">https://bugs.webkit.org/show_bug.cgi?id=286212</a>
<a href="https://rdar.apple.com/143188497">rdar://143188497</a>

Reviewed by Aditya Keerthi.

When a color with alpha channel was selected this would result in the
background of the parent element becoming visible. To prevent this we
perform a source-over color blending operation with opaque white. This
matches how the control behaves on iOS and seems like a reasonable
platform-neutral default.

For macOS we want to render a diagonally divided rectangle with one of
the triangles using opaque black as input for the blending operation
and the other opaque white to match the platform color well.

* LayoutTests/fast/forms/color/color-input-swatch-expected.txt: Added.
* LayoutTests/fast/forms/color/color-input-swatch.html: Added.
* LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt: Added.
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::updateColorSwatch):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::setColorWellSwatchBackground):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::setColorWellSwatchBackground):

Canonical link: <a href="https://commits.webkit.org/289314@main">https://commits.webkit.org/289314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887aa6d5a3be8a3a9ab284f25a5568ad655c975e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24671 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32549 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93099 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75669 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74850 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17502 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13444 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18878 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->