### PR TITLE
CacheStorageRecordInformation is not isolated copied when passed across threads

### DIFF
--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -87,21 +87,43 @@ template<bool isEnumOrConvertibleToInteger, bool isThreadSafeRefCounted, typenam
 template<typename T> struct CrossThreadCopierBase<true, false, T> : public CrossThreadCopierPassThrough<T> {
 };
 
-// Classes that have an isolatedCopy() method get a default specialization.
+// All non-specified types passed to crossThreadCopy() must provide isolatedCopy().
 template<typename T>
 struct CrossThreadCopierBase<false, false, T> {
     using Type = T;
-    static constexpr bool IsNeeded = HasIsolatedCopy<T>::value;
-    template<typename U> static auto copy(U&& value) -> Type
+    static constexpr bool IsNeeded = true;
+    static Type copy(const Type& value)
     {
-        if constexpr (HasIsolatedCopy<U>::value)
-            return std::forward<U>(value).isolatedCopy();
-        else
-            return std::forward<U>(value);
+        return value.isolatedCopy();
+    }
+
+    static Type copy(Type&& value)
+    {
+        return WTFMove(value).isolatedCopy();
     }
 };
 
 // Custom copy methods.
+template<typename T, typename Deleter>
+struct CrossThreadCopierBase<false, false, std::unique_ptr<T, Deleter>> {
+    using Type = std::unique_ptr<T, Deleter>;
+    static constexpr bool IsNeeded = false;
+    static Type copy(Type&& value)
+    {
+        return WTFMove(value);
+    }
+};
+
+template<typename T>
+struct CrossThreadCopierBase<false, false, RetainPtr<T>> {
+    using Type = RetainPtr<T>;
+    static constexpr bool IsNeeded = false;
+    static Type copy(Type&& value)
+    {
+        return WTFMove(value);
+    }
+};
+
 template<typename T> struct CrossThreadCopierBase<false, true, T> {
     using RefCountedType = typename CrossThreadCopierBaseHelper::RemovePointer<T>::Type;
     static_assert(std::is_convertible<RefCountedType*, ThreadSafeRefCountedBase*>::value, "T is not convertible to ThreadSafeRefCounted!");
@@ -209,8 +231,8 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 };
 
 // Default specialization for HashSets of CrossThreadCopyable classes
-template<typename T> struct CrossThreadCopierBase<false, false, HashSet<T> > {
-    using Type = HashSet<T>;
+template<typename T, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey> struct CrossThreadCopierBase<false, false, HashSet<T, HashFunctions, Traits, TableTraits, shouldValidateKey>> {
+    using Type = HashSet<T, HashFunctions, Traits, TableTraits, shouldValidateKey>;
     static constexpr bool IsNeeded = CrossThreadCopier<T>::IsNeeded;
     static Type copy(const Type& source)
     {

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -626,4 +626,9 @@ TextStream& operator<<(TextStream& stream, const MediaTime& time)
     return stream << time.toJSONString();
 }
 
+MediaTime MediaTime::isolatedCopy() const
+{
+    return *this;
+}
+
 }

--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -136,6 +136,7 @@ public:
     };
 
     MediaTime toTimeScale(uint32_t, RoundingFlags = RoundingFlags::HalfAwayFromZero) const;
+    MediaTime isolatedCopy() const;
 
 private:
     void setTimeScale(uint32_t, RoundingFlags = RoundingFlags::HalfAwayFromZero);

--- a/Source/WebCore/Modules/cookie-store/CookieChangeSubscription.h
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeSubscription.h
@@ -42,6 +42,9 @@ struct CookieChangeSubscription {
         , url(WTFMove(url))
     { }
 
+    CookieChangeSubscription isolatedCopy() const & { return { name.isolatedCopy(), url.isolatedCopy() }; }
+    CookieChangeSubscription isolatedCopy() && { return { WTFMove(name).isolatedCopy(), WTFMove(url).isolatedCopy() }; }
+
     explicit CookieChangeSubscription(WTF::HashTableDeletedValueType deletedValue)
         : name(deletedValue)
     { }

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.h
@@ -41,6 +41,7 @@ struct WebTransportBidirectionalStreamConstructionParameters {
     WEBCORE_EXPORT WebTransportBidirectionalStreamConstructionParameters(WebTransportBidirectionalStreamConstructionParameters&&);
     WEBCORE_EXPORT WebTransportBidirectionalStreamConstructionParameters& operator=(WebTransportBidirectionalStreamConstructionParameters&&);
     WEBCORE_EXPORT ~WebTransportBidirectionalStreamConstructionParameters();
+    WebTransportBidirectionalStreamConstructionParameters isolatedCopy() && { return { identifier, Ref { sink } }; }
 
     WebTransportStreamIdentifier identifier;
     Ref<WritableStreamSink> sink;

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.h
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.h
@@ -30,6 +30,7 @@
 #include "CompiledContentExtension.h"
 #include "ContentExtension.h"
 #include "ContentExtensionRule.h"
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/StringHash.h>
@@ -84,7 +85,15 @@ public:
 
     WEBCORE_EXPORT static bool shouldBeMadeSecure(const URL&);
 
+    ContentExtensionsBackend() = default;
+    ContentExtensionsBackend isolatedCopy() && { return ContentExtensionsBackend { crossThreadCopy(WTFMove(m_contentExtensions)) }; }
+
 private:
+    explicit ContentExtensionsBackend(UncheckedKeyHashMap<String, Ref<ContentExtension>>&& contentExtensions)
+        : m_contentExtensions(WTFMove(contentExtensions))
+    {
+    }
+
     ActionsFromContentRuleList actionsFromContentRuleList(const ContentExtension&, const String& urlString, const ResourceLoadInfo&, ResourceFlags) const;
 
     UncheckedKeyHashMap<String, Ref<ContentExtension>> m_contentExtensions;

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SecurityOriginData.h"
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/URL.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/ContentType.h
+++ b/Source/WebCore/platform/ContentType.h
@@ -59,6 +59,9 @@ public:
     bool operator==(const ContentType& other) const { return raw() == other.raw(); }
     bool operator!=(const ContentType& other) const { return !(*this == other); }
 
+    ContentType isolatedCopy() const & { return { m_type.isolatedCopy(), m_typeWasInferredFromExtension }; }
+    ContentType isolatedCopy() && { return { WTFMove(m_type).isolatedCopy(), m_typeWasInferredFromExtension }; }
+
 private:
     String m_type;
     bool m_typeWasInferredFromExtension { false };

--- a/Source/WebCore/platform/graphics/VideoPlaybackQualityMetrics.h
+++ b/Source/WebCore/platform/graphics/VideoPlaybackQualityMetrics.h
@@ -45,6 +45,8 @@ struct VideoPlaybackQualityMetrics {
         displayCompositedVideoFrames += other.displayCompositedVideoFrames;
         return *this;
     }
+
+    VideoPlaybackQualityMetrics isolatedCopy() const { return *this; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/PhotoCapabilities.h
+++ b/Source/WebCore/platform/mediastream/PhotoCapabilities.h
@@ -35,6 +35,8 @@ enum class FillLightMode : uint8_t;
 enum class RedEyeReduction : uint8_t;
 
 struct PhotoCapabilities {
+    PhotoCapabilities isolatedCopy() const { return *this; }
+
     std::optional<RedEyeReduction> redEyeReduction;
     std::optional<MediaSettingsRange> imageHeight;
     std::optional<MediaSettingsRange> imageWidth;

--- a/Source/WebCore/platform/mediastream/PhotoSettings.h
+++ b/Source/WebCore/platform/mediastream/PhotoSettings.h
@@ -33,6 +33,8 @@ namespace WebCore {
 enum class FillLightMode : uint8_t;
 
 struct PhotoSettings {
+    PhotoSettings isolatedCopy() const { return *this; }
+
     std::optional<FillLightMode> fillLightMode;
     std::optional<double> imageHeight;
     std::optional<double> imageWidth;

--- a/Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h
+++ b/Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RegistrableDomain.h"
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 
@@ -49,6 +50,23 @@ struct OrganizationStorageAccessPromptQuirk {
         { }
 
     OrganizationStorageAccessPromptQuirk() = default;
+    OrganizationStorageAccessPromptQuirk isolatedCopy() const &
+    {
+        return {
+            crossThreadCopy(organizationName),
+            crossThreadCopy(quirkDomains),
+            crossThreadCopy(triggerPages)
+        };
+    }
+
+    OrganizationStorageAccessPromptQuirk isolatedCopy() &&
+    {
+        return {
+            crossThreadCopy(WTFMove(organizationName)),
+            crossThreadCopy(WTFMove(quirkDomains)),
+            crossThreadCopy(WTFMove(triggerPages))
+        };
+    }
 };
 
 static bool operator==(const OrganizationStorageAccessPromptQuirk& a, const OrganizationStorageAccessPromptQuirk& b)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
@@ -74,6 +74,20 @@ CacheStorageRecordInformation CacheStorageRecordInformation::isolatedCopy() &&
     };
 }
 
+CacheStorageRecordInformation CacheStorageRecordInformation::isolatedCopy() const &
+{
+    return {
+        crossThreadCopy(m_key),
+        m_insertionTime,
+        m_identifier,
+        m_updateResponseCounter,
+        m_size,
+        crossThreadCopy(m_url),
+        m_hasVaryStar,
+        crossThreadCopy(m_varyHeaders)
+    };
+}
+
 void CacheStorageRecordInformation::setURL(URL&& url)
 {
     RELEASE_ASSERT(!url.string().impl()->isAtom());

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -37,6 +37,7 @@ public:
     CacheStorageRecordInformation(NetworkCache::Key&&, double insertionTime, uint64_t identifier, uint64_t updateResponseCounter, uint64_t size, URL&&, bool hasVaryStar, HashMap<String, String>&& varyHeaders);
     void updateVaryHeaders(const WebCore::ResourceRequest&, const WebCore::ResourceResponse::CrossThreadData&);
     CacheStorageRecordInformation isolatedCopy() &&;
+    CacheStorageRecordInformation isolatedCopy() const &;
 
     const NetworkCache::Key& key() const { return m_key; }
     double insertionTime() const { return m_insertionTime; }

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "RTCNetwork.h"
 
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/StdLibExtras.h>
 
 #if USE(LIBWEBRTC)
@@ -61,6 +62,23 @@ rtc::Network RTCNetwork::value() const
     network.SetIPs(WTFMove(vector), true);
 
     return network;
+}
+
+RTCNetwork RTCNetwork::isolatedCopy() const
+{
+    return RTCNetwork {
+        crossThreadCopy(name),
+        crossThreadCopy(description),
+        prefix,
+        prefixLength,
+        type,
+        id,
+        preference,
+        active,
+        ignored,
+        scopeID,
+        crossThreadCopy(ips)
+    };
 }
 
 namespace RTC::Network {

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -60,6 +60,7 @@ struct IPAddress {
     {
     }
 
+    IPAddress isolatedCopy() const { return *this; }
     rtc::IPAddress rtcAddress() const;
 
     bool isUnspecified() const { return std::holds_alternative<UnspecifiedFamily>(value); }
@@ -74,6 +75,7 @@ struct InterfaceAddress {
     }
 
     rtc::InterfaceAddress rtcAddress() const;
+    InterfaceAddress isolatedCopy() const { return *this; }
 
     IPAddress address;
     int ipv6Flags;
@@ -104,6 +106,7 @@ struct RTCNetwork {
 
     RTCNetwork() = default;
     explicit RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips);
+    RTCNetwork isolatedCopy() const;
 
     rtc::Network value() const;
 

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
@@ -64,6 +64,8 @@ static PlatformGrant grantCapability(const PlatformCapability& capability, const
 struct PlatformExtensionCapabilityGrants {
     PlatformGrant gpuProcessGrant;
     PlatformGrant webProcessGrant;
+
+    PlatformExtensionCapabilityGrants isolatedCopy() const & { return { gpuProcessGrant, webProcessGrant }; }
 };
 
 enum class ExtensionCapabilityGrantError: uint8_t {


### PR DESCRIPTION
#### 9d8de91ee2cbfa9731b1b8171818b193c254daf7
<pre>
CacheStorageRecordInformation is not isolated copied when passed across threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=286393">https://bugs.webkit.org/show_bug.cgi?id=286393</a>
<a href="https://rdar.apple.com/108372325">rdar://108372325</a>

Reviewed by Chris Dumez.

CacheStorageRecordInformation only has isolatedCopy function for rvalue reference, but in
CacheStorageDiskStore::readRecordsInternal(), isolatedCopy() is not invoked on rvalue reference. In this case,
CrossThreadCopier will fall back to use copy constructor, and CacheStorageRecordInformation is not properly copied. To
fix it, add CacheStorageRecordInformation::isolatedCopy() for lvalue reference and make sure CrossThreadCopier will
invoke that.

Also, to make the code more robust, now types involved in crossThreadCopy() are required to provide isolatedCopy()
function -- CrossThreadCopier will no longer use default copy constructor. This helps catch a few issues where objects
are not properly copied due to missing isolatedCopy function.

* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/MediaTime.cpp:
(WTF::MediaTime::isolatedCopy const):
* Source/WTF/wtf/MediaTime.h:
* Source/WebCore/Modules/cookie-store/CookieChangeSubscription.h:
(WebCore::CookieChangeSubscription::isolatedCopy const):
(WebCore::CookieChangeSubscription::isolatedCopy):
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.h:
(WebCore::WebTransportBidirectionalStreamConstructionParameters::isolatedCopy):
* Source/WebCore/contentextensions/ContentExtensionsBackend.h:
(WebCore::ContentExtensions::ContentExtensionsBackend::isolatedCopy):
(WebCore::ContentExtensions::ContentExtensionsBackend::ContentExtensionsBackend):
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:
* Source/WebCore/platform/ContentType.h:
(WebCore::ContentType::isolatedCopy const):
(WebCore::ContentType::isolatedCopy):
* Source/WebCore/platform/graphics/VideoPlaybackQualityMetrics.h:
(WebCore::VideoPlaybackQualityMetrics::isolatedCopy const):
* Source/WebCore/platform/mediastream/PhotoCapabilities.h:
(WebCore::PhotoCapabilities::isolatedCopy const):
* Source/WebCore/platform/mediastream/PhotoSettings.h:
(WebCore::PhotoSettings::isolatedCopy const):
* Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h:
(WebCore::OrganizationStorageAccessPromptQuirk::isolatedCopy const):
(WebCore::OrganizationStorageAccessPromptQuirk::isolatedCopy):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp:
(WebKit::CacheStorageRecordInformation::isolatedCopy):
(WebKit::CacheStorageRecordInformation::isolatedCopy const):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h:
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::isolatedCopy const):
* Source/WebKit/Shared/RTCNetwork.h:
(WebKit::RTC::Network::IPAddress::isolatedCopy const):
(WebKit::RTC::Network::InterfaceAddress::isolatedCopy const):
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
(WebKit::PlatformExtensionCapabilityGrants::isolatedCopy const):

Canonical link: <a href="https://commits.webkit.org/289347@main">https://commits.webkit.org/289347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/571c80fe0e71a7048fc454fc431efe966a1eb854

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86570 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66986 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24752 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32712 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36424 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79357 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75104 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93300 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85348 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13728 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9942 "Found 1 new test failure: fast/webgpu/type-checker-array-without-argument.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75764 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74955 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17627 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13751 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107836 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13489 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25951 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->