### PR TITLE
[Ventura] WebCodecs AudioDecoder tests intermittently fail on Ventura

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5797,11 +5797,11 @@ imported/w3c/web-platform-tests/html/canvas/offscreen/text/canvas.2d.fontStretch
 imported/w3c/web-platform-tests/html/canvas/offscreen/text/canvas.2d.fontStretch.ultra-expanded.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker.html [ Failure ]
 
-# Flac and Vorbis decoding requires an extra description which isn't provided.
-imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?flac [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?vorbis [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?flac [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?vorbis [ Failure ]
+# Flac and Vorbis decoding requires an extra description which isn't provided. Skipped as the tests time out.
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?flac [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?vorbis [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?flac [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?vorbis [ Skip ]
 
 # HEVC support may not be available to all platforms.
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_annexb [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.js
@@ -28,7 +28,12 @@ const ADTS_AAC_DATA = {
     {offset: 1513, size: 166}, {offset: 1679, size: 216},
     {offset: 1895, size: 183}
   ],
-  duration: 24000
+  duration: 24000,
+  output: {
+    chunk_frames: [2048, 3072],
+    frames: 10240,
+    fuzz: 0
+  }
 };
 
 const MP3_DATA = {
@@ -45,7 +50,12 @@ const MP3_DATA = {
     {offset: 2061, size: 288}, {offset: 2349, size: 288},
     {offset: 2637, size: 288}, {offset: 2925, size: 288}
   ],
-  duration: 24000
+  duration: 24000,
+  output: {
+    chunk_frames: [2304, 3456],
+    frames: 11520,
+    fuzz: 529
+  }
 };
 
 const MP4_AAC_DATA = {
@@ -68,7 +78,12 @@ const MP4_AAC_DATA = {
     {offset: 1667, size: 209},
     {offset: 1876, size: 176},
   ],
-  duration: 21333
+  duration: 21333,
+  output: {
+    chunk_frames: [2048, 3072],
+    frames: 10240,
+    fuzz: 0
+  }
 };
 
 const OPUS_DATA = {
@@ -86,7 +101,12 @@ const OPUS_DATA = {
     {offset: 2079, size: 289}, {offset: 2368, size: 286},
     {offset: 2654, size: 296}, {offset: 2950, size: 294}
   ],
-  duration: 20000
+  duration: 20000,
+  output: {
+    chunk_frames: [1608, 2256], // 960 frames in each packet less codec delay.
+    frames: 9288,
+    fuzz: 0
+  }
 };
 
 const FLAC_DATA = {
@@ -102,7 +122,12 @@ const FLAC_DATA = {
     { offset: 10564, size: 2038 },
     { offset: 12602, size: 521 },
   ],
-  duration: 20000
+  duration: 20000,
+  output: {
+    chunk_frames: [9216, 10240],
+    frames: 10240,
+    fuzz: 0
+  }
 };
 
 function pcm(codec, dataOffset) {
@@ -117,7 +142,12 @@ function pcm(codec, dataOffset) {
     // Chunk are arbitrary and will be generated lazily
     chunks: [],
     offset: dataOffset,
-    duration: 0
+    duration: 0,
+    output: {
+      chunk_frames: [0, 0],
+      frames: 0,
+      fuzz: 0
+    }
   }
 }
 
@@ -150,7 +180,12 @@ const VORBIS_DATA = {
     {offset: 4127, size: 37}, {offset: 4164, size: 107},
     {offset: 4271, size: 172}
   ],
-  duration: 21333
+  duration: 21333,
+  output: {
+    chunk_frames: [128, 704],
+    frames: 4800,
+    fuzz: 0
+  }
 };
 
 // Allows mutating `callbacks` after constructing the AudioDecoder, wraps calls
@@ -182,6 +217,7 @@ function view(buffer, {offset, size}) {
 let CONFIG = null;
 let CHUNK_DATA = null;
 let CHUNKS = null;
+let OUTPUT = null;
 promise_setup(async () => {
   const data = {
     '?adts_aac': ADTS_AAC_DATA,
@@ -218,6 +254,7 @@ promise_setup(async () => {
   const buf = await response.arrayBuffer();
 
   CONFIG = {...data.config};
+  OUTPUT = {...data.output};
   if (data.config.description) {
     // The description for decoding vorbis is expected to be in Xiph extradata format.
     // https://w3c.github.io/webcodecs/vorbis_codec_registration.html#audiodecoderconfig-description
@@ -258,12 +295,17 @@ promise_setup(async () => {
       case "pcm-f32": bytesPerSample = 4; break;
       default: bytesPerSample = 1; break;
     }
+    let numberOfFrames = 0;
     while (offset < buf.byteLength) {
       let size = Math.min(buf.byteLength - offset, PACKET_LENGTH);
       assert_equals(size % bytesPerSample, 0);
       CHUNK_DATA.push(view(buf, {offset, size}));
+      numberOfFrames += size / bytesPerSample;
       offset += size;
     }
+    OUTPUT.frames = numberOfFrames;
+    OUTPUT.chunk_frames[0] = (PACKET_LENGTH * 2) / bytesPerSample;
+    OUTPUT.chunk_frames[1] = (PACKET_LENGTH * 3) / bytesPerSample;
     data.duration = 1000 * 1000 * PACKET_LENGTH / data.config.sampleRate / bytesPerSample;
   } else {
     CHUNK_DATA = data.chunks.map((chunk, i) => view(buf, chunk));
@@ -337,7 +379,7 @@ promise_test(async t => {
 
   let outputs = 0;
   callbacks.output = frame => {
-    outputs++;
+    outputs += frame.numberOfFrames;
     frame.close();
   };
 
@@ -347,7 +389,7 @@ promise_test(async t => {
   });
 
   await decoder.flush();
-  assert_equals(outputs, CONFIG.codec === 'vorbis' ? CHUNKS.length - 1 : CHUNKS.length, 'outputs');
+  assert_approx_equals(outputs, OUTPUT.frames, OUTPUT.fuzz, "number of decoded frames matches");
 }, 'Test decoding');
 
 promise_test(async t => {
@@ -356,7 +398,7 @@ promise_test(async t => {
 
   let outputs = 0;
   callbacks.output = frame => {
-    outputs++;
+    outputs += frame.numberOfFrames;
     frame.close();
   };
 
@@ -367,7 +409,7 @@ promise_test(async t => {
       {type: 'key', timestamp: CHUNKS[0].duration - 42, data: CHUNK_DATA[1]}));
 
   await decoder.flush();
-  assert_equals(outputs, CONFIG.codec === 'vorbis' ? 1 : 2, 'outputs');
+  assert_approx_equals(outputs, OUTPUT.chunk_frames[0], OUTPUT.fuzz, "number of decoded frames matches");
 }, 'Test decoding a with negative timestamp');
 
 promise_test(async t => {
@@ -376,7 +418,7 @@ promise_test(async t => {
 
   let outputs = 0;
   callbacks.output = frame => {
-    outputs++;
+    outputs += frame.numberOfFrames;
     frame.close();
   };
 
@@ -385,11 +427,11 @@ promise_test(async t => {
   decoder.decode(CHUNKS[1]);
 
   await decoder.flush();
-  assert_equals(outputs, CONFIG.codec === 'vorbis' ? 1 : 2, 'outputs');
+  assert_approx_equals(outputs, OUTPUT.chunk_frames[0], OUTPUT.fuzz, "number of decoded frames matches");
 
   decoder.decode(CHUNKS[2]);
   await decoder.flush();
-  assert_equals(outputs, CONFIG.codec === 'vorbis' ? 2 : 3, 'outputs');
+  assert_approx_equals(outputs, OUTPUT.chunk_frames[1], OUTPUT.fuzz, "number of decoded frames matches");
 }, 'Test decoding after flush');
 
 promise_test(async t => {
@@ -421,6 +463,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   const callbacks = {};
+  callbacks.output = frame => { frame.close(); };
   const decoder = createAudioDecoder(t, callbacks);
 
   // No decodes yet.

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1322,6 +1322,16 @@ imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.
 webkit.org/b/284626 imported/w3c/web-platform-tests/webcodecs/audio-data.any.html [ Failure ]
 webkit.org/b/284626 imported/w3c/web-platform-tests/webcodecs/audio-data.any.worker.html [ Failure ]
 
+# webkit.org/b/286526 
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?opus [ Failure ] # Do not drain decoder on flush.
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_u8 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s16 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s24 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?opus [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_u8 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s16 [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s24 [ Failure ]
+
 # Input/output waveforms don't match...
 webkit.org/b/284429 imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Failure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2396,31 +2396,9 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 [ Sequoia arm64 ] http/tests/media/fairplay/fps-mse-unmuxed-same-key.html [ Failure ]
 http/tests/media/fairplay/fps-mse-multi-key-renewal.html [ Pass Failure ] 
 
-# webkit.org/b/284075 Opus and MP3 decoders aren't working with raw content (no magic cookie)
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Skip ]
+# webkit.org/b/284075 Opus decoder isn't working with raw content (no magic cookie provided)
 [ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?opus [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Skip ]
 [ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?opus [ Skip ]
-
-# Ventura doesn't support some sampling rates or contents used by the tests. tracked by webkit.org/b/284671
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?adts_aac [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp4_aac [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_alaw [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_ulaw [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_u8 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s16 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s24 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_s32 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?pcm_f32 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?adts_aac [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp4_aac [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_alaw [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_ulaw [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_u8 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s16 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s24 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_s32 [ Skip ]
-[ Ventura ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?pcm_f32 [ Skip ]
 
 # Ventura doesn't support resampling when encoding to Opus, causing the test to fail.
 [ Ventura ] imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Failure ]

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -68,16 +68,7 @@ WebCodecsAudioData::WebCodecsAudioData(ScriptExecutionContext& context, WebCodec
 {
 }
 
-WebCodecsAudioData::~WebCodecsAudioData()
-{
-    if (m_isDetached)
-        return;
-    if (auto* context = scriptExecutionContext()) {
-        context->postTask([](auto& context) {
-            context.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "A AudioData was destroyed without having been closed explicitly"_s);
-        });
-    }
-}
+WebCodecsAudioData::~WebCodecsAudioData() = default;
 
 std::optional<AudioSampleFormat> WebCodecsAudioData::format() const
 {

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -83,7 +83,6 @@ Modules/webaudio/WaveShaperDSPKernel.cpp
 Modules/webaudio/WaveShaperNode.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/PublicKeyCredential.cpp
-Modules/webcodecs/WebCodecsAudioData.cpp
 Modules/webcodecs/WebCodecsUtilities.h
 Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
 Modules/webdatabase/ChangeVersionWrapper.cpp

--- a/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
@@ -370,7 +370,7 @@ Ref<GenericPromise> InternalAudioDecoderCocoa::flush()
         LOG(Media, "Decoder closed, nothing to flush");
         return GenericPromise::createAndResolve();
     }
-    return converter()->flush()->whenSettled(queueSingleton(), [protectedThis = Ref { *this }] {
+    return converter()->drain()->whenSettled(queueSingleton(), [protectedThis = Ref { *this }] {
         protectedThis->processedDecodedOutputs();
         return GenericPromise::createAndResolve();
     });


### PR DESCRIPTION
#### 48e84cccc7c15486695f56b892b849ff6cf4dcbb
<pre>
[Ventura] WebCodecs AudioDecoder tests intermittently fail on Ventura
<a href="https://bugs.webkit.org/show_bug.cgi?id=284671">https://bugs.webkit.org/show_bug.cgi?id=284671</a>
<a href="https://rdar.apple.com/141465725">rdar://141465725</a>

Reviewed by Philippe Normand.

Underlying issue was fixed by 289260@main.

Fly-By: The test checked that for each AudioDecoder.decode() operation you
got one and exactly one callback call. This isn&apos;t a valid assumption as
a single decode could lead to multiple output calls or less.
Only after a call to flush() ensure that all frames have been decoded.

So we modify the WPT test to check that the number of decoded frames is valid
and not check the number of callback calls.

* LayoutTests/TestExpectations:
* LayoutTests/platform/glib/TestExpectations: GStreamer returns half the expected amount of PCM frames, lodged as webkit.org/b/286526
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.js: Ensure AudioData object is closed early.
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp: There is no spec requirements that AudioData must be explicitly closed. Remove console warning.
(WebCore::WebCodecsAudioData::~WebCodecsAudioData): Deleted.
* Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp:
(WebCore::InternalAudioDecoderCocoa::flush): Drain the internal decoder rather than flush it.
This is inline with what both gecko and blink are doing and is closer to the spec which states:
&quot;Signal [[codec implementation]] to emit all internal pending outputs.&quot;

Canonical link: <a href="https://commits.webkit.org/289383@main">https://commits.webkit.org/289383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9096b391650fee0853359a6cf370352a42cc7eea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37516 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67086 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24858 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4993 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4778 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32908 "Found 60 new test failures: fast/repaint/switch-overflow-vertical-rl.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/websocket/tests/hybi/client-close-2.html imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-space-7.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36634 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13937 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75889 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75084 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18464 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6722 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13960 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13698 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->