### PR TITLE
AX: Make m_nodeObjectMapping a WeakHashMap to avoid WeakRef crashes

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -584,7 +584,7 @@ AccessibilityObject* AXObjectCache::get(Node& node) const
     if (renderID)
         return m_objects.get(*renderID);
 
-    auto nodeID = m_nodeObjectMapping.getOptional(node);
+    auto nodeID = m_nodeObjectMapping.get(node);
     return nodeID ? m_objects.get(*nodeID) : nullptr;
 }
 
@@ -1169,7 +1169,7 @@ void AXObjectCache::remove(Node& node)
 {
     AXTRACE(makeString("AXObjectCache::remove Node& 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
 
-    remove(m_nodeObjectMapping.takeOptional(node));
+    remove(m_nodeObjectMapping.take(node));
     remove(node.renderer());
 
     // If we're in the middle of a cache update, don't modify any of these vectors because we are currently
@@ -1261,7 +1261,7 @@ void AXObjectCache::onRendererCreated(Element& element)
 
     // If there is already an AXObject that was created for this element,
     // remove it since there will be a new AXRenderObject created using the renderer.
-    if (auto axID = m_nodeObjectMapping.getOptional(element)) {
+    if (auto axID = m_nodeObjectMapping.get(element)) {
         // The removal needs to be async because this is called during a RenderTree
         // update and remove(AXID) updates the isolated tree, that in turn calls
         // parentObjectUnignored() on the object being removed, that may result

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -449,13 +449,6 @@ Node::~Node()
         // Not refing document because it may be in the middle of destruction.
         auto& document = this->document(); // Store document before clearing out m_treeScope.
 
-        // FIXME: We also cleanup nodes in the AXObjectCache via Node::willBeDeletedFrom(Document&), and we should really
-        // only have to do this cleanup in one spot. However, only cleaning up in Node::willBeDeletedFrom(Document&) causes
-        // WeakRef crashes, as willBeDeletedFrom seems to miss some Nodes, thus "poisoning" AXObjectCache::m_nodeObjectMapping
-        // with a nullified WeakRef, causing any subsequent operation (e.g. a lookup) to crash.
-        if (CheckedPtr cache = document.existingAXObjectCache())
-            cache->remove(*this);
-
         // The call to decrementReferencingNodeCount() below may destroy the document so we need to clear our
         // m_treeScope CheckedPtr beforehand.
         m_treeScope = nullptr;


### PR DESCRIPTION
#### 52a7fd41f9066841d26530ac96f5c0310d42e1c0
<pre>
AX: Make m_nodeObjectMapping a WeakHashMap to avoid WeakRef crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=286398">https://bugs.webkit.org/show_bug.cgi?id=286398</a>
<a href="https://rdar.apple.com/143446394">rdar://143446394</a>

Reviewed by Chris Fleizach.

We made an attempt to fix this crash in <a href="https://commits.webkit.org/289060@main">https://commits.webkit.org/289060@main</a>, but have since found a website
where this bug reproduces consistently, confirming that the speculative fix from that commit did not work. The crash
is reproducible by turning VoiceOver on and starting a Speedometer run at <a href="https://browserbench.org/Speedometer3.0.">https://browserbench.org/Speedometer3.0.</a>

Fundamentally, we are failing to remove nodes from m_nodeObjectMapping, which prior to this commit was of type:

UncheckedKeyHashMap&lt;WeakRef&lt;Node, WeakPtrImplWithEventTargetData&gt;, AXID&gt;

This happens due to this sequence:

  1. We add a node to the map
  2. The document that node belongs to gets its m_frame set to nullptr via Document::willDetachFrame().
  3. When that node is destroyed, we can no longer get an existingAXObjectCache() to clean it up, since
     the node&apos;s document has no m_frame. The WeakRef for that node in m_nodeObjectMapping becomes null.
  4. Something else tries to access m_nodeObjectMapping, causing a lookup. During the lookup, when we try
     to compare against the null WeakRef, we crash.

One option would be to clear out AXObjectCache::m_nodeObjectMapping when willDetachFrame() is called. But its not clear
that&apos;s always the right thing to do, as the document and frame lifecycle is complicated when considering things like
the back-forward cache.

As a stop-gap fix to prevent the crashes and ensure at least m_nodeObjectMapping is cleaned up (even though we&apos;re still
missing clean-up for other things in AXObjectCache::remove(Node&amp;)), make m_nodeObjectMapping a WeakHashMap. This is
an improvement over status quo — we stop crashing, and we leak less. This seems fine for now, as this scenario seems
very rare.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::get const):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::onRendererCreated):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::~Node):

Canonical link: <a href="https://commits.webkit.org/289293@main">https://commits.webkit.org/289293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/474053e27de8a89e0a730bb2bea20c3fe6fe425c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37080 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66826 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24617 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78143 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47140 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32453 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92991 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19032 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6258 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18798 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->