### PR TITLE
Unreviewed, reverting 289258@main (49d79a2453de)

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -284,11 +284,13 @@ class AXObjectCache final : public CanMakeWeakPtr<AXObjectCache>, public CanMake
     friend class AXTextMarker;
     friend WTF::TextStream& operator<<(WTF::TextStream&, AXObjectCache&);
 public:
-    explicit AXObjectCache(Page&, Document*);
+    explicit AXObjectCache(Document&);
     ~AXObjectCache();
 
+    // Returns the root object for the entire document.
+    WEBCORE_EXPORT AXCoreObject* rootObject();
     // Returns the root object for a specific frame.
-    WEBCORE_EXPORT AXCoreObject* rootObjectForFrame(LocalFrame&);
+    WEBCORE_EXPORT AccessibilityObject* rootObjectForFrame(LocalFrame*);
 
     // Creation/retrieval of AX objects associated with a DOM or RenderTree object.
     inline AccessibilityObject* getOrCreate(RenderObject* renderer)

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
@@ -219,7 +219,7 @@ AccessibilityObjectAtspi* AccessibilityRootAtspi::child() const
     if (!cache)
         return nullptr;
 
-    AXCoreObject* rootObject = cache->rootObjectForFrame(frame);
+    AXCoreObject* rootObject = cache->rootObject();
     return rootObject ? rootObject->wrapper() : nullptr;
 }
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2517,7 +2517,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if ([hitTestResult isKindOfClass:[NSAccessibilityRemoteUIElement class]]) {
         RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
         if (!backingObject)
-            return callback(@"no backing object");
+            return;
 
         auto* axObject = backingObject->accessibilityHitTest(IntPoint(point));
         if (axObject && axObject->isRemoteFrame()) {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2226,6 +2226,7 @@ private:
     StringWithDirection m_rawTitle;
     RefPtr<Element> m_titleElement;
 
+    std::unique_ptr<AXObjectCache> m_axObjectCache;
     const std::unique_ptr<DocumentMarkerController> m_markers;
     
     Timer m_styleRecalcTimer;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4070,24 +4070,6 @@ void Page::appearanceDidChange()
     });
 }
 
-void Page::clearAXObjectCache()
-{
-    m_axObjectCache = nullptr;
-}
-
-AXObjectCache* Page::axObjectCache()
-{
-    if (!m_axObjectCache) {
-        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
-        RefPtr mainFrameDocument = localMainFrame ? localMainFrame->document() : nullptr;
-        if (mainFrameDocument && !mainFrameDocument->hasLivingRenderTree())
-            return nullptr;
-        m_axObjectCache = makeUnique<AXObjectCache>(*this, mainFrameDocument.get());
-        Document::hasEverCreatedAnAXObjectCache = true;
-    }
-    return m_axObjectCache.get();
-}
-
 void Page::setUnobscuredSafeAreaInsets(const FloatBoxExtent& insets)
 {
     if (m_unobscuredSafeAreaInsets == insets)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -96,7 +96,6 @@ namespace IDBClient {
 class IDBConnectionToServer;
 }
 
-class AXObjectCache;
 class AccessibilityRootAtspi;
 class ApplePayAMSUIPaymentHandler;
 class ActivityStateChangeObserver;
@@ -677,10 +676,6 @@ public:
 
     WEBCORE_EXPORT void accessibilitySettingsDidChange();
     WEBCORE_EXPORT void appearanceDidChange();
-
-    void clearAXObjectCache();
-    AXObjectCache* existingAXObjectCache() { return m_axObjectCache.get(); }
-    WEBCORE_EXPORT AXObjectCache* axObjectCache();
 
     // Page and FrameView both store a Pagination value. Page::pagination() is set only by API,
     // and FrameView::pagination() is set only by CSS. Page::pagination() will affect all
@@ -1481,7 +1476,6 @@ private:
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
     bool m_prefersNonBlinkingCursor { false };
 #endif
-    std::unique_ptr<AXObjectCache> m_axObjectCache;
 
     TimerThrottlingState m_timerThrottlingState { TimerThrottlingState::Disabled };
     MonotonicTime m_timerThrottlingStateLastChangedTime;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6445,7 +6445,7 @@ void WebPageProxy::updateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCo
 
 void WebPageProxy::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point, CompletionHandler<void(String)>&& callback)
 {
-    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::ResolveAccessibilityHitTestForTesting(frameID, point), WTFMove(callback));
+    sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::ResolveAccessibilityHitTestForTesting(point), WTFMove(callback));
 }
 
 void WebPageProxy::updateSandboxFlags(IPC::Connection& connection, WebCore::FrameIdentifier frameID, WebCore::SandboxFlags sandboxFlags)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -322,7 +322,7 @@ void* WKAccessibilityRootObject(WKBundleFrameRef frameRef)
     if (!axObjectCache)
         return nullptr;
 
-    auto* root = axObjectCache->rootObjectForFrame(*frame);
+    auto* root = axObjectCache->rootObject();
     if (!root)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -480,13 +480,10 @@ void WebPage::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::Fram
 #endif
 }
 
-void WebPage::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, const WebCore::IntPoint& point, CompletionHandler<void(String)>&& completionHandler)
+void WebPage::resolveAccessibilityHitTestForTesting(const WebCore::IntPoint& point, CompletionHandler<void(String)>&& completionHandler)
 {
-    RefPtr webFrame = WebProcess::singleton().webFrame(frameID);
-    if (!webFrame)
-        return completionHandler("NULL"_s);
 #if PLATFORM(MAC)
-    if (id coreObject = [m_mockAccessibilityElement accessibilityRootObjectWrapper:webFrame->coreLocalFrame()]) {
+    if (id coreObject = [m_mockAccessibilityElement accessibilityRootObjectWrapper]) {
         if (id hitTestResult = [coreObject accessibilityHitTest:point]) {
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             completionHandler([hitTestResult accessibilityAttributeValue:@"AXInfoStringForTesting"]);
@@ -496,7 +493,7 @@ void WebPage::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier fra
     }
 #endif
     UNUSED_PARAM(point);
-    completionHandler("NULL"_s);
+    completionHandler(makeString("NULL"_s));
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
@@ -78,12 +78,12 @@
     WebCore::IntPoint convertedPoint = m_page->accessibilityScreenToRootView(WebCore::IntPoint(point));
 
     // If we are hit-testing a remote element, offset the hit test by the scroll of the web page.
-    if (RefPtr focusedLocalFrame = [self focusedLocalFrame]) {
-        if (CheckedPtr frameView = focusedLocalFrame->view())
+    if (RefPtr remoteLocalFrame = [self remoteLocalFrame]) {
+        if (CheckedPtr frameView = remoteLocalFrame->view())
             convertedPoint.moveBy(frameView->scrollPosition());
     }
 
-    return [[self accessibilityRootObjectWrapper:[self focusedLocalFrame]] accessibilityHitTest:convertedPoint];
+    return [[self accessibilityRootObjectWrapper] accessibilityHitTest:convertedPoint];
 }
 
 @end

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -884,7 +884,7 @@ void WebFrame::setAccessibleName(const AtomString& accessibleName)
     if (!document)
         return;
     
-    RefPtr rootObject = document->axObjectCache()->rootObjectForFrame(*localFrame);
+    RefPtr rootObject = document->axObjectCache()->rootObject();
     if (!rootObject)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1664,14 +1664,12 @@ std::pair<URL, WebCore::DidFilterLinkDecoration> WebPage::applyLinkDecorationFil
     return { url, WebCore::DidFilterLinkDecoration::No };
 }
 
-void WebPage::bindRemoteAccessibilityFrames(int, WebCore::FrameIdentifier, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
+void WebPage::bindRemoteAccessibilityFrames(int, WebCore::FrameIdentifier, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&&)
 {
-    completionHandler({ }, { });
 }
 
-void WebPage::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&& completionHandler)
+void WebPage::resolveAccessibilityHitTestForTesting(const WebCore::IntPoint&, CompletionHandler<void(String)>&&)
 {
-    completionHandler({ });
 }
 
 void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2467,7 +2467,7 @@ private:
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
     void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&&);
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
-    void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&&);
+    void resolveAccessibilityHitTestForTesting(const WebCore::IntPoint&, CompletionHandler<void(String)>&&);
 
     void requestAllTextAndRects(CompletionHandler<void(Vector<std::pair<String, WebCore::FloatRect>>&&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -498,7 +498,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t> dataToken) -> (Vector<uint8_t> token, int processIdentifier) Synchronous
     UpdateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
-    ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
+    ResolveAccessibilityHitTestForTesting(WebCore::IntPoint point) -> (String result)
     EnableAccessibility()
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -73,9 +73,9 @@ class AXCoreObject;
 - (void)setHasMainFramePlugin:(bool)hasPlugin;
 - (void)setFrameIdentifier:(const WebCore::FrameIdentifier&)frameID;
 
-- (id)accessibilityRootObjectWrapper:(WebCore::LocalFrame*)frame;
+- (id)accessibilityRootObjectWrapper;
 - (id)accessibilityFocusedUIElement;
 - (WebCore::IntPoint)accessibilityRemoteFrameOffset;
-- (WebCore::LocalFrame *)focusedLocalFrame;
+- (WebCore::LocalFrame *)remoteLocalFrame;
 
 @end

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -26,15 +26,14 @@
 #import "config.h"
 #import "WKAccessibilityWebPageObjectBase.h"
 
+#import "WebFrame.h"
+#import "WebPage.h"
 #import "WKArray.h"
 #import "WKNumber.h"
 #import "WKRetainPtr.h"
 #import "WKSharedAPICast.h"
 #import "WKString.h"
 #import "WKStringCF.h"
-#import "WebFrame.h"
-#import "WebPage.h"
-#import "WebProcess.h"
 #import <WebCore/AXObjectCache.h>
 #import <WebCore/Document.h>
 #import <WebCore/FrameTree.h>
@@ -60,7 +59,15 @@ namespace ax = WebCore::Accessibility;
     if (!page)
         return nullptr;
 
-    return page->axObjectCache();
+    if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame())) {
+        if (auto* document = localMainFrame->document())
+            return document->axObjectCache();
+    } else if (RefPtr remoteLocalFrame = [self remoteLocalFrame]) {
+        CheckedPtr document = remoteLocalFrame ? remoteLocalFrame->document() : nullptr;
+        return document ? document->axObjectCache() : nullptr;
+    }
+
+    return nullptr;
 }
 
 - (void)enableAccessibilityForAllProcesses
@@ -90,7 +97,7 @@ namespace ax = WebCore::Accessibility;
     return retrieveBlock();
 }
 
-- (id)accessibilityRootObjectWrapper:(WebCore::LocalFrame*)frame
+- (id)accessibilityRootObjectWrapper
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (!isMainRunLoop()) {
@@ -99,7 +106,7 @@ namespace ax = WebCore::Accessibility;
     }
 #endif
 
-    return ax::retrieveAutoreleasedValueFromMainThread<id>([protectedSelf = retainPtr(self), frame = RefPtr { frame }] () -> RetainPtr<id> {
+    return ax::retrieveAutoreleasedValueFromMainThread<id>([protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
         if (!WebCore::AXObjectCache::accessibilityEnabled())
             [protectedSelf enableAccessibilityForAllProcesses];
 
@@ -107,7 +114,7 @@ namespace ax = WebCore::Accessibility;
             return protectedSelf.get().accessibilityPluginObject;
 
         if (auto cache = protectedSelf.get().axObjectCache) {
-            if (auto* root = frame ? cache->rootObjectForFrame(*frame) : nullptr)
+            if (auto* root = cache->rootObject())
                 return root->wrapper();
         }
 
@@ -200,22 +207,15 @@ namespace ax = WebCore::Accessibility;
 
 - (id)accessibilityFocusedUIElement
 {
-    return [[self accessibilityRootObjectWrapper:[self focusedLocalFrame]] accessibilityFocusedUIElement];
+    return [[self accessibilityRootObjectWrapper] accessibilityFocusedUIElement];
 }
 
-- (WebCore::LocalFrame *)focusedLocalFrame
+- (WebCore::LocalFrame *)remoteLocalFrame
 {
     if (!m_page)
         return nullptr;
 
-    if (!m_frameID)
-        return dynamicDowncast<WebCore::LocalFrame>(m_page->mainFrame());
-
     auto* page = m_page->corePage();
-    ASSERT(page);
-    ASSERT(page->settings().siteIsolationEnabled());
-
-    // FIXME: This needs to be made thread safe when the isolated accessibility tree is on.
     for (auto& rootFrame : page->rootFrames()) {
         if (rootFrame->frameID() == m_frameID)
             return rootFrame.ptr();

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -146,7 +146,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSArray *)accessibilityChildren
 {
-    id wrapper = [self accessibilityRootObjectWrapper:[self focusedLocalFrame]];
+    id wrapper = [self accessibilityRootObjectWrapper];
     return wrapper ? @[wrapper] : @[];
 }
 
@@ -344,8 +344,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
         if (CheckedPtr localFrameView = protectedSelf->m_page->localMainFrameView())
             convertedPoint.moveBy(localFrameView->scrollPosition());
-        else if (RefPtr focusedLocalFrame = [protectedSelf focusedLocalFrame]) {
-            if (CheckedPtr frameView = focusedLocalFrame->view())
+        else if (RefPtr remoteLocalFrame = [protectedSelf remoteLocalFrame]) {
+            if (CheckedPtr frameView = remoteLocalFrame->view())
                 convertedPoint.moveBy(frameView->scrollPosition());
         }
         if (auto* page = protectedSelf->m_page->corePage())
@@ -353,7 +353,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return convertedPoint;
     });
     
-    return [[self accessibilityRootObjectWrapper:[self focusedLocalFrame]] accessibilityHitTest:convertedPoint];
+    return [[self accessibilityRootObjectWrapper] accessibilityHitTest:convertedPoint];
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -2149,7 +2149,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     if (!_private->coreFrame || !_private->coreFrame->document())
         return;
     
-    auto* rootObject = _private->coreFrame->document()->axObjectCache()->rootObjectForFrame(*_private->coreFrame);
+    auto* rootObject = _private->coreFrame->document()->axObjectCache()->rootObject();
     if (rootObject)
         rootObject->setAccessibleName(AtomString { name });
 }
@@ -2191,15 +2191,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!document || !document->axObjectCache())
         return nil;
     
-    auto* rootObject = document->axObjectCache()->rootObjectForFrame(*_private->coreFrame);
+    auto* rootObject = document->axObjectCache()->rootObjectForFrame(_private->coreFrame);
     if (!rootObject)
         return nil;
     
     // The root object will be a WebCore scroll view object. In WK1, scroll views are handled
     // by the system and the root object should be the web area (instead of the scroll view).
-    auto* rootAccessibilityObject = dynamicDowncast<WebCore::AccessibilityObject>(rootObject);
-    if (rootAccessibilityObject && rootAccessibilityObject->isAttachment() && rootAccessibilityObject->firstChild())
-        return rootAccessibilityObject->firstChild()->wrapper();
+    if (rootObject->isAttachment() && rootObject->firstChild())
+        return rootObject->firstChild()->wrapper();
     
     return rootObject->wrapper();
 }


### PR DESCRIPTION
#### 4c7605778bee15f73439b1256db79cadefefced4
<pre>
Unreviewed, reverting 289258@main (49d79a2453de)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286427">https://bugs.webkit.org/show_bug.cgi?id=286427</a>
<a href="https://rdar.apple.com/143498466">rdar://143498466</a>

REGRESSION(289258@main): Broke many Internal tests

Reverted change:

    Move AXObjectCache from Document to Page
    <a href="https://bugs.webkit.org/show_bug.cgi?id=286199">https://bugs.webkit.org/show_bug.cgi?id=286199</a>
    289258@main (49d79a2453de)

Canonical link: <a href="https://commits.webkit.org/289301@main">https://commits.webkit.org/289301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da82d273f17f2b9d2c989e16863bdaa81bc67ff2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86424 "4 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/5971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40759 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88479 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/6224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/14009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/91331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89430 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/6224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/6224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/32594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/6224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/33468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/13623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/14009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/93172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/13830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/74137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/17535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13433 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/13646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/13399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/16843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->