### PR TITLE
Node::normalize() can overflow destination string, resulting in an assert

### DIFF
--- a/LayoutTests/fast/dom/normalize-doesnt-check-string-length-expected.txt
+++ b/LayoutTests/fast/dom/normalize-doesnt-check-string-length-expected.txt
@@ -1,0 +1,10 @@
+This test passes if there is no crash and there's an exception
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS container.normalize() threw exception InvalidModificationError: Normalized Node String representation exceeds implementation maximum length..
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/normalize-doesnt-check-string-length.html
+++ b/LayoutTests/fast/dom/normalize-doesnt-check-string-length.html
@@ -1,0 +1,23 @@
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        function runTest() {
+            const MAX_LENGTH = 1 << 28;
+
+            const largeString = 'A'.repeat(MAX_LENGTH);
+
+            const container = document.getElementById('container');
+
+            for (let i = 0; i < 9; ++i)
+                container.appendChild(document.createTextNode(largeString));
+
+            shouldThrowErrorName('container.normalize()', 'InvalidModificationError');
+            description("This test passes if there is no crash and there's an exception");
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div id="container" hidden></div>
+</body>
+</html>

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -193,7 +193,7 @@ public:
     virtual const AtomString& namespaceURI() const;
     virtual const AtomString& prefix() const;
     virtual ExceptionOr<void> setPrefix(const AtomString&);
-    WEBCORE_EXPORT void normalize();
+    WEBCORE_EXPORT ExceptionOr<void> normalize();
 
     bool isSameNode(Node* other) const { return this == other; }
     WEBCORE_EXPORT bool isEqualNode(Node*) const;


### PR DESCRIPTION
#### 3f975ad6e201b37a19f7ed0af4473872caf4898d
<pre>
Node::normalize() can overflow destination string, resulting in an assert
<a href="https://rdar.apple.com/141028000">rdar://141028000</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286451">https://bugs.webkit.org/show_bug.cgi?id=286451</a>

Reviewed by Chris Dumez, Ryosuke Niwa, and Alexey Proskuryakov.

This fixes the bug by raising an exception if the next node overflows the accumulated string.

* LayoutTests/fast/dom/normalize-doesnt-check-string-length-expected.txt:
* LayoutTests/fast/dom/normalize-doesnt-check-string-length.html:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::normalize):
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/289518@main">https://commits.webkit.org/289518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e3b2da54feb8216ea2a908e603f82117294f3cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14790 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47731 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33318 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37067 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14373 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76212 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75424 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18196 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7302 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13584 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19685 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14137 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17580 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->