### PR TITLE
Crash at API::getContentRuleListSourceFromMappedFile().

### DIFF
--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -112,7 +112,7 @@ struct ContentRuleListMetaData {
     uint32_t unused32bits { false };
     uint64_t unused64bits1 { 0 };
     uint64_t unused64bits2 { 0 }; // Additional space on disk reserved so we can add something without incrementing the version number.
-    
+
     size_t fileSize() const
     {
         return headerSize(version)
@@ -267,7 +267,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             ASSERT(!metaData.topURLFiltersBytecodeSize);
             ASSERT(!metaData.frameURLFiltersBytecodeSize);
         }
-        
+
         void writeSource(WTF::String&& sourceJSON) final
         {
             ASSERT(!m_sourceWritten);
@@ -304,7 +304,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             m_urlFiltersBytecodeWritten += bytecode.size();
             writeToFile(WebKit::NetworkCache::Data(bytecode.span()));
         }
-        
+
         void writeTopURLFiltersBytecode(Vector<DFABytecode>&& bytecode) final
         {
             ASSERT(!m_frameURLFiltersBytecodeWritten);
@@ -317,7 +317,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             m_frameURLFiltersBytecodeWritten += bytecode.size();
             writeToFile(WebKit::NetworkCache::Data(bytecode.span()));
         }
-        
+
         void finalize() final
         {
             m_metaData.sourceSize = m_sourceWritten;
@@ -331,9 +331,10 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
                 closeFile(m_fileHandle);
                 m_fileError = true;
             }
+
             writeToFile(header);
         }
-        
+
         bool hadErrorWhileWritingToFile() { return m_fileError; }
 
     private:
@@ -341,6 +342,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
         {
             writeToFile(WebKit::NetworkCache::Data(asByteSpan(value)));
         }
+
         void writeToFile(const WebKit::NetworkCache::Data& data)
         {
             if (!m_fileError && !writeDataToFile(data, m_fileHandle)) {
@@ -348,7 +350,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
                 m_fileError = true;
             }
         }
-        
+
         PlatformFileHandle m_fileHandle;
         ContentRuleListMetaData& m_metaData;
         size_t m_sourceWritten { 0 };
@@ -364,9 +366,10 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
         WTFLogAlways("Content Rule List compiling failed: Opening temporary file failed.");
         return makeUnexpected(ContentRuleListStore::Error::CompileFailed);
     }
-    
+
     std::array<uint8_t, CurrentVersionFileHeaderSize> invalidHeader;
     invalidHeader.fill(0xFF);
+
     // This header will be rewritten in CompilationClient::finalize.
     if (writeToFile(temporaryFileHandle, invalidHeader) == -1) {
         WTFLogAlways("Content Rule List compiling failed: Writing header to file failed.");
@@ -382,6 +385,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
         closeFile(temporaryFileHandle);
         return makeUnexpected(compilerError);
     }
+
     if (compilationClient.hadErrorWhileWritingToFile()) {
         WTFLogAlways("Content Rule List compiling failed: Writing to file failed.");
         closeFile(temporaryFileHandle);
@@ -445,20 +449,29 @@ static WTF::String getContentRuleListSourceFromMappedFile(const MappedData& mapp
 {
     ASSERT(!RunLoop::isMain());
 
+    if (mappedData.metaData.version == std::numeric_limits<decltype(mappedData.metaData.version)>::max()) {
+        WTFLogAlways("Content Rule List source recovery failed: Version is invalid.");
+        return { };
+    }
+
     if (mappedData.metaData.version < 9) {
         WTFLogAlways("Content Rule List source recovery failed: Version is too old to recover the original JSON source from disk.");
         return { };
     }
 
     auto sourceSizeBytes = mappedData.metaData.sourceSize;
-    if (!sourceSizeBytes) {
+    if (!sourceSizeBytes || sourceSizeBytes == std::numeric_limits<decltype(sourceSizeBytes)>::max()) {
         WTFLogAlways("Content Rule List source recovery failed: No source size specified; cannot retrieve content.");
         return { };
     }
 
-    auto dataSpan = mappedData.data.span();
     auto headerSizeBytes = headerSize(mappedData.metaData.version);
+    if (headerSizeBytes > std::numeric_limits<decltype(headerSizeBytes)>::max() - sourceSizeBytes) {
+        WTFLogAlways("Content Rule List source recovery failed: Source size is invalid and would overflow.");
+        return { };
+    }
 
+    auto dataSpan = mappedData.data.span();
     if (dataSpan.size() < headerSizeBytes + sourceSizeBytes) {
         WTFLogAlways("Content Rule List source recovery failed: Data size is smaller than the header and source size; data is invalid.");
         return { };
@@ -629,7 +642,7 @@ void ContentRuleListStore::invalidateContentRuleListVersion(const WTF::String& i
     closeFile(file);
 }
 
-void ContentRuleListStore::corruptContentRuleList(const WTF::String& identifier, bool usingCurrentVersion)
+void ContentRuleListStore::corruptContentRuleListHeader(const WTF::String& identifier, bool usingCurrentVersion)
 {
     auto file = openFile(constructedPath(m_storePath, identifier), FileOpenMode::ReadWrite);
     if (file == invalidPlatformFileHandle)
@@ -640,6 +653,21 @@ void ContentRuleListStore::corruptContentRuleList(const WTF::String& identifier,
     ContentRuleListMetaData invalidHeader = { CurrentContentRuleListFileVersion - 1, random.getUint64(), random.getUint64(), random.getUint64(), random.getUint64(), random.getUint64() };
     if (usingCurrentVersion)
         invalidHeader.version = CurrentContentRuleListFileVersion;
+
+    auto bytesWritten = writeToFile(file, asByteSpan(invalidHeader));
+    ASSERT_UNUSED(bytesWritten, bytesWritten == sizeof(invalidHeader));
+
+    closeFile(file);
+}
+
+void ContentRuleListStore::invalidateContentRuleListHeader(const WTF::String& identifier)
+{
+    auto file = openFile(constructedPath(m_storePath, identifier), FileOpenMode::ReadWrite);
+    if (file == invalidPlatformFileHandle)
+        return;
+
+    std::array<uint8_t, CurrentVersionFileHeaderSize> invalidHeader;
+    invalidHeader.fill(0xFF);
 
     auto bytesWritten = writeToFile(file, asByteSpan(invalidHeader));
     ASSERT_UNUSED(bytesWritten, bytesWritten == sizeof(invalidHeader));

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -76,7 +76,8 @@ public:
     // For testing only.
     void synchronousRemoveAllContentRuleLists();
     void invalidateContentRuleListVersion(const WTF::String& identifier);
-    void corruptContentRuleList(const WTF::String& identifier, bool usingCurrentVersion);
+    void corruptContentRuleListHeader(const WTF::String& identifier, bool usingCurrentVersion);
+    void invalidateContentRuleListHeader(const WTF::String& identifier);
     void getContentRuleListSource(WTF::String&& identifier, CompletionHandler<void(WTF::String)>);
 
 private:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -169,10 +169,17 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 #endif
 }
 
-- (void)_corruptContentRuleListForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion
+- (void)_corruptContentRuleListHeaderForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    _contentRuleListStore->corruptContentRuleList(identifier, usingCurrentVersion);
+    _contentRuleListStore->corruptContentRuleListHeader(identifier, usingCurrentVersion);
+#endif
+}
+
+- (void)_invalidateContentRuleListHeaderForIdentifier:(NSString *)identifier
+{
+#if ENABLE(CONTENT_EXTENSIONS)
+    _contentRuleListStore->invalidateContentRuleListHeader(identifier);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
@@ -30,7 +30,8 @@
 // For testing only.
 - (void)_removeAllContentRuleLists;
 - (void)_invalidateContentRuleListVersionForIdentifier:(NSString *)identifier;
-- (void)_corruptContentRuleListForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion;
+- (void)_corruptContentRuleListHeaderForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion;
+- (void)_invalidateContentRuleListHeaderForIdentifier:(NSString *)identifier;
 - (void)_getContentRuleListSourceForIdentifier:(NSString *)identifier completionHandler:(void (^)(NSString *))completionHandler;
 
 + (instancetype)defaultStoreWithLegacyFilename;


### PR DESCRIPTION
#### cc6d84db42845365e98b60c72b9d1e42fd97b953
<pre>
Crash at API::getContentRuleListSourceFromMappedFile().
<a href="https://webkit.org/b/286452">https://webkit.org/b/286452</a>
<a href="https://rdar.apple.com/141639647">rdar://141639647</a>

Reviewed by Alex Christensen.

If the app crashed while compiling the content rule list, an invalid header of
all 0xFF bytes would be saved. This causes us to try to recompile on launch,
but our checks were insufficient for this case. Add additional header checks
before reading the file further.

Fixed some stray whitespace in the file.

* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::getContentRuleListSourceFromMappedFile): Check the header values for max().
(API::ContentRuleListStore::invalidateContentRuleListHeader): Added.
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore _invalidateContentRuleListHeaderForIdentifier:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, InvalidHeader)): Added.

Canonical link: <a href="https://commits.webkit.org/289350@main">https://commits.webkit.org/289350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8e69176d613b331b372dafb4c73f61459e4b7e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86649 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40981 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14214 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/91493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89652 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/4883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/4682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/32786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/33671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/13802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/93365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14003 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/74277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/19294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/17695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13825 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/13563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/17007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->