### PR TITLE
[WebGPU] GPUDevice bindGroup cache does not handle buffers with different offsets

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286407-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286407-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286407.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286407.html
@@ -1,0 +1,205 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+// START
+adapter0 = await navigator.gpu.requestAdapter();
+promise0 = adapter0.requestDevice();
+device0 = await promise0;
+buffer0 = device0.createBuffer({
+  size : 4483,
+  usage : GPUBufferUsage.STORAGE | GPUBufferUsage});
+videoFrame0 = new VideoFrame(new ArrayBuffer(16), {
+  codedWidth : 2,
+  codedHeight : 2,
+  format : 'I420',
+  timestamp : 0,
+  });
+veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 4,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage,
+      externalTexture : {}
+    },
+    {
+      binding : 110,
+      visibility : GPUShaderStage.COMPUTE | GPUShaderStage,
+      buffer : {type : 'storage', }},
+    {
+      binding : 208,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage', }}]});
+externalTexture1 =
+    device0.importExternalTexture({source : videoFrame0, });
+buffer9 = device0.createBuffer({
+  size : 1199,
+  usage : GPUBufferUsage.STORAGE | GPUBufferUsage});
+
+device0.createBindGroup({
+  layout : veryExplicitBindGroupLayout4,
+  entries : [
+    {binding : 110, resource : {buffer : buffer0, size : 608}},
+    {binding : 208, resource : {buffer : buffer9, size : 488}},
+    {binding : 4, resource : externalTexture1}]});
+bindGroup11 = device0.createBindGroup({
+  layout : veryExplicitBindGroupLayout4,
+  entries : [
+    {binding : 208, resource : {buffer : buffer0}},
+    {binding : 110, resource : {buffer : buffer9}},
+    {binding : 4, resource : externalTexture1}]});
+
+shaderModule0 = device0.createShaderModule({
+  code : ` ;
+              var<workgroup> vw0: vec4h;
+              fn unconst_f32(v: f32) -> f32 {
+            return v;
+            }
+              fn unconst_u32(v: u32) -> u32 {
+            return v;
+            }
+              struct T4 {
+              @size(8) f0: atomic<u32>}
+              fn unconst_f16(v: f16) -> f16 {
+            return v;
+            }
+              @group(0) @binding(208) var<storage, read_write> buffer14: array<array<array<f16, 9>, 16>>;
+              fn unconst_bool(v: bool) -> bool {
+            return v;
+            }
+              struct FragmentOutput0 {
+              @location(0) f0: vec4f}
+              @group(0) @binding(4) var et0: texture_external;
+              var<private> vp0= vec2i(548, 40);
+              @must_use  fn fn1() -> FragmentOutput0 {
+              var out: FragmentOutput0;
+              buffer14[unconst_u32(636)][unconst_u32(772)][unconst_u32(68)] = buffer14[arrayLength(&buffer14)][unconst_u32(105)][unconst_u32(843)];
+              let ptr0= &(buffer13)[unconst_u32(45)][u32()];
+              vw0 = vec4h(buffer13[unconst_u32(61)][unconst_u32(56)][unconst_u32(96)][0][0]);
+              let ptr1= &(buffer13)[(79)][0][0];
+              let ptr2: ptr<storage, array<array<array<f16, 1>, 1>, 3>, read_write> = &buffer13[(142)][0];
+              var vf1vec2f = sin(vec2f(unconst_f32(0.00835), unconst_f32(0.08881)));
+              let ptr3= &buffer14[(3)][15][(6)];
+              out.f0 = vec4f(f32(buffer13[arrayLength(&buffer13)][unconst_u32(179)][unconst_u32(5)][unconst_u32(250)][unconst_u32(2)]));
+              return out;
+              _ = buffer13;
+              _ = buffer14;
+            }
+              struct T3 {
+              @align(8) @size(8) f0: array<array<array<array<array<u32, 1>, 1>, 1>, 1>, >}
+              fn fn2() -> T7 {
+              var out: T7;
+              out.f0 -= vec4f(f32(mix(unconst_f16(22810.8), unconst_f16(1406.4), unconst_f16(970.0))));
+              let vf4vec2f = step(vec2f(unconst_f32(0.2235), unconst_f32(0.06957)), vec2f(unconst_f32(0.1694), unconst_f32(0.1216)));
+              var vf5= any(unconst_bool(true));
+              vf5 = bool(step(vec2f(unconst_f32(-0.03114), unconst_f32(0.04869)), vec2f(unconst_f32(-0.1820), unconst_f32(0.4481)))[0]);
+              let vf6bool = (unconst_bool(true) || any(vec4(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(true))));
+              if vf5 {
+            let vf9vec3f = faceForward(vec3f(unconst_f32(0.07414), unconst_f32(0.1799), unconst_f32(0.01477)), vec3f(unconst_f32(0.09116), unconst_f32(0.1702), unconst_f32(0.1474)), vec3f(unconst_f32(-0.1086), unconst_f32(0.2409), unconst_f32(0.1656)));
+          }
+              let vf11vec2u = textureDimensions(et0);
+              let ptr4= &vf5;
+              return out;
+            }
+              struct T7 {
+              @size(48) f0: vec4f}
+              @group(0) @binding(110) var<storage, read_write> buffer13: array<array<array<array<array<f16, 1>, 1>, 3>, 1>>;
+              @compute @workgroup_size(2, ) fn compute0() {
+              _ = fn1();
+              let ptr11: ptr<storage, array<array<f16, 1>, 1>, read_write> = &(buffer13)[arrayLength(&(buffer13))][unconst_u32(4)][unconst_u32(91)];
+              buffer13[unconst_u32(27)][unconst_u32(342)][unconst_u32(204)][unconst_u32(6)][unconst_u32(46)] = buffer13[unconst_u32(333)][unconst_u32(317)][2][0][0];
+            }
+             `});
+{
+}
+pipelineLayout4 = device0.createPipelineLayout(
+    {bindGroupLayouts : [ veryExplicitBindGroupLayout4 ]});
+{
+}
+pipeline6 = await device0.createComputePipelineAsync({
+  layout : pipelineLayout4,
+  compute : {module : shaderModule0 }
+});
+commandEncoder52 = device0.createCommandEncoder();
+{
+}
+computePassEncoder38 = commandEncoder52.beginComputePass();
+try {
+  computePassEncoder38.setPipeline(pipeline6)} catch {
+}
+try {
+  computePassEncoder38.setBindGroup(0, bindGroup11)} catch {
+}
+{
+}
+try {
+  computePassEncoder38.dispatchWorkgroups(11)} catch {
+}
+{
+}
+try {
+  computePassEncoder38.end()} catch {
+}
+commandBuffer3 = commandEncoder52.finish();
+{
+}
+try {
+  device0.queue.submit([ commandBuffer3 ])} catch {
+}
+// END
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
@@ -87,6 +87,10 @@ struct GPUBindGroupEntry {
             return false;
         });
     }
+    static bool equalSizes(const std::optional<GPUSize64>& a, const std::optional<GPUSize64>& b)
+    {
+        return (!a && !b) || (a && b && *a == *b);
+    }
     static bool equal(const GPUBufferBinding& entry, const GPUBindingResource& otherEntry)
     {
         return WTF::switchOn(otherEntry, [&](const RefPtr<GPUSampler>&) -> bool {
@@ -94,7 +98,7 @@ struct GPUBindGroupEntry {
         }, [&](const RefPtr<GPUTextureView>&) -> bool {
             return false;
         }, [&](const GPUBufferBinding& bufferBinding) -> bool {
-            return bufferBinding.buffer.get() == entry.buffer.get();
+            return bufferBinding.buffer.get() == entry.buffer.get() && bufferBinding.offset == entry.offset && equalSizes(bufferBinding.size, entry.size);
         }, [&](const RefPtr<GPUExternalTexture>&) -> bool {
             return false;
         });


### PR DESCRIPTION
#### 7605701f47be57dda96ead432207538a743d2302
<pre>
[WebGPU] GPUDevice bindGroup cache does not handle buffers with different offsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=286407">https://bugs.webkit.org/show_bug.cgi?id=286407</a>
<a href="https://rdar.apple.com/143114463">rdar://143114463</a>

Reviewed by Cameron McCormack.

The GPUDevice GPUBindGroup cache incorrectly reused bind groups with
the same buffer but different offsets and sizes. Reuse should only be
applied to identical offsets and sizes otherwise and OOB read may occur.

* LayoutTests/fast/webgpu/nocrash/fuzz-286407-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-286407.html: Added.
Add regression test.

* Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h:
(WebCore::GPUBindGroupEntry::equalSizes):
(WebCore::GPUBindGroupEntry::equal):
Unlike GPUTexture, GPUSampler, and GPUExternalTextures, GPUBuffers
may specificy an offset into the buffer.

Canonical link: <a href="https://commits.webkit.org/289317@main">https://commits.webkit.org/289317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43b943e057acf3337c893f6acb70c743e5803a10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91220 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32495 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36207 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93151 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75688 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74870 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18427 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18826 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13284 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16725 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->