### PR TITLE
[libpas] Control PGM Activation Rate w/ Environment Variable

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -322,6 +322,15 @@ void pas_probabilistic_guard_malloc_initialize_pgm(void)
     if (!pas_probabilistic_guard_malloc_is_initialized) {
         pas_probabilistic_guard_malloc_is_initialized = true;
 
+        const char* pgm_activation_rate_env = getenv("PGM_ACTIVATION_RATE");
+        if (pgm_activation_rate_env) {
+            int pgm_activation_rate = atoi(pgm_activation_rate_env);
+            if (pgm_activation_rate > 0) {
+                pas_probabilistic_guard_malloc_random = PAS_MIN(pgm_activation_rate, 65535);
+                return;
+            }
+        }
+
         if (PAS_LIKELY(pas_get_fast_random(1000) >= 1)) {
             pas_probabilistic_guard_malloc_can_use = false;
             return;


### PR DESCRIPTION
#### 475ba4bb30abe1feec5de61b0d72501e13c51862
<pre>
[libpas] Control PGM Activation Rate w/ Environment Variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=286488">https://bugs.webkit.org/show_bug.cgi?id=286488</a>
<a href="https://rdar.apple.com/problem/143579494">rdar://problem/143579494</a>

Reviewed by NOBODY (OOPS!).

Allow controlling PGM Activation Rate by setting PGM_ACTIVATION_RATE.

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_initialize_pgm):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/475ba4bb30abe1feec5de61b0d72501e13c51862

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86680 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41012 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91525 "Hash 475ba4bb for PR 39500 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37412 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14245 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/91525 "Hash 475ba4bb for PR 39500 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24807 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4905 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78479 "Found 1 new API test failure: TestWebKitAPI.ContentRuleList.ResourceTypes (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/91525 "Hash 475ba4bb for PR 39500 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4703 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32810 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fill-columns-001.html imported/w3c/web-platform-tests/resource-timing/resource_connection_reuse_mixed_content.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36530 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79463 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93420 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85452 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74301 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75006 "Found 2 new API test failures: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19321 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6618 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13856 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107945 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13594 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25978 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->