### PR TITLE
ciso646:46:4: warning: "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros" [-W#warnings]

### DIFF
--- a/Source/WebCore/PAL/config.h
+++ b/Source/WebCore/PAL/config.h
@@ -36,6 +36,4 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
-#include <ciso646>
-
 #endif

--- a/Source/WebCore/config.h
+++ b/Source/WebCore/config.h
@@ -48,8 +48,6 @@
 #include <wtf/IsoMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
-#include <ciso646>
-
 #endif
 
 #if USE(CG)


### PR DESCRIPTION
#### 403fba703947e7b9e7bb9569f43b5d6a45e8ce49
<pre>
ciso646:46:4: warning: &quot;&lt;ciso646&gt; is deprecated in C++17, use &lt;version&gt; to detect implementation-specific macros&quot; [-W#warnings]
<a href="https://bugs.webkit.org/show_bug.cgi?id=286324">https://bugs.webkit.org/show_bug.cgi?id=286324</a>

Reviewed by Adrian Perez de Castro.

The purpose of this header is to access macros like __GLIBC__. It is
obsoleted and replaced by &lt;version&gt; but we generally don&apos;t need to
include this manually because it will be pulled in by other system
headers. It was originally needed here to support the DisallowCType
check that was added in 96006@main and removed in 288854@main, so
probably don&apos;t need it anymore.

* Source/WebCore/PAL/config.h:
* Source/WebCore/config.h:

Canonical link: <a href="https://commits.webkit.org/289666@main">https://commits.webkit.org/289666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9737716e12dbba7906362c6f7999f6bb78c2c52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67613 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25364 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33610 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94283 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20049 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18475 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7652 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20021 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->