### PR TITLE
Crash under WorkerWorkerAgent::connectToAllWorkerInspectorProxies() on the bots

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1073,6 +1073,8 @@ int compareSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 size_t find(std::span<T, TExtent> haystack, std::span<U, UExtent> needle)
 {
+    static_assert(sizeof(T) == 1);
+    static_assert(sizeof(T) == sizeof(U));
     auto* result = static_cast<T*>(memmem(haystack.data(), haystack.size(), needle.data(), needle.size())); // NOLINT
     if (!result)
         return notFound;

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -526,6 +526,13 @@ template<typename CharacterTypeA, typename CharacterTypeB> inline bool equalIgno
     return true;
 }
 
+template<typename CharacterTypeA, typename CharacterTypeB> inline bool spanHasPrefixIgnoringASCIICase(std::span<const CharacterTypeA> span, std::span<const CharacterTypeB> prefix)
+{
+    if (span.size() < prefix.size())
+        return false;
+    return equalIgnoringASCIICaseWithLength(span, prefix, prefix.size());
+}
+
 template<typename CharacterTypeA, typename CharacterTypeB> inline bool equalIgnoringASCIICase(std::span<const CharacterTypeA> a, std::span<const CharacterTypeB> b)
 {
     return a.size() == b.size() && equalIgnoringASCIICaseWithLength(a, b, a.size());
@@ -787,23 +794,23 @@ ALWAYS_INLINE const UChar* find16NonASCII(std::span<const UChar> data)
 }
 #endif
 
-template<typename CharacterType, std::enable_if_t<std::is_integral_v<CharacterType>>* = nullptr>
-inline size_t find(std::span<const CharacterType> characters, CharacterType matchCharacter, size_t index = 0)
+template<typename CharacterType1, typename CharacterType2, std::enable_if_t<std::is_integral_v<CharacterType1> && std::is_integral_v<CharacterType2> && sizeof(CharacterType1) == sizeof(CharacterType2)>* = nullptr>
+inline size_t find(std::span<const CharacterType1> characters, CharacterType2 matchCharacter, size_t index = 0)
 {
-    if constexpr (sizeof(CharacterType) == 1) {
+    if constexpr (sizeof(CharacterType1) == 1) {
         if (index >= characters.size())
             return notFound;
-        auto* result = reinterpret_cast<const CharacterType*>(find8(std::bit_cast<const uint8_t*>(characters.data() + index), matchCharacter, characters.size() - index));
+        auto* result = reinterpret_cast<const CharacterType1*>(find8(std::bit_cast<const uint8_t*>(characters.data() + index), matchCharacter, characters.size() - index));
         ASSERT(!result || static_cast<unsigned>(result - characters.data()) >= index);
         if (result)
             return result - characters.data();
         return notFound;
     }
 
-    if constexpr (sizeof(CharacterType) == 2) {
+    if constexpr (sizeof(CharacterType1) == 2) {
         if (index >= characters.size())
             return notFound;
-        auto* result = reinterpret_cast<const CharacterType*>(find16(std::bit_cast<const uint16_t*>(characters.data() + index), matchCharacter, characters.size() - index));
+        auto* result = reinterpret_cast<const CharacterType1*>(find16(std::bit_cast<const uint16_t*>(characters.data() + index), matchCharacter, characters.size() - index));
         ASSERT(!result || static_cast<unsigned>(result - characters.data()) >= index);
         if (result)
             return result - characters.data();
@@ -1233,5 +1240,6 @@ using WTF::isLatin1;
 using WTF::span;
 using WTF::spanIncludingNullTerminator;
 using WTF::span8;
+using WTF::spanHasPrefixIgnoringASCIICase;
 using WTF::span8IncludingNullTerminator;
 using WTF::charactersContain;

--- a/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
@@ -44,12 +44,9 @@ PageWorkerAgent::~PageWorkerAgent() = default;
 
 void PageWorkerAgent::connectToAllWorkerInspectorProxies()
 {
-    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxiesCopy()) {
-        if (auto* document = dynamicDowncast<Document>(proxy->scriptExecutionContext())) {
-            if (document->page() == &m_page)
-                connectToWorkerInspectorProxy(proxy);
-        }
-    }
+    WorkerInspectorProxy::forEachProxyInContext(*m_page.identifier(), [&](auto& proxy) {
+        connectToWorkerInspectorProxy(proxy);
+    });
 }
 
 } // namespace Inspector

--- a/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
@@ -44,12 +44,9 @@ WorkerWorkerAgent::~WorkerWorkerAgent() = default;
 
 void WorkerWorkerAgent::connectToAllWorkerInspectorProxies()
 {
-    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxiesCopy()) {
-        if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(proxy->scriptExecutionContext())) {
-            if (globalScope == &m_globalScope)
-                connectToWorkerInspectorProxy(proxy);
-        }
-    }
+    WorkerInspectorProxy::forEachProxyInContext(m_globalScope.identifier(), [&](auto& proxy) {
+        connectToWorkerInspectorProxy(proxy);
+    });
 }
 
 } // namespace Inspector

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -105,19 +105,17 @@ static SubtagComparison subtagCompare(std::span<const LChar> key, std::span<cons
 
     result.keyLength = key.size();
     result.keyContinue = result.keyLength;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (auto* hyphenPointer = memchr(key.data(), '-', key.size())) {
-        result.keyLength = static_cast<const LChar*>(hyphenPointer) - key.data();
+    if (size_t hyphenIndex = find(key, '-'); hyphenIndex != notFound) {
+        result.keyLength = hyphenIndex;
         result.keyContinue = result.keyLength + 1;
     }
 
     result.rangeLength = range.size();
     result.rangeContinue = result.rangeLength;
-    if (auto* hyphenPointer = memchr(range.data(), '-', range.size())) {
-        result.rangeLength = static_cast<const LChar*>(hyphenPointer) - range.data();
+    if (size_t hyphenIndex = find(range, '-'); hyphenIndex != notFound) {
+        result.rangeLength = hyphenIndex;
         result.rangeContinue = result.rangeLength + 1;
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (result.keyLength == result.rangeLength)
         result.comparison = compareSpans(key.first(result.keyLength), range.first(result.keyLength));

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -35,6 +35,24 @@
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/WeakHashSet.h>
+
+namespace WTF {
+
+struct HashTraits<std::variant<WebCore::PageIdentifier, WebCore::ScriptExecutionContextIdentifier>> : public VariantHashTraits<HashTraits<WebCore::PageIdentifier>, HashTraits<WebCore::ScriptExecutionContextIdentifier>> {
+    static void constructDeletedValue(std::variant<WebCore::PageIdentifier, WebCore::ScriptExecutionContextIdentifier>& slot)
+    {
+        slot = WebCore::PageIdentifier::hashTableDeletedValue();
+    }
+    static bool isDeletedValue(const std::variant<WebCore::PageIdentifier, WebCore::ScriptExecutionContextIdentifier>& value)
+    {
+        if (auto* pageIdentifier = std::get_if<WebCore::PageIdentifier>(&value))
+            return pageIdentifier->isHashTableDeletedValue();
+        return false;
+    }
+};
+
+}
 
 namespace WebCore {
 
@@ -42,17 +60,36 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerInspectorProxy);
 
 using namespace Inspector;
 
-static Lock proxiesLock;
-static WeakHashSet<WorkerInspectorProxy>& proxies() WTF_REQUIRES_LOCK(proxiesLock)
+static std::optional<PageOrWorkerGlobalScopeIdentifier> pageOrWorkerGlobalScopeIdentifier(ScriptExecutionContext& context)
 {
-    static NeverDestroyed<WeakHashSet<WorkerInspectorProxy>> proxies;
+    if (auto* document = dynamicDowncast<Document>(context)) {
+        if (auto* page = document->page(); page && page->identifier())
+            return PageOrWorkerGlobalScopeIdentifier { *page->identifier() };
+        return std::nullopt;
+    }
+    return context.identifier();
+}
+
+static Lock proxiesLock;
+static HashMap<PageOrWorkerGlobalScopeIdentifier, WeakHashSet<WorkerInspectorProxy>>& proxies() WTF_REQUIRES_LOCK(proxiesLock)
+{
+    static NeverDestroyed<HashMap<PageOrWorkerGlobalScopeIdentifier, WeakHashSet<WorkerInspectorProxy>>> proxies;
     return proxies;
 }
 
-WeakHashSet<WorkerInspectorProxy> WorkerInspectorProxy::allWorkerInspectorProxiesCopy()
+void WorkerInspectorProxy::forEachProxyInContext(PageOrWorkerGlobalScopeIdentifier contextIdentifier, NOESCAPE const Function<void(WorkerInspectorProxy&)>& apply)
 {
-    Locker lock { proxiesLock };
-    return proxies();
+    Vector<Ref<WorkerInspectorProxy>> proxiesForContext;
+    {
+        Locker lock { proxiesLock };
+        auto iterator = proxies().find(contextIdentifier);
+        if (iterator == proxies().end())
+            return;
+        proxiesForContext = copyToVectorOf<Ref<WorkerInspectorProxy>>(iterator->value);
+    }
+
+    for (auto& proxy : proxiesForContext)
+        apply(proxy);
 }
 
 WorkerInspectorProxy::WorkerInspectorProxy(const String& identifier)
@@ -72,16 +109,19 @@ WorkerThreadStartMode WorkerInspectorProxy::workerStartMode(ScriptExecutionConte
     return pauseOnStart ? WorkerThreadStartMode::WaitForInspector : WorkerThreadStartMode::Normal;
 }
 
-void WorkerInspectorProxy::workerStarted(ScriptExecutionContext* scriptExecutionContext, WorkerThread* thread, const URL& url, const String& name)
+void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecutionContext, WorkerThread* thread, const URL& url, const String& name)
 {
     ASSERT(!m_workerThread);
-    m_scriptExecutionContext = scriptExecutionContext;
+    m_scriptExecutionContext = &scriptExecutionContext;
+    m_contextIdentifier = pageOrWorkerGlobalScopeIdentifier(scriptExecutionContext);
+
     m_workerThread = thread;
     m_url = url;
     m_name = name;
-    {
+    if (m_contextIdentifier) {
         Locker lock { proxiesLock };
-        proxies().add(*this);
+        auto& proxiesForContext = proxies().add(*m_contextIdentifier, WeakHashSet<WorkerInspectorProxy> { }).iterator->value;
+        proxiesForContext.add(*this);
     }
 
     InspectorInstrumentation::workerStarted(*this);
@@ -93,9 +133,15 @@ void WorkerInspectorProxy::workerTerminated()
         return;
 
     InspectorInstrumentation::workerTerminated(*this);
-    {
+    if (m_contextIdentifier) {
         Locker lock { proxiesLock };
-        proxies().remove(*this);
+        auto iterator = proxies().find(*m_contextIdentifier);
+        RELEASE_ASSERT(iterator != proxies().end());
+        auto& proxiesForContext = iterator->value;
+        ASSERT(proxiesForContext.contains(*this));
+        proxiesForContext.remove(*this);
+        if (proxiesForContext.isEmptyIgnoringNullReferences())
+            proxies().remove(iterator);
     }
 
     m_scriptExecutionContext = nullptr;

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -25,11 +25,14 @@
 
 #pragma once
 
+#include "PageIdentifier.h"
+#include "ScriptExecutionContextIdentifier.h"
+#include <variant>
+#include <wtf/Function.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
-#include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
 // All of these methods should be called on the Main Thread.
@@ -41,6 +44,8 @@ class ScriptExecutionContext;
 class WorkerThread;
 
 enum class WorkerThreadStartMode;
+
+using PageOrWorkerGlobalScopeIdentifier = std::variant<PageIdentifier, ScriptExecutionContextIdentifier>;
 
 class WorkerInspectorProxy : public RefCounted<WorkerInspectorProxy>, public CanMakeWeakPtr<WorkerInspectorProxy, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerInspectorProxy);
@@ -60,7 +65,7 @@ public:
         virtual void sendMessageFromWorkerToFrontend(WorkerInspectorProxy&, String&&) = 0;
     };
 
-    static WeakHashSet<WorkerInspectorProxy> allWorkerInspectorProxiesCopy();
+    static void forEachProxyInContext(PageOrWorkerGlobalScopeIdentifier, NOESCAPE const Function<void(WorkerInspectorProxy&)>&);
 
     const URL& url() const { return m_url; }
     const String& name() const { return m_name; }
@@ -68,7 +73,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return m_scriptExecutionContext.get(); }
 
     WorkerThreadStartMode workerStartMode(ScriptExecutionContext&);
-    void workerStarted(ScriptExecutionContext*, WorkerThread*, const URL&, const String& name);
+    void workerStarted(ScriptExecutionContext&, WorkerThread*, const URL&, const String& name);
     void workerTerminated();
 
     void resumeWorkerIfPaused();
@@ -81,6 +86,7 @@ private:
     explicit WorkerInspectorProxy(const String& identifier);
 
     RefPtr<ScriptExecutionContext> m_scriptExecutionContext;
+    std::optional<PageOrWorkerGlobalScopeIdentifier> m_contextIdentifier;
     RefPtr<WorkerThread> m_workerThread;
     String m_identifier;
     URL m_url;

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -174,7 +174,7 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
     workerThreadCreated(thread.get());
     thread->start();
 
-    m_inspectorProxy->workerStarted(m_scriptExecutionContext.get(), thread.ptr(), scriptURL, name);
+    m_inspectorProxy->workerStarted(*m_scriptExecutionContext, thread.ptr(), scriptURL, name);
 }
 
 void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& message)

--- a/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm
@@ -26,25 +26,28 @@
 #import <WebKitLegacy/WebNSDataExtras.h>
 
 #import <wtf/Assertions.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/text/ParsingUtilities.h>
+#import <wtf/text/StringCommon.h>
 
 @implementation NSData (WebNSDataExtras)
 
 - (NSString *)_webkit_guessedMIMETypeForXML
 {
-    NSUInteger length = [self length];
-    const UInt8* bytes = static_cast<const UInt8*>([self bytes]);
+    auto bytes = span(self);
 
-#define CHANNEL_TAG_LENGTH 7
+    constexpr size_t channelTagLength = 7;
 
-    const char* p = byteCast<char>(bytes);
-    int remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (CHANNEL_TAG_LENGTH - 1);
+    size_t remaining = std::min<NSUInteger>(bytes.size(), WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (channelTagLength - 1);
+    bytes = bytes.first(remaining);
 
     BOOL foundRDF = false;
 
-    while (remaining > 0) {
+    while (!bytes.empty()) {
         // Look for a "<".
-        const char* hit = static_cast<const char*>(memchr(p, '<', remaining));
-        if (!hit)
+        auto hitIndex = WTF::find(bytes, '<');
+        if (hitIndex == notFound)
             break;
 
         // We are trying to identify RSS or Atom. RSS has a top-level
@@ -56,21 +59,21 @@
         // bail if we don't find an <rss>, <feed> or <rdf> element
         // right after those.
 
+        auto hit = bytes.subspan(hitIndex);
         if (foundRDF) {
-            if (!strncasecmp(hit, "<channel", strlen("<channel")))
+            if (spanHasPrefixIgnoringASCIICase(hit, "<channel"_span))
                 return @"application/rss+xml";
-        } else if (!strncasecmp(hit, "<rdf", strlen("<rdf")))
+        } else if (spanHasPrefixIgnoringASCIICase(hit, "<rdf"_span))
             foundRDF = TRUE;
-        else if (!strncasecmp(hit, "<rss", strlen("<rss")))
+        else if (spanHasPrefixIgnoringASCIICase(hit, "<rss"_span))
             return @"application/rss+xml";
-        else if (!strncasecmp(hit, "<feed", strlen("<feed")))
+        else if (spanHasPrefixIgnoringASCIICase(hit, "<feed"_span))
             return @"application/atom+xml";
-        else if (strncasecmp(hit, "<?", strlen("<?")) && strncasecmp(hit, "<!", strlen("<!")))
+        else if (!spanHasPrefixIgnoringASCIICase(hit, "<?"_span) && !spanHasPrefixIgnoringASCIICase(hit, "<!"_span))
             return nil;
 
         // Skip the "<" and continue.
-        remaining -= (hit + 1) - p;
-        p = hit + 1;
+        skip(bytes, hitIndex + 1);
     }
 
     return nil;
@@ -78,81 +81,77 @@
 
 - (NSString *)_webkit_guessedMIMEType
 {
-#define JPEG_MAGIC_NUMBER_LENGTH 4
-#define SCRIPT_TAG_LENGTH 7
-#define TEXT_HTML_LENGTH 9
-#define VCARD_HEADER_LENGTH 11
-#define VCAL_HEADER_LENGTH 15
+    constexpr size_t scriptTagLength = 7;
+    constexpr size_t textHTMLLength = 9;
 
     NSString *MIMEType = [self _webkit_guessedMIMETypeForXML];
     if ([MIMEType length])
         return MIMEType;
 
-    NSUInteger length = [self length];
-    const char* bytes = static_cast<const char*>([self bytes]);
+    auto bytes = span(self);
 
-    const char* p = bytes;
-    int remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (SCRIPT_TAG_LENGTH - 1);
-    while (remaining > 0) {
+    size_t remaining = std::min<NSUInteger>(bytes.size(), WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (scriptTagLength - 1);
+    auto cursor = bytes.first(remaining);
+    while (!cursor.empty()) {
         // Look for a "<".
-        const char* hit = static_cast<const char*>(memchr(p, '<', remaining));
-        if (!hit)
+        size_t hitIndex = WTF::find(cursor, '<');
+        if (hitIndex == notFound)
             break;
 
+        auto hit = cursor.subspan(hitIndex);
         // If we found a "<", look for "<html>" or "<a " or "<script".
-        if (!strncasecmp(hit, "<html>", strlen("<html>"))
-            || !strncasecmp(hit, "<a ", strlen("<a "))
-            || !strncasecmp(hit, "<script", strlen("<script"))
-            || !strncasecmp(hit, "<title>", strlen("<title>"))) {
+        if (spanHasPrefixIgnoringASCIICase(hit, "<html>"_span)
+            || spanHasPrefixIgnoringASCIICase(hit, "<a "_span)
+            || spanHasPrefixIgnoringASCIICase(hit, "<script"_span)
+            || spanHasPrefixIgnoringASCIICase(hit, "<title>"_span)) {
             return @"text/html";
         }
 
         // Skip the "<" and continue.
-        remaining -= (hit + 1) - p;
-        p = hit + 1;
+        skip(cursor, hitIndex + 1);
     }
 
     // Test for a broken server which has sent the content type as part of the content.
     // This code could be improved to look for other mime types.
-    p = bytes;
-    remaining = std::min<NSUInteger>(length, WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (TEXT_HTML_LENGTH - 1);
-    while (remaining > 0) {
+    remaining = std::min<NSUInteger>(bytes.size(), WEB_GUESS_MIME_TYPE_PEEK_LENGTH) - (textHTMLLength - 1);
+    cursor = bytes.first(remaining);
+    while (!cursor.empty()) {
         // Look for a "t" or "T".
-        const char* hit = nullptr;
-        const char* lowerhit = static_cast<const char*>(memchr(p, 't', remaining));
-        const char* upperhit = static_cast<const char*>(memchr(p, 'T', remaining));
-        if (!lowerhit && !upperhit)
+        size_t lowerHitIndex = WTF::find(cursor, 't');
+        size_t upperHitIndex = WTF::find(cursor, 'T');
+        if (lowerHitIndex == notFound && upperHitIndex == notFound)
             break;
 
-        if (!lowerhit)
-            hit = upperhit;
-        else if (!upperhit)
-            hit = lowerhit;
+        size_t hitIndex;
+        if (lowerHitIndex == notFound)
+            hitIndex = upperHitIndex;
+        else if (upperHitIndex == notFound)
+            hitIndex = lowerHitIndex;
         else
-            hit = std::min<const char*>(lowerhit, upperhit);
+            hitIndex = std::min<size_t>(lowerHitIndex, upperHitIndex);
+        auto hit = cursor.subspan(hitIndex);
 
         // If we found a "t/T", look for "text/html".
-        if (!strncasecmp(hit, "text/html", TEXT_HTML_LENGTH))
+        if (spanHasPrefixIgnoringASCIICase(hit, "text/html"_span))
             return @"text/html";
 
         // Skip the "t/T" and continue.
-        remaining -= (hit + 1) - p;
-        p = hit + 1;
+        skip(cursor, hitIndex + 1);
     }
 
-    if ((length >= VCARD_HEADER_LENGTH) && !strncmp(bytes, "BEGIN:VCARD", VCARD_HEADER_LENGTH))
+    if (spanHasPrefix(bytes, "BEGIN:VCARD"_span))
         return @"text/vcard";
-    if ((length >= VCAL_HEADER_LENGTH) && !strncmp(bytes, "BEGIN:VCALENDAR", VCAL_HEADER_LENGTH))
+    if (spanHasPrefix(bytes, "BEGIN:VCALENDAR"_span))
         return @"text/calendar";
 
     // Test for plain text.
     NSUInteger i;
-    for (i = 0; i < length; ++i) {
+    for (i = 0; i < bytes.size(); ++i) {
         char c = bytes[i];
         if ((c < 0x20 || c > 0x7E) && (c != '\t' && c != '\r' && c != '\n'))
             break;
     }
-    if (i == length) {
+    if (i == bytes.size()) {
         // Didn't encounter any bad characters, looks like plain text.
         return @"text/plain";
     }
@@ -160,14 +159,8 @@
     // Looks like this is a binary file.
 
     // Sniff for the JPEG magic number.
-    if ((length >= JPEG_MAGIC_NUMBER_LENGTH) && !strncmp(bytes, "\xFF\xD8\xFF\xE0", JPEG_MAGIC_NUMBER_LENGTH))
+    if (spanHasPrefix(bytes, WTF::span(static_cast<const char*>("\xFF\xD8\xFF\xE0"))))
         return @"image/jpeg";
-
-#undef JPEG_MAGIC_NUMBER_LENGTH
-#undef SCRIPT_TAG_LENGTH
-#undef TEXT_HTML_LENGTH
-#undef VCARD_HEADER_LENGTH
-#undef VCAL_HEADER_LENGTH
 
     return nil;
 }
@@ -175,9 +168,7 @@
 - (BOOL)_web_isCaseInsensitiveEqualToCString:(const char *)string
 {
     ASSERT(string);
-
-    const char* bytes = static_cast<const char*>([self bytes]);
-    return !strncasecmp(bytes, string, [self length]);
+    return equalLettersIgnoringASCIICase(span(self), span(string));
 }
 
 @end

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3517,6 +3517,10 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_memmem:
         error(line_number, 'safercpp/memmem', 4, "Use WTF::find() or WTF::contains() instead of memmem().")
 
+    uses_memchr = search(r'memchr\(', line)
+    if uses_memchr:
+        error(line_number, 'safercpp/memchr', 4, "Use WTF::find() instead of memchr().")
+
     uses_strstr = search(r'strstr\(', line)
     if uses_strstr:
         error(line_number, 'safercpp/strstr', 4, "Use WTF::find() or WTF::contains() instead of strstr().")
@@ -4860,6 +4864,7 @@ class CppChecker(object):
         'runtime/wtf_make_unique',
         'runtime/wtf_move',
         'runtime/wtf_never_destroyed',
+        'safercpp/memchr',
         'safercpp/memcmp',
         'safercpp/memcpy',
         'safercpp/memmem',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6299,6 +6299,11 @@ class WebKitStyleTest(CppStyleTestBase):
             'foo.cpp')
 
         self.assert_lint(
+            'char* result = memchr(haystack, c, strlen(haystack));',
+            'Use WTF::find() instead of memchr().  [safercpp/memchr] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
             'char* result = strstr(haystack, needle);',
             'Use WTF::find() or WTF::contains() instead of strstr().  [safercpp/strstr] [4]',
             'foo.cpp')

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -47,9 +47,10 @@ static const char* dataAsString(NSData *data)
     static std::array<char, 1000> buffer;
     if ([data length] > buffer.size() - 1)
         return "ERROR";
-    if (memchr([data bytes], 0, [data length]))
+    auto dataSpan = span(data);
+    if (find(dataSpan, 0) != notFound)
         return "ERROR";
-    memcpySpan(std::span { buffer }, span(data));
+    memcpySpan(std::span { buffer }, dataSpan);
     buffer[[data length]] = '\0';
     return buffer.data();
 }


### PR DESCRIPTION
#### d1dc7063181921637b735934248f0fca41982a4f
<pre>
Crash under WorkerWorkerAgent::connectToAllWorkerInspectorProxies() on the bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=286300">https://bugs.webkit.org/show_bug.cgi?id=286300</a>

Reviewed by NOBODY (OOPS!).

WorkerWorkerAgent::connectToAllWorkerInspectorProxies() was getting called off the main thread
and iterating over the WeakHashSet returned by `WorkerInspectorProxy::allWorkerInspectorProxiesCopy()`.
The loop in connectToAllWorkerInspectorProxies() was ref&apos;ing each WorkerInspectorProxy before checking
if the proxy is relevant for the current agent. This ref&apos;ing was needed for safety since the proxy could
get destroyed concurrently on another thread otherwise. However, WorkerInspectorProxy is not
ThreadSafeRefCounted and we were using WeakPtr (instead of ThreadSafeWeakPtr). As a result, the ref&apos;ing
of the object on another thread wasn&apos;t safe. Making WorkerInspectorProxy thread safe is not trivial since
it holds strings.

To make the code thread-safe, the global map of WorkerInspectorProxy now stores the context identifier
as key. When looking up the context identifier in the HashMap, we&apos;re holding a lock so we&apos;re safe on this
front. We then ref the proxies and add them to a Vector while holding the lock. The ref&apos;ing is safe here
before we know we&apos;re only ref&apos;ing the proxies for the right context and thus on the correct thread.

* Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp:
(WebCore::PageWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp:
(WebCore::WorkerWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
(WebCore::pageOrWorkerGlobalScopeIdentifier):
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::WorkerInspectorProxy::forEachProxyInContext):
(WebCore::WorkerInspectorProxy::workerStarted):
(WebCore::WorkerInspectorProxy::workerTerminated):
(WebCore::WorkerInspectorProxy::allWorkerInspectorProxiesCopy): Deleted.
* Source/WebCore/workers/WorkerInspectorProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
</pre>
----------------------------------------------------------------------
#### b8cdb5d11d20bafcbae5e3b9d2bc5e63562e4d58
<pre>
Reduce use of memchr() in the codebase <a href="https://bugs.webkit.org/show_bug.cgi?id=286337">https://bugs.webkit.org/show_bug.cgi?id=286337</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/StdLibExtras.h:
(WTF::find):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::spanHasPrefixIgnoringASCIICase):
(WTF::sizeof):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::subtagCompare):
* Source/WebKitLegacy/mac/Misc/WebNSDataExtras.mm:
(-[NSData _webkit_guessedMIMETypeForXML]):
(-[NSData _webkit_guessedMIMEType]):
(-[NSData _web_isCaseInsensitiveEqualToCString:]):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::dataAsString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1dc7063181921637b735934248f0fca41982a4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86079 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5691 "Hash d1dc7063 for PR 39393 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40441 "Hash d1dc7063 for PR 39393 does not build (failure)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/36976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88124 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5931 "Hash d1dc7063 for PR 39393 does not build (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/13704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/91081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/36976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89082 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/5931 "Hash d1dc7063 for PR 39393 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/40441 "Hash d1dc7063 for PR 39393 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/85560 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/5931 "Hash d1dc7063 for PR 39393 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/40441 "Hash d1dc7063 for PR 39393 does not build (failure)") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79002 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/5931 "Hash d1dc7063 for PR 39393 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/40441 "Hash d1dc7063 for PR 39393 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84988 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/13326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/13704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/92855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13538 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/40441 "Hash d1dc7063 for PR 39393 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/92855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/18936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/40441 "Hash d1dc7063 for PR 39393 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13356 "Failed to compile WebKit") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107420 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13124 "Failed to compile WebKit") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25864 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/16565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14911 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->