### PR TITLE
Resync Cookie Store API WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
@@ -1,3 +1,4 @@
 
 PASS cookieStore fires change event for cookie deleted by cookieStore.delete()
+FAIL cookieStore does not fire change events for non-existing expired cookies assert_equals: expected 2 but got 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window.js
@@ -1,22 +1,75 @@
 'use strict';
 
 promise_test(async testCase => {
-  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  // The events are asynchronously dispatched. Let's wait for both in the
+  // expected order to avoid race conditions.
+
+  {
+    const eventPromise = new Promise((resolve) => {
+      cookieStore.onchange = resolve;
+    });
+    await cookieStore.set('cookie-name', 'cookie-value');
+
+    const event = await eventPromise;
+    assert_true(event instanceof CookieChangeEvent);
+    assert_equals(event.type, 'change');
+    assert_equals(event.changed.length, 1);
+    assert_equals(event.changed[0].name, 'cookie-name');
+  }
+
+  {
+    const eventPromise = new Promise((resolve) => {
+      cookieStore.onchange = resolve;
+    });
+    await cookieStore.delete('cookie-name');
+    const event = await eventPromise;
+    assert_true(event instanceof CookieChangeEvent);
+    assert_equals(event.type, 'change');
+    assert_equals(event.deleted.length, 1);
+    assert_equals(event.deleted[0].name, 'cookie-name');
+    assert_equals(
+        event.deleted[0].value, undefined,
+        'Cookie change events for deletions should not have cookie values');
+    assert_equals(event.changed.length, 0);
+  }
+}, 'cookieStore fires change event for cookie deleted by cookieStore.delete()');
+
+promise_test(async testCase => {
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
   });
 
   const eventPromise = new Promise((resolve) => {
-    cookieStore.onchange = resolve;
+    const events = [];
+    cookieStore.onchange = event => {
+      events.push(event);
+      if (event.type === 'change' &&
+          event.deleted.length === 1 &&
+          event.deleted[0].name === 'cookie-name') {
+         resolve(events);
+       }
+    }
   });
+
+  await cookieStore.delete('cookie-unknown');
+  await cookieStore.set('cookie-name', 'cookie-value');
+  await cookieStore.delete('cookie-another-unknown');
   await cookieStore.delete('cookie-name');
-  const event = await eventPromise;
-  assert_true(event instanceof CookieChangeEvent);
-  assert_equals(event.type, 'change');
-  assert_equals(event.deleted.length, 1);
-  assert_equals(event.deleted[0].name, 'cookie-name');
-  assert_equals(
-      event.deleted[0].value, undefined,
-      'Cookie change events for deletions should not have cookie values');
-  assert_equals(event.changed.length, 0);
-}, 'cookieStore fires change event for cookie deleted by cookieStore.delete()');
+
+  const events = await eventPromise;
+
+  assert_equals(events.length, 2);
+  assert_true(events[0] instanceof CookieChangeEvent);
+  assert_equals(events[0].type, 'change');
+  assert_equals(events[0].changed.length, 1);
+  assert_equals(events[0].changed[0].name, 'cookie-name');
+
+  assert_true(events[1] instanceof CookieChangeEvent);
+  assert_equals(events[1].type, 'change');
+  assert_equals(events[1].deleted.length, 1);
+  assert_equals(events[1].deleted[0].name, 'cookie-name');
+}, 'cookieStore does not fire change events for non-existing expired cookies');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window.js
@@ -1,22 +1,37 @@
 'use strict';
 
 promise_test(async testCase => {
-  await cookieStore.set('cookie-name', 'cookie-value');
   testCase.add_cleanup(async () => {
     await cookieStore.delete('cookie-name');
   });
 
-  const eventPromise = new Promise((resolve) => {
-    cookieStore.onchange = resolve;
-  });
+  // The events are asynchronously dispatched. Let's wait for both in the
+  // expected order to avoid race conditions.
+  {
+    const eventPromise = new Promise((resolve) => {
+      cookieStore.onchange = resolve;
+    });
+    await cookieStore.set('cookie-name', 'cookie-value');
 
-  await cookieStore.set('cookie-name', 'new-cookie-value');
+    const event = await eventPromise;
+    assert_true(event instanceof CookieChangeEvent);
+    assert_equals(event.type, 'change');
+    assert_equals(event.changed.length, 1);
+    assert_equals(event.changed[0].name, 'cookie-name');
+  }
 
-  const event = await eventPromise;
-  assert_true(event instanceof CookieChangeEvent);
-  assert_equals(event.type, 'change');
-  assert_equals(event.changed.length, 1);
-  assert_equals(event.changed[0].name, 'cookie-name');
-  assert_equals(event.changed[0].value, 'new-cookie-value');
-  assert_equals(event.deleted.length, 0);
+  {
+    const eventPromise = new Promise((resolve) => {
+      cookieStore.onchange = resolve;
+    });
+    await cookieStore.set('cookie-name', 'new-cookie-value');
+
+    const event = await eventPromise;
+    assert_true(event instanceof CookieChangeEvent);
+    assert_equals(event.type, 'change');
+    assert_equals(event.changed.length, 1);
+    assert_equals(event.changed[0].name, 'cookie-name');
+    assert_equals(event.changed[0].value, 'new-cookie-value');
+    assert_equals(event.deleted.length, 0);
+  }
 }, 'cookieStore fires change event for cookie overwritten by cookieStore.set()');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
@@ -8,4 +8,6 @@ PASS cookieStore.getAll with absolute url in options
 PASS cookieStore.getAll with relative url in options
 PASS cookieStore.getAll with invalid url path in options
 PASS cookieStore.getAll with invalid url host in options
+FAIL cookieStore.getAll with absolute url with fragment in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
+FAIL cookieStore.getAll with absolute different url in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt
@@ -6,6 +6,8 @@ PASS cookieStore.getAll with name in options
 PASS cookieStore.getAll with name in both positional arguments and options
 PASS cookieStore.getAll with absolute url in options
 PASS cookieStore.getAll with relative url in options
-FAIL cookieStore.getAll with invalid url path in options assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.getAll with same-origin url path in options
 PASS cookieStore.getAll with invalid url host in options
+PASS cookieStore.getAll with absolute url with fragment in options
+PASS cookieStore.getAll with absolute different url in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.js
@@ -8,7 +8,7 @@ promise_test(async testCase => {
   const currentPath = currentUrl.pathname;
   const currentDirectory =
       currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
-  
+
   await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
 
   await cookieStore.set(
@@ -19,8 +19,8 @@ promise_test(async testCase => {
 
   // This changes the Document's current URL to this different URL.
   // The Document's creation URL does not change.
-  // If set() and getAll() use Document's current URL, the cookie will be set 
-  // using the original URL above, and the get below will fail since it looks 
+  // If set() and getAll() use Document's current URL, the cookie will be set
+  // using the original URL above, and the get below will fail since it looks
   // for cookies with this different URL. If they both use the creation URL,
   // the get will succeed since it won't use this different URL to search.
   let different_url = `${self.location.protocol}//${self.location.host}/different/path`;

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
@@ -8,4 +8,6 @@ PASS cookieStore.get with absolute url in options
 PASS cookieStore.get with relative url in options
 PASS cookieStore.get with invalid url path in options
 PASS cookieStore.get with invalid url host in options
+FAIL cookieStore.get with absolute url with fragment in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
+FAIL cookieStore.get with absolute different url in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.serviceworker-expected.txt
@@ -6,6 +6,8 @@ PASS cookieStore.get with name in options
 PASS cookieStore.get with name in both positional arguments and options
 PASS cookieStore.get with absolute url in options
 PASS cookieStore.get with relative url in options
-FAIL cookieStore.get with invalid url path in options assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.get with same-origin url path in options
 PASS cookieStore.get with invalid url host in options
+PASS cookieStore.get with absolute url with fragment in options
+PASS cookieStore.get with absolute different url in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.js
@@ -8,7 +8,7 @@ promise_test(async testCase => {
   const currentPath = currentUrl.pathname;
   const currentDirectory =
       currentPath.substr(0, currentPath.lastIndexOf('/') + 1);
-  
+
   await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
 
   await cookieStore.set(
@@ -19,8 +19,8 @@ promise_test(async testCase => {
 
   // This changes the Document's current URL to this different URL.
   // The Document's creation URL does not change.
-  // If set() and get() use Document's current URL, the cookie will be set 
-  // using the original URL above, and the get below will fail since it looks 
+  // If set() and get() use Document's current URL, the cookie will be set
+  // using the original URL above, and the get below will fail since it looks
   // for cookies with this different URL. If they both use the creation URL,
   // the get will succeed since it won't use this different URL to search.
   let different_url = `${self.location.protocol}//${self.location.host}/different/path`;

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.sub.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS cookieStore.get() option url ignores fragments
+PASS cookieStore.get() option url + pushState()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.sub.https.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<meta charset='utf-8'>
+<title>Async Cookies: cookieStore basic API on creation URL with fragments</title>
+<link rel='help' href='https://github.com/WICG/cookie-store'>
+<link rel='author' href='baku@mozilla.com' title='Andrea Marchesini'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='resources/helpers.js'></script>
+<style>iframe { display: none; }</style>
+
+<script>
+'use strict';
+
+const kUrl = '/cookie-store/resources/helper_iframe.sub.html';
+
+promise_test(async t => {
+  const url = new URL(kUrl, location);
+
+  const iframe = await createIframe(url + "#fragment", t);
+  assert_true(iframe != null);
+
+  iframe.contentWindow.postMessage({
+    opname: 'set-cookie',
+    name: 'cookie-name',
+    value: 'cookie-value',
+  }, '*');
+
+  t.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: '{{host}}' });
+  });
+
+  await waitForMessage();
+
+  iframe.contentWindow.postMessage({
+    opname: 'get-cookie',
+    name: 'cookie-name',
+    options: { url: url.href }
+  }, '*');
+
+  const message = await waitForMessage();
+
+  const { frameCookie } = message;
+  assert_not_equals(frameCookie, null);
+  assert_equals(frameCookie.name, 'cookie-name');
+  assert_equals(frameCookie.value, 'cookie-value');
+}, 'cookieStore.get() option url ignores fragments');
+
+promise_test(async t => {
+  const url = new URL(kUrl, location);
+
+  const iframe = await createIframe(url + "#fragment", t);
+  assert_true(iframe != null);
+
+  iframe.contentWindow.postMessage({
+    opname: 'set-cookie',
+    name: 'cookie-name',
+    value: 'cookie-value',
+  }, '*');
+
+  t.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', domain: '{{host}}' });
+  });
+
+  await waitForMessage();
+
+  iframe.contentWindow.postMessage({
+    opname: 'push-state',
+  }, '*');
+
+  await waitForMessage();
+
+  iframe.contentWindow.postMessage({
+    opname: 'get-cookie',
+    name: 'cookie-name',
+    options: { url: url.href }
+  }, '*');
+
+  const message = await waitForMessage();
+
+  const { frameCookie } = message;
+  assert_not_equals(frameCookie, null);
+  assert_equals(frameCookie.name, 'cookie-name');
+  assert_equals(frameCookie.value, 'cookie-value');
+}, 'cookieStore.get() option url + pushState()');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore on DOMWindow of detached iframe (crbug.com/774626) assert_equals: expected object "[object CookieStore]" but got null
+PASS cookieStore on DOMWindow of detached iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>cookieStore on DOMWindow of detached iframe (crbug.com/774626)</title>
+<title>cookieStore on DOMWindow of detached iframe</title>
 <link rel="help" href="https://github.com/WICG/cookie-store">
 <link rel="author" href="pwnall@chromium.org" title="Victor Costan">
 <script src="/resources/testharness.js"></script>
@@ -14,6 +14,8 @@ test(() => {
   const frameWindow = iframe.contentWindow;
 
   iframe.parentNode.removeChild(iframe);
-  assert_equals(null, frameWindow.cookieStore);
+
+  // By spec, window.cookieStore isn't nullable.
+  assert_true(frameWindow.cookieStore != null);
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/helper_iframe.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/helper_iframe.sub.html
@@ -23,9 +23,12 @@
       });
       event.source.postMessage('Cookie has been set', event.origin);
     } else if (opname === 'get-cookie') {
-      const { name } = event.data
-      const frameCookie = await cookieStore.get(name);
+      const { name, options } = event.data
+      const frameCookie = await cookieStore.get(name, options);
       event.source.postMessage({frameCookie}, event.origin);
+    } else if (opname === 'push-state') {
+      history.pushState("foo", null, "some/path");
+      event.source.postMessage('pushState called');
     }
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/w3c-import.log
@@ -34,11 +34,14 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_origins.sub.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.sub.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_ordering.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https.html


### PR DESCRIPTION
#### c78fa00e208b060b7c02ba0ce5292a00c7bedb8f
<pre>
Resync Cookie Store API WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=286430">https://bugs.webkit.org/show_bug.cgi?id=286430</a>
<a href="https://rdar.apple.com/143512034">rdar://143512034</a>

Reviewed by Chris Dumez.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/4ea529d692eb9a3bfe7e105f119984c9e96eb1fd">https://github.com/web-platform-tests/wpt/commit/4ea529d692eb9a3bfe7e105f119984c9e96eb1fd</a>

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window.js:
(promise_test.async testCase.async const):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window.js:
(promise_test.async testCase.async const):
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.js:
(self.GLOBAL.isWorker.promise_test.async testCase):
(else.promise_test.async testCase.async const):
(else.promise_test.async testCase):
(promise_test.async testCase.async const):
(promise_test.async testCase):
(promise_test.async testCase.async let):
(promise_test.async testCase.async self):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_creation_url.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.js:
(self.GLOBAL.isWorker.promise_test.async testCase):
(else.promise_test.async testCase):
(promise_test.async testCase.async let):
(promise_test.async testCase):
(promise_test.async testCase.async self):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.sub.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_creation_url.sub.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_in_detached_frame.https.html:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/resources/helper_iframe.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/289333@main">https://commits.webkit.org/289333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7daff584e0eb5cbf175a57dca4e25d73d6ef3765

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66945 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32664 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36382 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75731 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74914 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18438 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17585 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13701 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->