### PR TITLE
Simplify TestController::createTestURL()

### DIFF
--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1503,14 +1503,13 @@ WKRetainPtr<WKStringRef> TestController::backgroundFetchState(WKStringRef)
 
 WKURLRef TestController::createTestURL(std::span<const char> pathOrURL)
 {
-    if (contains(pathOrURL, "http://"_span) || contains(pathOrURL, "https://"_span))
-        return WKURLCreateWithUTF8String(pathOrURL.data(), pathOrURL.size());
-
-    size_t length = pathOrURL.size();
-    if (!length)
+    if (pathOrURL.empty())
         return nullptr;
 
-    if (length >= 7 && contains(pathOrURL, "file://"_span)) {
+    if (spanHasPrefix(pathOrURL, "http://"_span) || spanHasPrefix(pathOrURL, "https://"_span))
+        return WKURLCreateWithUTF8String(pathOrURL.data(), pathOrURL.size());
+
+    if (spanHasPrefix(pathOrURL, "file://"_span)) {
         auto url = adoptWK(WKURLCreateWithUTF8String(pathOrURL.data(), pathOrURL.size()));
         auto path = testPath(url.get());
         auto pathString = String::fromUTF8(std::span { path });
@@ -1522,37 +1521,11 @@ WKURLRef TestController::createTestURL(std::span<const char> pathOrURL)
     }
 
     // Creating from filesytem path.
-
-#if PLATFORM(WIN)
-    bool isAbsolutePath = !PathIsRelativeA(String::fromUTF8(pathOrURL).utf8().data());
-#else
-    bool isAbsolutePath = pathOrURL[0] == pathSeparator;
-#endif
-    auto filePrefix = "file://"_span;
-
-    MallocSpan<char> buffer;
-    size_t pathLength = 0;
-    if (isAbsolutePath) {
-        buffer = MallocSpan<char>::malloc(filePrefix.size() + length);
-        memcpySpan(buffer.mutableSpan(), filePrefix);
-        memcpySpan(buffer.mutableSpan().subspan(filePrefix.size()), pathOrURL);
-        pathLength = buffer.span().size();
-    } else {
-        buffer = MallocSpan<char>::malloc(filePrefix.size() + PATH_MAX + length + 1); // 1 for the pathSeparator
-        memcpySpan(buffer.mutableSpan(), filePrefix);
-        if (!getcwd(buffer.mutableSpan().subspan(filePrefix.size()).data(), PATH_MAX))
-            return nullptr;
-        size_t numCharacters = strlen(buffer.span().data());
-        buffer[numCharacters] = pathSeparator;
-        memcpySpan(buffer.mutableSpan().subspan(numCharacters + 1), pathOrURL);
-        pathLength = numCharacters + 1 + pathOrURL.size();
-    }
-
-    auto cPath = buffer.span().first(pathLength);
-    auto url = adoptWK(WKURLCreateWithUTF8String(cPath.data(), cPath.size()));
+    auto urlString = makeString("file://"_s, FileSystem::realPath(String::fromUTF8(pathOrURL))).utf8();
+    auto url = adoptWK(WKURLCreateWithUTF8String(urlString.data(), urlString.length()));
     auto path = testPath(url.get());
     auto pathString = String::fromUTF8(std::span { path });
-    if (!m_usingServerMode && !WTF::FileSystemImpl::fileExists(pathString)) {
+    if (!m_usingServerMode && !FileSystem::fileExists(pathString)) {
         printf("Failed: File ‘%s’ was not found or is inaccessible\n", pathString.utf8().data());
         return nullptr;
     }


### PR DESCRIPTION
#### d53641225b408731c603278b77539a80316f8edd
<pre>
Simplify TestController::createTestURL()
<a href="https://bugs.webkit.org/show_bug.cgi?id=286374">https://bugs.webkit.org/show_bug.cgi?id=286374</a>

Reviewed by Darin Adler and Youenn Fablet.

Simplify TestController::createTestURL() by leveraging the FileSystem API.

* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createTestURL):

Canonical link: <a href="https://commits.webkit.org/289291@main">https://commits.webkit.org/289291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/366f29267f0b7d3dccb977b5b0db1a233926e8dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66818 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24611 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47129 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32438 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74842 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6237 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13426 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13462 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13230 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16663 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->