### PR TITLE
ShareableBitmap create methods are unconventional

### DIFF
--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -112,14 +112,11 @@ RefPtr<Image> Image::create(ImageObserver& observer)
     return BitmapImage::create(&observer);
 }
 
-std::optional<Ref<Image>> Image::create(RefPtr<ShareableBitmap>&& bitmap)
+RefPtr<Image> Image::create(RefPtr<ShareableBitmap>&& bitmap)
 {
     if (!bitmap)
-        return std::nullopt;
-    RefPtr image = bitmap->createImage();
-    if (!image)
-        return std::nullopt;
-    return image.releaseNonNull();
+        return nullptr;
+    return bitmap->createImage();
 }
 
 bool Image::supportsType(const String& type)

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -63,7 +63,7 @@ public:
     virtual ~Image();
     
     WEBCORE_EXPORT static RefPtr<Image> create(ImageObserver&);
-    WEBCORE_EXPORT static std::optional<Ref<Image>> create(RefPtr<ShareableBitmap>&&);
+    WEBCORE_EXPORT static RefPtr<Image> create(RefPtr<ShareableBitmap>&&);
     WEBCORE_EXPORT static bool supportsType(const String&);
     static bool isPDFResource(const String& mimeType, const URL&);
 

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -137,16 +137,16 @@ RefPtr<ShareableBitmap> ShareableBitmap::create(Handle&& handle, SharedMemory::P
     return create(handle.m_configuration, sharedMemory.releaseNonNull());
 }
 
-std::optional<Ref<ShareableBitmap>> ShareableBitmap::createReadOnly(std::optional<Handle>&& handle)
+RefPtr<ShareableBitmap> ShareableBitmap::createReadOnly(std::optional<Handle>&& handle)
 {
     if (!handle)
-        return std::nullopt;
+        return nullptr;
 
-    auto sharedMemory = SharedMemory::map(WTFMove(handle->m_handle), SharedMemory::Protection::ReadOnly);
+    RefPtr sharedMemory = SharedMemory::map(WTFMove(handle->m_handle), SharedMemory::Protection::ReadOnly);
     if (!sharedMemory)
-        return std::nullopt;
+        return nullptr;
 
-    return adoptRef(*new ShareableBitmap(handle->m_configuration, sharedMemory.releaseNonNull()));
+    return adoptRef(new ShareableBitmap(handle->m_configuration, sharedMemory.releaseNonNull()));
 }
 
 auto ShareableBitmap::createHandle(SharedMemory::Protection protection) const -> std::optional<Handle>

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -147,7 +147,7 @@ public:
     WEBCORE_EXPORT static RefPtr<ShareableBitmap> create(Handle&&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite);
 
     // Create a shareable bitmap from a ReadOnly handle.
-    WEBCORE_EXPORT static std::optional<Ref<ShareableBitmap>> createReadOnly(std::optional<Handle>&&);
+    WEBCORE_EXPORT static RefPtr<ShareableBitmap> createReadOnly(std::optional<Handle>&&);
 
     WEBCORE_EXPORT std::optional<Handle> createHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const;
 


### PR DESCRIPTION
#### b04f2ee635ea4a777d9540fafaecd70944d95cbe
<pre>
ShareableBitmap create methods are unconventional
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Typically nullable constructors are of form:
 RefPtr&lt;T&gt; T::create(...)

Most of Image and ShareableBitmap create functions are like this.
The ones that are called by the IPC deserialization are not. This is
a bit confusing.

TODO: Fix the IPC generator to accept RefPtr for such constructors.

* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::create):
* Source/WebCore/platform/graphics/Image.h:
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmap::createReadOnly):
* Source/WebCore/platform/graphics/ShareableBitmap.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b04f2ee635ea4a777d9540fafaecd70944d95cbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86351 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5903 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40688 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91264 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37154 "Hash b04f2ee6 for PR 39447 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88406 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6157 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13940 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/91264 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/37154 "Hash b04f2ee6 for PR 39447 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89358 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/6157 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/40688 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/91264 "Hash b04f2ee6 for PR 39447 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/6157 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/40688 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36260 "Hash b04f2ee6 for PR 39447 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/6157 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/40688 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93096 "Hash b04f2ee6 for PR 39447 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13555 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/13940 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/93096 "Hash b04f2ee6 for PR 39447 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13763 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/40688 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/93096 "Hash b04f2ee6 for PR 39447 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/40688 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6380 "Hash b04f2ee6 for PR 39447 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13579 "Hash b04f2ee6 for PR 39447 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18868 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13332 "Hash b04f2ee6 for PR 39447 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16775 "Hash b04f2ee6 for PR 39447 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15116 "Hash b04f2ee6 for PR 39447 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->