### PR TITLE
[iOS][visionOS] web.webex.com: Icons inside some buttons can be too small

### DIFF
--- a/LayoutTests/interaction-region/button-in-link-expected.txt
+++ b/LayoutTests/interaction-region/button-in-link-expected.txt
@@ -13,10 +13,10 @@ Some text but also a button and another that overflows
 
       (interaction regions [
         (interaction (20,20) width=442 height=67),
-        (interaction (265,46) width=171 height=23)
+        (interaction (289,46) width=147 height=23)
         (cornerRadius 6.00),
-        (guard (156,37) width=98 height=38),
-        (interaction (156,47) width=98 height=18)
+        (guard (180,37) width=98 height=38),
+        (interaction (180,47) width=98 height=18)
         (cornerRadius 10.00)])
       )
     )

--- a/LayoutTests/platform/ios/css2.1/20110323/replaced-elements-001-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/20110323/replaced-elements-001-expected.txt
@@ -10,10 +10,10 @@ layer at (0,0) size 800x156
         RenderBlock (anonymous) at (0,0) size 752x20
           RenderText {#text} at (0,0) size 36x19
             text run at (0,0) width 36: "         "
-        RenderButton {INPUT} at (364,20) size 24x16 [color=#007AFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]
+        RenderButton {INPUT} at (369,20) size 14x16 [color=#007AFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]
       RenderBlock {FORM} at (0,88) size 784x36
         RenderBlock {DIV} at (16,0) size 752x36 [bgcolor=#008000]
           RenderBlock (anonymous) at (0,0) size 752x20
             RenderText {#text} at (0,0) size 36x19
               text run at (0,0) width 36: "         "
-          RenderButton {INPUT} at (364,20) size 24x16 [color=#FFFFFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]
+          RenderButton {INPUT} at (369,20) size 14x16 [color=#FFFFFF] [bgcolor=#FFA500] [border: (1px solid #FFFFFF)]

--- a/LayoutTests/platform/ios/fast/forms/001-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/001-expected.txt
@@ -43,23 +43,23 @@ layer at (0,0) size 800x695
         RenderTable {TABLE} at (0,0) size 784x86 [border: (2px outset #000000)]
           RenderTableSection {TBODY} at (2,2) size 780x82
             RenderTableRow {TR} at (0,0) size 780x82
-              RenderTableCell {TD} at (0,0) size 125x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 123x80 [color=#FFFFFF] [bgcolor=#007AFF] [border: (40px solid #FF0000)]
-                  RenderBlock (anonymous) at (51,40) size 21x14
+              RenderTableCell {TD} at (0,0) size 115x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 113x80 [color=#FFFFFF] [bgcolor=#007AFF] [border: (40px solid #FF0000)]
+                  RenderBlock (anonymous) at (46,40) size 21x14
                     RenderText at (0,0) size 21x14
                       text run at (0,0) width 21: "Foo"
-              RenderTableCell {TD} at (124,40) size 656x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (114,40) size 666x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
         RenderTable {TABLE} at (0,86) size 784x86 [border: (2px outset #000000)]
           RenderTableSection {TBODY} at (2,2) size 780x82
             RenderTableRow {TR} at (0,0) size 780x82
-              RenderTableCell {TD} at (0,0) size 174x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 172x80 [color=#007AFF] [bgcolor=#E9E9EA] [border: (40px solid #FF0000)]
-                  RenderBlock (anonymous) at (51,40) size 70x14
+              RenderTableCell {TD} at (0,0) size 164x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 162x80 [color=#007AFF] [bgcolor=#E9E9EA] [border: (40px solid #FF0000)]
+                  RenderBlock (anonymous) at (46,40) size 70x14
                     RenderText at (0,0) size 70x14
                       text run at (0,0) width 70: "Submit a bug"
-              RenderTableCell {TD} at (173,40) size 607x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (163,40) size 617x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
         RenderBlock (anonymous) at (0,172) size 784x80
-          RenderButton {INPUT} at (0,0) size 122x80 [color=#007AFF] [bgcolor=#E9E9EA] [border: (40px solid #FF0000)]
-            RenderBlock (anonymous) at (51,40) size 20x14
+          RenderButton {INPUT} at (0,0) size 112x80 [color=#007AFF] [bgcolor=#E9E9EA] [border: (40px solid #FF0000)]
+            RenderBlock (anonymous) at (46,40) size 20x14
               RenderText at (0,0) size 20x14
                 text run at (0,0) width 20: "Foo"

--- a/LayoutTests/platform/ios/fast/forms/button-default-title-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/button-default-title-expected.txt
@@ -11,27 +11,27 @@ layer at (0,0) size 800x670
           text run at (0,0) width 352: "This button should have the default submit button title:"
       RenderBlock (anonymous) at (0,77) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#FFFFFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 56x15
-            RenderText at (8,0) size 40x14
-              text run at (8,0) width 40: "Submit"
+          RenderBlock (anonymous) at (7,3) size 66x15
+            RenderText at (13,0) size 40x14
+              text run at (13,0) width 40: "Submit"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,114) size 784x21
         RenderText {#text} at (0,0) size 300x19
           text run at (0,0) width 300: "This button should should have the title \"Foo\":"
       RenderBlock (anonymous) at (0,150) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#FFFFFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 56x15
-            RenderText at (17,0) size 22x14
-              text run at (17,0) width 22: "Foo"
+          RenderBlock (anonymous) at (7,3) size 66x15
+            RenderText at (22,0) size 22x14
+              text run at (22,0) width 22: "Foo"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,187) size 784x21
         RenderText {#text} at (0,0) size 316x19
           text run at (0,0) width 316: "This button should have a single space in its title:"
       RenderBlock (anonymous) at (0,223) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#FFFFFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 56x15
-            RenderText at (26,0) size 4x14
-              text run at (26,0) width 4: " "
+          RenderBlock (anonymous) at (7,3) size 66x15
+            RenderText at (31,0) size 4x14
+              text run at (31,0) width 4: " "
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,260) size 784x21
         RenderText {#text} at (0,0) size 208x19
@@ -47,27 +47,27 @@ layer at (0,0) size 800x670
           text run at (0,0) width 339: "This button should have the default reset button title:"
       RenderBlock (anonymous) at (0,414) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 56x15
-            RenderText at (13,0) size 30x14
-              text run at (13,0) width 30: "Reset"
+          RenderBlock (anonymous) at (7,3) size 66x15
+            RenderText at (18,0) size 30x14
+              text run at (18,0) width 30: "Reset"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,451) size 784x21
         RenderText {#text} at (0,0) size 300x19
           text run at (0,0) width 300: "This button should should have the title \"Foo\":"
       RenderBlock (anonymous) at (0,487) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 56x15
-            RenderText at (18,0) size 20x14
-              text run at (18,0) width 20: "Foo"
+          RenderBlock (anonymous) at (7,3) size 66x15
+            RenderText at (23,0) size 20x14
+              text run at (23,0) width 20: "Foo"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,524) size 784x21
         RenderText {#text} at (0,0) size 316x19
           text run at (0,0) width 316: "This button should have a single space in its title:"
       RenderBlock (anonymous) at (0,560) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 56x15
-            RenderText at (26,0) size 4x14
-              text run at (26,0) width 4: " "
+          RenderBlock (anonymous) at (7,3) size 66x15
+            RenderText at (31,0) size 4x14
+              text run at (31,0) width 4: " "
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,597) size 784x21
         RenderText {#text} at (0,0) size 208x19

--- a/LayoutTests/platform/ios/fast/forms/button-style-color-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/button-style-color-expected.txt
@@ -15,38 +15,38 @@ layer at (0,0) size 800x600
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (172,0) size 5x19
         text run at (172,0) width 5: " "
-      RenderButton {BUTTON} at (176,3) size 85x16 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,1) size 61x14
+      RenderButton {BUTTON} at (176,3) size 75x16 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (7,1) size 61x14
           RenderText {#text} at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (260,0) size 5x19
-        text run at (260,0) width 5: " "
-      RenderButton {BUTTON} at (264,3) size 85x16 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,1) size 61x14
+      RenderText {#text} at (250,0) size 5x19
+        text run at (250,0) width 5: " "
+      RenderButton {BUTTON} at (254,3) size 75x16 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (7,1) size 61x14
           RenderText {#text} at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (348,0) size 5x19
-        text run at (348,0) width 5: " "
-      RenderButton {INPUT} at (352,1) size 85x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+      RenderText {#text} at (328,0) size 5x19
+        text run at (328,0) width 5: " "
+      RenderButton {INPUT} at (332,1) size 85x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
         RenderBlock (anonymous) at (12,3) size 61x14
           RenderText at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (436,0) size 5x19
-        text run at (436,0) width 5: " "
-      RenderButton {INPUT} at (440,1) size 86x20 [color=#FF0000] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+      RenderText {#text} at (416,0) size 5x19
+        text run at (416,0) width 5: " "
+      RenderButton {INPUT} at (420,1) size 86x20 [color=#FF0000] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
         RenderBlock (anonymous) at (12,3) size 61x14
           RenderText at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (525,0) size 5x19
-        text run at (525,0) width 5: " "
-      RenderButton {INPUT} at (529,3) size 85x16 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,1) size 61x14
+      RenderText {#text} at (505,0) size 5x19
+        text run at (505,0) width 5: " "
+      RenderButton {INPUT} at (509,3) size 75x16 [color=#007AFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (7,1) size 61x14
           RenderText at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
-      RenderText {#text} at (613,0) size 5x19
-        text run at (613,0) width 5: " "
-      RenderButton {INPUT} at (617,3) size 85x16 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,1) size 61x14
+      RenderText {#text} at (583,0) size 5x19
+        text run at (583,0) width 5: " "
+      RenderButton {INPUT} at (587,3) size 75x16 [color=#FF0000] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (7,1) size 61x14
           RenderText at (0,0) size 61x14
             text run at (0,0) width 61: "Test Button"
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/forms/input-first-letter-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-first-letter-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 602x19
         text run at (0,0) width 602: "This test passes if it doesn't crash and if the Submit button does not honor the first-letter style."
       RenderBR {BR} at (601,0) size 1x19
-      RenderButton {INPUT} at (0,20) size 64x16 [color=#FFFFFF] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,1) size 40x14
+      RenderButton {INPUT} at (0,20) size 54x16 [color=#FFFFFF] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (7,1) size 40x14
           RenderText at (0,0) size 40x14
             text run at (0,0) width 40: "Submit"
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/forms/select-baseline-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/select-baseline-expected.txt
@@ -39,11 +39,11 @@ layer at (0,0) size 800x600
             text run at (0,0) width 21: "test"
       RenderText {#text} at (278,24) size 5x19
         text run at (278,24) width 5: " "
-      RenderButton {BUTTON} at (282,38) size 25x2 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #FFFFFF)]
-      RenderText {#text} at (306,24) size 5x19
-        text run at (306,24) width 5: " "
-      RenderButton {BUTTON} at (310,27) size 45x16 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,1) size 21x14
+      RenderButton {BUTTON} at (282,38) size 15x2 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #FFFFFF)]
+      RenderText {#text} at (296,24) size 5x19
+        text run at (296,24) width 5: " "
+      RenderButton {BUTTON} at (300,27) size 35x16 [color=#00008B] [bgcolor=#ADD8E6] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (7,1) size 21x14
           RenderText {#text} at (0,0) size 21x14
             text run at (0,0) width 21: "test"
       RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -881,15 +881,14 @@ input:is([type="button"], [type="submit"], [type="reset"]), input[type="file"]::
     align-items: flex-start;
     text-align: center;
     cursor: default;
+    padding-inline: 6px;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
     color: ButtonText;
     padding-block: 2px 3px;
-    padding-inline: 6px;
     border: 2px outset ButtonFace;
     background-color: ButtonFace;
 #else
-    padding-block: 0;
-    padding-inline: 1em;
+    padding-block: 0; /* override input padding */
     border: 1px solid -webkit-control-background;
     font: 11px system-ui;
     color: -apple-system-blue;


### PR DESCRIPTION
#### ecdb7e0d240e9c71f87d407d37988a8fe3bb7a97
<pre>
[iOS][visionOS] web.webex.com: Icons inside some buttons can be too small
<a href="https://bugs.webkit.org/show_bug.cgi?id=286447">https://bugs.webkit.org/show_bug.cgi?id=286447</a>
<a href="https://rdar.apple.com/138155959">rdar://138155959</a>

Reviewed by Aditya Keerthi.

The default inline button padding on iOS is too large and squashes the SVG within the button.
`RenderThemeIOS::adjustButtonStyle` already sets this larger padding for `appearance: auto`.

For `appearance: none`, we can just re-use the default desktop inline padding of 6px, to be compatible and interoperable with other browsers.

* LayoutTests/interaction-region/button-in-link-expected.txt:
* LayoutTests/platform/ios/css2.1/20110323/replaced-elements-001-expected.txt:
* LayoutTests/platform/ios/fast/forms/001-expected.txt:
* LayoutTests/platform/ios/fast/forms/button-default-title-expected.txt:
* LayoutTests/platform/ios/fast/forms/button-style-color-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-first-letter-expected.txt:
* LayoutTests/platform/ios/fast/forms/select-baseline-expected.txt:
* Source/WebCore/css/html.css:
(input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;]), input[type=&quot;file&quot;]::file-selector-button, button):

Canonical link: <a href="https://commits.webkit.org/289343@main">https://commits.webkit.org/289343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f593039299bbe2c2df8d69e7ebd00a15973ab395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24749 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93292 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74946 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19245 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6518 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13458 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13757 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->