### PR TITLE
Have ""_span be `constexpr` and return a `std::span<const char>` instead of `std::span<const LChar>`

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -43,7 +43,7 @@ JSStringRef JSStringCreateWithCFString(CFStringRef string)
     // it can hold.  (<rdar://problem/6806478>)
     size_t length = CFStringGetLength(string);
     if (!length)
-        return &OpaqueJSString::create(""_span).leakRef();
+        return &OpaqueJSString::create(""_span8).leakRef();
 
     Vector<LChar, 1024> lcharBuffer(length);
     CFIndex usedBufferLength;

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1442,7 +1442,7 @@ void Option::dump(StringBuilder& builder) const
         builder.append(span(m_optionRange.rangeString()));
         break;
     case Options::Type::OptionString:
-        builder.append('"', m_optionString ? span8(m_optionString) : ""_span, '"');
+        builder.append('"', m_optionString ? span8(m_optionString) : ""_span8, '"');
         break;
     case Options::Type::GCLogLevel:
         builder.append(m_gcLogLevel);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1362,17 +1362,17 @@ auto SectionParser::parseCustom() -> PartialResult
         section.payload[byteNumber] = byte;
     }
 
-    if (WTF::Unicode::equal("name"_span, section.name.span())) {
+    if (WTF::Unicode::equal("name"_span8, section.name.span())) {
         NameSectionParser nameSectionParser(section.payload, m_info);
         auto nameSection = nameSectionParser.parse();
         if (nameSection)
             m_info->nameSection = WTFMove(*nameSection);
         else
             dataLogLnIf(Options::dumpWasmWarnings(), "Could not parse name section: ", nameSection.error());
-    } else if (WTF::Unicode::equal("metadata.code.branch_hint"_span, section.name.span())) {
+    } else if (WTF::Unicode::equal("metadata.code.branch_hint"_span8, section.name.span())) {
         BranchHintsSectionParser branchHintsSectionParser(section.payload, m_info);
         branchHintsSectionParser.parse();
-    } else if (WTF::Unicode::equal("sourceMappingURL"_span, section.name.span())) {
+    } else if (WTF::Unicode::equal("sourceMappingURL"_span8, section.name.span())) {
         SourceMappingURLSectionParser sourceMappingURLSectionParser(section.payload, m_info);
         sourceMappingURLSectionParser.parse();
     }

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -413,7 +413,7 @@ static int findMonth(std::span<const LChar> monthStr)
     std::array<LChar, 3> needle;
     for (unsigned i = 0; i < 3; ++i)
         needle[i] = toASCIILower(monthStr[i]);
-    auto haystack = "janfebmaraprmayjunjulaugsepoctnovdec"_span;
+    constexpr auto haystack = "janfebmaraprmayjunjulaugsepoctnovdec"_span;
     if (size_t index = find(haystack, std::span { needle }); index != notFound) {
         if (!(index % 3))
             return index / 3;
@@ -854,13 +854,13 @@ double parseDate(std::span<const LChar> dateString, bool& isLocalTime)
 
             skipSpacesAndComments(dateString);
 
-            if (skipLettersExactlyIgnoringASCIICase(dateString, "am"_span)) {
+            if (skipLettersExactlyIgnoringASCIICase(dateString, "am"_span8)) {
                 if (hour > 12)
                     return std::numeric_limits<double>::quiet_NaN();
                 if (hour == 12)
                     hour = 0;
                 skipSpacesAndComments(dateString);
-            } else if (skipLettersExactlyIgnoringASCIICase(dateString, "pm"_span)) {
+            } else if (skipLettersExactlyIgnoringASCIICase(dateString, "pm"_span8)) {
                 if (hour > 12)
                     return std::numeric_limits<double>::quiet_NaN();
                 if (hour != 12)
@@ -882,7 +882,7 @@ double parseDate(std::span<const LChar> dateString, bool& isLocalTime)
     // Don't fail if the time zone is missing. 
     // Some websites omit the time zone (4275206).
     if (!dateString.empty()) {
-        if (skipLettersExactlyIgnoringASCIICase(dateString, "gmt"_span) || skipLettersExactlyIgnoringASCIICase(dateString, "utc"_span))
+        if (skipLettersExactlyIgnoringASCIICase(dateString, "gmt"_span8) || skipLettersExactlyIgnoringASCIICase(dateString, "utc"_span8))
             isLocalTime = false;
 
         if (!dateString.empty() && (dateString.front() == '+' || dateString.front() == '-')) {

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1382,7 +1382,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             if (*c == '/' || *c == '\\') {
                 ++c;
                 copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
-                appendToASCIIBuffer("://"_span);
+                appendToASCIIBuffer("://"_span8);
                 if (m_urlIsSpecial)
                     state = State::SpecialAuthorityIgnoreSlashes;
                 else {
@@ -1415,7 +1415,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                 }
             } else {
                 syntaxViolation(c);
-                appendToASCIIBuffer("//"_span);
+                appendToASCIIBuffer("//"_span8);
             }
             state = State::SpecialAuthorityIgnoreSlashes;
             break;
@@ -1527,7 +1527,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     appendToASCIIBuffer('?');
                     ++c;
                 } else {
-                    appendToASCIIBuffer("///?"_span);
+                    appendToASCIIBuffer("///?"_span8);
                     ++c;
                     m_url.m_userStart = currentPosition(c) - 2;
                     m_url.m_userEnd = m_url.m_userStart;
@@ -1549,7 +1549,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     copyURLPartsUntil(base, URLPart::QueryEnd, c, nonUTF8QueryEncoding);
                     appendToASCIIBuffer('#');
                 } else {
-                    appendToASCIIBuffer("///#"_span);
+                    appendToASCIIBuffer("///#"_span8);
                     m_url.m_userStart = currentPosition(c) - 2;
                     m_url.m_userEnd = m_url.m_userStart;
                     m_url.m_passwordEnd = m_url.m_userStart;
@@ -1571,14 +1571,14 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     if (base.isValid() && base.protocolIsFile()) {
                         if (base.host().isEmpty()) {
                             copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
-                            appendToASCIIBuffer(":///"_span);
+                            appendToASCIIBuffer(":///"_span8);
                         } else {
                             copyURLPartsUntil(base, URLPart::PortEnd, c, nonUTF8QueryEncoding);
                             appendToASCIIBuffer('/');
                             copiedHost = true;
                         }
                     } else
-                        appendToASCIIBuffer("///"_span);
+                        appendToASCIIBuffer("///"_span8);
                     if (!copiedHost) {
                         m_url.m_userStart = currentPosition(c) - 1;
                         m_url.m_userEnd = m_url.m_userStart;
@@ -1601,7 +1601,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     syntaxViolation(c);
                 if (base.isValid() && base.protocolIsFile()) {
                     copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
-                    appendToASCIIBuffer(":/"_span);
+                    appendToASCIIBuffer(":/"_span8);
                 }
                 appendToASCIIBuffer('/');
                 advance(c);
@@ -1619,7 +1619,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                 if (base.isValid() && base.protocolIsFile()) {
                     if (base.host().isEmpty()) {
                         copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
-                        appendToASCIIBuffer(":///"_span);
+                        appendToASCIIBuffer(":///"_span8);
                     } else {
                         copyURLPartsUntil(base, URLPart::PortEnd, c, nonUTF8QueryEncoding);
                         appendToASCIIBuffer('/');
@@ -1627,7 +1627,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                     }
                 } else {
                     syntaxViolation(c);
-                    appendToASCIIBuffer("//"_span);
+                    appendToASCIIBuffer("//"_span8);
                 }
                 if (!copiedHost) {
                     m_url.m_userStart = currentPosition(c) - 1;
@@ -1662,7 +1662,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                         ASSERT(windowsQuirk || parsedDataView(currentPosition(c) - 1) == '/');
                         if (UNLIKELY(*c == '?')) {
                             syntaxViolation(c);
-                            appendToASCIIBuffer("/?"_span);
+                            appendToASCIIBuffer("/?"_span8);
                             ++c;
                             if (nonUTF8QueryEncoding) {
                                 queryBegin = c;
@@ -1675,7 +1675,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
                         }
                         if (UNLIKELY(*c == '#')) {
                             syntaxViolation(c);
-                            appendToASCIIBuffer("/#"_span);
+                            appendToASCIIBuffer("/#"_span8);
                             ++c;
                             m_url.m_pathAfterLastSlash = currentPosition(c) - 1;
                             m_url.m_pathEnd = m_url.m_pathAfterLastSlash;
@@ -1915,7 +1915,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             break;
         }
         syntaxViolation(c);
-        appendToASCIIBuffer("///"_span);
+        appendToASCIIBuffer("///"_span8);
         m_url.m_userStart = currentPosition(c) - 1;
         m_url.m_userEnd = m_url.m_userStart;
         m_url.m_passwordEnd = m_url.m_userStart;
@@ -1933,7 +1933,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             if (base.isValid() && base.protocolIsFile()) {
                 if (base.host().isEmpty()) {
                     copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
-                    appendToASCIIBuffer(":/"_span);
+                    appendToASCIIBuffer(":/"_span8);
                 } else {
                     copyURLPartsUntil(base, URLPart::PortEnd, c, nonUTF8QueryEncoding);
                     appendToASCIIBuffer('/');
@@ -1942,7 +1942,7 @@ void URLParser::parse(std::span<const CharacterType> input, const URL& base, con
             }
             if (!copiedHost) {
                 m_url.m_userStart = currentPosition(c) + 1;
-                appendToASCIIBuffer("//"_span);
+                appendToASCIIBuffer("//"_span8);
                 m_url.m_userEnd = m_url.m_userStart;
                 m_url.m_passwordEnd = m_url.m_userStart;
                 m_url.m_hostEnd = m_url.m_userStart;
@@ -2159,7 +2159,7 @@ void URLParser::serializeIPv6(URLParser::IPv6Address address)
             if (piece)
                 appendToASCIIBuffer(':');
             else
-                appendToASCIIBuffer("::"_span);
+                appendToASCIIBuffer("::"_span8);
             while (piece < 8 && !address[piece])
                 piece++;
             if (piece == 8)

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -151,7 +151,17 @@ constexpr ASCIILiteral operator""_s(const char* characters, size_t)
     return result;
 }
 
-constexpr std::span<const LChar> operator""_span(const char* characters, size_t n)
+constexpr std::span<const char> operator""_span(const char* characters, size_t n)
+{
+    auto span = unsafeMakeSpan(characters, n);
+#if ASSERT_ENABLED
+    for (size_t i = 0, size = span.size(); i < size; ++i)
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(span[i]));
+#endif
+    return span;
+}
+
+constexpr std::span<const LChar> operator""_span8(const char* characters, size_t n)
 {
     auto span = byteCast<LChar>(unsafeMakeSpan(characters, n));
 #if ASSERT_ENABLED

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
@@ -36,12 +36,12 @@ namespace WebCore {
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeSaltKey(const Vector<uint8_t>& rawKey)
 {
-    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span, "salt"_span, 96);
+    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span8, "salt"_span8, 96);
 }
 
 static ExceptionOr<Vector<uint8_t>> createBaseSFrameKey(const Vector<uint8_t>& rawKey)
 {
-    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span, "key"_span, 128);
+    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span8, "key"_span8, 128);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeAuthenticationKey(const Vector<uint8_t>& rawKey)
@@ -50,7 +50,7 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeAuthenticationKey(c
     if (key.hasException())
         return key;
 
-    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span, "auth"_span, 256);
+    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span8, "auth"_span8, 256);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const Vector<uint8_t>& rawKey)
@@ -59,7 +59,7 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const
     if (key.hasException())
         return key;
 
-    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span, "enc"_span, 128);
+    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span8, "enc"_span8, 128);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::decryptData(std::span<const uint8_t> data, const Vector<uint8_t>& iv, const Vector<uint8_t>& key)

--- a/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
@@ -151,7 +151,7 @@ std::optional<Vector<uint8_t>> decryptAES128GCMPayload(const ClientKeys& clientK
      * cek_info = "Content-Encoding: aes128gcm" || 0x00
      * CEK = HMAC-SHA-256(PRK, cek_info || 0x01)[0..15]
      */
-    static const auto cekInfo = "Content-Encoding: aes128gcm\x00\x01"_span;
+    static const auto cekInfo = "Content-Encoding: aes128gcm\x00\x01"_span8;
     auto cek = hmacSHA256(prk, cekInfo);
     cek.shrink(16);
 
@@ -160,7 +160,7 @@ std::optional<Vector<uint8_t>> decryptAES128GCMPayload(const ClientKeys& clientK
      * nonce_info = "Content-Encoding: nonce" || 0x00
      * NONCE = HMAC-SHA-256(PRK, nonce_info || 0x01)[0..11]
      */
-    static const auto nonceInfo = "Content-Encoding: nonce\x00\x01"_span;
+    static const auto nonceInfo = "Content-Encoding: nonce\x00\x01"_span8;
     auto nonce = hmacSHA256(prk, nonceInfo);
     nonce.shrink(12);
 
@@ -236,7 +236,7 @@ std::optional<Vector<uint8_t>> decryptAESGCMPayload(const ClientKeys& clientKeys
      * IKM = HMAC-SHA-256(PRK_combine, auth_info || 0x01)
      * PRK = HMAC-SHA-256(salt, IKM)
      */
-    static const auto authInfo = "Content-Encoding: auth\x00\x01"_span;
+    static const auto authInfo = "Content-Encoding: auth\x00\x01"_span8;
     auto prkCombine = hmacSHA256(clientKeys.sharedAuthSecret, *ecdhSecretResult);
     auto ikm = hmacSHA256(prkCombine, authInfo);
     auto prk = hmacSHA256(salt, ikm);

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1396,7 +1396,7 @@ sub generateFindNameForLength
                     }
                     print F ")) {\n";
                 } else {
-                    print F "${indent}if (WTF::equal($bufferStart, \"". substr($string, $currentIndex, $length - $currentIndex) . "\"_span)) {\n";
+                    print F "${indent}if (WTF::equal($bufferStart, \"". substr($string, $currentIndex, $length - $currentIndex) . "\"_span8)) {\n";
                 }
             }
             print F "$indent    return ${enumClass}::$enumValue;\n";

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1128,17 +1128,17 @@ std::pair<double, double> VTTCue::getPositionCoordinates() const
 VTTCue::CueSetting VTTCue::settingName(VTTScanner& input)
 {
     CueSetting parsedSetting = None;
-    if (input.scan("vertical"_span))
+    if (input.scan("vertical"_span8))
         parsedSetting = Vertical;
-    else if (input.scan("line"_span))
+    else if (input.scan("line"_span8))
         parsedSetting = Line;
-    else if (input.scan("position"_span))
+    else if (input.scan("position"_span8))
         parsedSetting = Position;
-    else if (input.scan("size"_span))
+    else if (input.scan("size"_span8))
         parsedSetting = Size;
-    else if (input.scan("align"_span))
+    else if (input.scan("align"_span8))
         parsedSetting = Align;
-    else if (input.scan("region"_span))
+    else if (input.scan("region"_span8))
         parsedSetting = Region;
 
     // Verify that a ':' follows.

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -164,17 +164,17 @@ void VTTRegion::setRegionSettings(const String& inputString)
 
 VTTRegion::RegionSetting VTTRegion::scanSettingName(VTTScanner& input)
 {
-    if (input.scan("id:"_span))
+    if (input.scan("id:"_span8))
         return Id;
-    if (input.scan("lines:"_span))
+    if (input.scan("lines:"_span8))
         return Lines;
-    if (input.scan("width:"_span))
+    if (input.scan("width:"_span8))
         return Width;
-    if (input.scan("viewportanchor:"_span))
+    if (input.scan("viewportanchor:"_span8))
         return ViewportAnchor;
-    if (input.scan("regionanchor:"_span))
+    if (input.scan("regionanchor:"_span8))
         return RegionAnchor;
-    if (input.scan("scroll:"_span))
+    if (input.scan("scroll:"_span8))
         return Scroll;
 
     return None;

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -235,7 +235,7 @@ void WebVTTParser::parse()
 void WebVTTParser::fileFinished()
 {
     ASSERT(m_state != Finished);
-    parseBytes("\n\n"_span);
+    parseBytes("\n\n"_span8);
     m_state = Finished;
 }
 
@@ -446,7 +446,7 @@ WebVTTParser::ParseState WebVTTParser::collectTimingsAndSettings(const String& l
     input.skipWhile<isASCIIWhitespace<UChar>>();
 
     // Steps 6 - 9 - If the next three characters are not "-->", abort and return failure.
-    if (!input.scan("-->"_span))
+    if (!input.scan("-->"_span8))
         return BadCue;
     
     input.skipWhile<isASCIIWhitespace<UChar>>();

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -339,7 +339,7 @@ bool TextResourceDecoder::hasEqualEncodingForCharset(const String& charset) cons
 // Returns the position of the encoding string.
 static size_t findXMLEncoding(std::span<const uint8_t> string, size_t& encodingLength)
 {
-    size_t position = find(string, "encoding"_span);
+    size_t position = find(string, "encoding"_span8);
     if (position == notFound)
         return notFound;
     position += 8;
@@ -436,7 +436,7 @@ bool TextResourceDecoder::checkForCSSCharset(std::span<const uint8_t> data, bool
 
     data = m_buffer.span();
 
-    if (skipCharactersExactly(data, "@charset \""_span)) {
+    if (skipCharactersExactly(data, "@charset \""_span8)) {
         size_t index = 0;
         while (index < data.size() && data[index] != '"')
             ++index;

--- a/Source/WebCore/platform/network/DNS.cpp
+++ b/Source/WebCore/platform/network/DNS.cpp
@@ -108,7 +108,7 @@ bool IPAddress::isLoopback() const
         [] (const struct in_addr& address) {
         return address.s_addr == htonl(INADDR_LOOPBACK);
     }, [] (const struct in6_addr& address) {
-        const auto in6addrLoopback = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1"_span;
+        constexpr auto in6addrLoopback = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1"_span;
         return equalSpans(asByteSpan(address.s6_addr), in6addrLoopback);
     }, [] (const WTF::HashTableEmptyValueType&) {
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -99,7 +99,7 @@ struct SubtagComparison {
     int comparison;
 };
 
-static SubtagComparison subtagCompare(std::span<const LChar> key, std::span<const LChar> range)
+static SubtagComparison subtagCompare(std::span<const char> key, std::span<const char> range)
 {
     SubtagComparison result;
 
@@ -107,14 +107,14 @@ static SubtagComparison subtagCompare(std::span<const LChar> key, std::span<cons
     result.keyContinue = result.keyLength;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (auto* hyphenPointer = memchr(key.data(), '-', key.size())) {
-        result.keyLength = static_cast<const LChar*>(hyphenPointer) - key.data();
+        result.keyLength = static_cast<const char*>(hyphenPointer) - key.data();
         result.keyContinue = result.keyLength + 1;
     }
 
     result.rangeLength = range.size();
     result.rangeContinue = result.rangeLength;
     if (auto* hyphenPointer = memchr(range.data(), '-', range.size())) {
-        result.rangeLength = static_cast<const LChar*>(hyphenPointer) - range.data();
+        result.rangeLength = static_cast<const char*>(hyphenPointer) - range.data();
         result.rangeContinue = result.rangeLength + 1;
     }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -140,7 +140,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 // However, if the key we're testing against is "de-de", then we should report "equal to",
 // because these are the quotes we should use for all "de" except for "de-ch".
 struct QuotesForLanguage {
-    std::span<const LChar> language;
+    std::span<const char> language;
     UChar checkFurther;
     UChar open1;
     UChar close1;
@@ -212,7 +212,7 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
 {
     // Table of quotes from http://www.whatwg.org/specs/web-apps/current-work/multipage/rendering.html#quotes
     // FIXME: This table is out-of-date.
-    static const std::array quoteTable {
+    static constexpr std::array quoteTable {
         QuotesForLanguage { "af"_span,         0, 0x201c, 0x201d, 0x2018, 0x2019 },
         QuotesForLanguage { "agq"_span,        0, 0x201e, 0x201d, 0x201a, 0x2019 },
         QuotesForLanguage { "ak"_span,         0, 0x201c, 0x201d, 0x2018, 0x2019 },
@@ -392,12 +392,12 @@ static const QuotesForLanguage* quotesForLanguage(const String& language)
     if (!length)
         return nullptr;
 
-    Vector<LChar> languageKeyBuffer(length);
+    Vector<char> languageKeyBuffer(length);
     for (unsigned i = 0; i < length; ++i) {
         UChar character = toASCIILower(language[i]);
         if (!(isASCIILower(character) || character == '-'))
             return nullptr;
-        languageKeyBuffer[i] = static_cast<LChar>(character);
+        languageKeyBuffer[i] = static_cast<char>(character);
     }
 
     QuotesForLanguage languageKey = { languageKeyBuffer.span(), 0, 0, 0, 0, 0 };

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -755,7 +755,7 @@ static void runGetFileModificationTimeTest(const String& path, Function<std::opt
     // Modify the file.
     auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite);
     EXPECT_TRUE(FileSystem::isHandleValid(fileHandle));
-    FileSystem::writeToFile(fileHandle, "foo"_span);
+    FileSystem::writeToFile(fileHandle, "foo"_span8);
     FileSystem::closeFile(fileHandle);
 
     auto newModificationTime = fileModificationTime(path);


### PR DESCRIPTION
#### df4aa6259d05c25cadaf68099f2ac9929207db16
<pre>
Have &quot;&quot;_span be `constexpr` and return a `std::span&lt;const char&gt;` instead of `std::span&lt;const LChar&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=286388">https://bugs.webkit.org/show_bug.cgi?id=286388</a>

Reviewed by Darin Adler.

Have &quot;&quot;_span be `constexpr` and return a `std::span&lt;const char&gt;` instead of `std::span&lt;const LChar&gt;`.
One can still get a `std::span&lt;const LChar&gt;` by using &quot;&quot;_span8. One big benefit of &quot;&quot;_span is that
it now can be used to initialize `constexpr` variables since it doesn&apos;t require converting into LChar
using `byteCast&lt;&gt;()`.

* Source/JavaScriptCore/API/JSStringRefCF.cpp:
(JSStringCreateWithCFString):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::OptionsHelper::Option::dump const):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseCustom):
* Source/WTF/wtf/DateMath.cpp:
(WTF::findMonth):
(WTF::parseDate):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::parse):
(WTF::URLParser::serializeIPv6):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::StringLiterals::operator_span):
(WTF::StringLiterals::operator_span8):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp:
(WebCore::RTCRtpSFrameTransformer::computeSaltKey):
(WebCore::createBaseSFrameKey):
(WebCore::RTCRtpSFrameTransformer::computeAuthenticationKey):
(WebCore::RTCRtpSFrameTransformer::computeEncryptionKey):
* Source/WebCore/Modules/push-api/PushMessageCrypto.cpp:
(WebCore::PushCrypto::decryptAES128GCMPayload):
(WebCore::PushCrypto::decryptAESGCMPayload):
* Source/WebCore/dom/make_names.pl:
(generateFindNameForLength):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::settingName):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::scanSettingName):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::fileFinished):
(WebCore::WebVTTParser::collectTimingsAndSettings):
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::findXMLEncoding):
(WebCore::TextResourceDecoder::checkForCSSCharset):
* Source/WebCore/platform/network/DNS.cpp:
(WebCore::IPAddress::isLoopback const):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::subtagCompare):
(WebCore::quotesForLanguage):

Canonical link: <a href="https://commits.webkit.org/289290@main">https://commits.webkit.org/289290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bd585e5e11cc6f0380d11340d6debf0154484f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66803 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24598 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47114 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32417 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36131 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79072 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93067 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85059 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75657 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74835 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6218 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13424 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13440 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18757 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107509 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13209 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25880 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->