### PR TITLE
[libpas] Replace printf calls with pas_log

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h
@@ -190,7 +190,7 @@ pas_generic_large_free_heap_try_allocate(
         return pas_allocation_result_create_success_with_zero_mode(0, pas_zero_mode_is_all_zero);
     
     if (PAS_GENERIC_LARGE_FREE_HEAP_VERBOSE >= 2)
-        printf("Allocating size = %zu\n", size);
+        pas_log("Allocating size = %zu\n", size);
     
     pas_alignment_validate(alignment);
     pas_heap_lock_assert_held();
@@ -221,7 +221,7 @@ pas_generic_large_free_heap_try_allocate(
         bool found_candidate;
         
         if (PAS_GENERIC_LARGE_FREE_HEAP_VERBOSE >= 2) {
-            printf("Could not allocate %zu bytes with alignment %zu/%zu. Free list status:\n",
+            pas_log("Could not allocate %zu bytes with alignment %zu/%zu. Free list status:\n",
                    size, alignment.alignment, alignment.alignment_begin);
             generic_heap_config->dump(heap);
         }
@@ -229,7 +229,7 @@ pas_generic_large_free_heap_try_allocate(
         page_allocation = config->aligned_allocator(size, alignment, config->aligned_allocator_arg);
         if (!page_allocation.result) {
             if (PAS_GENERIC_LARGE_FREE_HEAP_VERBOSE >= 2)
-                printf("Returning failure.\n");
+                pas_log("Returning failure.\n");
             return pas_allocation_result_create_failure();
         }
         
@@ -246,7 +246,7 @@ pas_generic_large_free_heap_try_allocate(
            assume that this is too unlikely to matter. */
         
         if (PAS_GENERIC_LARGE_FREE_HEAP_VERBOSE >= 2) {
-            printf("Just before candidate search after allocating from the source...\n");
+            pas_log("Just before candidate search after allocating from the source...\n");
             generic_heap_config->dump(heap);
         }
         
@@ -423,7 +423,7 @@ pas_generic_large_free_heap_try_allocate(
     PAS_ASSERT(result.did_succeed);
     
     if (PAS_GENERIC_LARGE_FREE_HEAP_VERBOSE >= 2) {
-        printf("After allocating %p for size %zu:\n", (void*)result.begin, size);
+        pas_log("After allocating %p for size %zu:\n", (void*)result.begin, size);
         generic_heap_config->dump(heap);
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_deferred_commit_log.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_free_heap_deferred_commit_log.c
@@ -92,7 +92,7 @@ static void commit(pas_large_virtual_range range)
         return;
     
     if (verbose) {
-        printf("Committing %p...%p.\n",
+        pas_log("Committing %p...%p.\n",
                (void*)range.begin,
                (void*)range.end);
     }

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap.c
@@ -118,8 +118,8 @@ static pas_allocation_result allocate_impl(pas_large_heap* heap,
     *size = pas_round_up_to_power_of_2(*size, *alignment);
     
     if (verbose) {
-        printf("large heap allocating large object of size %zu\n", *size);
-        printf("large heap cartesian tree minimum = %p, num mapped bytes = %zu\n", pas_cartesian_tree_minimum(&heap->free_heap.tree), heap->free_heap.num_mapped_bytes);
+        pas_log("large heap allocating large object of size %zu\n", *size);
+        pas_log("large heap cartesian tree minimum = %p, num mapped bytes = %zu\n", pas_cartesian_tree_minimum(&heap->free_heap.tree), heap->free_heap.num_mapped_bytes);
     }
     
     initialize_config(&config, &data, heap, heap_config);

--- a/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c
@@ -91,7 +91,7 @@ static pas_aligned_allocation_result large_aligned_allocator(size_t size,
          here, the memory we have gotten from the OS is still clean, so it doesn't count against our
          peak dirty. */
     if (verbose)
-        printf("Taking %zu later.\n", aligned_size);
+        pas_log("Taking %zu later.\n", aligned_size);
     pas_physical_page_sharing_pool_take_later(aligned_size);
     
     allocation_result = data->cache->provider(

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -93,7 +93,7 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     pas_allocation_result result = pas_allocation_result_create_failure();
 
     if (verbose)
-        printf("Memory requested to allocate %zu\n", size);
+        pas_log("Memory requested to allocate %zu\n", size);
 
     if (!large_heap || !size || !heap_config || !transaction)
         return result;
@@ -196,7 +196,7 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
     static const bool verbose = false;
 
     if (verbose)
-        printf("Memory Address Requested to Deallocate %p\n", mem);
+        pas_log("Memory Address Requested to Deallocate %p\n", mem);
 
     uintptr_t key = (uintptr_t) mem;
     PAS_PROFILE(PGM_DEALLOCATE, key);
@@ -248,7 +248,7 @@ bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem)
     static const bool verbose = false;
 
     if (verbose)
-        printf("Checking if is PGM entry\n");
+        pas_log("Checking if is PGM entry\n");
 
     pas_ptr_hash_map_entry* entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void*) mem);
     return (entry && entry->value);
@@ -262,7 +262,7 @@ pas_large_map_entry pas_probabilistic_guard_malloc_return_as_large_map_entry(uin
     pas_large_map_entry ret = { };
 
     if (verbose)
-        printf("Grabbing PGM allocated size\n");
+        pas_log("Grabbing PGM allocated size\n");
 
     pas_ptr_hash_map_entry * entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void *) mem);
     if (entry && entry->value) {
@@ -345,7 +345,7 @@ void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(void)
 
 void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_storage* value, const char* operation)
 {
-    printf("******************************************************\n"
+    pas_log("******************************************************\n"
         " %s\n\n"
         " Overall System Stats"
         " free_wasted_mem  : %zu\n"

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.c
@@ -139,12 +139,12 @@ static void timed_wait(pthread_cond_t* cond, pthread_mutex_t* mutex,
         (uint64_t)(1000. * 1000. * 1000.));
     
     if (verbose) {
-        printf("Doing timed wait with target wake up at %.2lf.\n",
+        pas_log("Doing timed wait with target wake up at %.2lf.\n",
                absolute_timeout_in_milliseconds);
     }
     pthread_cond_timedwait(cond, mutex, &time_to_wake_up);
     if (verbose)
-        printf("Woke up from timed wait at %.2lf.\n", get_time_in_milliseconds());
+        pas_log("Woke up from timed wait at %.2lf.\n", get_time_in_milliseconds());
 }
 
 static bool handle_expendable_memory(pas_expendable_memory_scavenge_kind kind)
@@ -219,7 +219,7 @@ static void* scavenger_thread_main(void* arg)
         should_go_again = false;
         
         if (verbose)
-            printf("Scavenger is running.\n");
+            pas_log("Scavenger is running.\n");
 
 #if PAS_LOCAL_ALLOCATOR_MEASURE_REFILL_EFFICIENCY
         pas_local_allocator_refill_efficiency_lock_lock();
@@ -239,7 +239,7 @@ static void* scavenger_thread_main(void* arg)
         thread_local_cache_decommit_action = pas_thread_local_cache_decommit_no_action;
         if ((pas_scavenger_tick_count % PAS_THREAD_LOCAL_CACHE_DECOMMIT_PERIOD_COUNT) == 0) {
             if (verbose)
-                printf("Attempt to decommit unused TLC\n");
+                pas_log("Attempt to decommit unused TLC\n");
             thread_local_cache_decommit_action = pas_thread_local_cache_decommit_if_possible_action;
         }
         should_go_again |=
@@ -307,7 +307,7 @@ static void* scavenger_thread_main(void* arg)
         time_in_milliseconds = get_time_in_milliseconds();
         
         if (verbose)
-            printf("Finished a round of scavenging at %.2lf.\n", time_in_milliseconds);
+            pas_log("Finished a round of scavenging at %.2lf.\n", time_in_milliseconds);
         
         /* By default we need to sleep for a short while and then try again. */
         absolute_timeout_in_milliseconds_for_period_sleep =
@@ -315,7 +315,7 @@ static void* scavenger_thread_main(void* arg)
 
         if (should_go_again) {
             if (verbose)
-                printf("Waiting for a period.\n");
+                pas_log("Waiting for a period.\n");
 
             /* This field is accessed a lot by other threads, so don't write to it if we don't
                have to. */
@@ -326,14 +326,14 @@ static void* scavenger_thread_main(void* arg)
             
             if (pas_scavenger_current_state == pas_scavenger_state_polling) {
                 if (verbose)
-                    printf("Will consider deep sleep.\n");
+                    pas_log("Will consider deep sleep.\n");
                 
                 /* do one more round of polling but this time indicating that it's the last
                    chance. */
                 pas_scavenger_current_state = pas_scavenger_state_deep_sleep;
             } else {
                 if (verbose)
-                    printf("Considering deep sleep.\n");
+                    pas_log("Considering deep sleep.\n");
                 
                 PAS_ASSERT(pas_scavenger_current_state == pas_scavenger_state_deep_sleep);
                 
@@ -378,7 +378,7 @@ static void* scavenger_thread_main(void* arg)
                 shut_down_callback();
             
             if (verbose)
-                printf("Killing the scavenger.\n");
+                pas_log("Killing the scavenger.\n");
             return NULL;
         }
     }
@@ -430,7 +430,7 @@ void pas_scavenger_notify_eligibility_if_needed(void)
         return;
     
     if (verbose)
-        printf("It's not polling so need to do something.\n");
+        pas_log("It's not polling so need to do something.\n");
     
     data = ensure_data_instance(pas_lock_is_not_held);
     pthread_mutex_lock(&data->lock);

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.c
@@ -58,7 +58,7 @@ pas_simple_free_heap_helpers_try_allocate_with_manual_alignment(
     pas_heap_lock_assert_held();
 
     if (verbose) {
-        printf("%s: Doing simple free heap allocation with size = %zu, alignment = %zu/%zu.\n",
+        pas_log("%s: Doing simple free heap allocation with size = %zu, alignment = %zu/%zu.\n",
                pas_heap_kind_get_string(heap_kind), size, alignment.alignment,
                alignment.alignment_begin);
     }
@@ -73,7 +73,7 @@ pas_simple_free_heap_helpers_try_allocate_with_manual_alignment(
                                                      size, alignment,
                                                      &config);
     if (verbose)
-        printf("Simple allocated %p with size %zu\n", (void*)result.begin, size);
+        pas_log("Simple allocated %p with size %zu\n", (void*)result.begin, size);
 
     if (exaggerate_cost && result.did_succeed) {
         pas_simple_large_free_heap_deallocate(free_heap,
@@ -118,7 +118,7 @@ void pas_simple_free_heap_helpers_deallocate(
     if (!size)
         return;
     if (verbose) {
-        printf("%s: Simple freeing %p with size %zu\n",
+        pas_log("%s: Simple freeing %p with size %zu\n",
                pas_heap_kind_get_string(heap_kind), ptr, size);
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c
@@ -423,7 +423,7 @@ static void fix_free_list_if_necessary(pas_simple_large_free_heap* heap,
     new_capacity = PAS_MAX(heap->free_list_size << 1, PAS_BOOTSTRAP_FREE_LIST_MINIMUM_SIZE);
     
     if (verbose && verbosity >= 2)
-        printf("Allocating new free list with new_capacity = %zu:\n", new_capacity);
+        pas_log("Allocating new free list with new_capacity = %zu:\n", new_capacity);
     new_free_list = (void*)try_allocate_without_fixing(
         heap,
         new_capacity * sizeof(pas_large_free),
@@ -458,7 +458,7 @@ static void fix_free_list_if_necessary(pas_simple_large_free_heap* heap,
     }
 
     if (verbose && verbosity >= 2) {
-        printf("Fixed:\n");
+        pas_log("Fixed:\n");
         dump_free_list(heap);
     }
 }
@@ -475,7 +475,7 @@ pas_allocation_result pas_simple_large_free_heap_try_allocate(pas_simple_large_f
     fix_free_list_if_necessary(heap, config);
     
     if (verbose) {
-        printf("After allocating %p for size %zu:\n", (void*)result.begin, size);
+        pas_log("After allocating %p for size %zu:\n", (void*)result.begin, size);
         dump_free_list(heap);
     }
 
@@ -495,7 +495,7 @@ void pas_simple_large_free_heap_deallocate(pas_simple_large_free_heap* heap,
     fix_free_list_if_necessary(heap, config);
 
     if (verbose) {
-        printf("After deallocating %p for size %zu:\n", (void*)begin, end - begin);
+        pas_log("After deallocating %p for size %zu:\n", (void*)begin, end - begin);
         dump_free_list(heap);
     }
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -172,7 +172,7 @@ static pas_thread_local_cache* allocate_cache(unsigned allocator_index_capacity)
     size = pas_thread_local_cache_size_for_allocator_index_capacity(allocator_index_capacity);
     
     if (verbose)
-        printf("Cache size: %zu\n", size);
+        pas_log("Cache size: %zu\n", size);
     
     result = (pas_thread_local_cache*)pas_large_utility_free_heap_allocate_with_alignment(
         size, pas_alignment_create_traditional(pas_page_malloc_alignment()), "pas_thread_local_cache");
@@ -340,7 +340,7 @@ pas_local_allocator_result pas_thread_local_cache_get_local_allocator_slow(
         new_thread_local_cache = allocate_cache(index_capacity);
     
         if (verbose)
-            printf("[%d] Reallocating TLC %p -> %p\n", getpid(), thread_local_cache, new_thread_local_cache);
+            pas_log("[%d] Reallocating TLC %p -> %p\n", getpid(), thread_local_cache, new_thread_local_cache);
     
         new_thread_local_cache->node = thread_local_cache->node;
     
@@ -824,7 +824,7 @@ static void suspend(pas_thread_local_cache* cache, scavenger_thread_suspend_data
     thread_suspend_data->did_suspend = true;
     
     if (verbose)
-        printf("Suspending TLC %p with thread %p.\n", cache, cache->thread);
+        pas_log("Suspending TLC %p with thread %p.\n", cache, cache->thread);
 
     thread = cache->thread;
     PAS_ASSERT(thread);


### PR DESCRIPTION
#### 0db021d7ff56b886defea60c4ccf1d52008253ec
<pre>
[libpas] Replace printf calls with pas_log
<a href="https://bugs.webkit.org/show_bug.cgi?id=286478">https://bugs.webkit.org/show_bug.cgi?id=286478</a>
<a href="https://rdar.apple.com/143571022">rdar://143571022</a>

Reviewed by Keith Miller.

pas_log is preferred because it synchronizes between threads and
doesn&apos;t buffer.

* Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h:
(pas_generic_large_free_heap_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_large_free_heap_deferred_commit_log.c:
(commit):
* Source/bmalloc/libpas/src/libpas/pas_large_heap.c:
(allocate_impl):
* Source/bmalloc/libpas/src/libpas/pas_large_heap_physical_page_sharing_cache.c:
(large_aligned_allocator):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_check_exists):
(pas_probabilistic_guard_malloc_return_as_large_map_entry):
(pas_probabilistic_guard_malloc_debug_info):
* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(timed_wait):
(scavenger_thread_main):
(pas_scavenger_notify_eligibility_if_needed):
* Source/bmalloc/libpas/src/libpas/pas_simple_free_heap_helpers.c:
(pas_simple_free_heap_helpers_try_allocate_with_manual_alignment):
(pas_simple_free_heap_helpers_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_simple_large_free_heap.c:
(fix_free_list_if_necessary):
(pas_simple_large_free_heap_try_allocate):
(pas_simple_large_free_heap_deallocate):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(allocate_cache):
(pas_thread_local_cache_get_local_allocator_slow):
(suspend):

Canonical link: <a href="https://commits.webkit.org/289353@main">https://commits.webkit.org/289353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3494f10fda64bca4e48dee08f92b5b5b7f35f06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40979 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14212 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/91491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89650 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/4881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78452 "Build was cancelled. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/4680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32783 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/79429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93362 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85418 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13800 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74993 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18449 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/19292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17692 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13823 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107912 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13561 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/25966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/17005 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 39498") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->