### PR TITLE
REGRESSION(285726@main?): [macOS wk2]: http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html is a flaky failure (flaky in EWS)

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html
@@ -32,7 +32,7 @@
         if (context) {
             context.fillStyle = "#ff0000";
             context.fillRect(0, 0, 200, 200);
-            if (Date.now() - drawStartTime < 500) {
+            if (Date.now() - drawStartTime < 1000) {
                 window.requestAnimationFrame(doRedImageDraw);
             } else {
                 drawStartTime = Date.now();
@@ -51,7 +51,15 @@
         }
     }
 
-    async_test(t => {
+    function waitForEvent(object, eventName, testName)
+    {
+        return new Promise((resolve, reject) => {
+            object.addEventListener(eventName, (e) => resolve(e), { once: true });
+            setTimeout(() => reject("waitForEvent " + (testName ? (testName + " ") : "") + "timed out for " + eventName), 2500);
+        });
+    }
+
+    promise_test(async (test) => {
         const ac = new AudioContext();
         const osc = ac.createOscillator();
         const dest = ac.createMediaStreamDestination();
@@ -64,48 +72,47 @@
         video.addTrack(audio.getAudioTracks()[0]);
         assert_equals(video.getAudioTracks().length, 1, "video mediastream starts with one audio track");
         const recorder = new MediaRecorder(video);
-        let mode = 0;
-
-        recorder.ondataavailable = t.step_func(blobEvent => {
-            assert_true(blobEvent instanceof BlobEvent, 'the type of event should be BlobEvent');
-            assert_equals(blobEvent.type, 'dataavailable', 'the event type should be dataavailable');
-            assert_true(blobEvent.isTrusted, 'isTrusted should be true when the event is created by C++');
-            assert_true(blobEvent.data instanceof Blob, 'the type of data should be Blob');
-            assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
-            player.src = window.URL.createObjectURL(blobEvent.data);
-            const resFrame = document.getElementById("frame");
-            const resContext = resFrame.getContext('2d');
-
-            player.oncanplay = t.step_func(() => {
-                assert_greater_than(player.duration, 0.1, 'the duration should be greater than 100ms');
-                player.play();
-            });
-            player.onplay = () => {
-                player.pause();
-                player.currentTime = 0.05;
-            };
-            player.onseeked = t.step_func(() => {
-                resContext.drawImage(player, 0, 0);
-                if (!mode) {
-                    _assertPixelApprox(resFrame, 25, 25, 255, 0, 0, 255, "25, 25", "255, 0, 0, 255", 50);
-                    _assertPixelApprox(resFrame, 50, 50, 255, 0, 0, 255, "50, 50", "255, 0, 0, 255", 50);
-                    mode = 1;
-                    player.currentTime = Math.min(1.5, player.duration - 0.05);
-                } else {
-                    _assertPixelApprox(resFrame, 20, 20, 0, 255, 0, 255, "20, 20", "0, 255, 0, 255", 50);
-                    _assertPixelApprox(resFrame, 199, 199, 0, 255, 0, 255, "199, 199", "0, 255, 0, 255", 50);
-                    t.done();
-                }
-            });
-            player.load();
-        });
         drawStartTime = Date.now();
         doRedImageDraw();
         recorder.start();
         assert_equals(recorder.state, 'recording', 'MediaRecorder has been started successfully');
-        setTimeout(() => {
-            recorder.stop();
-        }, 2000);
+        setTimeout(() => { recorder.stop(); }, 2000);
+
+        const blobEvent = await waitForEvent(recorder, 'dataavailable');
+        assert_true(blobEvent instanceof BlobEvent, 'the type of event should be BlobEvent');
+        assert_equals(blobEvent.type, 'dataavailable', 'the event type should be dataavailable');
+        assert_true(blobEvent.isTrusted, 'isTrusted should be true when the event is created by C++');
+        assert_true(blobEvent.data instanceof Blob, 'the type of data should be Blob');
+        assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
+
+        const MediaSource = self.ManagedMediaSource || self.MediaSource;
+        player.disableRemotePlayback = true;
+        const source = new MediaSource();
+        player.src = URL.createObjectURL(source);
+        await waitForEvent(source, 'sourceopen');
+        const sourceBuffer = source.addSourceBuffer("video/mp4");
+        sourceBuffer.appendBuffer(await blobEvent.data.arrayBuffer());
+        await waitForEvent(sourceBuffer, 'updateend');
+        source.endOfStream();
+
+        const resFrame = document.getElementById("frame");
+        const resContext = resFrame.getContext('2d');
+
+        assert_greater_than(player.duration, 1, 'the duration should be greater than 1s');
+        await player.play();
+
+        player.pause();
+        player.currentTime = Math.min(1.5, player.duration - 0.05);
+        await waitForEvent(player, 'seeked');
+        resContext.drawImage(player, 0, 0);
+        _assertPixelApprox(resFrame, 20, 20, 0, 255, 0, 255, "20, 20", "0, 255, 0, 255", 50);
+        _assertPixelApprox(resFrame, 199, 199, 0, 255, 0, 255, "199, 199", "0, 255, 0, 255", 50);
+
+        player.currentTime = 0;
+        await waitForEvent(player, 'seeked');
+        resContext.drawImage(player, 0, 0);
+        _assertPixelApprox(resFrame, 25, 25, 255, 0, 0, 255, "25, 25", "255, 0, 0, 255", 50);
+        _assertPixelApprox(resFrame, 50, 50, 255, 0, 0, 255, "50, 50", "255, 0, 0, 255", 50);
     }, 'MediaRecorder can successfully record the video for a audio-video stream');
 
 </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1915,7 +1915,8 @@ webkit.org/b/283144 [ Sequoia ] http/tests/storageAccess/grant-storage-access-un
 webkit.org/b/283144 [ Sequoia ] http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html [ Failure ]
 webkit.org/b/283144 [ Sequoia ] http/tests/storageAccess/request-and-grant-access-then-navigate-same-site-should-have-access.https.html [ Failure ]
 
-webkit.org/b/283210 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Pass Failure ]
+# On x86_64 Ventura bots, stream recording doesnt always complete within the 2s.
+[ Ventura x86_64 ] http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Pass Failure ]
 
 webkit.org/b/283596 [ Sequoia+ Debug ] ipc/cfnetwork-crashes-with-string-to-string-http-headers.html [ Skip ]
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -742,7 +742,7 @@ auto VideoMediaSampleRenderer::copyDisplayedPixelBuffer() -> DisplayedPixelBuffe
         CMTime currentTime = PAL::CMTimebaseGetTime(timebase.get());
         CMTime presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(nextSample.get());
 
-        if (PAL::CMTimeCompare(presentationTime, currentTime) > 0)
+        if (PAL::CMTimeCompare(presentationTime, currentTime) > 0 && (!m_lastDisplayedSample || PAL::CMTimeCompare(presentationTime, *m_lastDisplayedSample) > 0))
             return;
 
         imageBuffer = (CVPixelBufferRef)PAL::CMSampleBufferGetImageBuffer(nextSample.get());


### PR DESCRIPTION
#### 8dd1134bc4ffb7a0b21e37f4bddfb8d27af14b13
<pre>
REGRESSION(285726@main?): [macOS wk2]: http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html is a flaky failure (flaky in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283210">https://bugs.webkit.org/show_bug.cgi?id=283210</a>
<a href="https://rdar.apple.com/140007072">rdar://140007072</a>

Reviewed by Youenn Fablet.

The test was painting red in a canvas for 0.5s following by green for 1.5.
However, due the the MediaRecorder potentially taking times to actually start recording
it was possible that we only got a single red frame at the start of the video.
The test seeked to 0.05 check the colours and then at the duration-0.05.
Due to the delay described above, at 0.05 the frame could actually be green.
Instead we should be seeking to 0; however as the video may not have starting
playing then, we wouldn&apos;t have got the seekend event.
So instead we first seek to the end, check that it&apos;s green and then seek
to the start and check that it&apos;s red.
We also paint red for 1s instead of 0.5s to give more time for the recording
to start on slow machines.

Manually testing however still indicated an issue, with the MP4 player
(specifically MediaPlayerPrivateAVFObjC) there&apos;s no guarantee that when
the seeked even is fired, the right frame is actually already displayed
(webkit.org/b/236755), and so checking the frame could fail as the old
frame is still being displayed.

To get around this we now use a MediaSource insted as the MSE player (and WebM player)
do guarantee that the right frame is being displayed once the seeked event is fired.

Fly-By: VideoMediaSampleRenderer::copyDisplayedPixelBuffer may have returned
nullptr when seeking to 0 and the first video frame had a time in the future
(such video file can be currently incorrectly generated by the MediaRecorder).

* LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer): Return the
last video frame, even if in the future if it is currently visible.

Canonical link: <a href="https://commits.webkit.org/289400@main">https://commits.webkit.org/289400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a02be156218143b2cca91f0d05fdabd0e81857f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91675 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67117 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24888 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47436 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4811 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor-iframe.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32945 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36677 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75918 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75114 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19433 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6788 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19263 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->