### PR TITLE
[JSC] Fix license header in `DFGLoopUnrollingPhase.cpp`

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -1,5 +1,5 @@
 /*
- * Cloneright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
#### ee2ef8924309ed1a42719d474be2f5200694cd7a
<pre>
[JSC] Fix license header in `DFGLoopUnrollingPhase.cpp`
<a href="https://bugs.webkit.org/show_bug.cgi?id=286368">https://bugs.webkit.org/show_bug.cgi?id=286368</a>

Reviewed by NOBODY (OOPS!).

This patch fixes license header in `DFGLoopUnrollingPhase.cpp`

* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee2ef8924309ed1a42719d474be2f5200694cd7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36969 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66772 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24567 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32346 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36056 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78993 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33205 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92993 "Failed to checkout and rebase branch from PR 39389") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84979 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13601 "Failed to checkout and rebase branch from PR 39389") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9761 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75582 "70 flakes 196 failures") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13529 "Failed to checkout and rebase branch from PR 39389") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73905 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74757 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.Find, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/image, /TestWebKit:WebKit.UserMediaBasic ... (failure)") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18416 "Failed to checkout and rebase branch from PR 39389") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17336 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13340 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18695 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107409 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13115 "Failed to compile WebKit") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25861 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16822 "Failed to checkout and rebase branch from PR 39389") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14902 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->