### PR TITLE
[popover] Tabbing out of a popover causes a hang in certain cases

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -2,9 +2,11 @@ Button1  Button2  Invoker0  Invoker1  Button3  Button4
 Invoker  after
 Show popover
 Toggle popover Other focusable element
+Toggle popover Popover with focusable element Nested popover with focusable element
 
 PASS Popover focus navigation
 PASS Circular reference tab navigation
 PASS Popover focus returns when popover is hidden by invoker
 PASS Popover focus only returns to invoker when focus is within the popover
+PASS Cases where the next focus candidate isn't in the direct parent scope
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html
@@ -173,3 +173,35 @@ promise_test(async t => {
   assert_equals(document.activeElement,otherElement,'focus does not move because it was not inside the popover');
 }, "Popover focus only returns to invoker when focus is within the popover");
 </script>
+
+<div id=no-focus-candidate>
+  <button popovertarget=no-focus-candidate-p tabindex="0">Toggle popover</button>
+  <div popover id=no-focus-candidate-p>
+    Popover with <button tabindex="0" popovertarget=no-focus-candidate-p2>focusable element</button>
+    <div popover id=no-focus-candidate-p2>Nested popover with <button tabindex="0">focusable element</button></div>
+  </div>
+</div>
+<script>
+promise_test(async t => {
+  const invoker = document.querySelector('#no-focus-candidate>button');
+  const popover = document.querySelector('#no-focus-candidate>[popover]');
+  const nestedPopover = document.querySelector('#no-focus-candidate>[popover]>[popover]');
+  invoker.focus(); // Make sure button is focused.
+  assert_equals(document.activeElement,invoker);
+  invoker.click(); // Activate the invoker
+  assert_true(popover.matches(':popover-open'), 'popover should be invoked by invoker');
+  assert_equals(document.activeElement,invoker, 'invoker should still be focused');
+  await sendTab();
+  assert_equals(document.activeElement,popover.querySelector('button'),'next up is the popover');
+  await sendEnter(); // Show nested popover
+  assert_true(nestedPopover.matches(':popover-open'), 'nested popover should be invoked by invoker');
+  await sendTab();
+  assert_equals(document.activeElement, nestedPopover.querySelector('button'), 'focus on the nested popover button');
+  popover.querySelector('button').disabled = true; // Make the invoker no longer a focus candidate.
+  await sendShiftTab();
+  assert_equals(document.activeElement, invoker, 'initial invoker should be focused, nested popover invoker is skipped since it is disabled');
+  nestedPopover.querySelector('button').focus();
+  await sendTab();
+  assert_equals(document.activeElement, document.body, 'no more focusable elements after the button');
+}, "Cases where the next focus candidate isn't in the direct parent scope");
+</script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -1,10 +1,12 @@
-Button1  Button2  Invoker1  Button3  Button4
+Button1  Button2  Invoker0  Invoker1  Button3  Button4
 Invoker  after
 Show popover
-Toggle popover Popover with focusable element Other focusable element
+Toggle popover Other focusable element
+Toggle popover Popover with focusable element
 
 FAIL Popover focus navigation assert_equals: Hidden popover should be skipped expected Element node <button id="button2" tabindex="0">Button2</button> but got Element node <button id="button1" tabindex="0">Button1</button>
-FAIL Circular reference tab navigation assert_equals: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <button id="circular0" popovertarget="popover4" tabindex=...
+FAIL Circular reference tab navigation assert_equals: circular reference: Step 2 expected Element node <button id="circular1" autofocus="" popovertarget="popove... but got Element node <button id="circular0" popovertarget="popover4" tabindex=...
 FAIL Popover focus returns when popover is hidden by invoker assert_true: popover should be invoked by invoker expected true got false
 FAIL Popover focus only returns to invoker when focus is within the popover assert_equals: next up is the popover expected Element node <button tabindex="0">focusable element</button> but got Element node <button popovertarget="focus-return2-p" tabindex="0">Togg...
+FAIL Cases where the next focus candidate isn't in the direct parent scope assert_equals: next up is the popover expected Element node <button tabindex="0" popovertarget="no-focus-candidate-p2... but got Element node <button popovertarget="no-focus-candidate-p" tabindex="0"...
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -708,13 +708,12 @@ Element* FocusController::findFocusableElementAcrossFocusScope(FocusDirection di
         if (direction == FocusDirection::Backward && isFocusableScopeOwner(*owner, event))
             return findFocusableElementDescendingIntoSubframes(direction, owner.get(), event);
 
-        auto outerScope = FocusNavigationScope::scopeOf(*owner);
-
         // If we're getting out of a popover backwards, focus the invoker itself instead of the node preceding it, if possible.
         RefPtr invoker = invokerForOpenPopover(owner.get());
         if (invoker && direction == FocusDirection::Backward && invoker->isKeyboardFocusable(event))
             return invoker.get();
 
+        auto outerScope = FocusNavigationScope::scopeOf(invoker ? *invoker : *owner);
         if (auto* candidateInOuterScope = findFocusableElementWithinScope(direction, outerScope, invoker ? invoker.get() : owner.get(), event))
             return candidateInOuterScope;
         owner = outerScope.owner();


### PR DESCRIPTION
#### 0ef0f9c6f23b147a1dcea2733f3f66d367e58f6f
<pre>
[popover] Tabbing out of a popover causes a hang in certain cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=285811">https://bugs.webkit.org/show_bug.cgi?id=285811</a>
<a href="https://rdar.apple.com/143145544">rdar://143145544</a>

Reviewed by Ryosuke Niwa.

In the cases where we can&apos;t find a candidate in `FocusController::findFocusableElementAcrossFocusScope`, we fail to move up the chain
of scopes, since by spec the owner of the popover scope is the popover itself [0]. The loop then ends up infinite when this happens.

To fix this, make sure to define outerScope to be the scope of the invoker in the case of the popover, rather than the scope of the
popover itself, otherwise the owner will keep pointing to the popover itself, and repeat infinitely.

Extend pre-existing WPT to avoid regressing this, and to ensure nested popover cases or backwards navigation are handled correctly.

[0]: <a href="https://html.spec.whatwg.org/multipage/interaction.html#associated-focus-navigation-owner">https://html.spec.whatwg.org/multipage/interaction.html#associated-focus-navigation-owner</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementAcrossFocusScope):

Canonical link: <a href="https://commits.webkit.org/289277@main">https://commits.webkit.org/289277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cfff886f1a75b226d10b41bb96471b10c181790

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40605 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13865 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/91200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78155 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32468 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33337 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/93004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74033 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18408 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17433 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13505 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/13263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16702 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->