### PR TITLE
REGRESSION(288409@main): Main frame history state may be incorrectly created after navigating back

### DIFF
--- a/LayoutTests/fast/history/go-back-then-navigate-subframe-expected.txt
+++ b/LayoutTests/fast/history/go-back-then-navigate-subframe-expected.txt
@@ -1,0 +1,9 @@
+Tests that navigating an iframe after going back does not create a new main frame history item.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/history/go-back-then-navigate-subframe.html
+++ b/LayoutTests/fast/history/go-back-then-navigate-subframe.html
@@ -1,0 +1,27 @@
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that navigating an iframe after going back does not create a new main frame history item.");
+jsTestIsAsync = true;
+
+function runTest() {
+    if (sessionStorage.didNavigate) {
+        delete sessionStorage.didNavigate;
+        setTimeout(() => {
+            const iframe = document.getElementById("frame");
+            iframe.src = "about:blank";
+            iframe.addEventListener("load", () => {
+                iframe.addEventListener("load", () => {
+                    finishJSTest();
+                });
+                history.back();
+            });
+        }, 0);
+    } else {
+        setTimeout(() => {
+            location.href = 'data:text/html,<script> history.back(); <\/script>';
+        }, 0);
+        sessionStorage.didNavigate = true;
+    }
+}
+</script>
+<iframe id="frame" src="resources/frame-initial-url.html#noalert"></iframe>

--- a/LayoutTests/fast/history/resources/frame-final-url.html
+++ b/LayoutTests/fast/history/resources/frame-final-url.html
@@ -1,5 +1,6 @@
 final page contents
 <script>
-alert('Final URL loaded.');
+if (location.hash != "#noalert")
+    alert('Final URL loaded.');
 top.runTest();
 </script>

--- a/LayoutTests/fast/history/resources/frame-initial-url.html
+++ b/LayoutTests/fast/history/resources/frame-initial-url.html
@@ -1,5 +1,6 @@
 initial frame contents
 <script>
-alert('Initial URL loaded.');
-window.location='frame-final-url.html';
+if (location.hash != "#noalert")
+    alert('Initial URL loaded.');
+window.location='frame-final-url.html' + location.hash;
 </script>

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -224,6 +224,12 @@ void HistoryItem::setTarget(const AtomString& target)
     notifyChanged();
 }
 
+void HistoryItem::setFrameID(std::optional<FrameIdentifier> frameID)
+{
+    m_frameID = frameID;
+    notifyChanged();
+}
+
 const IntPoint& HistoryItem::scrollPosition() const
 {
     return m_scrollPosition;

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -137,7 +137,7 @@ public:
     WEBCORE_EXPORT void setOriginalURLString(const String&);
     WEBCORE_EXPORT void setReferrer(const String&);
     WEBCORE_EXPORT void setTarget(const AtomString&);
-    void setFrameID(std::optional<FrameIdentifier> frameID) { m_frameID = frameID; }
+    WEBCORE_EXPORT void setFrameID(std::optional<FrameIdentifier>);
     WEBCORE_EXPORT void setTitle(const String&);
     void setIsTargetItem(bool isTargetItem) { m_isTargetItem = isTargetItem; }
     

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1058,6 +1058,7 @@ void FrameLoader::loadURLIntoChildFrame(const URL& url, const String& referer, L
     if (parentItem && parentItem->children().size() && isBackForwardLoadType(loadType()) && !m_frame->document()->loadEventFinished()) {
         if (RefPtr childItem = parentItem->childItemWithTarget(childFrame.tree().uniqueName())) {
             Ref childLoader = childFrame.loader();
+            childItem->setFrameID(childFrame.frameID());
             childLoader->m_requestedHistoryItem = childItem;
             childLoader->loadDifferentDocumentItem(*childItem, nullptr, loadType(), MayAttemptCacheOnlyLoadForFormSubmissionItem, ShouldTreatAsContinuingLoad::No);
             return;


### PR DESCRIPTION
#### 50ae75698db1c459c7bdd39d47b1e389da2495ea
<pre>
REGRESSION(288409@main): Main frame history state may be incorrectly created after navigating back
<a href="https://bugs.webkit.org/show_bug.cgi?id=286438">https://bugs.webkit.org/show_bug.cgi?id=286438</a>
<a href="https://rdar.apple.com/143418935">rdar://143418935</a>

Reviewed by Alex Christensen.

FrameLoader::loadURLIntoChildFrame contains logic to reload child frames with history items from another
page when navigating through the back/forward list. This behavior caused an issue after 288409@main,
where loading a history item created by another page into a new iframe caused the UI process to create a
new main frame history item when trying to reconstruct the history item tree.

To fix this, we need to update the history item’s frameID to match the iframe that it is being loaded
into.

* LayoutTests/fast/history/go-back-then-navigate-subframe-expected.txt: Added.
* LayoutTests/fast/history/go-back-then-navigate-subframe.html: Added.
* LayoutTests/fast/history/resources/frame-final-url.html:
* LayoutTests/fast/history/resources/frame-initial-url.html:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::setFrameID):
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::setFrameID): Deleted.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURLIntoChildFrame):

Canonical link: <a href="https://commits.webkit.org/289329@main">https://commits.webkit.org/289329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2def055bbbf63823b87be990e2625789804f394a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91373 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14072 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47253 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32654 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36375 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93227 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9906 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13876 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/74187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/74908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17578 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13452 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13694 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/18962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->