### PR TITLE
Update StringImpl::copyCharacters() to take spans and do bounds validation

### DIFF
--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -338,7 +338,7 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
                 StringView view0 = *rope0->substringBase()->valueInternal().impl();
                 unsigned offset = rope0->substringOffset();
 
-                view0.substring(offset, rope0Length).getCharacters(buffer.first(buffer.size() - rope0Length));
+                view0.substring(offset, rope0Length).getCharacters(buffer);
                 return;
             }
             MUST_TAIL_CALL return resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer.first(rope0Length), stackLimit);

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -49,7 +49,7 @@ static inline void appendStringToData(std::span<CharacterType>& data, StringView
 template<typename OutputCharacterType, typename SeparatorCharacterType>
 static inline void appendStringToData(std::span<OutputCharacterType>& data, std::span<const SeparatorCharacterType> separator)
 {
-    StringImpl::copyCharacters(data.data(), separator);
+    StringImpl::copyCharacters(data, separator);
     skip(data, separator.size());
 }
 

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -97,7 +97,7 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCharCode, (JSGlobalObject* globalObject, Call
         if (UNLIKELY(!isLatin1(character))) {
             std::span<UChar> buf16Bit;
             auto impl16Bit = StringImpl::createUninitialized(length, buf16Bit);
-            StringImpl::copyCharacters(buf16Bit.data(), buf8Bit.first(i));
+            StringImpl::copyCharacters(buf16Bit, buf8Bit.first(i));
             buf16Bit[i] = character;
             ++i;
             for (; i < length; ++i) {

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -321,7 +321,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstrings(JSGlobalObject* globalObject, 
         Checked<size_t, AssertNoOverflow> bufferPos = 0;
         for (auto range : substringRanges) {
             size_t srcLen = range.distance();
-            StringImpl::copyCharacters(buffer.subspan(bufferPos.value()).data(), sourceData.subspan(range.begin(), srcLen));
+            StringImpl::copyCharacters(buffer.subspan(bufferPos.value()), sourceData.subspan(range.begin(), srcLen));
             bufferPos += srcLen;
         }
 
@@ -340,7 +340,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstrings(JSGlobalObject* globalObject, 
     Checked<size_t, AssertNoOverflow> bufferPos = 0;
     for (auto& range : substringRanges) {
         size_t srcLen = range.distance();
-        StringImpl::copyCharacters(buffer.subspan(bufferPos.value()).data(), sourceData.subspan(range.begin(), srcLen));
+        StringImpl::copyCharacters(buffer.subspan(bufferPos.value()), sourceData.subspan(range.begin(), srcLen));
         bufferPos += srcLen;
     }
 

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -79,7 +79,7 @@ public:
 
     unsigned length() const { return m_buffer.length; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), m_buffer.span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_buffer.span()); }
 
 private:
     const HexNumberBuffer& m_buffer;

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -854,9 +854,9 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
 
     outBuffer.grow(i);
     if (sourceBuffer.is8Bit())
-        StringImpl::copyCharacters(outBuffer.data(), sourceBuffer.span8().first(i));
+        StringImpl::copyCharacters(outBuffer.mutableSpan(), sourceBuffer.span8().first(i));
     else
-        StringImpl::copyCharacters(outBuffer.data(), sourceBuffer.span16().first(i));
+        StringImpl::copyCharacters(outBuffer.mutableSpan(), sourceBuffer.span16().first(i));
 
     for (; i < length; ) {
         char32_t c = sourceBuffer.characterStartingAt(i);

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -159,7 +159,7 @@ void StringBuilder::append(std::span<const UChar> characters)
     }
     RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
     if (auto destination = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))); destination.data())
-        StringImpl::copyCharacters(destination.data(), characters);
+        StringImpl::copyCharacters(destination, characters);
 }
 
 void StringBuilder::append(std::span<const LChar> characters)
@@ -169,10 +169,10 @@ void StringBuilder::append(std::span<const LChar> characters)
     RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
     if (is8Bit()) {
         if (auto destination = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))); destination.data())
-            StringImpl::copyCharacters(destination.data(), characters);
+            StringImpl::copyCharacters(destination, characters);
     } else {
         if (auto destination = extendBufferForAppending<UChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))); destination.data())
-            StringImpl::copyCharacters(destination.data(), characters);
+            StringImpl::copyCharacters(destination, characters);
     }
 }
 

--- a/Source/WTF/wtf/text/StringBuilderInternals.h
+++ b/Source/WTF/wtf/text/StringBuilderInternals.h
@@ -41,10 +41,7 @@ template<typename AllocationCharacterType, typename CurrentCharacterType> void S
     }
 
     ASSERT(!hasOverflowed());
-
-    // FIXME: StringImpl::copyCharacters() should take in 2 spans or we should call memcpySpan().
-    RELEASE_ASSERT(newBufferCharacters.size() >= currentCharactersToCopy.size());
-    StringImpl::copyCharacters(newBufferCharacters.data(), currentCharactersToCopy);
+    StringImpl::copyCharacters(newBufferCharacters, currentCharactersToCopy);
 
     m_buffer = WTFMove(buffer);
     m_string = { };

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -130,7 +130,7 @@ public:
 
     unsigned length() const { return m_characters.size(); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), m_characters); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_characters); }
 
 private:
     std::span<const LChar> m_characters;
@@ -147,7 +147,7 @@ public:
     unsigned length() const { return m_characters.size(); }
     bool is8Bit() const { return m_characters.empty(); }
     void writeTo(std::span<LChar>) const { ASSERT(m_characters.empty()); }
-    void writeTo(std::span<UChar> destination) const { StringImpl::copyCharacters(destination.data(), m_characters); }
+    void writeTo(std::span<UChar> destination) const { StringImpl::copyCharacters(destination, m_characters); }
 
 private:
     std::span<const UChar> m_characters;
@@ -168,7 +168,7 @@ public:
     {
         using CharacterTypeForString = std::conditional_t<sizeof(CharacterType) == sizeof(LChar), LChar, UChar>;
         static_assert(sizeof(CharacterTypeForString) == sizeof(CharacterType));
-        StringImpl::copyCharacters(destination.data(), spanReinterpretCast<const CharacterTypeForString>(m_characters));
+        StringImpl::copyCharacters(destination, spanReinterpretCast<const CharacterTypeForString>(m_characters));
     }
 
 private:

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -78,7 +78,7 @@ public:
 
     unsigned length() const { return m_length; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, span()); }
 
 private:
     std::span<const LChar> span() const LIFETIME_BOUND { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
@@ -122,7 +122,7 @@ public:
 
     unsigned length() const { return m_number.length(); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), m_number.span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
 
 private:
     const FormattedNumber& m_number;
@@ -156,7 +156,7 @@ public:
 
     unsigned length() const { return m_number.length(); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), m_number.span()); }
+    template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
 
 private:
     const FormattedCSSNumber& m_number;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -609,12 +609,12 @@ template<bool isSpecialCharacter(UChar)> inline bool StringView::containsOnly() 
 
 template<typename CharacterType> inline void StringView::getCharacters8(std::span<CharacterType> destination) const
 {
-    StringImpl::copyCharacters(destination.data(), span8());
+    StringImpl::copyCharacters(destination, span8());
 }
 
 template<typename CharacterType> inline void StringView::getCharacters16(std::span<CharacterType> destination) const
 {
-    StringImpl::copyCharacters(destination.data(), span16());
+    StringImpl::copyCharacters(destination, span16());
 }
 
 template<typename CharacterType> inline void StringView::getCharacters(std::span<CharacterType> destination) const
@@ -633,7 +633,7 @@ inline StringView::UpconvertedCharactersWithSize<N>::UpconvertedCharactersWithSi
         return;
     }
     m_upconvertedCharacters.grow(string.m_length);
-    StringImpl::copyCharacters(m_upconvertedCharacters.data(), string.span8());
+    StringImpl::copyCharacters(m_upconvertedCharacters.mutableSpan(), string.span8());
     m_characters = m_upconvertedCharacters.span();
 }
 

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -452,7 +452,7 @@ String String::make8Bit(std::span<const UChar> source)
 {
     std::span<LChar> destination;
     String result = String::createUninitialized(source.size(), destination);
-    StringImpl::copyCharacters(destination.data(), source);
+    StringImpl::copyCharacters(destination, source);
     return result;
 }
 
@@ -462,7 +462,7 @@ void String::convertTo16Bit()
         return;
     std::span<UChar> destination;
     auto convertedString = String::createUninitialized(length(), destination);
-    StringImpl::copyCharacters(destination.data(), span8());
+    StringImpl::copyCharacters(destination, span8());
     *this = WTFMove(convertedString);
 }
 

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -32,6 +32,16 @@
 
 namespace WTF {
 
+static std::span<const LChar> latin1ContextSpan(UText* uText)
+{
+    return unsafeMakeSpan(static_cast<const LChar*>(uText->context), uText->a);
+}
+
+static std::span<UChar> chunkSpan(UText* uText)
+{
+    return unsafeMakeSpan(const_cast<UChar*>(uText->chunkContents), uText->chunkLength);
+}
+
 // Latin1 provider
 
 static UText* uTextLatin1Clone(UText*, const UText*, UBool, UErrorCode*);
@@ -142,10 +152,7 @@ static UBool uTextLatin1Access(UText* uText, int64_t index, UBool forward)
         uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
     }
     uText->chunkLength = static_cast<int32_t>(uText->chunkNativeLimit - uText->chunkNativeStart);
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    StringImpl::copyCharacters(const_cast<UChar*>(uText->chunkContents), unsafeMakeSpan(static_cast<const LChar*>(uText->context) + uText->chunkNativeStart, uText->chunkLength));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    StringImpl::copyCharacters(chunkSpan(uText), latin1ContextSpan(uText).subspan(uText->chunkNativeStart, uText->chunkLength));
 
     uText->nativeIndexingLimit = uText->chunkLength;
 
@@ -183,9 +190,7 @@ static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, UC
         size_t trimmedLength = length;
         if (trimmedLength > dest.size())
             trimmedLength = dest.size();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        StringImpl::copyCharacters(dest.data(), unsafeMakeSpan(static_cast<const LChar*>(uText->context) + start, trimmedLength));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        StringImpl::copyCharacters(dest, latin1ContextSpan(uText).subspan(start, trimmedLength));
     }
 
     if (length < dest.size()) {
@@ -301,7 +306,7 @@ static void textLatin1ContextAwareMoveInPrimaryContext(UText* text, int64_t nati
     text->nativeIndexingLimit = text->chunkLength;
     text->chunkOffset = forward ? 0 : text->chunkLength;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    StringImpl::copyCharacters(const_cast<UChar*>(text->chunkContents), unsafeMakeSpan(static_cast<const LChar*>(text->p) + (text->chunkNativeStart - text->b), text->chunkLength));
+    StringImpl::copyCharacters(chunkSpan(text), unsafeMakeSpan(static_cast<const LChar*>(text->p) + (text->chunkNativeStart - text->b), text->chunkLength));
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 


### PR DESCRIPTION
#### 1ab6226d0714c683a76810fa340e29c48856faa1
<pre>
Update StringImpl::copyCharacters() to take spans and do bounds validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=286435">https://bugs.webkit.org/show_bug.cgi?id=286435</a>

Reviewed by Darin Adler.

Also fix an issue in `JSRopeString::resolveToBuffer()` where we were artificially
reducing the size of the output buffer we were passing to `StringView::getCharacters()`
as it was tripping the subspan assertions. The code was safe since the buffer was large
enough, however, `StringView::getCharacters()` could not know that.

Note that the assertions are only debug assertions for now due to performance concerns
but we should try and make them release assertions wherever performance allows. The
assertions are currently in StringImpl::copyCharacters() but I intend to move them
to copyElements() in a follow-up as this requires even more refactoring.

* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::appendStringToData):
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::jsSpliceSubstrings):
* Source/WTF/wtf/HexNumber.h:
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::writeTo const):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::escapeUnsafeCharacters):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::append):
* Source/WTF/wtf/text/StringBuilderInternals.h:
(WTF::StringBuilder::allocateBuffer):
* Source/WTF/wtf/text/StringConcatenate.h:
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
(WTF::StringTypeAdapter&lt;FormattedNumber&gt;::writeTo const):
(WTF::StringTypeAdapter&lt;FormattedCSSNumber&gt;::writeTo const):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::createInternal):
(WTF::StringImpl::foldCase):
(WTF::StringImpl::convertASCIICase):
(WTF::StringImpl::replace):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::copyCharacters):
(WTF::StringImpl::removeCharactersImpl):
(WTF::StringImpl::createByReplacingInCharacters):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::getCharacters8 const):
(WTF::StringView::getCharacters16 const):
(WTF::StringView::UpconvertedCharactersWithSize&lt;N&gt;::UpconvertedCharactersWithSize):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::make8Bit):
(WTF::String::convertTo16Bit):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::uTextLatin1Access):
(WTF::uTextLatin1Extract):
(WTF::textLatin1ContextAwareMoveInPrimaryContext):

Canonical link: <a href="https://commits.webkit.org/289466@main">https://commits.webkit.org/289466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14b34815d76ec4621d8573001e2083e2d5494053

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37707 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14547 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67225 "Failed to checkout and rebase branch from PR 39461") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24995 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33097 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36822 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79754 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93714 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85742 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14130 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76030 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75227 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19558 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7009 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13558 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14149 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19440 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108236 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13894 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26049 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->