### PR TITLE
[Skia][cairo] TestWebCore.ImageBufferTests.ImageBufferSubPixelDrawing fails

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -49,6 +49,7 @@ ImageBufferCairoSurfaceBackend::ImageBufferCairoSurfaceBackend(const Parameters&
     , m_context(m_surface.get())
 {
     ASSERT(cairo_surface_status(m_surface.get()) == CAIRO_STATUS_SUCCESS);
+    m_context.applyDeviceScaleFactor(parameters.resolutionScale);
 }
 
 GraphicsContext& ImageBufferCairoSurfaceBackend::context()

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
@@ -63,6 +63,7 @@ ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend(const Parameters& p
     , m_surface(WTFMove(surface))
     , m_context(*m_surface->getCanvas(), renderingMode, parameters.purpose)
 {
+    m_context.applyDeviceScaleFactor(parameters.resolutionScale);
 }
 
 ImageBufferSkiaSurfaceBackend::~ImageBufferSkiaSurfaceBackend() = default;

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -191,7 +191,7 @@ private:
 
 GLContext* PlatformDisplay::skiaGLContext()
 {
-#if !(PLATFORM(PLAYSTATION) && USE(COORDINATED_GRAPHICS))
+#if PLATFORM(GTK) || PLATFORM(WPE) || (PLATFORM(PLAYSTATION) && !USE(COORDINATED_GRAPHICS))
     if (!s_skiaGLContext) {
         s_skiaGLContext = SkiaGLContext::create(*this);
         m_skiaGLContexts.add(*s_skiaGLContext);

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -185,8 +185,10 @@ endif ()
 # TestWebCore definitions
 if (ENABLE_WEBCORE)
     set(TestWebCore_SOURCES
+        GraphicsTestUtilities.cpp
         TestsController.cpp
         Utilities.cpp
+        WebCoreTestUtilities.cpp
 
         Tests/WebCore/AffineTransform.cpp
         Tests/WebCore/AudioSampleFormat.cpp
@@ -203,6 +205,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/GridPosition.cpp
         Tests/WebCore/HTMLParserIdioms.cpp
         Tests/WebCore/HTTPParsers.cpp
+        Tests/WebCore/ImageBufferTests.cpp
         Tests/WebCore/IntPointTests.cpp
         Tests/WebCore/IntRectTests.cpp
         Tests/WebCore/IntSizeTests.cpp

--- a/Tools/TestWebKitAPI/WebCoreTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/WebCoreTestUtilities.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "WebCoreTestUtilities.h"
 
-#import <wtf/MemoryFootprint.h>
+#include <wtf/MemoryFootprint.h>
 
 namespace TestWebKitAPI {
 

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -226,6 +226,12 @@
             },
             "ComplexTextControllerTest.TotalWidthWithJustification": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug":"webkit.org/b/284628"}}
+            },
+            "ImageBufferTests.ImageBufferSubTypeCreateCreatesSubtypes": {
+                "expected": {"all": {"status": ["CRASH"], "bug":"webkit.org/b/286456"}}
+            },
+            "ImageBufferTests.ImageBufferSubPixelDrawing": {
+                "expected": {"all": {"status": ["CRASH"], "bug":"webkit.org/b/286456"}}
             }
         }
     },


### PR DESCRIPTION
#### 3b5561ce3cda7ad90dd199d3ceebc1d58a95fdeb
<pre>
[Skia][cairo] TestWebCore.ImageBufferTests.ImageBufferSubPixelDrawing fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=286406">https://bugs.webkit.org/show_bug.cgi?id=286406</a>

Reviewed by Carlos Garcia Campos.

TestWebCore.ImageBufferTests.ImageBufferSubPixelDrawing was failing
for Skia and cairo ports because the device scale factor wasn&apos;t
applied to ImageBuffer.

Windows Skia port was freezing while destroying skiaGLContext now. It
doesn&apos;s support accelerated image buffer yet. Disabled skiaGLContext
for now.

The tests are skipped for GTK and WPE ports now. &lt;<a href="https://webkit.org/b/286456">https://webkit.org/b/286456</a>&gt;
Only tested with Windows Cairo and Windows Skia ports.

* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::ImageBufferCairoSurfaceBackend):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp:
(WebCore::ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend):
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::PlatformDisplay::skiaGLContext):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/WebCoreTestUtilities.cpp:
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/289415@main">https://commits.webkit.org/289415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/204a1554cc035cdaf8d468d1449b2fe2faf2c8dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37311 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67165 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32718 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36428 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93290 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75755 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74943 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6516 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13503 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19017 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->