### PR TITLE
REGRESSION(286883@main): ASSERT NOT REACHED in WebCore::toResourceLoadPriority(CFURLRequestPriority)

### DIFF
--- a/LayoutTests/ipc/url-requestPriority-out-of-range-expected.txt
+++ b/LayoutTests/ipc/url-requestPriority-out-of-range-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit did not crash.

--- a/LayoutTests/ipc/url-requestPriority-out-of-range.html
+++ b/LayoutTests/ipc/url-requestPriority-out-of-range.html
@@ -38,20 +38,13 @@
                                         timeWindowDelay: 118,
                                         timeWindowDuration: 15,
                                         networkServiceType: 0,
-                                        requestPriority: 0,
+                                        // must be -1 to 4
+                                        requestPriority: 20,
                                         isHTTP: {
                                             optionalValue: true
                                         },
                                         httpMethod: {},
-                                        // This crashes CFNetwork
-                                        headerFields: {
-                                            optionalValue: [{
-                                                alias: ['A', {
-                                                    variantType: 'String',
-                                                    variant: location.href
-                                                }]
-                                            }]
-                                        },
+                                        headerFields: {},
                                         body: {
                                             optionalValue: {
                                                 dataReference: {}

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -27,6 +27,7 @@
 #import "CoreIPCNSURLRequest.h"
 
 #import "GeneratedSerializers.h"
+#import <WebCore/ResourceLoadPriority.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -250,7 +251,10 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
 
     [dict setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(m_data.networkServiceType)] forKey:@"networkServiceType"];
 
-    SET_DICT_FROM_PRIMITIVE(requestPriority, NSNumber, Int);
+    int clampedRequestPriority = std::min(std::max(m_data.requestPriority, -1),
+        static_cast<int>(WTF::enumToUnderlyingType(WebCore::ResourceLoadPriority::Highest)));
+    [dict setObject:[NSNumber numberWithInt:clampedRequestPriority] forKey:@"requestPriority"];
+
     SET_DICT_FROM_OPTIONAL_PRIMITIVE(isHTTP, NSNumber, Bool);
     SET_DICT_FROM_OPTIONAL_MEMBER(httpMethod);
 


### PR DESCRIPTION
#### 3a885897a634abba8d8c80b086bd8eb0fe1ede39
<pre>
REGRESSION(286883@main): ASSERT NOT REACHED in WebCore::toResourceLoadPriority(CFURLRequestPriority)
<a href="https://rdar.apple.com/140442183">rdar://140442183</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283596">https://bugs.webkit.org/show_bug.cgi?id=283596</a>

Reviewed by Ryosuke Niwa.

This fixes the regression by setting a value for the priority that is within bounds, and prevents future asserts by clamping

* LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers.html:
* LayoutTests/ipc/url-requestPriority-out-of-range-expected.txt: Added.
* LayoutTests/ipc/url-requestPriority-out-of-range.html: Copied from LayoutTests/ipc/cfnetwork-crashes-with-string-to-string-http-headers.html.
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::toID const):

Canonical link: <a href="https://commits.webkit.org/289501@main">https://commits.webkit.org/289501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41b3645fcef327cb9e31970737bf5d4e7a667974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67336 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25089 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36982 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93872 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14288 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76138 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74715 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75339 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19679 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18116 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7205 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19600 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->