### PR TITLE
[Cookie Store API] Throw error on attempt to set cookies for a public suffix domain

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -40,6 +40,7 @@
 #include "JSCookieListItem.h"
 #include "JSDOMPromiseDeferred.h"
 #include "Page.h"
+#include "PublicSuffixStore.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "SecurityOrigin.h"
@@ -441,6 +442,11 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
         // FIXME: <rdar://85515842> Obtain the encoded length without allocating and encoding.
         if (cookie.domain.utf8().length() > maximumAttributeValueSize) {
             promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the domain must not be greater than "_s, maximumAttributeValueSize, " bytes"_s) });
+            return;
+        }
+
+        if (PublicSuffixStore::singleton().isPublicSuffix(cookie.domain)) {
+            promise->reject(Exception { ExceptionCode::TypeError, "The domain must not be a public suffix"_s });
             return;
         }
 


### PR DESCRIPTION
#### f9cc03148c7fce295e58191df2725cbc8062733d
<pre>
[Cookie Store API] Throw error on attempt to set cookies for a public suffix domain
<a href="https://bugs.webkit.org/show_bug.cgi?id=286382">https://bugs.webkit.org/show_bug.cgi?id=286382</a>
<a href="https://rdar.apple.com/143095098">rdar://143095098</a>

Reviewed by Chris Dumez.

If there is an attempt to set a cookie with a public-suffix domain (like &quot;com&quot;), and
the current host is &quot;*.com&quot;, then &quot;com&quot; passes the domain rules in the Cookie Store spec.
But CFNetwork does not set the cookie--and since the CFNetwork API for setting the cookie
does not return an error, CookieStore::set() returns a success even though the
cookie wasn&apos;t set.

The spec does not say anything about checking for public-suffix domains, but Chrome
does return an error for this. To match Chrome, we alter CookieStore::set() to return
an error if the domain is a public-suffix.

This is tested by a new API test in CookieStoreAPI.mm.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieStoreAPI.mm:
(TestWebKitAPI::TEST(WebKit, CookieStoreSetCookieForPublicSuffixDomain)):

Canonical link: <a href="https://commits.webkit.org/289296@main">https://commits.webkit.org/289296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d75dcb564397651c79ea16a2f0bb7ae3361b92ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24613 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89216 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32436 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36150 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92966 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75607 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74782 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/18410 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6233 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13429 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->