### PR TITLE
Improve divide-by-zero workaround in `AutoTableLayout`

### DIFF
--- a/LayoutTests/fast/table/auto-layout-close-to-max-width-expected.txt
+++ b/LayoutTests/fast/table/auto-layout-close-to-max-width-expected.txt
@@ -1,0 +1,5 @@
+PASS document.getElementById("onlyTable").offsetWidth is 999999
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/table/auto-layout-close-to-max-width.html
+++ b/LayoutTests/fast/table/auto-layout-close-to-max-width.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<style>
+#outer {
+    width: 2000000px;
+}
+
+table {
+    border-collapse: collapse;
+}
+</style>
+<div id='outer'>
+<table id='onlyTable' width='999999px;'>
+  <tr>
+    <td>
+      <div></div>
+    </td>
+  </tr>
+</table>
+</div>
+<script>
+    shouldEvaluateTo('document.getElementById("onlyTable").offsetWidth', 999999);
+</script>

--- a/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred-expected.txt
+++ b/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred-expected.txt
@@ -1,0 +1,5 @@
+PASS document.getElementById("onlyTable").offsetWidth is 1000000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred.html
+++ b/LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<style>
+#outer {
+    width: 2000000px;
+}
+
+table {
+    border-collapse: collapse;
+}</style>
+<div id='outer'>
+<table id='onlyTable'>
+  <tr>
+    <td width='100%'>
+      <div></div>
+    </td>
+    <td width='60%'>
+      <div width='10px;'></div>
+    </td>
+  </tr>
+</table>
+</div>
+<script>
+    shouldEvaluateTo('document.getElementById("onlyTable").offsetWidth', 1000000);
+</script>

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 2002 Lars Knoll (knoll@kde.org)
  *           (C) 2002 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -221,10 +221,6 @@ void AutoTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, Layout
     float maxNonPercent = 0;
     bool scaleColumnsForSelf = intrinsics == TableIntrinsics::ForLayout;
 
-    // We substitute 0 percent by (epsilon / percentScaleFactor) percent in two places below to avoid division by zero.
-    // FIXME: Handle the 0% cases properly.
-    const float epsilon = 1 / 128.0f;
-
     float remainingPercent = 100;
     for (size_t i = 0; i < m_layoutStruct.size(); ++i) {
         minWidth += m_layoutStruct[i].effectiveMinLogicalWidth;
@@ -232,7 +228,12 @@ void AutoTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, Layout
         if (scaleColumnsForSelf) {
             if (m_layoutStruct[i].effectiveLogicalWidth.isPercent()) {
                 float percent = std::min(m_layoutStruct[i].effectiveLogicalWidth.percent(), remainingPercent);
-                float logicalWidth = m_layoutStruct[i].effectiveMaxLogicalWidth * 100 / std::max(percent, epsilon);
+                // When percent columns meet or exceed 100% and there are remaining
+                // columns, the other browsers (FF, Edge) use an artificially high max
+                // width, so we do too. Instead of division by zero, logicalWidth and
+                // maxNonPercent are set to tableMaxWidth.
+                // Issue: https://github.com/w3c/csswg-drafts/issues/1501
+                float logicalWidth = (percent > 0) ? m_layoutStruct[i].effectiveMaxLogicalWidth * 100 / percent : tableMaxWidth;
                 maxPercent = std::max(logicalWidth,  maxPercent);
                 remainingPercent -= percent;
             } else
@@ -241,9 +242,9 @@ void AutoTableLayout::computeIntrinsicLogicalWidths(LayoutUnit& minWidth, Layout
     }
 
     if (scaleColumnsForSelf) {
-        maxNonPercent = maxNonPercent * 100 / std::max(remainingPercent, epsilon);
-        m_scaledWidthFromPercentColumns = LayoutUnit(std::min<float>(maxNonPercent, tableMaxWidth));
-        m_scaledWidthFromPercentColumns = std::max(m_scaledWidthFromPercentColumns, LayoutUnit(std::min<float>(maxPercent, tableMaxWidth)));
+        if (maxNonPercent > 0)
+            maxNonPercent = (remainingPercent > 0) ? maxNonPercent * 100 / remainingPercent : tableMaxWidth;
+        m_scaledWidthFromPercentColumns = std::min(LayoutUnit(tableMaxWidth), LayoutUnit(std::max(maxPercent, maxNonPercent)));
         if (m_scaledWidthFromPercentColumns > maxWidth && shouldScaleColumnsForParent(*m_table))
             maxWidth = m_scaledWidthFromPercentColumns;
     }


### PR DESCRIPTION
#### a331ed86d3b809ddef882898f5370ccca3738926
<pre>
Improve divide-by-zero workaround in `AutoTableLayout`

<a href="https://bugs.webkit.org/show_bug.cgi?id=276283">https://bugs.webkit.org/show_bug.cgi?id=276283</a>
<a href="https://rdar.apple.com/131669385">rdar://131669385</a>

Reviewed by Alan Baradlay and Antti Koivisto.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/6c84d2ae7c82ce83fb9ce9c3124917933d4c863c">https://chromium.googlesource.com/chromium/src.git/+/6c84d2ae7c82ce83fb9ce9c3124917933d4c863c</a>

In some situations, table percentage widths exceed 100%, causing
division by zero. The previous code would divide by an arbitrarily
small number to avoid division by zero and get an arbitrary high
value. Since FF/Edge always set to a max width (which is still
unspecified), we now also set to a max width (maxTableWidth).

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::computeIntrinsicLogicalWidths):
* LayoutTests/fast/table/auto-layout-close-to-max-width.html: Add Test Case
* LayoutTests/fast/table/auto-layout-close-to-max-width-expected.txt: Add Test Case Expectation
* LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred.html: Add Test Case
* LayoutTests/fast/table/auto-layout-width-percentage-exceed-hundred-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/289381@main">https://commits.webkit.org/289381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5919da647a4ae210abd5efb6a84083902cd349c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37124 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66851 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24646 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93148 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18462 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6300 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18840 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->