### PR TITLE
[LBSE][GTK][WPE] Composited SVG shapes are blurry when an ancestor is upscaled

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1945,7 +1945,6 @@ imported/w3c/web-platform-tests/svg/animations/reinserting-svg-into-document.htm
 imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-opacity.html [ ImageOnlyFailure ]
 
 # The following tests need LBSE enabled builds, which is off by default for this port.
-svg/compositing [ Skip ]
 svg/z-index [ Skip ]
 svg/foreignObject/respect-block-margin.html [ Skip ]
 

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=0-110; totalPixels=0-850" />
+<meta name="fuzzy" content="maxDifference=0-110; totalPixels=0-941" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=0-102; totalPixels=0-850" />
+<meta name="fuzzy" content="maxDifference=0-102; totalPixels=0-941" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=0-102; totalPixels=2371-2372" />
+<meta name="fuzzy" content="maxDifference=0-124; totalPixels=0-2372" />
 
 <style>
     html, body {

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-900" />
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-942" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=0-111; totalPixels=800-900" />
+<meta name="fuzzy" content="maxDifference=0-111; totalPixels=0-1006" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-padding.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=86-209; totalPixels=298-934" />
+<meta name="fuzzy" content="maxDifference=0-209; totalPixels=0-1002" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/compositing/outermost-svg-with-border.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=70-111; totalPixels=0-818" />
+<meta name="fuzzy" content="maxDifference=0-111; totalPixels=0-1003" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/compositing/svg-poster-circle.html
+++ b/LayoutTests/svg/compositing/svg-poster-circle.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-    <meta name="fuzzy" content="maxDifference=38; totalPixels=8904-8973" />
+    <meta name="fuzzy" content="maxDifference=0-92; totalPixels=0-11526" />
 
     <style>
       html, body {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -96,6 +96,10 @@ private:
 
     void deviceOrPageScaleFactorChanged() override;
 
+    float rootRelativeScaleFactor() const { return m_rootRelativeScaleFactor; }
+    void setShouldUpdateRootRelativeScaleFactor(bool value) override { m_shouldUpdateRootRelativeScaleFactor = value; }
+    void updateRootRelativeScale();
+
     bool setFilters(const FilterOperations&) override;
     void setMaskLayer(RefPtr<GraphicsLayer>&&) override;
     void setReplicatedByLayer(RefPtr<GraphicsLayer>&&) override;
@@ -210,6 +214,8 @@ private:
         TransformationMatrix cachedCombined;
     } m_layerTransform;
     bool m_needsUpdateLayerTransform { false };
+    bool m_shouldUpdateRootRelativeScaleFactor : 1 { false };
+    float m_rootRelativeScaleFactor { 1.0f };
     RefPtr<CoordinatedPlatformLayerBufferProxy> m_contentsBufferProxy;
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_contentsDisplayDelegate;
     RefPtr<NativeImage> m_contentsImage;


### PR DESCRIPTION
#### 3d57fb9908dbb3b3cdb6fe1b742c761fc5841df3
<pre>
[LBSE][GTK][WPE] Composited SVG shapes are blurry when an ancestor is upscaled
<a href="https://bugs.webkit.org/show_bug.cgi?id=286468">https://bugs.webkit.org/show_bug.cgi?id=286468</a>

Reviewed by Nikolas Zimmermann.

`GraphicsLayerCoordinated` should calculate and use the root relative scale,
similiarly to what `GraphicsLayerCA` already does.

This patch makes all `svg/compositing` tests pass on GTK and WPE
after slightly updating fuzziness for some of them.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child.html:
* LayoutTests/svg/compositing/outermost-svg-directly-composited-shape-child.html:
* LayoutTests/svg/compositing/outermost-svg-directly-composited-transformed-group-child.html:
* LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html:
* LayoutTests/svg/compositing/outermost-svg-with-border-padding-margin.html:
* LayoutTests/svg/compositing/outermost-svg-with-border-padding.html:
* LayoutTests/svg/compositing/outermost-svg-with-border.html:
* LayoutTests/svg/compositing/svg-poster-circle.html:
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::updateRootRelativeScale):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

Canonical link: <a href="https://commits.webkit.org/289615@main">https://commits.webkit.org/289615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09f2f645c565235e3212aa1002106248d49cd93b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25328 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79184 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33578 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76412 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14922 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75639 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18607 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20018 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7611 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14686 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19981 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14429 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->