### PR TITLE
[scroll-animations] setting the effect of a scroll-driven animation fails to recompute effect timing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-effect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-effect-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting the effect of scroll-driven animation computes percentage timing values.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-effect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-effect.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Setting the effect of a scroll-driven animation</title>
+<link rel="help"
+      href="https://drafts.csswg.org/web-animations-1/#setting-the-associated-effect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="testcommon.js"></script>
+<style>
+  #scroller {
+    overflow-y: scroll;
+    height: 100px;
+    width: 100px;
+  }
+
+  #target {
+    width: 100%;
+    height: 1000%;
+    background-color: green;
+  }
+</style>
+<body>
+
+<div id="scroller">
+    <div id="target"></div>
+</div>
+
+<script>
+'use strict';
+
+test(() => {
+  const scroller = document.getElementById("scroller");
+  const target = document.getElementById("target");
+
+  const timeline = new ScrollTimeline({ source: scroller });
+  const animation = target.animate(null, { timeline });
+  assert_percents_equal(animation.effect.getComputedTiming().endTime, 100);
+
+  animation.effect = new KeyframeEffect(target, { opacity: [0, 1] });
+  assert_percents_equal(animation.effect.getComputedTiming().endTime, 100);
+}, 'Setting the effect of scroll-driven animation computes percentage timing values.');
+
+</script>
+</body>

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -52,8 +52,7 @@ void AnimationEffect::setAnimation(WebAnimation* animation)
         return;
 
     m_animation = animation;
-    if (animation)
-        animation->updateRelevance();
+    m_timingDidMutate = true;
 }
 
 EffectTiming AnimationEffect::getBindingsTiming() const

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -246,6 +246,7 @@ private:
     void computeHasReferenceFilter();
     void computeHasSizeDependentTransform();
     void analyzeAcceleratedProperties();
+    void updateIsAssociatedWithProgressBasedTimeline();
 
     void abilityToBeAcceleratedDidChange();
     void updateAcceleratedAnimationIfNecessary();

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -228,7 +228,6 @@ void WebAnimation::setEffectInternal(RefPtr<AnimationEffect>&& newEffect, bool d
         oldEffect->setAnimation(nullptr);
         if (!doNotRemoveFromTimeline && previousTarget && previousTarget != newTarget)
             previousTarget->animationWasRemoved(*this);
-        updateRelevance();
     }
 
     if (m_effect) {
@@ -236,6 +235,8 @@ void WebAnimation::setEffectInternal(RefPtr<AnimationEffect>&& newEffect, bool d
         if (newTarget && previousTarget != newTarget)
             newTarget->animationWasAdded(*this);
     }
+
+    updateRelevance();
 
     InspectorInstrumentation::didSetWebAnimationEffect(*this);
 }


### PR DESCRIPTION
#### d80503b4c350cf810ffa9dae94f4ac4be54af973
<pre>
[scroll-animations] setting the effect of a scroll-driven animation fails to recompute effect timing
<a href="https://bugs.webkit.org/show_bug.cgi?id=286471">https://bugs.webkit.org/show_bug.cgi?id=286471</a>
<a href="https://rdar.apple.com/143521617">rdar://143521617</a>

Reviewed by Anne van Kesteren.

The backing timing object of an `AnimationEffect` needs to be recomputed when certain properties of
the effect are changed. We failed to do so when the effect is associated to a new animation, instead
opting in `AnimationEffect::setAnimation()` to recompute the associated animation&apos;s relevance, which
would trigger an assertion when trying to compare timing values from the animation and the effect
which could be of conflicting types (time-based vs. percentage-based).

We now correctly set the `m_timingDidMutate` flag in `AnimationEffect::setAnimation()` and let the
relevance update be re-computed after the animation-to-effect relationships were updated in
`WebAnimation::setEffectInternal()`.

Likewise, for keyframe effects, we failed to re-compute the flag that indicates whether that effect
is associated with a scroll-driven animation when the effect was associated to a new animation. So
we factor the code setting that flag out of the `KeyframeEffect::animationTimelineDidChange()`
method into a new `KeyframeEffect::updateIsAssociatedWithProgressBasedTimeline()` method which we now
call from both `KeyframeEffect::animationTimelineDidChange()` and `KeyframeEffect::setAnimation()`.

We also introduce a new test which checks the times are recomputed correctly when a new effect is
associated with a scroll-driven animation. That test would hit assertions prior to this patch.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-effect-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-effect.html: Added.
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::setAnimation):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateIsAssociatedWithProgressBasedTimeline):
(WebCore::KeyframeEffect::animationTimelineDidChange):
(WebCore::KeyframeEffect::setAnimation):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setEffectInternal):

Canonical link: <a href="https://commits.webkit.org/289348@main">https://commits.webkit.org/289348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdb5b516667243f496c8559c20d5510163a28611

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67001 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89621 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4853 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47325 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36474 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75119 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93336 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13977 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/74266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74980 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6560 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13460 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13799 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->