### PR TITLE
[scroll-animations] Timeline-scope code should use isDescendantOrShadowDescendantOf

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline-timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline-timeline-scope-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: [object ViewTimeline]
+
+FAIL named timeline on pseudo-element attaches to parent scroll container assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline-timeline-scope.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline-timeline-scope.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Animating pseduo-element on scroller using named timeline</title>
+</head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="./support/testcommon.js"></script>
+<script src="testcommon.js"></script>
+<style type="text/css">
+.parent {
+  overflow: scroll;
+  timeline-scope: --t1;
+  width: 100px;
+  height: 100px;
+  margin: 1em;
+  outline: 1px solid;
+}
+.pseudo::after {
+  content: "";
+  display: block;
+  width: 50px;
+  height: 50px;
+  background: red;
+  animation: bg linear;
+  animation-timeline: --t1;
+}
+
+.pseudo::before {
+  content: "";
+  display: block;
+  overflow: scroll;
+  width: 100px;
+  height: 100px;
+  margin: 100px;
+  background-color: blue;
+  view-timeline: --t1 y;
+}
+
+.content {
+    width: 200px;
+    height: 200px;
+    background-color: yellow;
+}
+@keyframes bg {
+  from {
+    background: rgb(0, 255, 0);
+  }
+  to {
+    background: rgb(0, 0, 255);
+  }
+}
+</style>
+<body>
+  <div class="parent pseudo">
+    <div class="content">
+    </div>
+
+  </div>
+  <div id="log"></div>
+</body>
+<script type="text/javascript">
+  'use strict';
+
+  promise_test(async t => {
+    await waitForCSSScrollTimelineStyle();
+    const parent = document.querySelector('.parent');
+    console.log(document.getAnimations()[0].timeline);
+    assert_equals(getComputedStyle(parent, ':after').backgroundColor,
+                  'rgb(0, 255, 0)');
+  }, `named timeline on pseudo-element attaches to parent scroll container`);
+</script>
+</html>


### PR DESCRIPTION
#### b61375b98fd1d80bacf28ef13e62b9df2ecb329e
<pre>
[scroll-animations] Timeline-scope code should use isDescendantOrShadowDescendantOf
<a href="https://bugs.webkit.org/show_bug.cgi?id=286386">https://bugs.webkit.org/show_bug.cgi?id=286386</a>
<a href="https://rdar.apple.com/143433304">rdar://143433304</a>

Reviewed by NOBODY (OOPS!).

On <a href="https://codepen.io/t_afif/full/ZEgjNxm">https://codepen.io/t_afif/full/ZEgjNxm</a> view timelines are declared on pseudo elements. When combined with
timeline-scope, we end up using isDescendant which doesn&apos;t include pseudo elements, so change these call sites
to use isDescendantOrShadowDescendantOf. Also fix an issue where m_timelineScopeEntries is not properly updated.
The test is failing when run via wktr likely due to the timeline-scope issue where getComputedStyle isn&apos;t updated
after setting the new timeline.

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::determineTimelineForElement):
(WebCore::AnimationTimelinesController::updateTimelineForTimelineScope):
(WebCore::updateTimelinesForTimelineScope):
(WebCore::AnimationTimelinesController::updateNamedTimelineMapForTimelineScope):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::setTimelineScopeElement):
* Source/WebCore/animation/TimelineScope.h:
(WebCore::TimelineScope::operator== const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b61375b98fd1d80bacf28ef13e62b9df2ecb329e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89941 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69248 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26862 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92942 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7549 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7275 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35969 "Found 8 new test failures: fast/html/process-end-tag-for-inbody-crash.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fullscreen/empty-anonymous-block-continuation-crash.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39848 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96764 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77446 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10323 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22464 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->