### PR TITLE
[UnifiedPDF] At certain scales, "Previous Page" context menu option does not navigate to previous page in 2-up continuous mode

### DIFF
--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -181,10 +181,10 @@ void ScrollableArea::endKeyboardScroll(bool immediate)
         setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
 }
 
-void ScrollableArea::scrollToPositionWithoutAnimation(const FloatPoint& position, ScrollClamping clamping)
+bool ScrollableArea::scrollToPositionWithoutAnimation(const FloatPoint& position, ScrollClamping clamping)
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToPositionWithoutAnimation " << position);
-    scrollAnimator().scrollToPositionWithoutAnimation(position, clamping);
+    return scrollAnimator().scrollToPositionWithoutAnimation(position, clamping);
 }
 
 void ScrollableArea::scrollToPositionWithAnimation(const FloatPoint& position, const ScrollPositionChangeOptions& options)

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -89,7 +89,7 @@ public:
 
     WEBCORE_EXPORT bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1);
     WEBCORE_EXPORT void scrollToPositionWithAnimation(const FloatPoint&, const ScrollPositionChangeOptions& options = ScrollPositionChangeOptions::createProgrammatic());
-    WEBCORE_EXPORT void scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
+    WEBCORE_EXPORT bool scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
 
     WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
     WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(ScrollbarOrientation, float offset);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -144,7 +144,7 @@ private:
 
     void applyWheelEventDelta(FloatSize);
 
-    std::optional<PDFDocumentLayout::PageIndex> pageIndexForCurrentView(DocumentAnchorPoint) const override;
+    std::optional<PDFDocumentLayout::PageIndex> pageIndexForCurrentView(AnchorPoint) const override;
     void restorePDFPosition(const VisiblePDFPosition&) override;
 
     void ensurePageIsVisible(PDFDocumentLayout::PageIndex) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -1354,7 +1354,7 @@ void PDFDiscretePresentationController::didGeneratePreviewForPage(PDFDocumentLay
 
 #pragma mark -
 
-std::optional<PDFDocumentLayout::PageIndex> PDFDiscretePresentationController::pageIndexForCurrentView(DocumentAnchorPoint) const
+std::optional<PDFDocumentLayout::PageIndex> PDFDiscretePresentationController::pageIndexForCurrentView(AnchorPoint) const
 {
     return visibleRow().transform([](const auto& row) {
         return row.pages[0];

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -99,9 +99,10 @@ public:
         WebCore::FloatPoint pagePoint;
     };
 
-    enum class DocumentAnchorPoint : uint8_t { TopLeft, Center };
-    std::optional<VisiblePDFPosition> pdfPositionForCurrentView(DocumentAnchorPoint, bool preservePosition = true) const;
-    virtual std::optional<PDFDocumentLayout::PageIndex> pageIndexForCurrentView(DocumentAnchorPoint) const = 0;
+    enum class AnchorPoint : uint8_t { TopLeft, Center };
+    std::optional<VisiblePDFPosition> pdfPositionForCurrentView(AnchorPoint, bool preservePosition = true) const;
+    WebCore::FloatPoint anchorPointInDocumentSpace(AnchorPoint) const;
+    virtual std::optional<PDFDocumentLayout::PageIndex> pageIndexForCurrentView(AnchorPoint) const = 0;
     virtual void restorePDFPosition(const VisiblePDFPosition&) = 0;
 
     virtual void ensurePageIsVisible(PDFDocumentLayout::PageIndex) = 0;
@@ -138,8 +139,6 @@ protected:
     Ref<AsyncPDFRenderer> asyncRenderer();
     RefPtr<AsyncPDFRenderer> asyncRendererIfExists() const;
     void clearAsyncRenderer();
-
-    WebCore::FloatPoint anchorPointForDocument(DocumentAnchorPoint) const;
 
     Ref<UnifiedPDFPlugin> m_plugin;
     RefPtr<AsyncPDFRenderer> m_asyncRenderer;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -237,7 +237,7 @@ std::optional<PDFDocumentLayout::PageIndex> PDFPresentationController::pageIndex
     return { };
 }
 
-auto PDFPresentationController::pdfPositionForCurrentView(DocumentAnchorPoint anchorPoint, bool preservePosition) const -> std::optional<VisiblePDFPosition>
+auto PDFPresentationController::pdfPositionForCurrentView(AnchorPoint anchorPoint, bool preservePosition) const -> std::optional<VisiblePDFPosition>
 {
     if (!preservePosition)
         return { };
@@ -260,13 +260,13 @@ auto PDFPresentationController::pdfPositionForCurrentView(DocumentAnchorPoint an
     return VisiblePDFPosition { pageIndex, pagePoint };
 }
 
-FloatPoint PDFPresentationController::anchorPointForDocument(DocumentAnchorPoint anchorPoint) const
+FloatPoint PDFPresentationController::anchorPointInDocumentSpace(AnchorPoint anchorPoint) const
 {
     auto anchorPointInPluginSpace = [anchorPoint, checkedPlugin = CheckedRef { m_plugin.get() }] -> FloatPoint {
         switch (anchorPoint) {
-        case DocumentAnchorPoint::TopLeft:
+        case AnchorPoint::TopLeft:
             return { };
-        case DocumentAnchorPoint::Center:
+        case AnchorPoint::Center:
             return flooredIntPoint(checkedPlugin->size() / 2);
         }
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -74,7 +74,7 @@ private:
     CheckedPtr<WebCore::KeyboardScrollingAnimator> checkedKeyboardScrollingAnimator() const;
 #endif
 
-    std::optional<PDFDocumentLayout::PageIndex> pageIndexForCurrentView(DocumentAnchorPoint) const override;
+    std::optional<PDFDocumentLayout::PageIndex> pageIndexForCurrentView(AnchorPoint) const override;
     void restorePDFPosition(const VisiblePDFPosition&) override;
 
     void ensurePageIsVisible(PDFDocumentLayout::PageIndex) override { }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -335,9 +335,9 @@ std::optional<PDFDocumentLayout::PageIndex> PDFScrollingPresentationController::
 
 #pragma mark -
 
-std::optional<PDFDocumentLayout::PageIndex> PDFScrollingPresentationController::pageIndexForCurrentView(DocumentAnchorPoint anchorPoint) const
+std::optional<PDFDocumentLayout::PageIndex> PDFScrollingPresentationController::pageIndexForCurrentView(AnchorPoint anchorPoint) const
 {
-    return m_plugin->documentLayout().pageIndexAndPagePointForDocumentYOffset(anchorPointForDocument(anchorPoint).y()).first;
+    return m_plugin->documentLayout().pageIndexAndPagePointForDocumentYOffset(anchorPointInDocumentSpace(anchorPoint).y()).first;
 }
 
 void PDFScrollingPresentationController::restorePDFPosition(const VisiblePDFPosition& info)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -495,11 +495,11 @@ private:
     void revealPDFDestination(PDFDestination *);
     void revealPointInPage(WebCore::FloatPoint pointInPDFPageSpace, PDFDocumentLayout::PageIndex);
     void revealRectInPage(const WebCore::FloatRect& rectInPDFPageSpace, PDFDocumentLayout::PageIndex);
-    void revealPage(PDFDocumentLayout::PageIndex);
+    bool revealPage(PDFDocumentLayout::PageIndex);
     void revealFragmentIfNeeded();
 
     // Only use this if some other function has ensured that the correct page is visible.
-    void scrollToPointInContentsSpace(WebCore::FloatPoint);
+    bool scrollToPointInContentsSpace(WebCore::FloatPoint);
 
     OptionSet<WebCore::TiledBackingScrollability> computeScrollability() const;
 


### PR DESCRIPTION
#### 4923f3abc3d510db9ae1f74812b75c1debb62157
<pre>
[UnifiedPDF] At certain scales, &quot;Previous Page&quot; context menu option does not navigate to previous page in 2-up continuous mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=286440">https://bugs.webkit.org/show_bug.cgi?id=286440</a>
<a href="https://rdar.apple.com/139817364">rdar://139817364</a>

Reviewed by Simon Fraser and Megan Gardner.

The &quot;Previous Page&quot; context menu option would feel like a no-op (or
even, would navigate forwards) at certain scales because we would get
the index of the page &quot;currently&quot; in view, i.e. center-most page, and
only navigate backwards by a row. When zoomed out far enough, this
center-most page and the pages offset by a row are all roughly in the
middle of the page, so we don&apos;t end up invoking revealPage() on the
appropriate index.

This patch tries to be smarter about which page we land on with the
context menu option. We ideally want to end up on the first page above
the root view bounds, but this does not translate well to discrete
display modes because you only ever have one row visible in the root
view. Thus, we either go one row behind the page &quot;currently&quot; in view, or
use the metric I just mentioned.

Moreover, when zoomed out far enough, if the top edge of a page
perfectly aligns with the root view&apos;s edge, then our new metric makes us
land on said page consistently, taking us back to no-op-like navigation.
To avoid this, we teach the plugin to consult the return value of the
ScrollableArea helpers it uses under revealPage(). If we don&apos;t
successfully scroll during the reveal operation, we move back one row
and try again. More details about this later in the commit message.

* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollToPositionWithoutAnimation):
* Source/WebCore/platform/ScrollableArea.h:

Forward ScrollAnimator::scrollToPositionWithoutAnimation()&apos;s return value
through its ScrollableArea caller, which the plugin will use to
determine the success of scrollToPointInContentsSpace() calls.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::pageIndexForCurrentView const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::pdfPositionForCurrentView const):
(WebKit::PDFPresentationController::anchorPointInDocumentSpace const):
(WebKit::PDFPresentationController::anchorPointForDocument const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::pageIndexForCurrentView const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayout):

The changes above are all a drive-by naming change to better reflect the
coordinate space for `anchorPoint`.

(WebKit::UnifiedPDFPlugin::revealPage):
(WebKit::UnifiedPDFPlugin::scrollToPointInContentsSpace):

Return the result of ScrollableArea::scrollToPositionWithoutAnimation()
for the continuous display mode case. For discrete display modes, we can
always return true under the assumption that callers have ensured that
the correct page is visible.

(WebKit::UnifiedPDFPlugin::performContextMenuAction):

Canonical link: <a href="https://commits.webkit.org/289337@main">https://commits.webkit.org/289337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63c15fcae74a7342e867f02b78753fb838895649

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66980 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/24758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47304 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4620 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32725 "Found 8 new test failures: editing/undo/redo-reapply-edit-command-crash.html http/tests/security/contentSecurityPolicy/script-src-parsing-implicit-and-explicit-port-number.html http/tests/security/contentSecurityPolicy/script-src-star-cross-scheme.html http/tests/security/contentSecurityPolicy/source-list-parsing-10.html http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html http/tests/xmlhttprequest/cross-origin-cookie-storage.html imported/w3c/web-platform-tests/xhr/request-content-length.any.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36441 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93298 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9949 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74239 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/74960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18442 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19247 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17638 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13763 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13501 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->