### PR TITLE
Try to suspend processes that exceed background memory threshold instead of killing them

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -65,6 +65,12 @@ enum class WebsamProcessState : uint8_t {
     Inactive,
 };
 
+enum class WebsamFootprintLevel : uint8_t {
+    BelowInactiveKillThreshold,
+    BetweenInactiveAndActiveKillThreshold,
+    AboveActiveKillThreshold,
+};
+
 enum class Critical : bool { No, Yes };
 enum class Synchronous : bool { No, Yes };
 
@@ -101,7 +107,7 @@ public:
     WTF_EXPORT_PRIVATE void triggerMemoryPressureEvent(bool isCritical);
 #endif
 
-    void setMemoryKillCallback(WTF::Function<void()>&& function) { m_memoryKillCallback = WTFMove(function); }
+    void setMemoryKillCallback(WTF::Function<void(WebsamProcessState, WebsamFootprintLevel)>&& function) { m_memoryKillCallback = WTFMove(function); }
     void setMemoryPressureStatusChangedCallback(WTF::Function<void()>&& function) { m_memoryPressureStatusChangedCallback = WTFMove(function); }
     void setDidExceedProcessMemoryLimitCallback(WTF::Function<void(ProcessMemoryLimit)>&& function) { m_didExceedProcessMemoryLimitCallback = WTFMove(function); }
 
@@ -219,6 +225,8 @@ public:
 
 private:
     std::optional<size_t> thresholdForMemoryKill();
+    std::optional<size_t> thresholdForMemoryKillOfInactiveProcess();
+    std::optional<size_t> thresholdForMemoryKillOfActiveProcess();
     size_t thresholdForPolicy(MemoryUsagePolicy);
     MemoryUsagePolicy policyForFootprint(size_t);
 
@@ -253,7 +261,7 @@ private:
     MemoryUsagePolicy m_memoryUsagePolicy { MemoryUsagePolicy::Unrestricted };
 
     std::unique_ptr<RunLoop::Timer>m_measurementTimer;
-    WTF::Function<void()> m_memoryKillCallback;
+    WTF::Function<void(WebsamProcessState, WebsamFootprintLevel)> m_memoryKillCallback;
     WTF::Function<void()> m_memoryPressureStatusChangedCallback;
     WTF::Function<void(ProcessMemoryLimit)> m_didExceedProcessMemoryLimitCallback;
     LowMemoryHandler m_lowMemoryHandler;
@@ -285,3 +293,4 @@ using WTF::MemoryPressureHandler;
 using WTF::Synchronous;
 using WTF::SystemMemoryPressureStatus;
 using WTF::WebsamProcessState;
+using WTF::WebsamFootprintLevel;

--- a/Source/WebCore/page/PerformanceMonitor.cpp
+++ b/Source/WebCore/page/PerformanceMonitor.cpp
@@ -51,7 +51,7 @@ static constexpr const Seconds cpuUsageSamplingInterval { 10_min };
 
 static constexpr const Seconds memoryUsageMeasurementDelay { 10_s };
 
-static constexpr const Seconds delayBeforeProcessMayBecomeInactive { 8_min };
+static constexpr const Seconds delayBeforeProcessMayBecomeInactive { 1_min };
 
 static constexpr const double postPageLoadCPUUsageDomainReportingThreshold { 20.0 }; // Reporting pages using over 20% CPU is roughly equivalent to reporting the 10% worst pages.
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp
@@ -150,7 +150,7 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
         auto& memoryPressureHandler = MemoryPressureHandler::singleton();
         memoryPressureHandler.setConfiguration(*parameters.memoryPressureHandlerConfiguration);
         memoryPressureHandler.setShouldUsePeriodicMemoryMonitor(true);
-        memoryPressureHandler.setMemoryKillCallback([this] () {
+        memoryPressureHandler.setMemoryKillCallback([this] (auto&&, auto&&) {
             parentProcessConnection()->send(Messages::NetworkProcessProxy::DidExceedMemoryLimit(), 0);
         });
     }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -614,6 +614,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::WebKeyboardEvent',
         'WebKit::XRDeviceIdentifier',
         'WTF::SystemMemoryPressureStatus',
+        'WTF::WebsamFootprintLevel',
     ] + types_that_must_be_moved())
 
 
@@ -1415,6 +1416,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebKit::WebUserStyleSheetData': ['"WebUserContentControllerDataTypes.h"'],
         'WTF::UnixFileDescriptor': ['<wtf/unix/UnixFileDescriptor.h>'],
         'WTF::SystemMemoryPressureStatus': ['<wtf/MemoryPressureHandler.h>'],
+        'WTF::WebsamFootprintLevel': ['<wtf/MemoryPressureHandler.h>'],
         'webrtc::WebKitEncodedFrameInfo': ['"RTCWebKitEncodedFrameInfo.h"'],
     }
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -248,6 +248,13 @@ header: <wtf/Variant.h>
 [AdditionalEncoder=StreamConnectionEncoder, Nested] struct std::monostate {
 }
 
+header: <wtf/MemoryPressureHandler.h>
+[CustomHeader] enum class WTF::WebsamFootprintLevel : uint8_t {
+    BelowInactiveKillThreshold,
+    BetweenInactiveAndActiveKillThreshold,
+    AboveActiveKillThreshold,
+}
+
 enum class WTFLogLevel : uint8_t {
     Always,
     Error,

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -210,6 +210,17 @@ void ProcessThrottler::invalidateAllActivitiesAndDropAssertion()
     clearAssertion();
 }
 
+std::optional<ASCIILiteral> ProcessThrottler::anyActivityName() const
+{
+    for (auto& activity : m_foregroundActivities)
+        return activity.name();
+
+    for (auto& activity : m_backgroundActivities)
+        return activity.name();
+
+    return std::nullopt;
+}
+
 ProcessThrottleState ProcessThrottler::expectedThrottleState()
 {
     if (!m_foregroundActivities.isEmptyIgnoringNullReferences())

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -144,6 +144,8 @@ public:
 
     void invalidateAllActivitiesAndDropAssertion();
 
+    std::optional<ASCIILiteral> anyActivityName() const;
+
 private:
     friend class ProcessThrottlerActivity;
     friend WTF::TextStream& operator<<(WTF::TextStream&, const ProcessThrottler&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -734,6 +734,14 @@ bool WebPageProxy::hasValidOpeningAppLinkActivity() const
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
 
+void WebPageProxy::dropRecentlyVisibleActivity()
+{
+    m_mainFrameProcessActivityState->dropRecentlyVisibleActivity();
+    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+        remotePageProxy.processActivityState().dropRecentlyVisibleActivity();
+    });
+}
+
 void WebPageProxy::updateWebProcessSuspensionDelay()
 {
     m_mainFrameProcessActivityState->updateWebProcessSuspensionDelay();
@@ -7629,6 +7637,12 @@ void WebPageProxy::isNoLongerAssociatedWithRemotePage(RemotePageProxy&)
 bool WebPageProxy::hasAllowedToRunInTheBackgroundActivity() const
 {
     return internals().pageAllowedToRunInTheBackgroundActivityDueToTitleChanges || internals().pageAllowedToRunInTheBackgroundActivityDueToNotifications;
+}
+
+void WebPageProxy::dropAllowedToRunInTheBackgroundActivities()
+{
+    internals().pageAllowedToRunInTheBackgroundActivityDueToTitleChanges = nullptr;
+    internals().pageAllowedToRunInTheBackgroundActivityDueToNotifications = nullptr;
 }
 
 void WebPageProxy::didReceiveTitleForFrame(IPC::Connection& connection, FrameIdentifier frameID, String&& title, const UserData& userData)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2661,6 +2661,7 @@ public:
 #endif
 
     bool hasAllowedToRunInTheBackgroundActivity() const;
+    void dropAllowedToRunInTheBackgroundActivities();
 
     template<typename M> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&, OptionSet<IPC::SendOption> = { });
     template<typename M, typename C> void sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(std::optional<WebCore::FrameIdentifier>, M&&, C&&, OptionSet<IPC::SendOption> = { });
@@ -2715,6 +2716,7 @@ public:
     WebProcessActivityState& processActivityState();
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
+    void dropRecentlyVisibleActivity();
     void updateWebProcessSuspensionDelay();
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -51,7 +51,7 @@ static Seconds webProcessSuspensionDelay(const WebPageProxy* page)
 
 WebProcessActivityState::WebProcessActivityState(WebPageProxy& page)
     : m_page(page)
-#if PLATFORM(MAC)
+#if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     , m_wasRecentlyVisibleActivity(ProcessThrottlerTimedActivity::create(webProcessSuspensionDelay(&page)))
 #endif
 {
@@ -59,7 +59,7 @@ WebProcessActivityState::WebProcessActivityState(WebPageProxy& page)
 
 WebProcessActivityState::WebProcessActivityState(RemotePageProxy& page)
     : m_page(page)
-#if PLATFORM(MAC)
+#if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     , m_wasRecentlyVisibleActivity(ProcessThrottlerTimedActivity::create(webProcessSuspensionDelay(page.protectedPage().get())))
 #endif
 {
@@ -68,7 +68,7 @@ WebProcessActivityState::WebProcessActivityState(RemotePageProxy& page)
 void WebProcessActivityState::takeVisibleActivity()
 {
     m_isVisibleActivity = protectedProcess()->protectedThrottler()->foregroundActivity("View is visible"_s);
-#if PLATFORM(MAC)
+#if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     m_wasRecentlyVisibleActivity->setActivity(nullptr);
 #endif
 }
@@ -106,7 +106,7 @@ void WebProcessActivityState::takeMutedCaptureAssertion()
 void WebProcessActivityState::reset()
 {
     m_isVisibleActivity = nullptr;
-#if PLATFORM(MAC)
+#if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     m_wasRecentlyVisibleActivity->setActivity(nullptr);
 #endif
     m_isAudibleActivity = nullptr;
@@ -119,7 +119,7 @@ void WebProcessActivityState::reset()
 
 void WebProcessActivityState::dropVisibleActivity()
 {
-#if PLATFORM(MAC)
+#if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     if (WTF::numberOfProcessorCores() > 4)
         m_wasRecentlyVisibleActivity->setActivity(protectedProcess()->protectedThrottler()->backgroundActivity("View was recently visible"_s));
     else
@@ -127,6 +127,13 @@ void WebProcessActivityState::dropVisibleActivity()
 #endif
     m_isVisibleActivity = nullptr;
 }
+
+#if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
+void WebProcessActivityState::dropRecentlyVisibleActivity()
+{
+    m_wasRecentlyVisibleActivity->setActivity(nullptr);
+}
+#endif
 
 void WebProcessActivityState::dropAudibleActivity()
 {

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -64,6 +64,7 @@ public:
 #endif
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
+    void dropRecentlyVisibleActivity();
     void updateWebProcessSuspensionDelay();
     void takeAccessibilityActivityWhenInWindow();
     void takeAccessibilityActivity();

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -337,6 +337,8 @@ public:
     SystemMemoryPressureStatus memoryPressureStatus() const { return m_memoryPressureStatus; }
     void memoryPressureStatusChanged(SystemMemoryPressureStatus);
 
+    bool tryToForceSuspend();
+
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     void updateWebProcessSuspensionDelay();
 #endif
@@ -345,7 +347,7 @@ public:
 
     void didExceedCPULimit();
     void didExceedActiveMemoryLimit();
-    void didExceedInactiveMemoryLimit();
+    void didExceedInactiveMemoryLimit(WebsamFootprintLevel);
     void didExceedMemoryFootprintThreshold(size_t);
 
     void didCommitProvisionalLoad() { m_hasCommittedAnyProvisionalLoads = true; }

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -47,7 +47,7 @@ messages -> WebProcessProxy WantsDispatchMessage {
 #endif
 
     DidExceedActiveMemoryLimit()
-    DidExceedInactiveMemoryLimit()
+    DidExceedInactiveMemoryLimit(WTF::WebsamFootprintLevel level)
     DidExceedMemoryFootprintThreshold(size_t footprint)
     DidExceedCPULimit()
 


### PR DESCRIPTION
#### b43c3458ba33b006b598aba2dd83cf0727d28ca6
<pre>
Try to suspend processes that exceed background memory threshold instead of killing them
<a href="https://bugs.webkit.org/show_bug.cgi?id=286442">https://bugs.webkit.org/show_bug.cgi?id=286442</a>
<a href="https://rdar.apple.com/141308517">rdar://141308517</a>

Reviewed by NOBODY (OOPS!).

We&apos;d like to minimize the amount of webpages killed in the background (or &quot;inactive&quot; in
MemoryPressureHandler parlance) due to using too much memory, since that leads to a bad user
experience.

To enable this, we change the `WebProcessProxy::didExceedInactiveMemoryLimit` message to also carry
a new parameter providing more information about the footprint level that violated the inactive
memory limit. If the footprint level exceeds the foreground/active limit, then we continue to kill
the process as we always have. However, if the level is between the background/inactive and
foreground/active limit, then we attempt to suspend the process rather than killing it via
`WebProcessProxy::tryToForceSuspend`.

* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::thresholdForMemoryKillOfActiveProcessWithPageCount):
(WTF::thresholdForMemoryKillOfInactiveProcessWithPageCount):
(WTF::MemoryPressureHandler::thresholdForMemoryKill):
(WTF::MemoryPressureHandler::thresholdForMemoryKillOfInactiveProcess):
(WTF::MemoryPressureHandler::thresholdForMemoryKillOfActiveProcess):
(WTF::MemoryPressureHandler::shrinkOrDie):
(WTF::thresholdForMemoryKillOfActiveProcess): Deleted.
(WTF::thresholdForMemoryKillOfInactiveProcess): Deleted.
* Source/WTF/wtf/MemoryPressureHandler.h:
(WTF::MemoryPressureHandler::setMemoryKillCallback):
* Source/WebCore/page/PerformanceMonitor.cpp:
* Source/WebKit/NetworkProcess/soup/NetworkProcessSoup.cpp:
(WebKit::NetworkProcess::platformInitializeNetworkProcess):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
(headers_for_type):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dropRecentlyVisibleActivity):
(WebKit::WebPageProxy::dropAllowedToRunInTheBackgroundActivities):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::WebProcessActivityState):
(WebKit::WebProcessActivityState::takeVisibleActivity):
(WebKit::WebProcessActivityState::reset):
(WebKit::WebProcessActivityState::dropVisibleActivity):
(WebKit::WebProcessActivityState::dropRecentlyVisibleActivity):
* Source/WebKit/UIProcess/WebProcessActivityState.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::dropAllowedToRunInTheBackgroundActivities):
(WebKit::WebProcessProxy::dropRecentlyVisibleActivity):
(WebKit::WebProcessProxy::didExceedInactiveMemoryLimit):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43c3458ba33b006b598aba2dd83cf0727d28ca6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/105597 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/25346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/56209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/107638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/80196 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/108603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/20139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/95296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/60505 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/105075 "Passed tests") | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19888 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/13388 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55632 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/98235 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/89589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/13427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/113624 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/104215 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/24133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/89275 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/33097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/91525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88939 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/28177 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32661 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/38045 "") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/128527 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/32407 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/35109 "Found 2 new JSC stress test failures: wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager, wasm.yaml/wasm/gc/ref-i31-eq.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/34004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->