### PR TITLE
JSC should have options to more aggresively use PGM

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3951,7 +3951,7 @@ static NO_RETURN void printUsageStatement(bool help = false)
     fprintf(stderr, "  --options                  Dumps all JSC VM options and exits\n");
     fprintf(stderr, "  --dumpOptions              Dumps all non-default JSC VM options before continuing\n");
     fprintf(stderr, "  --<jsc VM option>=<value>  Sets the specified JSC VM option\n");
-#if PLATFORM(COCOA)
+#if USE(LIBPAS)
     fprintf(stderr, "  --crash-vm=<value>         Crash VM on startup due to PGM failure. Options PGMOOBLowerGuardPage, PGMOOBUpperGuardPage, or PGMUAF (For Testing Purposes).\n");
 #endif
     fprintf(stderr, "  --destroy-vm               Destroy VM before exiting\n");
@@ -3973,12 +3973,12 @@ static bool isMJSFile(char *filename)
     return false;
 }
 
-#if PLATFORM(COCOA)
+#if USE(LIBPAS)
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 static NEVER_INLINE void crashPGMUAF()
 {
-    WTF::forceEnablePGM();
+    WTF::forceEnablePGM(1);
     size_t allocSize = getpagesize() * 10000;
     char* result = static_cast<char*>(fastMalloc(allocSize));
     fastFree(result);
@@ -3987,7 +3987,7 @@ static NEVER_INLINE void crashPGMUAF()
 
 static NEVER_INLINE void crashPGMUpperGuardPage()
 {
-    WTF::forceEnablePGM();
+    WTF::forceEnablePGM(1);
     size_t allocSize = getpagesize() * 10000;
     char* result = static_cast<char*>(fastMalloc(allocSize));
     result = result + allocSize;
@@ -3996,7 +3996,7 @@ static NEVER_INLINE void crashPGMUpperGuardPage()
 
 static NEVER_INLINE void crashPGMLowerGuardPage()
 {
-    WTF::forceEnablePGM();
+    WTF::forceEnablePGM(1);
     size_t allocSize = getpagesize() * 10000;
     char* result = static_cast<char*>(fastMalloc(allocSize));
     result = result - 1;
@@ -4013,7 +4013,7 @@ void CommandLine::parseArguments(int argc, char** argv)
     Options::AllowUnfinalizedAccessScope scope;
     Options::initialize();
     Options::useSharedArrayBuffer() = true;
-    
+
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(APPLETV) && !PLATFORM(WATCHOS)
     Options::crashIfCantAllocateJITMemory() = true;
 #endif
@@ -4133,7 +4133,7 @@ void CommandLine::parseArguments(int argc, char** argv)
             m_dumpSamplingProfilerData = true;
             continue;
         }
-#if PLATFORM(COCOA)
+#if USE(LIBPAS)
         if (!strcmp(arg, "--crash-vm=PGMOOBLowerGuardPage"))
             crashPGMLowerGuardPage();
         if (!strcmp(arg, "--crash-vm=PGMOOBUpperGuardPage"))

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1092,6 +1092,7 @@ void Options::initialize()
             if (Options::useMachForExceptions())
                 handleSignalsWithMach();
 #endif
+
     });
 }
 
@@ -1107,6 +1108,11 @@ void Options::finalize()
     assertOptionsAreCoherent();
     if (UNLIKELY(Options::dumpOptions()))
         executeDumpOptions();
+
+#if USE(LIBPAS)
+    if (Options::libpasForcePGMWithRate())
+        WTF::forceEnablePGM(Options::libpasForcePGMWithRate());
+#endif
 
     OptionsHelper::releaseMetadata();
 }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -579,6 +579,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code."_s) \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \
+    v(Unsigned, libpasForcePGMWithRate, 0, Normal, "Forces on probablistic guard malloc and guards allocations with a rate 1/N (0 is disabled)"_s) \
     v(Bool, useWasmFaultSignalHandler, true, Normal, nullptr) \
     v(Bool, dumpUnlinkedDFGValidation, false, Normal, nullptr) \
     v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -874,9 +874,9 @@ void fastDisableScavenger()
     bmalloc::api::disableScavenger();
 }
 
-void forceEnablePGM()
+void forceEnablePGM(uint16_t guardMallocRate)
 {
-    bmalloc::api::forceEnablePGM();
+    bmalloc::api::forceEnablePGM(guardMallocRate);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -27,6 +27,11 @@
 
 #if !USE(SYSTEM_MALLOC)
 #include <bmalloc/BPlatform.h>
+// Enable USE(LIBPAS)
+// FIXME: Replaces uses of `#if !USE(SYSTEM_MALLOC) \n #if BUSE(LIBPAS)` with `#if USE(LIBPAS)`
+#if BUSE(LIBPAS)
+#define USE_LIBPAS 1
+#endif
 #endif
 
 namespace WTF {
@@ -208,7 +213,8 @@ WTF_EXPORT_PRIVATE void fastEnableMiniMode();
 
 WTF_EXPORT_PRIVATE void fastDisableScavenger();
 
-WTF_EXPORT_PRIVATE void forceEnablePGM();
+// allocate with guard pages at a rate of 1/guardMallocRate
+WTF_EXPORT_PRIVATE void forceEnablePGM(uint16_t guardMallocRate);
 
 class ForbidMallocUseForCurrentThreadScope {
 public:

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -233,10 +233,12 @@ void disableScavenger()
 #endif
 }
 
-void forceEnablePGM()
+void forceEnablePGM(uint16_t guardMallocRate)
 {
 #if BUSE(LIBPAS)
-    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled();
+    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(guardMallocRate);
+#else
+    BUNUSED_PARAM(guardMallocRate);
 #endif
 }
 

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -230,7 +230,7 @@ BEXPORT void enableMiniMode();
 
 // Used for debugging only.
 BEXPORT void disableScavenger();
-BEXPORT void forceEnablePGM();
+BEXPORT void forceEnablePGM(uint16_t guardMallocRate);
 
 #if BENABLE(MALLOC_SIZE)
 inline size_t mallocSize(const void* object)

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -334,11 +334,11 @@ void pas_probabilistic_guard_malloc_initialize_pgm(void)
 /*
  * This function shall be called for testing PGM behavior, since PGM enablement will be non-deterministic otherwise.
  */
-void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(void)
+void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(uint16_t pgm_random_rate)
 {
     pas_probabilistic_guard_malloc_is_initialized = true;
     pas_probabilistic_guard_malloc_can_use = true;
-    pas_probabilistic_guard_malloc_random = 1;
+    pas_probabilistic_guard_malloc_random = pgm_random_rate;
     pas_probabilistic_guard_malloc_counter = 0;
     memset(pgm_metadata_vector, 0, sizeof(pgm_metadata_vector));
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -151,7 +151,7 @@ static PAS_ALWAYS_INLINE bool pas_probabilistic_guard_malloc_should_call_pgm(voi
 }
 
 extern PAS_API void pas_probabilistic_guard_malloc_initialize_pgm(void);
-extern PAS_API void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(void);
+extern PAS_API void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(uint16_t pgm_random_rate);
 pas_large_map_entry pas_probabilistic_guard_malloc_return_as_large_map_entry(uintptr_t mem);
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/test/PGMTests.cpp
+++ b/Source/bmalloc/libpas/src/test/PGMTests.cpp
@@ -272,7 +272,7 @@ void testPGMErrors() {
 }
 
 void testPGMMetadataVectorManagement() {
-    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled();
+    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(1);
 
     pas_heap_lock_lock();
     pas_root* root = pas_root_create();
@@ -308,7 +308,7 @@ void testPGMMetadataVectorManagement() {
 }
 
 void testPGMMetadataVectorManagementFewDeallocations() {
-    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled();
+    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(1);
 
     pas_heap_lock_lock();
     pas_root* root = pas_root_create();
@@ -346,7 +346,7 @@ void testPGMMetadataVectorManagementFewDeallocations() {
 /* Backtrace API is currently not supported on PlayStation. */
 #if !PAS_PLATFORM(PLAYSTATION)
 void testPGMMetadataDoubleFreeBehavior() {
-    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled();
+    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(1);
 
     pas_heap_lock_lock();
     pas_root* root = pas_root_create();

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1141,7 +1141,8 @@ BASE_MODES = [
         "NoCJIT",
         "ftl-no-cjit",
         [
-            "--validateBytecode=true", "--validateGraphAtEachPhase=true"
+            "--validateBytecode=true", "--validateGraphAtEachPhase=true", "--libpasForcePGMWithRate=#{10 + rand(10)}",
+
         ] +
         FTL_OPTIONS +
         NO_CJIT_OPTIONS +
@@ -1153,6 +1154,7 @@ BASE_MODES = [
         [
             "--useDataICInFTL=true",
             "--allowNonSPTagging=false",
+            "--libpasForcePGMWithRate=#{10 + rand(10)}",
         ] +
         FTL_OPTIONS +
         NO_CJIT_OPTIONS
@@ -1255,6 +1257,7 @@ BASE_MODES = [
             "--validateGraph=true",
             "--validateBCE=true",
             "--airForceIRCAllocator=true",
+            "--libpasForcePGMWithRate=#{10 + rand(10)}",
         ] +
         FTL_OPTIONS +
         NO_CJIT_OPTIONS +
@@ -1354,6 +1357,7 @@ BASE_MODES = [
             "--useZombieMode=true",
             "--allowDoubleShape=false",
             "--alwaysHaveABadTime=true",
+            "--libpasForcePGMWithRate=#{10 + rand(10)}",
         ]
     ],
     [


### PR DESCRIPTION
#### 477444b37b601f38660f2115815a198d306676af
<pre>
JSC should have options to more aggresively use PGM
<a href="https://bugs.webkit.org/show_bug.cgi?id=286443">https://bugs.webkit.org/show_bug.cgi?id=286443</a>
<a href="https://rdar.apple.com/143525317">rdar://143525317</a>

Reviewed by Yusuke Suzuki and Mark Lam.

We recently had a bunch of bugs in PGM because it ran too infrequently
on the bots to be noticed. This patch plumbs out a way to force PGM to
run more aggressively and uses it for some JSC configurations.

* Source/JavaScriptCore/jsc.cpp:
(printUsageStatement):
(crashPGMUAF):
(crashPGMUpperGuardPage):
(crashPGMLowerGuardPage):
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::initialize):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::forceEnablePGM):
* Source/WTF/wtf/FastMalloc.h:
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::forceEnablePGM):
* Source/bmalloc/bmalloc/bmalloc.h:
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_initialize_pgm_as_enabled):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(std::testPGMMetadataVectorManagement):
(std::testPGMMetadataVectorManagementFewDeallocations):
(std::testPGMMetadataDoubleFreeBehavior):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/289461@main">https://commits.webkit.org/289461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/975d5b845ceca2a3d5a9cea49bd4acc327d4dc3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86916 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67195 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24967 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33037 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36766 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79733 "Failed to checkout and rebase branch from PR 39472") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93657 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85689 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75189 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18523 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6912 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19382 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108182 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13830 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26036 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->