### PR TITLE
Crash under WorkerWorkerAgent::connectToAllWorkerInspectorProxies() on the bots

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -505,8 +505,6 @@ inspector/agents/WebConsoleAgent.cpp
 inspector/agents/page/PageCanvasAgent.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
 inspector/agents/page/PageNetworkAgent.cpp
-inspector/agents/page/PageWorkerAgent.cpp
-inspector/agents/worker/WorkerWorkerAgent.cpp
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
 layout/formattingContexts/inline/text/TextUtil.cpp

--- a/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
@@ -44,12 +44,8 @@ PageWorkerAgent::~PageWorkerAgent() = default;
 
 void PageWorkerAgent::connectToAllWorkerInspectorProxies()
 {
-    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxiesCopy()) {
-        if (auto* document = dynamicDowncast<Document>(proxy->scriptExecutionContext())) {
-            if (document->page() == &m_page)
-                connectToWorkerInspectorProxy(proxy);
-        }
-    }
+    for (Ref proxy : WorkerInspectorProxy::proxiesForPage(*m_page.identifier()))
+        connectToWorkerInspectorProxy(proxy);
 }
 
 } // namespace Inspector

--- a/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
@@ -44,12 +44,8 @@ WorkerWorkerAgent::~WorkerWorkerAgent() = default;
 
 void WorkerWorkerAgent::connectToAllWorkerInspectorProxies()
 {
-    for (Ref proxy : WorkerInspectorProxy::allWorkerInspectorProxiesCopy()) {
-        if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(proxy->scriptExecutionContext())) {
-            if (globalScope == &m_globalScope)
-                connectToWorkerInspectorProxy(proxy);
-        }
-    }
+    for (Ref proxy : WorkerInspectorProxy::proxiesForWorkerGlobalScope(m_globalScope.identifier()))
+        connectToWorkerInspectorProxy(proxy);
 }
 
 } // namespace Inspector

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -174,7 +174,7 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
     workerThreadCreated(thread.get());
     thread->start();
 
-    m_inspectorProxy->workerStarted(m_scriptExecutionContext.get(), thread.ptr(), scriptURL, name);
+    m_inspectorProxy->workerStarted(*m_scriptExecutionContext, thread.ptr(), scriptURL, name);
 }
 
 void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& message)


### PR DESCRIPTION
#### 93d2569cbae15d0c282008b146e8e0ac0c3d737a
<pre>
Crash under WorkerWorkerAgent::connectToAllWorkerInspectorProxies() on the bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=286300">https://bugs.webkit.org/show_bug.cgi?id=286300</a>

Reviewed by Devin Rousso.

WorkerWorkerAgent::connectToAllWorkerInspectorProxies() was getting called off the main thread
and iterating over the WeakHashSet returned by `WorkerInspectorProxy::allWorkerInspectorProxiesCopy()`.
The loop in connectToAllWorkerInspectorProxies() was ref&apos;ing each WorkerInspectorProxy before checking
if the proxy is relevant for the current agent. This ref&apos;ing was needed for safety since the proxy could
get destroyed concurrently on another thread otherwise. However, WorkerInspectorProxy is not
ThreadSafeRefCounted and we were using WeakPtr (instead of ThreadSafeWeakPtr). As a result, the ref&apos;ing
of the object on another thread wasn&apos;t safe. Making WorkerInspectorProxy thread safe is not trivial since
it holds strings.

To make the code thread-safe, the global map of WorkerInspectorProxy now stores the context identifier
as key. When looking up the context identifier in the HashMap, we&apos;re holding a lock so we&apos;re safe on this
front. We then ref the proxies and add them to a Vector while holding the lock. The ref&apos;ing is safe here
before we know we&apos;re only ref&apos;ing the proxies for the right context and thus on the correct thread.

* Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp:
(WebCore::PageWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp:
(WebCore::WorkerWorkerAgent::connectToAllWorkerInspectorProxies):
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
(WebCore::pageOrWorkerGlobalScopeIdentifier):
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::WorkerInspectorProxy::forEachProxyInContext):
(WebCore::WorkerInspectorProxy::workerStarted):
(WebCore::WorkerInspectorProxy::workerTerminated):
(WebCore::WorkerInspectorProxy::allWorkerInspectorProxiesCopy): Deleted.
* Source/WebCore/workers/WorkerInspectorProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):

Canonical link: <a href="https://commits.webkit.org/289288@main">https://commits.webkit.org/289288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb00852587a6a89301b3ef7ee80b65139197ab4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24636 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93020 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9818 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75633 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74809 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17454 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13423 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18822 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->