### PR TITLE
Support video/webm;codecs=h264,pcm in MediaRecorder

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable-expected.txt
@@ -1,0 +1,5 @@
+
+
+
+PASS MediaRecorder can successfully record the video for an audio-video stream into a matroska file
+

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
@@ -1,0 +1,145 @@
+<!doctype html><!-- webkit-test-runner [ LimitedMatroskaSupportEnabled=true ] -->
+<html>
+<head>
+    <title>MediaRecorder Dataavailable</title>
+    <link rel="help" href="https://w3c.github.io/mediacapture-record/MediaRecorder.html#mediarecorder">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="../common/canvas-tests.js"></script>
+</head>
+<body>
+<div>
+    <video id="player">
+    </video>
+</div>
+<div>
+    <canvas id="canvas" width="200" height="200">
+    </canvas>
+    <canvas id="frame" width="200" height="200">
+    </canvas>
+</div>
+<script>
+    const MIMETYPE = 'video/webm; codecs=avc1.42000a,pcm';
+    var context;
+    var blobData = new Blob();
+    var paintingState = 0;
+    var canPlayReceived = false;
+    var playbackStarted = false;
+    // Needs to be a global variable to avoid being GCed (webkit.org/b/271227)
+    var oscillator;
+
+    function createVideoStream() {
+        const canvas = document.getElementById("canvas");
+        context = canvas.getContext('2d');
+        return canvas.captureStream();
+    }
+
+    function doRedImageDraw() {
+        if (context) {
+            context.fillStyle = "#ff0000";
+            context.fillRect(0, 0, 200, 200);
+            if (paintingState == 0)
+                window.requestAnimationFrame(doRedImageDraw);
+        }
+    }
+
+    function doGreenImageDraw() {
+        if (context) {
+            context.fillStyle = "#00ff00";
+            context.fillRect(0, 0, 200, 200);
+            if (paintingState == 1)
+                window.requestAnimationFrame(doGreenImageDraw);
+        }
+    }
+
+    function maybeStartPlayback() {
+        if (canPlayReceived && player.duration > 1 && !playbackStarted) {
+            playbackStarted = true;
+            player.play();
+        }
+    }
+
+    async_test(t => {
+        const ac = new AudioContext();
+        oscillator = ac.createOscillator();
+        const dest = ac.createMediaStreamDestination();
+        const audio = dest.stream;
+        oscillator.connect(dest);
+        oscillator.start();
+
+        const video = createVideoStream();
+        assert_equals(video.getAudioTracks().length, 0, "video mediastream starts with no audio track");
+        assert_equals(audio.getAudioTracks().length, 1, "audio mediastream starts with one audio track");
+        video.addTrack(audio.getAudioTracks()[0]);
+        assert_equals(video.getAudioTracks().length, 1, "video mediastream starts with one audio track");
+        const recorder = new MediaRecorder(video, { mimeType: MIMETYPE });
+        let mode = 0;
+
+        recorder.ondataavailable = t.step_func(blobEvent => {
+            assert_true(blobEvent instanceof BlobEvent, 'the type of event should be BlobEvent');
+            assert_equals(blobEvent.type, 'dataavailable', 'the event type should be dataavailable');
+            assert_true(blobEvent.isTrusted, 'isTrusted should be true when the event is created by C++');
+            assert_true(blobEvent.data instanceof Blob, 'the type of data should be Blob');
+            assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
+            blobData = new Blob([blobData, blobEvent.data]);
+
+            if (blobEvent.timecode == 0)
+                return;
+            if (blobEvent.timecode >= 0.2 && paintingState == 0) {
+                paintingState = 1;
+                doGreenImageDraw();
+                return;
+            }
+            assert_greater_than(blobEvent.timecode, .4, "more than .4s recorded");
+            if (++paintingState == 2) {
+                recorder.stop();
+                ac.close();
+                return;
+            }
+            player.src = window.URL.createObjectURL(blobData);
+            const resFrame = document.getElementById("frame");
+            const resContext = resFrame.getContext('2d');
+            player.load();
+
+            player.oncanplay = t.step_func(() => {
+                canPlayReceived = true;
+                maybeStartPlayback();
+            });
+            player.ondurationchange = t.step_func(() => {
+                maybeStartPlayback();
+            });
+            player.onplay = () => {
+                player.pause();
+                assert_greater_than(player.duration, .4, 'the duration should be greater than .4s')
+                player.currentTime = player.duration - 0.05;
+            };
+            player.onseeked = t.step_func(() => {
+                resContext.drawImage(player, 0, 0);
+                if (!mode) {
+                    _assertPixelApprox(resFrame, 20, 20, 20, 255, 0, 255, "20, 20", "0, 255, 0, 255", 50);
+                    _assertPixelApprox(resFrame, 199, 199, 20, 255, 0, 255, "199, 199", "0, 255, 0, 255", 50);
+                    player.currentTime = 0;
+                    mode = 1;
+                } else {
+                    _assertPixelApprox(resFrame, 25, 25, 255, 0, 0, 255, "25, 25", "255, 0, 0, 255", 50);
+                    _assertPixelApprox(resFrame, 50, 50, 255, 0, 0, 255, "50, 50", "255, 0, 0, 255", 50);
+                    t.done();
+                }
+            });
+        });
+
+        doRedImageDraw();
+        recorder.start(200);
+        assert_equals(recorder.state, 'recording', 'MediaRecorder has been started successfully');
+
+        setTimeout(() => {
+            paintingState = 3;
+            recorder.stop();
+            ac.close();
+            assert_unreached("recording didn't finish on time");
+        }, 5000);
+    }, 'MediaRecorder can successfully record the video for an audio-video stream into a matroska file');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1269,6 +1269,9 @@ webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-audio-bitrate.html [ Pa
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Crash Timeout Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-first-frame.html [ Failure Pass ]
 
+# No support for Matroska container in GStreamer port.
+http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
+
 # The mp4 test here is passing but the webm test fails, matroskademux fails to seek in push mode,
 # due to missing index. GLib baselines reflect this, the Pass expectation is kept here for future reference.
 webkit.org/b/282534 http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html [ Pass ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4325,6 +4325,21 @@ LegacyWebRTCOfferOptionsEnabled:
     WebCore:
       default: false
 
+LimitedMatroskaSupportEnabled:
+  type: bool
+  status: developer
+  category: media
+  humanReadableName: "Limited Matroska Support"
+  humanReadableDescription: "Enable H264 and PCM with WebM Player and MediaRecorder"
+  condition: ENABLE(MEDIA_RECORDER_WEBM)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 LinearMediaPlayerEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
@@ -239,6 +239,8 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, kCMFormatDesc
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, kCMFormatDescriptionExtension_ProjectionKind, CFStringRef, PAL_EXPORT)
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, kCMFormatDescriptionProjectionKind_Rectilinear, CFStringRef, PAL_EXPORT)
 
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMVideoFormatDescriptionCreateFromH264ParameterSets, OSStatus, (CFAllocatorRef allocator, size_t parameterSetCount, const uint8_t* const* parameterSetPointers, const size_t* parameterSetSizes, int NALUnitHeaderLength, CMFormatDescriptionRef* formatDescriptionOut), (allocator, parameterSetCount, parameterSetPointers, parameterSetSizes, NALUnitHeaderLength, formatDescriptionOut), PAL_EXPORT)
+
 #if PLATFORM(MAC)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMAudioDeviceClockCreate, OSStatus, (CFAllocatorRef allocator, CFStringRef deviceUID, CMClockRef* clockOut), (allocator, deviceUID, clockOut), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMBaseObjectGetDerivedStorage, void*, (CMBaseObjectRef baseObject), (baseObject), PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -411,6 +411,9 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, CoreMedia, kCMFormatDescriptionExten
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, CoreMedia, kCMFormatDescriptionProjectionKind_Rectilinear, CFStringRef)
 #define kCMFormatDescriptionProjectionKind_Rectilinear get_CoreMedia_kCMFormatDescriptionProjectionKind_Rectilinear()
 
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMVideoFormatDescriptionCreateFromH264ParameterSets, OSStatus, (CFAllocatorRef allocator, size_t parameterSetCount, const uint8_t* const* parameterSetPointers, const size_t* parameterSetSizes, int NALUnitHeaderLength, CMFormatDescriptionRef* formatDescriptionOut), (allocator, parameterSetCount, parameterSetPointers, parameterSetSizes, NALUnitHeaderLength, formatDescriptionOut))
+#define CMVideoFormatDescriptionCreateFromH264ParameterSets softLink_CoreMedia_CMVideoFormatDescriptionCreateFromH264ParameterSets
+
 namespace PAL {
 
 inline std::span<uint8_t> CMBlockBufferGetDataSpan(CMBlockBufferRef theBuffer, size_t offset = 0)

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -449,6 +449,7 @@ platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
 platform/graphics/cocoa/FontFamilySpecificationCoreTextCache.cpp
 platform/graphics/cocoa/FontPlatformDataCocoa.mm
 platform/graphics/cocoa/GraphicsContextCocoa.mm
+platform/graphics/cocoa/H264UtilitiesCocoa.mm
 platform/graphics/cocoa/HEVCUtilitiesCocoa.mm
 platform/graphics/cocoa/IOSurface.mm
 platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1124,6 +1124,8 @@ private:
     void setMutedInternal(bool muted, ForceMuteChange);
     bool implicitlyMuted() const { return m_implicitlyMuted.value_or(false); }
 
+    bool limitedMatroskaSupportEnabled() const;
+
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;
     Timer m_scanTimer;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1831,6 +1831,15 @@ bool Quirks::needsHotelsAnimationQuirk(Element& element, const RenderStyle& styl
     return !matches.hasException() && matches.returnValue();
 }
 
+bool Quirks::needsLimitedMatroskaSupport() const
+{
+#if ENABLE(MEDIA_RECORDER) && ENABLE(ALTERNATE_WEBM_PLAYER)
+    return isDomain("zencastr.com"_s);
+#else
+    return false;
+#endif
+}
+
 URL Quirks::topDocumentURL() const
 {
     if (UNLIKELY(!m_topDocumentURLForTesting.isEmpty()))

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -245,6 +245,8 @@ public:
 
     bool needsFacebookStoriesCreationFormQuirk(const Element&, const RenderStyle&) const;
 
+    bool needsLimitedMatroskaSupport() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;

--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -163,6 +163,12 @@ static bool hasSignatureForWebM(std::span<const uint8_t> sequence)
             //  7. If matched is true, abort these steps and return true.
             if (sequence[iter] == 0x77 && sequence[iter + 1] == 0x65 && sequence[iter + 2] == 0x62 && sequence[iter + 3] == 0x6d)
                 return true;
+
+            // case for matroska, treat it as webm.
+            if (iter + 8 >= length)
+                break;
+            if (sequence[iter] == 'm' && sequence[iter + 1] == 'a' && sequence[iter + 2] == 't' && sequence[iter + 3] == 'r' && sequence[iter + 4] == 'o' && sequence[iter + 5] == 's' && sequence[iter + 6] == 'k' && sequence[iter + 7] == 'a')
+                return true;
         }
         //  2. Increment iter by 1.
         iter++;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -54,11 +54,12 @@ public:
 
     virtual constexpr MediaPlayerType mediaPlayerType() const = 0;
 
+    using LoadOptions = MediaPlayer::LoadOptions;
     virtual void load(const String&) { }
-    virtual void load(const URL& url, const ContentType&, const String&) { load(url.string()); }
+    virtual void load(const URL& url, const LoadOptions&) { load(url.string()); }
 
 #if ENABLE(MEDIA_SOURCE)
-    virtual void load(const URL&, const ContentType&, MediaSourcePrivateClient&) = 0;
+    virtual void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) = 0;
 #endif
 #if ENABLE(MEDIA_STREAM)
     virtual void load(MediaStreamPrivate&) = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -205,7 +205,7 @@ void MediaPlayerPrivateAVFoundation::load(const String& url)
 }
 
 #if ENABLE(MEDIA_SOURCE)
-void MediaPlayerPrivateAVFoundation::load(const URL&, const ContentType&, MediaSourcePrivateClient&)
+void MediaPlayerPrivateAVFoundation::load(const URL&, const LoadOptions&, MediaSourcePrivateClient&)
 {
     setNetworkState(MediaPlayer::NetworkState::FormatError);
 }

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -171,7 +171,7 @@ protected:
     // MediaPlayerPrivatePrivateInterface overrides.
     void load(const String& url) override;
 #if ENABLE(MEDIA_SOURCE)
-    void load(const URL&, const ContentType&, MediaSourcePrivateClient&) override;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 #endif
 #if ENABLE(MEDIA_STREAM)
     void load(MediaStreamPrivate&) override { setNetworkState(MediaPlayer::NetworkState::FormatError); }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -181,10 +181,12 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         SeekCompleted,
     };
 
+    bool supportsLimitedMatroska() const { return m_loadOptions.supportsLimitedMatroska; }
+
 private:
     // MediaPlayerPrivateInterface
     void load(const String& url) override;
-    void load(const URL&, const ContentType&, MediaSourcePrivateClient&) override;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 #if ENABLE(MEDIA_STREAM)
     void load(MediaStreamPrivate&) override;
 #endif
@@ -417,6 +419,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool m_needsPlaceholderImage { false };
     bool m_preferDecompressionSession { false };
     bool m_canFallbackToDecompressionSession { false };
+    LoadOptions m_loadOptions;
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -325,7 +325,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const String&)
         player->networkStateChanged();
 }
 
-void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const ContentType&, MediaSourcePrivateClient& client)
+void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const LoadOptions& options, MediaSourcePrivateClient& client)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -337,6 +337,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const ContentType&, 
         m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
     m_mediaSourcePrivate->setResourceOwner(m_resourceOwner);
     m_mediaSourcePrivate->setVideoRenderer(layerOrVideoRenderer().get());
+    m_loadOptions = options;
 
     acceleratedRenderingStateChanged();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -106,7 +106,7 @@ private:
 
     void load(const String&) override;
 #if ENABLE(MEDIA_SOURCE)
-    void load(const URL&, const ContentType&, MediaSourcePrivateClient&) override;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 #endif
     void load(MediaStreamPrivate&) override;
     void cancelLoad() override;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -476,7 +476,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::load(const String&)
 }
 
 #if ENABLE(MEDIA_SOURCE)
-void MediaPlayerPrivateMediaStreamAVFObjC::load(const URL&, const ContentType&, MediaSourcePrivateClient&)
+void MediaPlayerPrivateMediaStreamAVFObjC::load(const URL&, const LoadOptions&, MediaSourcePrivateClient&)
 {
     // This media engine only supports MediaStream URLs.
     scheduleDeferredTask([this] {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -45,6 +45,7 @@
 #import "MediaSourcePrivateAVFObjC.h"
 #import "SharedBuffer.h"
 #import "SourceBufferParserAVFObjC.h"
+#import "SourceBufferParserWebM.h"
 #import "SourceBufferPrivateClient.h"
 #import "TimeRanges.h"
 #import "VideoMediaSampleRenderer.h"
@@ -124,6 +125,10 @@ SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC(MediaSourcePrivateAVFObjC
 #endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+
+    RefPtr player = this->player();
+    if (RefPtr webmParser = dynamicDowncast<SourceBufferParserWebM>(m_parser); webmParser && player && player->supportsLimitedMatroska())
+        webmParser->allowLimitedMatroska();
 
 #if !RELEASE_LOG_DISABLED
     m_parser->setLogger(m_logger.get(), m_logIdentifier);

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -122,8 +122,11 @@ String AudioTrackPrivateWebM::codec() const
     if (codecID == "A_VORBIS"_s)
         return "vorbis"_s;
 
-    if (codecID == "V_OPUS"_s)
+    if (codecID == "A_OPUS"_s)
         return "opus"_s;
+
+    if (codecID == "A_PCM/FLOAT/IEEE"_s)
+        return "pcm"_s;
 
     return emptyString();
 }

--- a/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+struct VideoInfo;
+
+WEBCORE_EXPORT RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t>);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "H264UtilitiesCocoa.h"
+
+#import "BitReader.h"
+#import "MediaSample.h"
+
+#import <pal/cf/CoreMediaSoftLink.h>
+
+namespace WebCore {
+
+RefPtr<VideoInfo> createVideoInfoFromAVCC(std::span<const uint8_t> avcc)
+{
+    if (avcc.size() < 7)
+        return nullptr;
+
+    BitReader reader { avcc };
+
+    // configurationVersion
+    reader.read(8);
+    // AVCProfileIndication;
+    reader.read(8);
+    // profile_compatibility;
+    reader.read(8);
+    // AVCLevelIndication;
+    reader.read(8);
+    // bit(6) reserved = '111111'b;
+    // unsigned int(2) lengthSizeMinusOne;
+    size_t lengthSize = (*reader.read<uint8_t>() & 0x3) + 1;
+    // bit(3) reserved = '111'b;
+    // unsigned int(5) numOfSequenceParameterSets;
+    size_t numOfSequenceParameterSets = 0x1f & *reader.read<uint8_t>();
+    if (!numOfSequenceParameterSets)
+        return nullptr;
+
+    constexpr size_t kNALTypeSize = 1;
+    constexpr uint8_t kSPSNAL = 7;
+    constexpr uint8_t kPPSNAL = 8;
+    constexpr uint8_t kNAL_REF_IDC_SEQ_PARAM_SET = 0x80;
+    constexpr uint8_t kNAL_REF_IDC_PIC_PARAM_SET = 0x60;
+
+    Vector<Vector<uint8_t>> paramSets;
+    paramSets.reserveInitialCapacity(numOfSequenceParameterSets + 1); // typical number of picture parameter set is 1.
+
+    for (size_t index = 0; index < numOfSequenceParameterSets; index++) {
+        auto size = reader.read<uint16_t>();
+        if (!size || *size < kNALTypeSize)
+            return nullptr;
+        auto nalType = reader.read<uint8_t>();
+        if (!nalType || (*nalType & 0x1f) != kSPSNAL)
+            return nullptr;
+        paramSets.append({ avcc.subspan(reader.byteOffset() - 1, *size) });
+        paramSets.last()[0] &= ~kNAL_REF_IDC_SEQ_PARAM_SET;
+        if (!reader.skipBytes(*size - kNALTypeSize))
+            return nullptr;
+    }
+
+    // unsigned int(8) numOfPictureParameterSets;
+    auto numOfPictureParameterSets = reader.read<uint8_t>();
+    if (!numOfPictureParameterSets || !*numOfPictureParameterSets)
+        return nullptr;
+    for (size_t index = 0; index < *numOfPictureParameterSets; index++) {
+        auto size = reader.read<uint16_t>();
+        if (!size || *size < kNALTypeSize)
+            return nullptr;
+        auto nalType = reader.read<uint8_t>();
+        if (!nalType || (*nalType & 0x1f) != kPPSNAL)
+            return nullptr;
+        paramSets.append({ avcc.subspan(reader.byteOffset() - 1, *size) });
+        paramSets.last()[0] |= kNAL_REF_IDC_PIC_PARAM_SET;
+        if (!reader.skipBytes(*size - kNALTypeSize))
+            return nullptr;
+    }
+
+    Vector<const uint8_t*> paramSetPtrs { paramSets.size(), [&paramSets](auto index) {
+        return paramSets[index].data();
+    } };
+    Vector<size_t> paramSetSizes { paramSets.size(), [&paramSets](auto index) {
+        return paramSets[index].size();
+    } };
+
+    CMFormatDescriptionRef rawDescription = nullptr;
+    if (PAL::CMVideoFormatDescriptionCreateFromH264ParameterSets(kCFAllocatorDefault, paramSetPtrs.size(), paramSetPtrs.data(), paramSetSizes.data(), lengthSize, &rawDescription))
+        return nullptr;
+    RetainPtr description = adoptCF(rawDescription);
+    auto dimensions = PAL::CMVideoFormatDescriptionGetDimensions(rawDescription);
+    auto presentationDimensions = PAL::CMVideoFormatDescriptionGetPresentationDimensions(rawDescription, true, true);
+
+    Ref info = VideoInfo::create();
+    info->codecName = kCMVideoCodecType_H264;
+    info->size = { static_cast<float>(dimensions.width), static_cast<float>(dimensions.height) };
+    info->displaySize = { static_cast<float>(presentationDimensions.width), static_cast<float>(presentationDimensions.height) };
+    info->atomData = SharedBuffer::create(avcc);
+
+    return info;
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -92,11 +92,11 @@ public:
 private:
     void setPreload(MediaPlayer::Preload) final;
     void doPreload();
-    void load(const String&) final;
+    void load(const URL&, const LoadOptions&) final;
     bool createResourceClient();
 
 #if ENABLE(MEDIA_SOURCE)
-    void load(const URL&, const ContentType&, MediaSourcePrivateClient&) final;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) final;
 #endif
 #if ENABLE(MEDIA_STREAM)
     void load(MediaStreamPrivate&) final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -186,7 +186,7 @@ MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngine
     if (parameters.isMediaSource || parameters.isMediaStream || parameters.requiresRemotePlayback)
         return MediaPlayer::SupportsType::IsNotSupported;
 
-    return SourceBufferParserWebM::isContentTypeSupported(parameters.type);
+    return SourceBufferParserWebM::isContentTypeSupported(parameters.type, parameters.supportsLimitedMatroska);
 }
 
 void MediaPlayerPrivateWebM::setPreload(MediaPlayer::Preload preload)
@@ -230,13 +230,15 @@ void MediaPlayerPrivateWebM::doPreload()
     }
 }
 
-void MediaPlayerPrivateWebM::load(const String& url)
+void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
     setReadyState(MediaPlayer::ReadyState::HaveNothing);
 
-    m_assetURL = URL({ }, url);
+    m_assetURL = url;
+    if (options.supportsLimitedMatroska)
+        m_parser->allowLimitedMatroska();
 
     doPreload();
 }
@@ -262,7 +264,7 @@ bool MediaPlayerPrivateWebM::createResourceClient()
 }
 
 #if ENABLE(MEDIA_SOURCE)
-void MediaPlayerPrivateWebM::load(const URL&, const ContentType&, MediaSourcePrivateClient&)
+void MediaPlayerPrivateWebM::load(const URL&, const LoadOptions&, MediaSourcePrivateClient&)
 {
     ERROR_LOG(LOGIDENTIFIER, "tried to load as mediasource");
 

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -31,6 +31,7 @@
 #include "AudioTrackPrivateWebM.h"
 #include "CMUtilities.h"
 #include "ContentType.h"
+#include "H264UtilitiesCocoa.h"
 #include "InbandTextTrackPrivate.h"
 #include "LibWebRTCMacros.h"
 #include "Logging.h"
@@ -717,7 +718,7 @@ Status WebMParser::OnEbml(const ElementMetadata&, const Ebml& ebml)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 
-    if (ebml.doc_type.is_present() && ebml.doc_type.value().compare("webm"))
+    if (ebml.doc_type.is_present() && (ebml.doc_type.value().compare("webm") && ebml.doc_type.value().compare("matroska")))
         return Status(Status::Code(ErrorCode::InvalidDocType));
 
     m_initializationSegmentEncountered = true;
@@ -844,6 +845,8 @@ Status WebMParser::OnTrackEntry(const ElementMetadata&, const TrackEntry& trackE
         if (codecString == "V_VP8"_s && isVP8DecoderAvailable())
             return VideoTrackData::create(CodecType::VP8, trackEntry, *this);
 #endif
+        if (codecString == "V_MPEG4/ISO/AVC"_s && m_allowLimitedMatroska)
+            return VideoTrackData::create(CodecType::H264, trackEntry, *this);
 
 #if ENABLE(VORBIS)
         if (codecString == "A_VORBIS"_s && isVorbisDecoderAvailable())
@@ -854,6 +857,8 @@ Status WebMParser::OnTrackEntry(const ElementMetadata&, const TrackEntry& trackE
         if (codecString == "A_OPUS"_s && isOpusDecoderAvailable())
             return AudioTrackData::create(CodecType::Opus, trackEntry, *this);
 #endif
+        if (codecString == "A_PCM/FLOAT/IEEE"_s && m_allowLimitedMatroska)
+            return AudioTrackData::create(CodecType::PCM, trackEntry, *this);
         return TrackData::create(CodecType::Unsupported, trackEntry, *this);
     }();
 
@@ -950,9 +955,11 @@ webm::Status WebMParser::OnFrame(const FrameMetadata& metadata, Reader* reader, 
         return Status(Status::kInvalidElementId);
     }
 
+    std::optional<bool> isKey;
     auto* block = WTF::switchOn(*m_currentBlock, [](Block& block) {
         return &block;
-    }, [](SimpleBlock& block) -> Block* {
+    }, [&isKey](SimpleBlock& block) -> Block* {
+        isKey = block.is_key_frame;
         return &block;
     });
     if (!block)
@@ -968,15 +975,17 @@ webm::Status WebMParser::OnFrame(const FrameMetadata& metadata, Reader* reader, 
     switch (trackData->codec()) {
     case CodecType::VP8:
     case CodecType::VP9:
+    case CodecType::H264:
     case CodecType::Vorbis:
     case CodecType::Opus:
+    case CodecType::PCM:
         break;
 
     case CodecType::Unsupported:
         return Skip(reader, bytesRemaining);
     }
 
-    auto result = trackData->consumeFrameData(*reader, metadata, bytesRemaining, MediaTime(block->timecode + m_currentTimecode, m_timescale) + m_currentDuration);
+    auto result = trackData->consumeFrameData(*reader, metadata, bytesRemaining, MediaTime(block->timecode + m_currentTimecode, m_timescale) + m_currentDuration, isKey);
     if (std::holds_alternative<webm::Status>(result))
         return std::get<webm::Status>(result);
     m_currentDuration += std::get<MediaTime>(result);
@@ -1041,13 +1050,13 @@ void WebMParser::VideoTrackData::resetCompletedFramesState()
     TrackData::resetCompletedFramesState();
 }
 
-WebMParser::ConsumeFrameDataResult WebMParser::VideoTrackData::consumeFrameData(webm::Reader& reader, const FrameMetadata& metadata, uint64_t* bytesRemaining, const MediaTime& presentationTime)
+WebMParser::ConsumeFrameDataResult WebMParser::VideoTrackData::consumeFrameData(webm::Reader& reader, const FrameMetadata& metadata, uint64_t* bytesRemaining, const MediaTime& presentationTime, std::optional<bool> isKey)
 {
-#if ENABLE(VP9)
     auto status = readFrameData(reader, metadata, bytesRemaining);
     if (!status.completed_ok())
         return status;
 
+#if ENABLE(VP9)
     constexpr size_t maxHeaderSize = 32; // The maximum length of a VP9 uncompressed header is 144 bits and 11 bytes for VP8. Round high.
     size_t segmentHeaderLength = std::min<size_t>(maxHeaderSize, metadata.size);
     auto contiguousBuffer = contiguousCompleteBlockBuffer(0, segmentHeaderLength);
@@ -1057,8 +1066,8 @@ WebMParser::ConsumeFrameDataResult WebMParser::VideoTrackData::consumeFrameData(
     }
     auto segmentHeaderData = contiguousBuffer->span().first(segmentHeaderLength);
 
-    bool isKey = false;
     if (codec() == CodecType::VP9) {
+        isKey = false;
         if (!m_headerParser.ParseUncompressedHeader(segmentHeaderData.data(), segmentHeaderData.size()))
             return Skip(&reader, bytesRemaining);
 
@@ -1067,13 +1076,25 @@ WebMParser::ConsumeFrameDataResult WebMParser::VideoTrackData::consumeFrameData(
             setFormatDescription(createVideoInfoFromVP9HeaderParser(m_headerParser, track().video.value()));
         }
     } else if (codec() == CodecType::VP8) {
+        isKey = false;
         auto header = parseVP8FrameHeader(segmentHeaderData);
         if (header && header->keyframe) {
             isKey = true;
             setFormatDescription(createVideoInfoFromVP8Header(*header, track().video.value()));
         }
     }
-
+#endif
+    if (codec() == CodecType::H264) {
+        if (!formatDescription()) {
+            if (!track().codec_private.is_present()) {
+                PARSER_LOG_ERROR_IF_POSSIBLE("H264 video track missing magic cookie");
+                return Skip(&reader, bytesRemaining);
+            }
+            auto& privateData = track().codec_private.value();
+            if (RefPtr videoInfo = createVideoInfoFromAVCC(privateData))
+                setFormatDescription(videoInfo.releaseNonNull());
+        }
+    }
     processPendingMediaSamples(presentationTime);
 
     if (formatDescription() && (!m_trackInfo || *formatDescription() != *m_trackInfo)) {
@@ -1086,17 +1107,11 @@ WebMParser::ConsumeFrameDataResult WebMParser::VideoTrackData::consumeFrameData(
         .presentationTime = presentationTime,
         .decodeTime = presentationTime,
         .data = WTFMove(m_completeFrameData),
-        .flags = isKey ? MediaSample::SampleFlags::IsSync : MediaSample::SampleFlags::None
+        .flags = isKey.value_or(false) ? MediaSample::SampleFlags::IsSync : MediaSample::SampleFlags::None
     });
 
     ASSERT(!*bytesRemaining);
     return webm::Status(webm::Status::kOkCompleted);
-#else
-    UNUSED_PARAM(presentationTime);
-    UNUSED_PARAM(sampleCount);
-    UNUSED_PARAM(metadata);
-    return Skip(&reader, bytesRemaining);
-#endif
 }
 
 void WebMParser::VideoTrackData::processPendingMediaSamples(const MediaTime& presentationTime)
@@ -1182,23 +1197,23 @@ void WebMParser::AudioTrackData::resetCompletedFramesState()
     TrackData::resetCompletedFramesState();
 }
 
-WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(webm::Reader& reader, const FrameMetadata& metadata, uint64_t* bytesRemaining, const MediaTime& presentationTime)
+WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(webm::Reader& reader, const FrameMetadata& metadata, uint64_t* bytesRemaining, const MediaTime& presentationTime, std::optional<bool>)
 {
     auto status = readFrameData(reader, metadata, bytesRemaining);
     if (!status.completed_ok())
         return status;
 
     if (!formatDescription()) {
-        if (!track().codec_private.is_present()) {
+        if (!track().codec_private.is_present() && codec() != CodecType::PCM) {
             PARSER_LOG_ERROR_IF_POSSIBLE("Audio track missing magic cookie");
             return Skip(&reader, bytesRemaining);
         }
 
         RefPtr<AudioInfo> formatDescription;
-        auto& privateData = track().codec_private.value();
         if (codec() == CodecType::Vorbis)
-            formatDescription = createVorbisAudioInfo(privateData);
+            formatDescription = createVorbisAudioInfo(track().codec_private.value());
         else if (codec() == CodecType::Opus) {
+            auto& privateData = track().codec_private.value();
             auto contiguousBuffer = contiguousCompleteBlockBuffer(0, kOpusMinimumFrameDataSize);
             if (!contiguousBuffer) {
                 PARSER_LOG_ERROR_IF_POSSIBLE("AudioTrackData::consumeFrameData: unable to create contiguous data block");
@@ -1218,6 +1233,13 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
                 PARSER_LOG_ERROR_IF_POSSIBLE("Failed to parse Opus private data");
                 return Skip(&reader, bytesRemaining);
             }
+        } else if (codec() == CodecType::PCM && track().audio.is_present()) {
+            formatDescription = AudioInfo::create();
+            auto& audio = track().audio.value();
+            formatDescription->codecName = kAudioFormatLinearPCM;
+            formatDescription->rate = audio.sampling_frequency.value();
+            formatDescription->channels = audio.channels.value();
+            formatDescription->bitDepth = audio.bit_depth.value();
         }
 
         if (!formatDescription) {
@@ -1225,10 +1247,12 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
             return Skip(&reader, bytesRemaining);
         }
 
-        m_packetDurationParser = makeUnique<PacketDurationParser>(*formatDescription);
-        if (!m_packetDurationParser->isValid()) {
-            PARSER_LOG_ERROR_IF_POSSIBLE("Failed to create PacketDurationParser from audio track header");
-            return Skip(&reader, bytesRemaining);
+        if (codec() == CodecType::Vorbis || codec() == CodecType::Opus) {
+            m_packetDurationParser = makeUnique<PacketDurationParser>(*formatDescription);
+            if (!m_packetDurationParser->isValid()) {
+                PARSER_LOG_ERROR_IF_POSSIBLE("Failed to create PacketDurationParser from audio track header");
+                return Skip(&reader, bytesRemaining);
+            }
         }
         setFormatDescription(formatDescription.releaseNonNull());
     }
@@ -1252,12 +1276,6 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
     }
 #endif
 
-    auto contiguousBuffer = contiguousCompleteBlockBuffer(0, codec() == CodecType::Opus ? kOpusMinimumFrameDataSize : kVorbisMinimumFrameDataSize);
-    if (!contiguousBuffer) {
-        PARSER_LOG_ERROR_IF_POSSIBLE("AudioTrackData::consumeFrameData: unable to create contiguous data block");
-        return Skip(&reader, bytesRemaining);
-    }
-
     bool shouldDrain = !!m_processedMediaSamples.info();
     if (formatDescription() && (!m_trackInfo || *formatDescription() != *m_trackInfo)) {
         if (shouldDrain)
@@ -1267,7 +1285,17 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
         parser().formatDescriptionChangedForTrackData(*this);
     }
 
-    MediaTime packetDuration = MediaTime(m_packetDurationParser->framesInPacket(contiguousBuffer->span()), downcast<AudioInfo>(formatDescription())->rate);
+    MediaTime packetDuration;
+
+    if (codec() == CodecType::Vorbis || codec() == CodecType::Opus) {
+        auto contiguousBuffer = contiguousCompleteBlockBuffer(0, codec() == CodecType::Opus ? kOpusMinimumFrameDataSize : kVorbisMinimumFrameDataSize);
+        if (!contiguousBuffer) {
+            PARSER_LOG_ERROR_IF_POSSIBLE("AudioTrackData::consumeFrameData: unable to create contiguous data block");
+            return Skip(&reader, bytesRemaining);
+        }
+        packetDuration = { static_cast<int64_t>(m_packetDurationParser->framesInPacket(contiguousBuffer->span())), downcast<AudioInfo>(formatDescription())->rate };
+    } else if (codec() == CodecType::PCM)
+        packetDuration = { static_cast<int64_t>(metadata.size / sizeof(float) / downcast<AudioInfo>(formatDescription())->channels), downcast<AudioInfo>(formatDescription())->rate };
     auto trimDuration = MediaTime::zeroTime();
     MediaTime localPresentationTime = presentationTime;
     if (m_remainingTrimDuration.isFinite() && m_remainingTrimDuration > MediaTime::zeroTime()) {
@@ -1319,12 +1347,12 @@ WebMParser::ConsumeFrameDataResult WebMParser::AudioTrackData::consumeFrameData(
 
 bool WebMParser::isSupportedVideoCodec(StringView name)
 {
-    return name == "V_VP8"_s || name == "V_VP9"_s;
+    return name == "V_VP8"_s || name == "V_VP9"_s || name == "V_MPEG4/ISO/AVC"_s;
 }
 
 bool WebMParser::isSupportedAudioCodec(StringView name)
 {
-    return name == "A_VORBIS"_s || name == "A_OPUS"_s;
+    return name == "A_VORBIS"_s || name == "A_OPUS"_s || name == "A_PCM/FLOAT/IEEE"_s;
 }
 
 SourceBufferParserWebM::SourceBufferParserWebM()
@@ -1337,7 +1365,7 @@ SourceBufferParserWebM::~SourceBufferParserWebM()
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 }
 
-MediaPlayerEnums::SupportsType SourceBufferParserWebM::isContentTypeSupported(const ContentType& type)
+MediaPlayerEnums::SupportsType SourceBufferParserWebM::isContentTypeSupported(const ContentType& type, bool supportsLimitedMatroska)
 {
 #if ENABLE(VP9) || ENABLE(VORBIS) || ENABLE(OPUS)
     if (!isWebmParserAvailable())
@@ -1412,6 +1440,9 @@ MediaPlayerEnums::SupportsType SourceBufferParserWebM::isContentTypeSupported(co
             continue;
         }
 #endif // ENABLE(OPUS)
+
+        if (supportsLimitedMatroska && (codec.startsWith("avc1."_s) || codec == "pcm"_s))
+            continue;
 
         return MediaPlayerEnums::SupportsType::IsNotSupported;
     }

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -114,6 +114,9 @@ String VideoTrackPrivateWebM::codec() const
     if (codecID == "V_VP8"_s)
         return "vp08"_s;
 
+    if (codecID == "V_MPEG4/ISO/AVC"_s)
+        return "h264"_s;
+
     return emptyString();
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -29,6 +29,7 @@
 #import "FormatDescriptionUtilities.h"
 #import "IOSurface.h"
 #import "Logging.h"
+#import "MediaSampleAVFObjC.h"
 #import "PixelBufferConformerCV.h"
 #import "VideoDecoder.h"
 #import "VideoFrame.h"

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -377,7 +377,7 @@ void MediaPlayerPrivateGStreamer::load(const String& urlString)
 }
 
 #if ENABLE(MEDIA_SOURCE)
-void MediaPlayerPrivateGStreamer::load(const URL&, const ContentType&, MediaSourcePrivateClient&)
+void MediaPlayerPrivateGStreamer::load(const URL&, const LoadOptions&, MediaSourcePrivateClient&)
 {
     // Properly fail so the global MediaPlayer tries to fallback to the next MediaPlayerPrivate.
     m_networkState = MediaPlayer::NetworkState::FormatError;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -121,7 +121,7 @@ public:
     bool hasAudio() const final { return m_hasAudio; }
     void load(const String &url) override;
 #if ENABLE(MEDIA_SOURCE)
-    void load(const URL&, const ContentType&, MediaSourcePrivateClient&) override;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 #endif
 #if ENABLE(MEDIA_STREAM)
     void load(MediaStreamPrivate&) override;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -144,7 +144,7 @@ void MediaPlayerPrivateGStreamerMSE::load(const String&)
         player->networkStateChanged();
 }
 
-void MediaPlayerPrivateGStreamerMSE::load(const URL& url, const ContentType&, MediaSourcePrivateClient& mediaSource)
+void MediaPlayerPrivateGStreamerMSE::load(const URL& url, const LoadOptions&, MediaSourcePrivateClient& mediaSource)
 {
     auto mseBlobURI = makeString("mediasource"_s, url.string().isEmpty() ? "blob://"_s : url.string());
     GST_DEBUG("Loading %s", mseBlobURI.ascii().data());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -50,7 +50,7 @@ public:
     constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::GStreamerMSE; }
 
     void load(const String&) override;
-    void load(const URL&, const ContentType&, MediaSourcePrivateClient&) override;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 
     void updateDownloadBufferingFlag() override { };
 

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -50,10 +50,10 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RecursiveLockAdapter.h>
 #import <wtf/RunLoop.h>
-#import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/ThreadSpecific.h>
 #import <wtf/Threading.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/spi/cf/CFRunLoopSPI.h>
 #import <wtf/spi/cocoa/objcSPI.h>
 #import <wtf/text/AtomString.h>

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -37,7 +37,7 @@
 
 IGNORE_WARNINGS_BEGIN("nullability-completeness")
 
-SOFT_LINK_FRAMEWORK(AVKit)
+SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebCore, AVKit)
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVTouchBarMediaSelectionOption)
 
 using WebCore::MediaSelectionOption;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -32,10 +32,11 @@
 #include "CAAudioStreamDescription.h"
 #include "CVUtilities.h"
 #include "ContentType.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "Logging.h"
 #include "MediaRecorderPrivateEncoder.h"
 #include "MediaStreamPrivate.h"
+#include "Quirks.h"
 #include "RealtimeIncomingVideoSourceCocoa.h"
 #include "SharedBuffer.h"
 #include "VideoFrameCV.h"
@@ -85,8 +86,10 @@ bool MediaRecorderPrivateAVFImpl::isTypeSupported(Document& document, ContentTyp
         bool isVP90 = (codec.startsWith("vp09"_s) || equal(codec, "vp9"_s) || equal(codec, "vp9.0"_s)) && !codec.startsWith("vp09.02"_s);
         bool isVP92 = codec.startsWith("vp09.02"_s);
         bool isVP8 = codec.startsWith("vp08"_s) || equal(codec, "vp8"_s) || equal(codec, "vp8.0"_s);
+        bool isH264 = codec.startsWith("avc1"_s);
         bool isOpus = codec == "opus"_s;
-        if (!(isVP90 && document.settings().webRTCVP9Profile0CodecEnabled()) && !(isVP92 && document.settings().webRTCVP9Profile2CodecEnabled()) && !isVP8 && !isOpus)
+        bool isPCM = codec == "pcm"_s;
+        if (!(isVP90 && document.settings().webRTCVP9Profile0CodecEnabled()) && !(isVP92 && document.settings().webRTCVP9Profile2CodecEnabled()) && !isVP8 && !isOpus && !((isH264 || isPCM) && (document.settings().limitedMatroskaSupportEnabled() || document.quirks().needsLimitedMatroskaSupport())))
             return false;
     }
     return true;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -163,11 +163,11 @@ bool MediaRecorderPrivateEncoder::initialize(const MediaRecorderPrivateOptions& 
             m_videoCodec = 'vp08';
         else if (codec == "opus"_s)
             m_audioCodec = kAudioFormatOpus;
-        else if (!isWebM && codec == "pcm"_s)
+        else if (codec == "pcm"_s)
             m_audioCodec = kAudioFormatLinearPCM;
         else if (!isWebM && codec == "alac"_s)
             m_audioCodec = kAudioFormatAppleLossless;
-        else if (!isWebM && startsWithLettersIgnoringASCIICase(codec, "avc1"_s))
+        else if (startsWithLettersIgnoringASCIICase(codec, "avc1"_s))
             m_videoCodec = kCMVideoCodecType_H264;
         else if (!isWebM && (codec.startsWith("hev1."_s) || codec.startsWith("hvc1."_s)))
             m_videoCodec = kCMVideoCodecType_HEVC;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -111,7 +111,7 @@ void MockMediaPlayerMediaSource::load(const String&)
     ASSERT_NOT_REACHED();
 }
 
-void MockMediaPlayerMediaSource::load(const URL&, const ContentType&, MediaSourcePrivateClient& source)
+void MockMediaPlayerMediaSource::load(const URL&, const LoadOptions&, MediaSourcePrivateClient& source)
 {
     if (RefPtr mediaSourcePrivate = downcast<MockMediaSourcePrivate>(source.mediaSourcePrivate())) {
         mediaSourcePrivate->setPlayer(this);

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -76,7 +76,7 @@ public:
 private:
     // MediaPlayerPrivate Overrides
     void load(const String& url) override;
-    void load(const URL&, const ContentType&, MediaSourcePrivateClient&) override;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
 #if ENABLE(MEDIA_STREAM)
     void load(MediaStreamPrivate&) override { }
 #endif

--- a/Source/WebCore/platform/video-codecs/BitReader.cpp
+++ b/Source/WebCore/platform/video-codecs/BitReader.cpp
@@ -53,11 +53,30 @@ std::optional<bool> BitReader::readBit()
         m_currentByte = m_data[m_index++];
         m_remainingBits = 8;
     }
-    
+
     bool value = m_currentByte & 0x80;
     --m_remainingBits;
     m_currentByte = m_currentByte << 1;
     return value;
 }
 
+bool BitReader::skipBytes(size_t bytes)
+{
+    m_index += bytes;
+    if (m_index >= m_data.size()) {
+        bool over = m_index > m_data.size() || m_remainingBits;
+        m_index = m_data.size();
+        m_remainingBits = 0;
+        return !over;
+    }
+    m_currentByte = m_data[m_index];
+    return true;
 }
+
+size_t BitReader::bitOffset() const
+{
+    ASSERT(m_index <= m_data.size());
+    return (m_remainingBits ? 8 - m_remainingBits : 0) + m_index * 8;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/video-codecs/BitReader.h
+++ b/Source/WebCore/platform/video-codecs/BitReader.h
@@ -37,11 +37,23 @@ public:
         : m_data(data)
     {
     }
-    
+
     std::optional<uint64_t> read(size_t);
     std::optional<bool> readBit();
-    
+    template <typename T> std::optional<T> read()
+    {
+        static_assert(std::is_unsigned<T>::value);
+        auto value = readBytes(sizeof(T));
+        if (!value)
+            return { };
+        return static_cast<T>(*value);
+    }
+    size_t bitOffset() const;
+    bool skipBytes(size_t);
+    size_t byteOffset() const { return m_index; }
+
 private:
+    std::optional<uint64_t> readBytes(size_t bytes) { return read(bytes * 8); }
     std::span<const uint8_t> m_data;
     size_t m_index { 0 };
     uint8_t m_currentByte { 0 };

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -163,7 +163,7 @@ void RemoteMediaPlayerProxy::getConfiguration(RemoteMediaPlayerConfiguration& co
     });
 }
 
-void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Handle>&& sandboxExtensionHandle, const ContentType& contentType, const String& keySystem, bool requiresRemotePlayback, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&& completionHandler)
+void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Handle>&& sandboxExtensionHandle, const MediaPlayer::LoadOptions& options, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&& completionHandler)
 {
     RemoteMediaPlayerConfiguration configuration;
     if (sandboxExtensionHandle) {
@@ -174,13 +174,13 @@ void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Han
             WTFLogAlways("Unable to create sandbox extension for media url.\n");
     }
 
-    protectedPlayer()->load(url, contentType, keySystem, requiresRemotePlayback);
+    protectedPlayer()->load(url, options);
     getConfiguration(configuration);
     completionHandler(WTFMove(configuration));
 }
 
 #if ENABLE(MEDIA_SOURCE)
-void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const WebCore::ContentType& contentType, RemoteMediaSourceIdentifier mediaSourceIdentifier, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&& completionHandler)
+void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const MediaPlayer::LoadOptions& options, RemoteMediaSourceIdentifier mediaSourceIdentifier, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&& completionHandler)
 {
     RefPtr manager = m_manager.get();
     ASSERT(manager && manager->gpuConnectionToWebProcess());
@@ -202,7 +202,7 @@ void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const WebCore::ContentTy
     if (auto preferences = sharedPreferencesForWebProcess())
         player->setDecompressionSessionPreferences(preferences->mediaSourcePrefersDecompressionSession, preferences->mediaSourceCanFallbackToDecompressionSession);
 #endif
-    player->load(url, contentType, *protectedMediaSourceProxy());
+    player->load(url, options, *protectedMediaSourceProxy());
 
     if (reattached)
         protectedMediaSourceProxy()->setMediaPlayers(*this, player->protectedPlayerPrivate().get());

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -76,6 +76,7 @@ class MachSendRight;
 
 namespace WebCore {
 class AudioTrackPrivate;
+struct MediaPlayerLoadOptions;
 class SecurityOriginData;
 class VideoTrackPrivate;
 
@@ -147,9 +148,9 @@ public:
     void prepareForPlayback(bool privateMode, WebCore::MediaPlayerEnums::Preload, bool preservesPitch, WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, WebCore::DynamicRangeMode);
     void prepareForRendering();
 
-    void load(URL&&, std::optional<SandboxExtension::Handle>&&, const WebCore::ContentType&, const String&, bool, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
+    void load(URL&&, std::optional<SandboxExtension::Handle>&&, const WebCore::MediaPlayerLoadOptions&, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
 #if ENABLE(MEDIA_SOURCE)
-    void loadMediaSource(URL&&, const WebCore::ContentType&, RemoteMediaSourceIdentifier, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
+    void loadMediaSource(URL&&, const WebCore::MediaPlayerLoadOptions&, RemoteMediaSourceIdentifier, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
 #endif
     void cancelLoad();
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -31,9 +31,9 @@
 messages -> RemoteMediaPlayerProxy {
     PrepareForPlayback(bool privateMode, enum:uint8_t WebCore::MediaPlayerPreload preload, bool preservesPitch, enum:uint8_t WebCore::MediaPlayerPitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, enum:uint8_t WebCore::DynamicRangeMode mode)
 
-    Load(URL url, std::optional<WebKit::SandboxExtensionHandle> sandboxExtension, WebCore::ContentType contentType, String keySystem, bool requiresRemotePlayback) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
+    Load(URL url, std::optional<WebKit::SandboxExtensionHandle> sandboxExtension, struct WebCore::MediaPlayerLoadOptions options) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
 #if ENABLE(MEDIA_SOURCE)
-    [EnabledBy=MediaSourceEnabled || ManagedMediaSourceEnabled] LoadMediaSource(URL url, WebCore::ContentType contentType, WebKit::RemoteMediaSourceIdentifier mediaSourceIdentifier) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
+    [EnabledBy=MediaSourceEnabled || ManagedMediaSourceEnabled] LoadMediaSource(URL url, struct WebCore::MediaPlayerLoadOptions options, WebKit::RemoteMediaSourceIdentifier mediaSourceIdentifier) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
 #endif
     CancelLoad()
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -988,6 +988,7 @@ def headers_for_type(type):
         'WebCore::MediaPlayerSupportsType': ['<WebCore/MediaPlayerEnums.h>'],
         'WebCore::MediaPlayerVideoGravity': ['<WebCore/MediaPlayerEnums.h>'],
         'WebCore::MediaEngineSupportParameters': ['<WebCore/MediaPlayer.h>'],
+        'WebCore::MediaPlayerLoadOptions': ['<WebCore/MediaPlayer.h>'],
         'WebCore::MediaPlayerReadyState': ['<WebCore/MediaPlayerEnums.h>'],
         'WebCore::MediaProducerMediaCaptureKind': ['<WebCore/MediaProducer.h>'],
         'WebCore::MediaProducerMediaState': ['<WebCore/MediaProducer.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4651,6 +4651,7 @@ header: <WebCore/MediaPlayer.h>
     bool isMediaSource;
     bool isMediaStream;
     bool requiresRemotePlayback;
+    bool supportsLimitedMatroska;
     Vector<WebCore::ContentType> contentTypesRequiringHardwareSupport;
     std::optional<Vector<String>> allowedMediaContainerTypes;
     std::optional<Vector<String>> allowedMediaCodecTypes;
@@ -4664,6 +4665,13 @@ header: <WebCore/MediaPlayer.h>
     MediaTime time;
     MediaTime negativeThreshold;
     MediaTime positiveThreshold;
+};
+
+header: <WebCore/MediaPlayer.h>
+[CustomHeader] struct WebCore::MediaPlayerLoadOptions {
+    WebCore::ContentType contentType;
+    bool requiresRemotePlayback;
+    bool supportsLimitedMatroska;
 };
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -238,7 +238,7 @@ void MediaPlayerPrivateRemote::prepareForPlayback(bool privateMode, MediaPlayer:
     connection().send(Messages::RemoteMediaPlayerProxy::PrepareForPlayback(privateMode, preload, preservesPitch, pitchCorrectionAlgorithm, prepareToPlay, prepareToRender, presentationSize, scale, preferredDynamicRangeMode), m_id);
 }
 
-void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentType, const String& keySystem)
+void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
 {
     std::optional<SandboxExtension::Handle> sandboxExtensionHandle;
     if (url.protocolIsFile()) {
@@ -273,7 +273,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
         sandboxExtensionHandle = WTFMove(handle);
     }
 
-    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, WTFMove(sandboxExtensionHandle), contentType, keySystem, m_player.get()->requiresRemotePlayback()), [weakThis = ThreadSafeWeakPtr { *this }, this](auto&& configuration) {
+    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, WTFMove(sandboxExtensionHandle), options), [weakThis = ThreadSafeWeakPtr { *this }, this](auto&& configuration) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -1014,7 +1014,7 @@ void MediaPlayerPrivateRemote::remoteVideoTrackConfigurationChanged(TrackID trac
 }
 
 #if ENABLE(MEDIA_SOURCE)
-void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentType, MediaSourcePrivateClient& client)
+void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options, MediaSourcePrivateClient& client)
 {
     if (m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE
         || (platformStrategies()->mediaStrategy().mockMediaSourceEnabled() && m_remoteEngineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::MockMSE)) {
@@ -1027,7 +1027,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
             }
             return RemoteMediaSourceIdentifier::generate();
         }();
-        connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::LoadMediaSource(url, contentType, identifier), [weakThis = ThreadSafeWeakPtr { *this }, this](RemoteMediaPlayerConfiguration&& configuration) {
+        connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::LoadMediaSource(url, options, identifier), [weakThis = ThreadSafeWeakPtr { *this }, this](RemoteMediaPlayerConfiguration&& configuration) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -251,11 +251,11 @@ private:
     const uint64_t m_logIdentifier;
 #endif
 
-    void load(const URL&, const WebCore::ContentType&, const String&) final;
+    void load(const URL&, const LoadOptions&) final;
     void prepareForPlayback(bool privateMode, WebCore::MediaPlayer::Preload, bool preservesPitch, bool prepareToPlay, bool prepareToRender) final;
 
 #if ENABLE(MEDIA_SOURCE)
-    void load(const URL&, const WebCore::ContentType&, WebCore::MediaSourcePrivateClient&) final;
+    void load(const URL&, const LoadOptions&, WebCore::MediaSourcePrivateClient&) final;
 #endif
 #if ENABLE(MEDIA_STREAM)
     void load(WebCore::MediaStreamPrivate&) final;


### PR DESCRIPTION
#### c4679bce9e547c744741633a116a98e8a01464ed
<pre>
Support video/webm;codecs=h264,pcm in MediaRecorder
<a href="https://bugs.webkit.org/show_bug.cgi?id=286409">https://bugs.webkit.org/show_bug.cgi?id=286409</a>
<a href="https://rdar.apple.com/143087016">rdar://143087016</a>

Reviewed by Youenn Fablet.

For web compatibility purposes, we add partial matroska support by allowing h264 and pcm codec in a webm.
This feature is placed behind a pref or if a site has a quirk to require it.

To achieve it we needed the following stages:
- Allow MediaRecorderPrivateWriterWebM accept a H264 and PCM track.
- Allow the SourceBufferParserWebM parse a H264 and PCM track.
  - We add a H264UtilitiesCocoa containing a method to parse the AVCC blob and
    and extract the SPS and PPS NALs to determine the characteristics of the video
    (we ignore the webm&apos;s container information in line with how we handle VP8 or VP9.
- Add playback support to the MediaPlayerPrivateWebM to be able to play the videos the MediaRecorder created.
- Add a MediaPlayer::LoadingOptions object to the MediaPlayer and MediaPlayerPrivate so that
  we can activate limited matroska support on a per site/video basis.
  LoadingOptions will also allow easier flexibility to serialise over IPC between the content and GPU process.
- Place the entire feature behind a developer pref (off by default) which can be overridden by a quirk.

* LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp:
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::canPlayType const):
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::setNetworkState):
(WebCore::HTMLMediaElement::selectNextSourceChild):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsLimitedMatroskaSupport const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/graphics/MIMESniffer.cpp:
(WebCore::MIMESniffer::hasSignatureForWebM):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::load):
(WebCore::MediaPlayer::nextBestMediaEngine):
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::contentMIMEType const):
(WebCore::MediaPlayer::contentTypeCodecs const):
(WebCore::MediaPlayer::contentMIMETypeWasInferredFromExtension const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::load):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::load):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::supportsLimitedMatroska const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::load):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::m_logIdentifier):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::codec const):
* Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.mm: Added.
(WebCore::createVideoInfoFromAVCC):
* Source/WebCore/platform/graphics/cocoa/H264UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::supportsType):
(WebCore::MediaPlayerPrivateWebM::load):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::OnEbml):
(WebCore::WebMParser::OnTrackEntry):
(WebCore::WebMParser::OnFrame):
(WebCore::WebMParser::VideoTrackData::consumeFrameData):
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
(WebCore::WebMParser::isSupportedVideoCodec):
(WebCore::WebMParser::isSupportedAudioCodec):
(WebCore::SourceBufferParserWebM::isContentTypeSupported):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:
(WebCore::WebMParser::TrackData::consumeFrameData):
(WebCore::WebMParser::allowLimitedMatroska):
(WebCore::SourceBufferParserWebM::allowLimitedMatroska):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::codec const):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm: Fixing unified build due to missing header.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::load):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::load):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/ios/wak/WebCoreThread.mm:
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm: Fix unified build.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::isTypeSupported):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::codecStringForMediaVideoCodecId):
(WebCore::MediaRecorderPrivateEncoder::initialize):
(WebCore::MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::mkvCodeIcForMediaVideoCodecId):
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addVideoTrack):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::load):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/video-codecs/BitReader.cpp:
(WebCore::BitReader::readBit):
(WebCore::BitReader::skipBytes):
(WebCore::BitReader::bitOffset const):
* Source/WebCore/platform/video-codecs/BitReader.h:
(WebCore::BitReader::read):
(WebCore::BitReader::byteOffset const):
(WebCore::BitReader::readBytes):
(WebKit::RemoteMediaPlayerProxy::load):
(WebKit::RemoteMediaPlayerProxy::loadMediaSource):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteTrackInfo.h:
(WebKit::RemoteAudioInfo::toAudioInfo const):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/289843@main">https://commits.webkit.org/289843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8855c80ba5e8c5e1e3799f1f1d34da4a6780d16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88148 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38898 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79736 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48394 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/87645 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34151 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38006 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80946 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94945 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86924 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15316 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76880 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75592 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76124 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18728 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/20520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8345 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15334 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109417 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26309 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18522 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->