### PR TITLE
[libpas][PGM] Fix PGM allocation failure fallback path

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -189,25 +189,6 @@ pas_large_heap_try_allocate(pas_large_heap* heap,
     return result;
 }
 
-pas_allocation_result
-pas_large_heap_try_allocate_pgm(pas_large_heap* heap,
-                            size_t size,
-                            size_t alignment,
-                            pas_allocation_mode allocation_mode,
-                            const pas_heap_config* heap_config,
-                            pas_physical_memory_transaction* transaction)
-{
-    pas_allocation_result result;
-    result = pas_probabilistic_guard_malloc_allocate(heap, size, allocation_mode, heap_config, transaction);
-
-    /* PGM may not succeed for a variety of reasons. We will give it a last ditch effort to try to do a
-       regular allocation instead. */
-    if (!result.did_succeed)
-        result = pas_large_heap_try_allocate(heap, size, alignment, allocation_mode, heap_config, transaction);
-
-    return result;
-}
-
 bool pas_large_heap_try_deallocate(uintptr_t begin,
                                    const pas_heap_config* heap_config)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.h
@@ -66,13 +66,6 @@ pas_large_heap_try_allocate(pas_large_heap* heap,
                             const pas_heap_config* config,
                             pas_physical_memory_transaction* transaction);
 
-PAS_API pas_allocation_result
-pas_large_heap_try_allocate_pgm(pas_large_heap* heap,
-                            size_t size, size_t alignment,
-                            pas_allocation_mode allocation_mode,
-                            const pas_heap_config* config,
-                            pas_physical_memory_transaction* transaction);
-
 /* Returns true if an object was found and deallocated. */
 PAS_API bool pas_large_heap_try_deallocate(uintptr_t base,
                                            const pas_heap_config* config);

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -99,6 +99,44 @@ pas_try_allocate_common_impl_fast(
 }
 
 static PAS_ALWAYS_INLINE pas_allocation_result
+pas_try_allocate_pgm(
+    bool verbose,
+    pas_heap* heap,
+    size_t size,
+    pas_allocation_mode allocation_mode,
+    pas_heap_config config)
+{
+    pas_allocation_result result;
+
+    result = pas_allocation_result_create_failure();
+
+    if (PAS_LIKELY(!pas_probabilistic_guard_malloc_can_use || !config.pgm_enabled))
+        return result;
+    if (PAS_LIKELY(!pas_probabilistic_guard_malloc_should_call_pgm()))
+        return result;
+
+    if (verbose)
+        pas_log("Attempting PGM allocation.\n");
+
+    pas_physical_memory_transaction transaction;
+    pas_physical_memory_transaction_construct(&transaction);
+
+    do {
+        PAS_ASSERT(!result.did_succeed);
+        pas_physical_memory_transaction_begin(&transaction);
+        pas_heap_lock_lock();
+
+        result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, size, allocation_mode, config.config_ptr, &transaction);
+
+        pas_heap_lock_unlock();
+    } while (!pas_physical_memory_transaction_end(&transaction));
+
+    if (result.did_succeed)
+        pas_scavenger_notify_eligibility_if_needed();
+    return result;
+}
+
+static PAS_ALWAYS_INLINE pas_allocation_result
 pas_try_allocate_common_impl_slow(
     pas_heap_ref* heap_ref,
     pas_heap_ref_kind heap_ref_kind,
@@ -151,31 +189,9 @@ pas_try_allocate_common_impl_slow(
         break;
     }
 
-
-    // Checking PGM allocation is requested for asked size. Consider it as a large heap allocation due to guard pages.
-    if (PAS_UNLIKELY(pas_probabilistic_guard_malloc_can_use && config.pgm_enabled && pas_probabilistic_guard_malloc_should_call_pgm())) {
-
-        if (verbose)
-            pas_log("PGM allocation is requested for asked size.\n");
-
-        pas_physical_memory_transaction transaction;
-        pas_physical_memory_transaction_construct(&transaction);
-
-        do {
-            PAS_ASSERT(!result.did_succeed);
-
-            pas_physical_memory_transaction_begin(&transaction);
-            pas_heap_lock_lock();
-
-            // Call PGM allocation for asked size
-            result = pas_large_heap_try_allocate_pgm(&heap->large_heap, size, alignment, allocation_mode, config.config_ptr, &transaction);
-            pas_heap_lock_unlock();
-        } while (!pas_physical_memory_transaction_end(&transaction));
-
-        pas_scavenger_notify_eligibility_if_needed();
-
+    result = pas_try_allocate_pgm(verbose, heap, size, allocation_mode, config);
+    if (PAS_UNLIKELY(result.did_succeed))
         return pas_msl_malloc_logging(size, result);
-    }
 
     if (verbose)
         pas_log("Asking heap for a directory.\n");


### PR DESCRIPTION
#### a235f958d30c86a1756884502754a8cb7c2a1efa
<pre>
[libpas][PGM] Fix PGM allocation failure fallback path
<a href="https://bugs.webkit.org/show_bug.cgi?id=286424">https://bugs.webkit.org/show_bug.cgi?id=286424</a>
<a href="https://rdar.apple.com/143344174">rdar://143344174</a>

Reviewed by Yusuke Suzuki.

PGM allocations are expected to fail under certain conditions.
Currently, the fallback path is taken within the &quot;transaction&quot;
which is not correct.

The problem occurs when:
1. The PGM allocation failed due to lock contention (try lock failed).
2. This sets the lock to be acquired in the next transaction iteration.
3. Before the transaction retry, the fallback path is taken, which might
   succeed.
4. Then the transaction retry logic kicks in, resulting in:
   PAS_ASSERT(!result.did_succeed);
Note that had this assert not been there, the fallback allocation would
have been leaked.

Instead, the fallback logic should occur outside of the transaction.
If the PGM allocation failed due to try lock failure, then the transaction will
acquire the lock and try again, as usual. Only if the allocation failed
due to other reasons will the new fallback allocation path be taken.

By structuring the code this way we also get the nice bonus that the
fallback allocation path is just falling through to the normal allocation
path, rather than a special case allocation from the large heap. This way,
that special and very infrequently executed case is removed.

* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(pas_large_heap_try_allocate_pgm): Deleted.
* Source/bmalloc/libpas/src/libpas/pas_large_heap.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
(pas_try_allocate_pgm):
(pas_try_allocate_common_impl_slow):

Canonical link: <a href="https://commits.webkit.org/289316@main">https://commits.webkit.org/289316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88a0dca3e33ec0bf0d00de19a2ab7b67bc1944f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86394 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24684 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47215 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32573 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36311 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79243 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93137 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85231 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74869 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18426 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17520 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13621 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107697 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13374 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25920 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->