### PR TITLE
[PassKeys] Make the search filter for PassKeys more broad.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -260,7 +260,6 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
     auto query = adoptNS([[NSMutableDictionary alloc] init]);
     [query setDictionary:@{
         (__bridge id)kSecClass: bridge_id_cast(kSecClassKey),
-        (__bridge id)kSecAttrKeyClass: bridge_id_cast(kSecAttrKeyClassPrivate),
         (__bridge id)kSecAttrAccessGroup: accessGroup,
         (__bridge id)kSecReturnAttributes: @YES,
         (__bridge id)kSecMatchLimit: bridge_id_cast(kSecMatchLimitAll),
@@ -662,7 +661,6 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     BOOL useAlternateKeychainAttribute = WebKit::shouldUseAlternateKeychainAttribute();
     auto query = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
         (id)kSecClassKey, (id)kSecClass,
-        (id)kSecAttrKeyClassPrivate, (id)kSecAttrKeyClass,
         (id)rp, (id)kSecAttrLabel,
         @YES, (id)kSecUseDataProtectionKeychain,
         nil
@@ -727,7 +725,6 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     BOOL useAlternateKeychainAttribute = WebKit::shouldUseAlternateKeychainAttribute();
     auto query = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
         (id)kSecClassKey, (id)kSecClass,
-        (id)kSecAttrKeyClassPrivate, (id)kSecAttrKeyClass,
         @YES, (id)kSecReturnRef,
         @YES, (id)kSecUseDataProtectionKeychain,
         (id)kSecAttrSynchronizableAny, (id)kSecAttrSynchronizable,

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -375,7 +375,6 @@ std::optional<WebCore::ExceptionData> LocalAuthenticator::processLargeBlobExtens
         auto fetchQuery = adoptNS([[NSMutableDictionary alloc] init]);
         [fetchQuery setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
             (id)kSecUseDataProtectionKeychain: @YES,
             (id)kSecReturnAttributes: @YES,
@@ -528,7 +527,6 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
         auto query = adoptNS([[NSMutableDictionary alloc] init]);
         [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrLabel: secAttrLabel,
             (id)kSecAttrApplicationLabel: m_provisionalCredentialId.get(),
             (id)kSecUseDataProtectionKeychain: @YES
@@ -685,7 +683,6 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
         BOOL useAlternateKeychainAttribute = shouldUseAlternateKeychainAttribute();
         NSMutableDictionary *queryDictionary = [@{
             (id)kSecClass: (id)kSecClassKey,
-            (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
             (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
             (id)kSecReturnRef: @YES,
             (id)kSecUseDataProtectionKeychain: @YES
@@ -734,7 +731,6 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
     auto query = adoptNS([[NSMutableDictionary alloc] init]);
     [query setDictionary:@{
         (id)kSecClass: (id)kSecClassKey,
-        (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
         (id)kSecUseDataProtectionKeychain: @YES
     }];

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -214,7 +214,6 @@ RetainPtr<NSArray> LocalConnection::getExistingCredentials(const String& rpId)
     // Search Keychain for existing credential matched the RP ID.
     NSDictionary *query = @{
         (id)kSecClass: (id)kSecClassKey,
-        (id)kSecAttrKeyClass: (id)kSecAttrKeyClassPrivate,
         (id)kSecAttrSynchronizable: (id)kSecAttrSynchronizableAny,
         (id)kSecAttrAccessGroup: LocalAuthenticatorAccessGroup,
         (id)kSecAttrLabel: rpId,


### PR DESCRIPTION
#### 8c16d17d9bf3bcdf3414da111498366bb0e700c1
<pre>
[PassKeys] Make the search filter for PassKeys more broad.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286372">https://bugs.webkit.org/show_bug.cgi?id=286372</a>
<a href="https://rdar.apple.com/143411897">rdar://143411897</a>

Reviewed by Pascoe.

It is possible that some private keys are actually marked wrongly as public
and thus are not showing up in search. This will let them show up.

It&apos;s not the best but should hopefully return what was being returned earlier.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
(+[_WKWebAuthenticationPanel exportLocalAuthenticatorCredentialWithGroupAndID:credential:error:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::processLargeBlobExtension):
(WebKit::LocalAuthenticator::continueGetAssertionAfterUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
(WebKit::LocalConnection::getExistingCredentials):

Canonical link: <a href="https://commits.webkit.org/289294@main">https://commits.webkit.org/289294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37d6615b5d6be08f785e601f76db30062306f576

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36998 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66785 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24577 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4375 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92881 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13354 "Failed to compile WebKit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75559 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13573 "Failed to compile WebKit") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74732 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6183 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13428 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13393 "Failed to compile WebKit") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18721 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13161 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16593 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14947 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->