### PR TITLE
[JSC] Missing Validation for Element Segment Initialization

### DIFF
--- a/JSTests/wasm/gc/const-exprs.js
+++ b/JSTests/wasm/gc/const-exprs.js
@@ -219,30 +219,38 @@ async function testInvalidConstExprs() {
 }
 
 async function testConstExprGlobalOrdering() {
-  instantiate(`
-    (module
-      (global i32 (i32.const 0))
-      (global i32 (global.get 0)))
-  `);
+  assert.throws(
+    () => compile(`
+        (module
+          (global i32 (i32.const 0))
+          (global i32 (global.get 0)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 24: get_global import kind index 0 is non-import"
+  );
 
-  instantiate(`
-    (module
-      (global i32 (i32.const 0))
-      (global i32 (i32.const 1))
-      (global i32 (i32.const 2))
-      (global i32 (global.get 1))
-      (global i32 (global.get 3)))
-  `);
+  assert.throws(
+    () => compile(`
+        (module
+          (global i32 (i32.const 0))
+          (global i32 (i32.const 1))
+          (global i32 (i32.const 2))
+          (global i32 (global.get 1))
+          (global i32 (global.get 3)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 34: get_global import kind index 1 is non-import"
+  );
 
-  {
-    let m = instantiate(`
-      (module
-        (global i32 (i32.add (i32.const 0) (i32.const 1)))
-        (global (export "g") i32 (i32.add (i32.const 1 (global.get 0)))))
-    `);
-
-    assert.eq(m.exports.g.value, 2);
-  }
+  assert.throws(
+    () => compile(`
+        (module
+          (global i32 (i32.add (i32.const 0) (i32.const 1)))
+          (global (export "g") i32 (i32.add (i32.const 1 (global.get 0)))))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 27: get_global import kind index 0 is non-import"
+  );
 
   instantiate(`
     (module
@@ -250,21 +258,29 @@ async function testConstExprGlobalOrdering() {
       (table 10 externref (global.get 0)))
   `, { m: { g: "foo" } });
 
-  instantiate(`
-    (module
-      (global i32 (i32.const 0))
-      (global i32 (i32.const 1))
-      (global i32 (i32.const 2))
-      (global i32 (global.get 1))
-      (global i32 (global.get 3)))
-  `);
+  assert.throws(
+    () => compile(`
+      (module
+        (global i32 (i32.const 0))
+        (global i32 (i32.const 1))
+        (global i32 (i32.const 2))
+        (global i32 (global.get 1))
+        (global i32 (global.get 3)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 34: get_global import kind index 1 is non-import"
+  );
 
-  instantiate(`
-    (module
-      (table (export "t") 64 funcref)
-      (global i32 (i32.const 5))
-      (elem (table 0) (offset (i32.add (global.get 0) (i32.const 42))) funcref (ref.null func)))
-  `);
+  assert.throws(
+    () => compile(`
+      (module
+        (table (export "t") 64 funcref)
+        (global i32 (i32.const 5))
+        (elem (table 0) (offset (i32.add (global.get 0) (i32.const 42))) funcref (ref.null func)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 52: get_global import kind index 0 is non-import"
+  );
 
   assert.throws(
     () => compile(`

--- a/JSTests/wasm/gc/simd.js
+++ b/JSTests/wasm/gc/simd.js
@@ -405,14 +405,18 @@ function testJSAPI() {
 }
 
 function testSIMDGlobal() {
-  instantiate(`
-    (module
-      (global v128 (v128.const i64x2 0 0))
-      (global v128 (v128.const i64x2 1 1))
-      (global v128 (v128.const i64x2 2 2))
-      (global v128 (global.get 1))
-      (global v128 (global.get 3)))
-  `);
+  assert.throws(
+    () => compile(`
+      (module
+        (global v128 (v128.const i64x2 0 0))
+        (global v128 (v128.const i64x2 1 1))
+        (global v128 (v128.const i64x2 2 2))
+        (global v128 (global.get 1))
+        (global v128 (global.get 3)))
+    `),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 82: get_global import kind index 1 is non-import"
+  );
 }
 
 testSIMDStruct();

--- a/JSTests/wasm/stress/init-expr-cannot-include-non-import-globals.js
+++ b/JSTests/wasm/stress/init-expr-cannot-include-non-import-globals.js
@@ -1,0 +1,19 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldThrow(() => {
+    var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,5,1,96,0,1,127,3,2,1,0,4,4,1,112,0,1,6,6,1,127,0,65,0,11,7,8,1,4,109,97,105,110,0,0,9,7,1,0,35,0,11,1,0,10,6,1,4,0,65,1,11,0,14,4,110,97,109,101,1,7,1,0,4,109,97,105,110,]);
+    var wasm_module = new WebAssembly.Module(wasm_code);
+}, `CompileError: WebAssembly.Module doesn't parse at byte 49: get_global import kind index 0 is non-import (evaluating 'new WebAssembly.Module(wasm_code)')`);

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -266,6 +266,7 @@ public:
         // Note that this check works for table initializers too, because no globals are registered when the table section is read and the count is 0.
         WASM_COMPILE_FAIL_IF(index >= m_info.globals.size(), "get_global's index ", index, " exceeds the number of globals ", m_info.globals.size());
         WASM_COMPILE_FAIL_IF(m_info.globals[index].mutability != Mutability::Immutable, "get_global import kind index ", index, " is mutable ");
+        WASM_COMPILE_FAIL_IF(m_info.globals[index].initializationType != GlobalInformation::InitializationType::IsImport, "get_global import kind index ", index, " is non-import");
 
         if (m_mode == Mode::Evaluate)
             result = ConstExprValue(m_instance->loadI64Global(index));

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -740,6 +740,7 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
 
         WASM_PARSER_FAIL_IF(index >= m_info->globals.size(), "get_global's index "_s, index, " exceeds the number of globals "_s, m_info->globals.size());
         WASM_PARSER_FAIL_IF(m_info->globals[index].mutability != Mutability::Immutable, "get_global import kind index "_s, index, " is mutable "_s);
+        WASM_PARSER_FAIL_IF(m_info->globals[index].initializationType != GlobalInformation::InitializationType::IsImport, "get_global import kind index ", index, " is non-import");
 
         resultType = m_info->globals[index].type;
         bitsOrImportNumber = index;


### PR DESCRIPTION
#### ed30693f477a49f16b2678a5b400cc7e51f02398
<pre>
[JSC] Missing Validation for Element Segment Initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=285746">https://bugs.webkit.org/show_bug.cgi?id=285746</a>
<a href="https://rdar.apple.com/143128477">rdar://143128477</a>

Reviewed by Keith Miller.

init-expr can only include imported globals.

* JSTests/wasm/stress/init-expr-cannot-include-non-import-globals.js: Added.
(shouldThrow):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::getGlobal):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseInitExpr):

Canonical link: <a href="https://commits.webkit.org/289363@main">https://commits.webkit.org/289363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8409a6d0f51451fd080dd711e930ceea0c53e0fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67022 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24806 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4904 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36528 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79461 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93418 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85450 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13831 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75005 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6616 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13474 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13854 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107943 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13592 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25977 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->