### PR TITLE
Expose more serialized type info for OptionalTuple types

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -339,7 +339,13 @@ Vector<SerializedTypeInfo> allSerializedTypes()
 #endif
                     ", bool"
                 ">"_s,
-                "optionalTuple"_s
+                "OptionalTuple<"
+                    "name"
+#if ENABLE(FEATURE)
+                    ", featureEnabledMember"
+#endif
+                    ", bitFieldMember"
+                ">"_s
             },
         } },
         { "WebKit::TemplateTest"_s, {
@@ -361,7 +367,9 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "OptionalTuple<"
                     "std::optional<WebCore::PlatformLayerIdentifier>"
                 ">"_s,
-                "optionalTuple"_s
+                "OptionalTuple<"
+                    "layer().layerIDForEncoding()"
+                ">"_s
             },
         } },
         { "WebCore::ScrollingStateFrameHostingNodeWithStuffAfterTuple"_s, {
@@ -378,7 +386,10 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                     "std::optional<WebCore::PlatformLayerIdentifier>"
                     ", bool"
                 ">"_s,
-                "optionalTuple"_s
+                "OptionalTuple<"
+                    "layer().layerIDForEncoding()"
+                    ", otherMember"
+                ">"_s
             },
             {
                 "int"_s,


### PR DESCRIPTION
#### dfa11c72ea8f9f107bc148644a791134f50fb448
<pre>
Expose more serialized type info for OptionalTuple types
<a href="https://bugs.webkit.org/show_bug.cgi?id=286439">https://bugs.webkit.org/show_bug.cgi?id=286439</a>
<a href="https://rdar.apple.com/143363065">rdar://143363065</a>

Reviewed by Brady Eidson.

optionalTuple isn&apos;t quite as descriptive to people looking through
the IPC metadata.  This replaces it with OptionalTuple&lt;&gt; with a list
of the member names.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_optional_tuple_type_info):
(generate_one_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):

Canonical link: <a href="https://commits.webkit.org/289351@main">https://commits.webkit.org/289351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cd7d979906be1cd2ba87557eb45d762767ebd81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37252 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24710 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78315 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47246 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/85978 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4560 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93216 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13660 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9899 "Found 3 new test failures: fast/events/event-handler-detached-document.html fast/writing-mode/english-rl-text-with-spelling-marker.html pdf/pdf-plugin-printing.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74901 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19174 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6459 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13464 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18954 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->