### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in SequenceLocked.h

### DIFF
--- a/Source/WTF/wtf/SequenceLocked.h
+++ b/Source/WTF/wtf/SequenceLocked.h
@@ -19,8 +19,8 @@
 #include <atomic>
 #include <type_traits>
 #include <wtf/Compiler.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WTF {
 
@@ -58,7 +58,7 @@ public:
             uint64_t versionBefore = m_version.load(std::memory_order_acquire);
             if (UNLIKELY((versionBefore & 1) == 1))
                 continue;
-            relaxedCopyFromAtomic(&result, m_storage.data(), sizeof(T));
+            relaxedCopyFromAtomic(asMutableByteSpan(result), std::span { m_storage });
             // Another acquire fence ensures that the load of 'm_version' below is
             // strictly ordered after the RelaxedCopyToAtomic call above.
             std::atomic_thread_fence(std::memory_order_acquire);
@@ -90,7 +90,7 @@ public:
         // this barrier is not for the fetch_add above. A release barrier for the
         // fetch_add would be before it, not after.
         std::atomic_thread_fence(std::memory_order_release);
-        relaxedCopyToAtomic(m_storage.data(), &value, sizeof(T));
+        relaxedCopyToAtomic(std::span { m_storage }, asByteSpan(value));
         // "Release" semantics ensure that none of the writes done by
         // relaxedCopyToAtomic() can be reordered after the following modification.
         m_version.store(version + 2, std::memory_order_release);
@@ -99,47 +99,35 @@ public:
 private:
     // Perform the equivalent of "memcpy(dst, src, size)", but using relaxed
     // atomics.
-    static void relaxedCopyFromAtomic(void* dst, const std::atomic<uint64_t>* src, size_t size)
+    static constexpr size_t storageSize = (sizeof(T) + sizeof(uint64_t) - 1) / sizeof(std::atomic<uint64_t>);
+    static void relaxedCopyFromAtomic(std::span<uint8_t> destination, std::span<const std::atomic<uint64_t>, storageSize> source)
     {
-        char* dstChar = static_cast<char*>(dst);
-        for (;size >= sizeof(uint64_t); size -= sizeof(uint64_t)) {
-            uint64_t word = src->load(std::memory_order_relaxed);
-            std::memcpy(dstChar, &word, sizeof(uint64_t));
-            dstChar += sizeof(uint64_t);
-            src++;
+        size_t sourceIndex = 0;
+        while (destination.size() >= sizeof(uint64_t)) {
+            uint64_t word = source[sourceIndex++].load(std::memory_order_relaxed);
+            memcpySpan(consumeSpan(destination, sizeof(word)), asByteSpan(word));
         }
-        if (size) {
-            uint64_t word = src->load(std::memory_order_relaxed);
-            std::memcpy(dstChar, &word, size);
-        }
+        ASSERT(destination.empty());
     }
 
     // Perform the equivalent of "memcpy(dst, src, size)", but using relaxed
     // atomics.
-    static void relaxedCopyToAtomic(std::atomic<uint64_t>* dst, const void* src, size_t size)
+    static void relaxedCopyToAtomic(std::span<std::atomic<uint64_t>, storageSize> destination, std::span<const uint8_t> source)
     {
-        const char* srcByte = static_cast<const char*>(src);
-        for (;size >= sizeof(uint64_t); size -= sizeof(uint64_t)) {
+        size_t destinationIndex = 0;
+        while (source.size() >= sizeof(uint64_t)) {
             uint64_t word;
-            std::memcpy(&word, srcByte, sizeof(word));
-            dst->store(word, std::memory_order_relaxed);
-            srcByte += sizeof(word);
-            dst++;
+            memcpySpan(asMutableByteSpan(word), consumeSpan(source, sizeof(word)));
+            destination[destinationIndex++].store(word, std::memory_order_relaxed);
         }
-        if (size) {
-            uint64_t word = 0;
-            std::memcpy(&word, srcByte, size);
-            dst->store(word, std::memory_order_relaxed);
-        }
+        ASSERT(source.empty());
     }
 
     std::atomic<uint64_t> m_version { 0 };
-    using Storage = std::array<std::atomic<uint64_t>, (sizeof(T) + sizeof(uint64_t) - 1) / sizeof(std::atomic<uint64_t>)>;
+    using Storage = std::array<std::atomic<uint64_t>, storageSize>;
     Storage m_storage { };
 };
 
 }
 
 using WTF::SequenceLocked;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### a84850bbdcb76547e5720b49a900e4ee797fa60c
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in SequenceLocked.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=286457">https://bugs.webkit.org/show_bug.cgi?id=286457</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/SequenceLocked.h:
(WTF::SequenceLocked::load const):
(WTF::SequenceLocked::store):
(WTF::SequenceLocked::relaxedCopyFromAtomic):
(WTF::SequenceLocked::relaxedCopyToAtomic):

Canonical link: <a href="https://commits.webkit.org/289349@main">https://commits.webkit.org/289349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffdb88334fe358705b9fc8108543b0051af9f423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37301 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66965 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24753 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36418 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79351 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93277 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85342 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74945 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19227 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6506 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13462 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13743 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107830 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13482 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25950 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->