### PR TITLE
60+10

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -327,7 +327,7 @@ void pas_probabilistic_guard_malloc_initialize_pgm(void)
             return;
         }
 #endif
-        pas_probabilistic_guard_malloc_random = pas_get_secure_random(20) + 100;
+        pas_probabilistic_guard_malloc_random = pas_get_secure_random(4) + 10;
     }
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -327,7 +327,7 @@ void pas_probabilistic_guard_malloc_initialize_pgm(void)
             return;
         }
 #endif
-        pas_probabilistic_guard_malloc_random = pas_get_secure_random(4) + 10;
+        pas_probabilistic_guard_malloc_random = pas_get_secure_random(10) + 60;
     }
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -321,13 +321,13 @@ void pas_probabilistic_guard_malloc_initialize_pgm(void)
 {
     if (!pas_probabilistic_guard_malloc_is_initialized) {
         pas_probabilistic_guard_malloc_is_initialized = true;
-
+#if 0
         if (PAS_LIKELY(pas_get_fast_random(1000) >= 1)) {
             pas_probabilistic_guard_malloc_can_use = false;
             return;
         }
-
-        pas_probabilistic_guard_malloc_random = pas_get_secure_random(1000) + 4000;
+#endif
+        pas_probabilistic_guard_malloc_random = pas_get_secure_random(20) + 100;
     }
 }
 


### PR DESCRIPTION
#### 60ff3e280f6d9b124f38ed8d379b3bea37c68c4f
<pre>
60+10
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_initialize_pgm):
</pre>
----------------------------------------------------------------------
#### a945fffcca795bc8c40d8b363cc1a6d5b3da800b
<pre>
[NOT FOR REVIEW] PGM testing
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reduce period to 10+-4

Explanation of why this fixes the bug (OOPS!).

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_initialize_pgm):
</pre>
----------------------------------------------------------------------
#### a005fcccd767266a0b2f50d63ff91b340374c244
<pre>
[NOT FOR REVIEW] PGM testing
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_initialize_pgm):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60ff3e280f6d9b124f38ed8d379b3bea37c68c4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91905 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67280 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25040 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47602 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36903 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79831 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93793 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85819 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75282 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19622 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18048 "Found 60 new test failures: accessibility/custom-elements/autocomplete.html accessibility/mac/basic-embed-pdf-accessibility.html accessibility/mac/content-editable-attributed-string.html accessibility/mac/stale-textmarker-crash.html compositing/clipping/border-radius-stacking-context-clip.html compositing/iframes/repaint-after-losing-scrollbars.html compositing/layer-creation/overlap-transforms.html compositing/repaint/copy-forward-dirty-region-purged.html compositing/scrolling/transformed-clipping-inside-scroller.html editing/deleting/delete-character-001.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7126 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14228 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108313 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13972 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26063 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->