### PR TITLE
Parameterize FixedVector, EmbeddedFixedVector on Malloc type

### DIFF
--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -35,31 +35,31 @@ namespace WTF {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(EmbeddedFixedVector);
 
-template<typename T>
-class EmbeddedFixedVector final : public TrailingArray<EmbeddedFixedVector<T>, T> {
+template<typename T, typename Malloc = EmbeddedFixedVectorMalloc>
+class EmbeddedFixedVector final : public TrailingArray<EmbeddedFixedVector<T, Malloc>, T> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(EmbeddedFixedVector);
     WTF_MAKE_NONCOPYABLE(EmbeddedFixedVector);
     WTF_MAKE_NONMOVABLE(EmbeddedFixedVector);
 public:
-    using Base = TrailingArray<EmbeddedFixedVector<T>, T>;
+    using Base = TrailingArray<EmbeddedFixedVector<T, Malloc>, T>;
 
     static UniqueRef<EmbeddedFixedVector> create(unsigned size)
     {
-        return UniqueRef { *new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size) };
+        return UniqueRef { *new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size) };
     }
 
     template<typename InputIterator>
     static UniqueRef<EmbeddedFixedVector> create(InputIterator first, InputIterator last)
     {
         unsigned size = Checked<uint32_t> { std::distance(first, last) };
-        return UniqueRef { *new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, first, last) };
+        return UniqueRef { *new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, first, last) };
     }
 
     template<size_t inlineCapacity, typename OverflowHandler>
     static UniqueRef<EmbeddedFixedVector> createFromVector(const Vector<T, inlineCapacity, OverflowHandler>& other)
     {
         unsigned size = Checked<uint32_t> { other.size() }.value();
-        return UniqueRef { *new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, other.begin(), other.end()) };
+        return UniqueRef { *new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, other.begin(), other.end()) };
     }
 
     template<size_t inlineCapacity, typename OverflowHandler>
@@ -67,20 +67,20 @@ public:
     {
         Vector<T, inlineCapacity, OverflowHandler> container = WTFMove(other);
         unsigned size = Checked<uint32_t> { container.size() }.value();
-        return UniqueRef { *new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, std::move_iterator { container.begin() }, std::move_iterator { container.end() }) };
+        return UniqueRef { *new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, std::move_iterator { container.begin() }, std::move_iterator { container.end() }) };
     }
 
     template<typename... Args>
     static UniqueRef<EmbeddedFixedVector> createWithSizeAndConstructorArguments(unsigned size, Args&&... args)
     {
-        return UniqueRef { *new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, std::forward<Args>(args)...) };
+        return UniqueRef { *new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(size, std::forward<Args>(args)...) };
     }
 
     template<std::invocable<size_t> Generator>
     static std::unique_ptr<EmbeddedFixedVector> createWithSizeFromGenerator(unsigned size, NOESCAPE Generator&& generator)
     {
 
-        auto result = std::unique_ptr<EmbeddedFixedVector> { new (NotNull, EmbeddedFixedVectorMalloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(typename Base::Failable { }, size, std::forward<Generator>(generator)) };
+        auto result = std::unique_ptr<EmbeddedFixedVector> { new (NotNull, Malloc::malloc(Base::allocationSize(size))) EmbeddedFixedVector(typename Base::Failable { }, size, std::forward<Generator>(generator)) };
         if (result->size() != size)
             return nullptr;
         return result;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -72,8 +72,10 @@ template<typename> class ArrayOf;
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 struct VectorBufferMalloc;
+struct EmbeddedFixedVectorMalloc;
 #else
 using VectorBufferMalloc = FastMalloc;
+using EmbeddedFixedVectorMalloc = FastMalloc;
 #endif
 
 template<typename> struct DefaultRefDerefTraits;
@@ -82,7 +84,7 @@ template<typename> class CompactPtr;
 template<typename> class CompletionHandler;
 template<typename, size_t = 0> class Deque;
 template<typename Key, typename, Key> class EnumeratedArray;
-template<typename> class FixedVector;
+template<typename, typename = WTF::EmbeddedFixedVectorMalloc> class FixedVector;
 template<typename> class Function;
 template<typename> struct IsSmartPtr;
 template<typename, typename = AnyThreadsAccessTraits> class LazyNeverDestroyed;


### PR DESCRIPTION
#### b0c6df0dd951b0589cd74ac7baad087305fc8a1b
<pre>
Parameterize FixedVector, EmbeddedFixedVector on Malloc type
<a href="https://bugs.webkit.org/show_bug.cgi?id=286426">https://bugs.webkit.org/show_bug.cgi?id=286426</a>
<a href="https://rdar.apple.com/143497080">rdar://143497080</a>

Reviewed by Mark Lam.

This allows you to pass in a Malloc parameter to FixedVector,
which will be used to allocate the backing store.

* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::createWithSizeAndConstructorArguments):
(WTF::FixedVector::createWithSizeFromGenerator):
(WTF::FixedVector::operator== const):
(WTF::FixedVector::swap):
(WTF::Malloc&gt;::contains const):
(WTF::Malloc&gt;::findIf const):
(WTF::Malloc&gt;::find const):
(WTF::swap):
(WTF::map):
(WTF::FixedVector&lt;T&gt;::contains const): Deleted.
(WTF::FixedVector&lt;T&gt;::findIf const): Deleted.
(WTF::FixedVector&lt;T&gt;::find const): Deleted.
* Source/WTF/wtf/Forward.h:

Canonical link: <a href="https://commits.webkit.org/289364@main">https://commits.webkit.org/289364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a8e9a9879b1aa504ec9a78ced2462e976314eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37418 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14251 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/24817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4917 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36536 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79469 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93426 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85458 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10036 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18454 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17728 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13862 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107951 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13600 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25980 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17044 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->