### PR TITLE
[JSC] Add Air MultiplyNegDouble / MultiplyNegFloat

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -3297,6 +3297,16 @@ public:
         m_assembler.fmul<32>(dest, op1, op2);
     }
 
+    void multiplyNegDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        m_assembler.fnmul<64>(dest, op1, op2);
+    }
+
+    void multiplyNegFloat(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        m_assembler.fnmul<32>(dest, op1, op2);
+    }
+
     void andDouble(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
     {
         m_assembler.vand<64>(dest, op1, op2);

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -3208,7 +3208,7 @@ private:
                     return false;
                 Value* multiplyLeft = m_value->child(0)->child(0);
                 Value* multiplyRight = m_value->child(0)->child(1);
-                Air::Opcode airOpcode = tryOpcodeForType(MultiplyNeg32, MultiplyNeg64, m_value->type());
+                Air::Opcode airOpcode = tryOpcodeForType(MultiplyNeg32, MultiplyNeg64, MultiplyNegDouble, MultiplyNegFloat, m_value->type());
                 auto tryNewAirOpcode = [&] () -> Air::Opcode {
                     if (airOpcode != MultiplyNeg64)
                         return Air::Oops;

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -341,6 +341,12 @@ x86: MulFloat U:F:32, UD:F:32
     Tmp, Tmp
     Addr, Tmp
 
+arm64: MultiplyNegDouble U:F:64, U:F:64, D:F:64
+    Tmp, Tmp, Tmp
+
+arm64: MultiplyNegFloat U:F:32, U:F:32, D:F:32
+    Tmp, Tmp, Tmp
+
 arm x86_64_avx: DivDouble U:F:64, U:F:64, D:F:64
     Tmp, Tmp, Tmp
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1133,6 +1133,8 @@ void testMulNegSignExtend32();
 void testMulNegZeroExtend32();
 void testMulArgDouble(double);
 void testMulArgsDouble(double, double);
+void testMulNegArgsDouble();
+void testMulNegArgsFloat();
 void testCallSimpleDouble(double, double);
 void testCallSimpleFloat(float, float);
 void testCallFunctionWithHellaDoubleArguments();

--- a/Source/JavaScriptCore/b3/testb3_2.cpp
+++ b/Source/JavaScriptCore/b3/testb3_2.cpp
@@ -1943,6 +1943,32 @@ void testMulImmsDouble(double a, double b)
     CHECK(isIdentical(compileAndRun<double>(proc), a * b));
 }
 
+void testMulNegArgsDouble()
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double>(proc, root);
+
+    Value* arg0 = arguments[0];
+    Value* arg1 = arguments[1];
+    Value* multiplied = root->appendNew<Value>(proc, Mul, Origin(), arg0, arg1);
+    Value* added = root->appendNew<Value>(proc, Neg, Origin(), multiplied);
+    root->appendNewControlValue(proc, Return, Origin(), added);
+
+    auto code = compileProc(proc);
+    auto testValues = floatingPointOperands<double>();
+    for (auto a : testValues) {
+        for (auto b : testValues) {
+            auto expected = -(a.value * b.value);
+            auto actual = invoke<double>(*code, a.value, b.value);
+            if (std::isnan(expected))
+                CHECK(std::isnan(actual));
+            else
+                CHECK_EQ(actual, expected);
+        }
+    }
+}
+
 void testMulArgFloat(float a)
 {
     Procedure proc;
@@ -2080,6 +2106,32 @@ void testMulArgsFloatWithEffectfulDoubleConversion(float a, float b)
     double effect = 0;
     CHECK(isIdentical(compileAndRun<int32_t>(proc, std::bit_cast<int32_t>(a), std::bit_cast<int32_t>(b), &effect), std::bit_cast<int32_t>(a * b)));
     CHECK(isIdentical(effect, static_cast<double>(a) * static_cast<double>(b)));
+}
+
+void testMulNegArgsFloat()
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<float, float>(proc, root);
+
+    Value* arg0 = arguments[0];
+    Value* arg1 = arguments[1];
+    Value* multiplied = root->appendNew<Value>(proc, Mul, Origin(), arg0, arg1);
+    Value* added = root->appendNew<Value>(proc, Neg, Origin(), multiplied);
+    root->appendNewControlValue(proc, Return, Origin(), added);
+
+    auto code = compileProc(proc);
+    auto testValues = floatingPointOperands<float>();
+    for (auto a : testValues) {
+        for (auto b : testValues) {
+            auto expected = -(a.value * b.value);
+            auto actual = invoke<float>(*code, a.value, b.value);
+            if (std::isnan(expected))
+                CHECK(std::isnan(actual));
+            else
+                CHECK_EQ(actual, expected);
+        }
+    }
 }
 
 void testDivArgDouble(double a)

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -4037,6 +4037,8 @@ void addArgTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& ta
     RUN(testMulNegArgs32());
     RUN(testMulNegSignExtend32());
     RUN(testMulNegZeroExtend32());
+    RUN(testMulNegArgsDouble());
+    RUN(testMulNegArgsFloat());
     
     RUN_BINARY(testMulArgNegArg, int64Operands(), int64Operands())
     RUN_BINARY(testMulNegArgArg, int64Operands(), int64Operands())


### PR DESCRIPTION
#### b31452172c5ccdd9908457bd18ac325aa77741d5
<pre>
[JSC] Add Air MultiplyNegDouble / MultiplyNegFloat
<a href="https://bugs.webkit.org/show_bug.cgi?id=286405">https://bugs.webkit.org/show_bug.cgi?id=286405</a>
<a href="https://rdar.apple.com/143450726">rdar://143450726</a>

Reviewed by Yijia Huang.

Adding MultiplyNegDouble / MultiplyNegFloat which is Neg(Mul(@a, @b)) =&gt;
MultiplyNeg(@a, @b) on ARM64.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::multiplyNegDouble):
(JSC::MacroAssemblerARM64::multiplyNegFloat):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_2.cpp:
(testMulNegArgsDouble):
(testMulNegArgsFloat):
* Source/JavaScriptCore/b3/testb3_3.cpp:
(addArgTests):

Canonical link: <a href="https://commits.webkit.org/289683@main">https://commits.webkit.org/289683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e7a2b0dd559aa9746adabe2aaaf4cef3d051d91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37113 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24642 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47162 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32497 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36210 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79158 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93027 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85147 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75635 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74063 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74811 "Found 100 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit.Find, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/image, /TestWebKit:WebKit.UserMediaBasic ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19065 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6289 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13671 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13531 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18829 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107612 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13287 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25898 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->