### PR TITLE
[WGSL] Generated metal does not compile from https://playcanvas.vercel.app/#/graphics/particles-mesh

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -878,8 +878,11 @@ const Type* RewriteGlobalVariables::packArrayType(const Types::Array* arrayType)
 {
     auto* structType = std::get_if<Types::Struct>(arrayType->element);
     if (!structType) {
-        if (arrayType->element->packing() & Packing::Vec3)
+        if (arrayType->element->packing() & Packing::Vec3) {
+            m_shaderModule.setUsesUnpackArray();
+            m_shaderModule.setUsesPackArray();
             m_shaderModule.setUsesPackedVec3();
+        }
         return nullptr;
     }
 

--- a/Source/WebGPU/WGSL/tests/valid/packing-nested-array.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing-nested-array.wgsl
@@ -1,0 +1,15 @@
+// RUN: %metal-compile main
+
+struct S {
+    x: array<vec3<f32>, 1>,
+    y: vec3f,
+}
+
+
+@group(0) @binding(0) var<storage, read> s : S;
+
+@compute @workgroup_size(1)
+fn main()
+{
+  _ = s.x;
+}


### PR DESCRIPTION
#### be74adeaac4cb1b243fd11f2bcc3d2bb267d6b8c
<pre>
[WGSL] Generated metal does not compile from <a href="https://playcanvas.vercel.app/#/graphics/particles-mesh">https://playcanvas.vercel.app/#/graphics/particles-mesh</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286005">https://bugs.webkit.org/show_bug.cgi?id=286005</a>
<a href="https://rdar.apple.com/142975586">rdar://142975586</a>

Reviewed by Mike Wyrzykowski.

While packing types, when visiting arrays of vec3 we marked that vec3 is used,
but failed to mark that the array is also used, which could result in the array
helpers missings from the generated metal code.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::packArrayType):
* Source/WebGPU/WGSL/tests/valid/packing-nested-array.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/289344@main">https://commits.webkit.org/289344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79cbaf5486c9cb4c9f139c1e9d613a1c9a0d131e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37250 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66925 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24711 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4753 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78312 "Failed to checkout and rebase branch from PR 39466") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4558 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93214 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75718 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74176 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74900 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17566 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6458 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18953 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->