### PR TITLE
WebCodecs VideoFrame visibleWidth and visibleHeight should check for rotation

### DIFF
--- a/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-rotation-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-rotation-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Check visible rect for rotated frames
+

--- a/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-rotation.html
+++ b/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-rotation.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Transfer MediaStreamTrack to dedicated worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<video id=video autplay playsinline></video>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+async function videoFrameFromMediaStreamTrackProcessor(track)
+{
+    const worker = await createWorker(`
+        self.onmessage = async (event) => {
+            const generator = new VideoTrackGenerator();
+            const processor = new MediaStreamTrackProcessor({ track: event.data });
+            const data = await processor.readable.getReader().read();
+            self.postMessage(data.value, [data.value]);
+            event.track.stop();
+        }
+    `);
+    worker.postMessage(track, [track]);
+    return new Promise(resolve => worker.onmessage = e => resolve(e.data));
+}
+
+async function waitForVideoSize(video, width, height, testName, count)
+{
+    if (video.videoWidth === width && video.videoHeight === height)
+        return Promise.resolve("video has expected size");
+
+    if (count === undefined)
+        count = 0;
+    if (++count > 20) {
+        if (!testName)
+            testName = "waitForVideoSize";
+        return Promise.reject(testName + " timed out, expected " + width + "x"+ height + " but got " + video.videoWidth + "x" + video.videoHeight);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return waitForVideoSize(video, width, height, testName, count);
+}
+
+
+promise_test(async test => {
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    await video.play();
+
+    const track = video.srcObject.getVideoTracks()[0];
+    const frame1 = await videoFrameFromMediaStreamTrackProcessor(track.clone());
+    test.add_cleanup(() => frame1.close());
+
+    assert_equals(frame1.visibleRect.width, track.getSettings().width, "frame1 visible width");
+    assert_equals(frame1.visibleRect.height, track.getSettings().height, "frame1 visible height");
+    assert_equals(frame1.displayWidth, track.getSettings().width, "frame1 display width");
+    assert_equals(frame1.displayHeight, track.getSettings().height, "frame1 display height");
+
+    if (window.internals)
+        window.internals.setCameraMediaStreamTrackOrientation(track, 90);
+    if (window.testRunner)
+        testRunner.setMockCameraOrientation(90);
+
+    await waitForVideoSize(video, 480, 640);
+
+    const frame2 = await videoFrameFromMediaStreamTrackProcessor(track.clone());
+    assert_equals(frame2.visibleRect.width, frame1.visibleRect.height, "visibleRect2.width");
+    assert_equals(frame2.visibleRect.height, frame1.visibleRect.width, "visibleRect2.height");
+    assert_equals(frame2.displayWidth, frame1.displayHeight, "display width 2");
+    assert_equals(frame2.displayHeight, frame1.displayWidth, "display height 2");
+}, "Check visible rect for rotated frames");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2240,6 +2240,8 @@ webrtc/video-rotation-black.html [ Crash Failure Pass Timeout ]
 
 fast/mediastream/video-rotation-clone.html [ Skip ]
 
+http/wpt/mediastream/mediastreamtrackprocessor-videoframe-rotation.html [ Failure ]
+
 # No AudioSession category handling in WPE/GTK ports.
 fast/mediastream/microphone-interruption-and-audio-session.html [ Skip ]
 

--- a/LayoutTests/webrtc/video-rotation-expected.txt
+++ b/LayoutTests/webrtc/video-rotation-expected.txt
@@ -5,4 +5,7 @@ PASS Track is enabled, video should not be black
 PASS Track is enabled and rotated, local video should not be black and should change size
 PASS Track is enabled and rotated, remote video should not be black and should change size
 PASS Track is enabled and rotated again, video should not be black and should change size
+PASS Validate visible rect information for 0 rotated frames
+PASS Validate visible rect information for 90 rotated frames
+PASS Validate visible rect information for 180 rotated frames
 

--- a/LayoutTests/webrtc/video-rotation.html
+++ b/LayoutTests/webrtc/video-rotation.html
@@ -96,9 +96,21 @@ promise_test((test) => {
     });
 }, "Setting video exchange");
 
-promise_test(async (test) => {
+promise_test(async t => {
    await checkVideoBlack(false, remoteVideo, "canvas0");
    await waitForVideoSize(remoteVideo, 320, 240);
+
+    test(t => {
+        const localFrame = new VideoFrame(localVideo);
+        t.add_cleanup(() => localFrame.close());
+        const remoteFrame = new VideoFrame(remoteVideo);
+        t.add_cleanup(() => remoteFrame.close());
+
+        assert_equals(localFrame.visibleRect.width, localFrame.codedWidth, "local frame width");
+        assert_equals(localFrame.visibleRect.height, localFrame.codedHeight, "local frame height");
+        assert_equals(remoteFrame.visibleRect.width, remoteFrame.codedWidth, "remote frame width");
+        assert_equals(remoteFrame.visibleRect.height, remoteFrame.codedHeight, "remote frame height");
+    }, "Validate visible rect information for 0 rotated frames");
 }, "Track is enabled, video should not be black");
 
 promise_test(async (test) => {
@@ -114,7 +126,7 @@ promise_test(async (test) => {
     await waitForVideoSize(localVideo, 240, 320);
 }, "Track is enabled and rotated, local video should not be black and should change size");
 
-promise_test(async (test) => {
+promise_test(async t => {
     if (window.internals)
         window.internals.setCameraMediaStreamTrackOrientation(track, 90);
     if (window.testRunner)
@@ -125,9 +137,21 @@ promise_test(async (test) => {
     });
 
     await waitForTrackRotation(remoteVideo.srcObject.getVideoTracks()[0], 90);
+
+    test(t => {
+        const localFrame = new VideoFrame(localVideo);
+        t.add_cleanup(() => localFrame.close());
+        const remoteFrame = new VideoFrame(remoteVideo);
+        t.add_cleanup(() => remoteFrame.close());
+
+        assert_equals(localFrame.visibleRect.width, localFrame.codedHeight, "local frame width");
+        assert_equals(localFrame.visibleRect.height, localFrame.codedWidth, "local frame height");
+        assert_equals(remoteFrame.visibleRect.width, remoteFrame.codedHeight, "remote frame width");
+        assert_equals(remoteFrame.visibleRect.height, remoteFrame.codedWidth, "remote frame height");
+    }, "Validate visible rect information for 90 rotated frames");
 }, "Track is enabled and rotated, remote video should not be black and should change size");
 
-promise_test(async (test) => {
+promise_test(async t => {
     if (window.internals)
         window.internals.setCameraMediaStreamTrackOrientation(track, 180);
     if (window.testRunner)
@@ -138,6 +162,18 @@ promise_test(async (test) => {
     });
 
     await waitForTrackRotation(remoteVideo.srcObject.getVideoTracks()[0], 180);
+
+    test(t => {
+        const localFrame = new VideoFrame(localVideo);
+        t.add_cleanup(() => localFrame.close());
+        const remoteFrame = new VideoFrame(remoteVideo);
+        t.add_cleanup(() => remoteFrame.close());
+
+        assert_equals(localFrame.visibleRect.width, localFrame.codedWidth, "local frame width");
+        assert_equals(localFrame.visibleRect.height, localFrame.codedHeight, "local frame height");
+        assert_equals(remoteFrame.visibleRect.width, remoteFrame.codedWidth, "remote frame width");
+        assert_equals(remoteFrame.visibleRect.height, remoteFrame.codedHeight, "remote frame height");
+    }, "Validate visible rect information for 180 rotated frames");
 }, "Track is enabled and rotated again, video should not be black and should change size");
         </script>
     </body>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -353,6 +353,8 @@ Ref<WebCodecsVideoFrame> WebCodecsVideoFrame::create(ScriptExecutionContext& con
     } else {
         result->m_data.visibleWidth = result->m_data.codedWidth;
         result->m_data.visibleHeight = result->m_data.codedHeight;
+        if (result->m_data.internalFrame->rotation() == VideoFrame::Rotation::Left || result->m_data.internalFrame->rotation() == VideoFrame::Rotation::Right)
+            std::swap(result->m_data.visibleWidth, result->m_data.visibleHeight);
     }
 
     result->m_data.displayWidth = init.displayWidth.value_or(result->m_data.visibleWidth);
@@ -428,7 +430,11 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
     result->m_data.codedWidth = codedWidth;
     result->m_data.codedHeight = codedHeight;
 
-    initializeVisibleRectAndDisplaySize(result.get(), init, DOMRectInit { 0, 0 , static_cast<double>(result->m_data.codedWidth), static_cast<double>(result->m_data.codedHeight) }, result->m_data.codedWidth, result->m_data.codedHeight);
+    DOMRectInit visibleRect { 0, 0 , static_cast<double>(result->m_data.codedWidth), static_cast<double>(result->m_data.codedHeight) };
+    if (result->m_data.internalFrame->rotation() == VideoFrame::Rotation::Left || result->m_data.internalFrame->rotation() == VideoFrame::Rotation::Right)
+        std::swap(visibleRect.width, visibleRect.height);
+
+    initializeVisibleRectAndDisplaySize(result.get(), init, visibleRect, result->m_data.codedWidth, result->m_data.codedHeight);
 
     result->m_data.duration = init.duration;
     if (init.timestamp)


### PR DESCRIPTION
#### 2a672d8539750ad53e3add163b47d29fb3e9e23f
<pre>
WebCodecs VideoFrame visibleWidth and visibleHeight should check for rotation
<a href="https://rdar.apple.com/143480580">rdar://143480580</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286421">https://bugs.webkit.org/show_bug.cgi?id=286421</a>

Reviewed by NOBODY (OOPS!).

As shown in <a href="https://w3c.github.io/webcodecs/#dom-videoframe-videoframe-data-init">https://w3c.github.io/webcodecs/#dom-videoframe-videoframe-data-init</a>, visibleWidth and visibleHeight are post frame rotation.
We thus swap visibleWidth and visibleHeight in case of 90 and 270 rotation.

This is important as rendering of video frames or texture generation in canvas will do the rotation.

* LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-rotation-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-rotation.html: Added.
* LayoutTests/webrtc/video-rotation-expected.txt:
* LayoutTests/webrtc/video-rotation.html:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::initializeFrameFromOtherFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1f9f8c53904c5ba064d1ed713fe99c2f47ca8dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73330 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30557 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53668 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4651 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82366 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81742 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16622 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28372 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->