### PR TITLE
usatoday.com: Rotating from landscape to portrait causes flickering

### DIFF
--- a/Source/WebCore/page/VisualViewport.cpp
+++ b/Source/WebCore/page/VisualViewport.cpp
@@ -174,7 +174,7 @@ void VisualViewport::update()
         m_offsetLeft = offsetLeft;
         m_offsetTop = offsetTop;
     }
-    if (m_width != width || m_height != height || m_scale != scale) {
+    if (m_width != width || m_height != height) {
         if (document)
             document->setNeedsVisualViewportResize();
         m_width = width;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		6B9ABE122086952F00D75DE6 /* HTTPParsers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B9ABE112086952F00D75DE6 /* HTTPParsers.cpp */; };
 		6BF4A683239ED4CD00E2F45B /* LoginStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6BF4A682239ED4CD00E2F45B /* LoginStatus.cpp */; };
 		6BFD294C1D5E6C1D008EC968 /* HashCountedSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A38D7E51C752D5F004F157D /* HashCountedSet.cpp */; };
+		6D51E1D72D42B17600032ECE /* VisualViewport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6D51E1D62D42B16C00032ECE /* VisualViewport.mm */; };
 		712E4BC125DDC52A0007201C /* AnimationFrameRate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 712E4BC025DDC52A0007201C /* AnimationFrameRate.cpp */; };
 		7141156429754422005011D6 /* PlatformCAAnimationKeyPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */; };
 		71E88C4124B5299C00665160 /* ShareSheetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 71E88C4024B5299C00665160 /* ShareSheetTests.mm */; };
@@ -2972,6 +2973,7 @@
 		6B4E861B2220A5520022F389 /* RegistrableDomain.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegistrableDomain.cpp; sourceTree = "<group>"; };
 		6B9ABE112086952F00D75DE6 /* HTTPParsers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPParsers.cpp; sourceTree = "<group>"; };
 		6BF4A682239ED4CD00E2F45B /* LoginStatus.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LoginStatus.cpp; sourceTree = "<group>"; };
+		6D51E1D62D42B16C00032ECE /* VisualViewport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VisualViewport.mm; sourceTree = "<group>"; };
 		6DE8CFD32D10ED7300C6FDBE /* ScreenTime.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScreenTime.mm; sourceTree = "<group>"; };
 		712E4BC025DDC52A0007201C /* AnimationFrameRate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AnimationFrameRate.cpp; sourceTree = "<group>"; };
 		7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformCAAnimationKeyPath.cpp; sourceTree = "<group>"; };
@@ -4941,6 +4943,7 @@
 				F402F56B23ECC2FB00865549 /* UIWKInteractionViewProtocol.mm */,
 				E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */,
 				079D45F12A2A6BBE003830C7 /* Viewport.mm */,
+				6D51E1D62D42B16C00032ECE /* VisualViewport.mm */,
 				F43E3BBE20DADA1E00A4E7ED /* WKScrollViewTests.mm */,
 				514958BD1F7427AC00E87BAD /* WKWebViewAutofillTests.mm */,
 				1CACADA0230620AD0007D54C /* WKWebViewOpaque.mm */,
@@ -7376,6 +7379,7 @@
 				079D45F22A2A6BBE003830C7 /* Viewport.mm in Sources */,
 				115EB3431EE0BA03003C2C0A /* ViewportSizeForViewportUnits.mm in Sources */,
 				51EB125724C67257000CB030 /* VirtualGamepad.mm in Sources */,
+				6D51E1D72D42B17600032ECE /* VisualViewport.mm in Sources */,
 				0F139E771A423A5B00F590F5 /* WeakObjCPtr.mm in Sources */,
 				7CCE7F191A411AE600447C4C /* WebArchive.cpp in Sources */,
 				7C83E04C1D0A641800FEBCF3 /* WebCoreNSURLSession.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/ios/VisualViewport.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/VisualViewport.mm
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewConfiguration.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(VisualViewport, RotationResize)
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 430, 812) configuration:configuration.get()]);
+
+    [webView synchronouslyLoadHTMLString:
+        @"<!DOCTYPE html>"
+        @"<html>"
+        @"<head>"
+            @"<meta name='viewport' width='700' content='initial-scale=1'/>"
+            @"<script>"
+                @"window.resizeCount = 0;"
+                @"let metaTagNewWidth;"
+                @"const visualViewport = window.visualViewport;"
+                @"window.visualViewport.addEventListener(\"resize\", function() {"
+                    @"var newWidth = Math.round(visualViewport.width * visualViewport.scale);"
+                    @"newWidth = 300 >= newWidth ? 300 : 700 <= newWidth ? 700 : \"device-width\";"
+                    @"metaTagNewWidth = document.querySelector(\"meta[name=viewport]\").content = \"width=\" + newWidth;"
+                    @"window.resizeCount = window.resizeCount + 1;"
+                    @"if (window.resizeCount == 2 && (window.innerWidth != 812 || window.innerHeight != 430 || visualViewport.scale != 1))"
+                        @"window.webkit.messageHandlers.testHandler.postMessage(\"fail\");"
+                @"});"
+            @"</script>"
+        @"</head>"
+        @"</html>"];
+
+    [webView performAfterReceivingMessage:@"fail" action:^{
+        FAIL();
+    }];
+
+    [webView _beginAnimatedResizeWithUpdates:^{
+        [webView setFrame:CGRectMake(0, 0, [webView frame].size.height, [webView frame].size.width)];
+    }];
+
+    [webView _endAnimatedResize];
+    [webView waitForNextPresentationUpdate];
+
+    int windowResizeCount = [[webView objectByEvaluatingJavaScript:@"window.resizeCount"] intValue];
+
+    EXPECT_EQ(windowResizeCount, 2);
+}
+}
+
+#endif


### PR DESCRIPTION
#### 7eac12ec2ff9679924ce2d6adc86c943cacdccf4
<pre>
usatoday.com: Rotating from landscape to portrait causes flickering
<a href="https://bugs.webkit.org/show_bug.cgi?id=286367">https://bugs.webkit.org/show_bug.cgi?id=286367</a>
<a href="https://rdar.apple.com/93767145">rdar://93767145</a>

Reviewed by Wenson Hsieh.

usatoday.com has a visual viewport flickering issue when rotating from landscape to portrait.
This issue happens when rotating from portrait to landscape as well, but does not flicker due
to the width cutoffs set in javascript for the website.
Additionally, this issue actually happens when we change the viewport width in the meta tag.

In this scenario, the new width is calculated based on the current visual viewport scale and width.

In our code, the issue was as follows:
1. Document::processViewport is called whenever the viewport meta tag changes
2. The scale is set
    - Layout change happens before VisibleContentRectUpdates
3. VisualViewport::update calls setNeedsVisualViewportResize()
4. A resize is dispatched
    - This is the extra/premature resize
5. (UI) WebpageProxy::updateVisibleContentRects is called which in turn calls
    (WEB) WebPage::updateVisibleContentRects
6. A resize is dispatched
    - This is the correct resize that we anticipate with updated width

The scale is updated in the UI process but the width is updated in the Web process.

Thus, the scale is updated ahead of the width and hits this section of code in VisualViewport.cpp:
if (m_width != width || m_height != height || m_scale != scale) {
        if (document)
            document-&gt;setNeedsVisualViewportResize();

We hit m_scale != scale and call document-&gt;setNeedsVisualViewportResize(); prematurely,
when we should be waiting until either the width or height changes as well.

Thus, the issue of the extra resize(s) is fixed by removing the condition to check
for scale changes when determining when to call resize. This is safe because visual viewport
scales should never update independently from width/height.

An API test was also added for this change.

* Source/WebCore/page/VisualViewport.cpp:
(WebCore::VisualViewport::update):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/ios/VisualViewport.mm: Added.
(TestWebKitAPI::TEST(VisualViewport, RotationResize)):

Canonical link: <a href="https://commits.webkit.org/289334@main">https://commits.webkit.org/289334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffe2f3ce562406fb99370e9a28f57523067f5223

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37262 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66935 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24717 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93228 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74915 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18439 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17577 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13695 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->