### PR TITLE
Add out-of-flow objects under the inline in a continuation chain, when possible

### DIFF
--- a/LayoutTests/fast/inline/add-abspos-before-block-inside-inline-expected.html
+++ b/LayoutTests/fast/inline/add-abspos-before-block-inside-inline-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>There should be a green square below, and no red.</p>
+<div style="width:40px; height:40px; background:green;"></div>

--- a/LayoutTests/fast/inline/add-abspos-before-block-inside-inline.html
+++ b/LayoutTests/fast/inline/add-abspos-before-block-inside-inline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+    #container { overflow:hidden; width:40px; height:40px; background:red; }
+    #abspos { position:absolute; display:none; width:40px; height:20px; background:green; }
+    #sibling { margin-top:20px; width:40px; height:20px; background:green; }
+</style>
+<p>There should be a green square below, and no red.</p>
+<div id="container">
+    <span>
+        <div id="abspos"></div><div id="sibling"></div>
+    </span>
+</div>
+<script>
+    document.body.offsetTop;
+    abspos.style.display = "block";
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -146,19 +147,21 @@ void RenderTreeBuilder::Inline::insertChildToContinuation(RenderInline& parent, 
     } else
         ASSERT_NOT_REACHED();
 
-    if (child->isFloatingOrOutOfFlowPositioned())
-        return m_builder.attachIgnoringContinuation(*beforeChildAncestor, WTFMove(child), beforeChild);
-
+    // If the two candidates are the same, no further checking is necessary.
     if (flow == beforeChildAncestor)
         return m_builder.attachIgnoringContinuation(*flow, WTFMove(child), beforeChild);
-    // A continuation always consists of two potential candidates: an inline or an anonymous
-    // block box holding block children.
-    bool childInline = newChildIsInline(parent, *child);
+
+    // A table part will be wrapped by an inline anonymous table when it is added
+    // to the layout tree, so treat it as inline when deciding where to add
+    // it. Floating and out-of-flow-positioned objects can also live under
+    // inlines, and since this about adding a child to an inline parent, we
+    // should not put them into a block continuation.
+    bool addInsideInline = newChildIsInline(parent, *child) || child->isFloatingOrOutOfFlowPositioned() || child->isTablePart();
     // The goal here is to match up if we can, so that we can coalesce and create the
     // minimal # of continuations needed for the inline.
-    if (childInline == beforeChildAncestor->isInline() || (beforeChild && beforeChild->isInline()))
+    if (addInsideInline == beforeChildAncestor->isInline() || (beforeChild && beforeChild->isInline()))
         return m_builder.attachIgnoringContinuation(*beforeChildAncestor, WTFMove(child), beforeChild);
-    if (flow->isInline() == childInline)
+    if (flow->isInline() == addInsideInline)
         return m_builder.attachIgnoringContinuation(*flow, WTFMove(child)); // Just treat like an append.
     return m_builder.attachIgnoringContinuation(*beforeChildAncestor, WTFMove(child), beforeChild);
 }


### PR DESCRIPTION
#### fb28c4640a58be29538ab01edecf1b7d2466c21d
<pre>
Add out-of-flow objects under the inline in a continuation chain, when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=247681">https://bugs.webkit.org/show_bug.cgi?id=247681</a>
<a href="https://rdar.apple.com/102421379">rdar://102421379</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/77ec19ddefb32688cd18277ed7412531b536401a">https://chromium.googlesource.com/chromium/src/+/77ec19ddefb32688cd18277ed7412531b536401a</a>

The same goes for floating objects. Only when a floating or out-of-flow
positioned object is to be added between two block-level children should we add
it to the anonymous block box holding the block-level children. If the new
child is to be added before a block-level child, and this beforeChild is the
first block-level child, we should rather make the new child the last child of
the preceding inline, rather than the first child of the anonymous block
containing block-level children. Also cleaned up and documented the code somewhat.

* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::insertChildToContinuation):
* LayoutTests/fast/inline/add-abspos-before-block-inside-inline.html:
* LayoutTests/fast/inline/add-abspos-before-block-inside-inline-expected.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb28c4640a58be29538ab01edecf1b7d2466c21d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66959 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47280 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32701 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93299 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75761 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74951 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6502 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18997 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->