### PR TITLE
[Test 2] Partially re-apply other half of 288829@main to test if that part is a Speedometer 3 regression

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -201,6 +201,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/images"
     "${WEBCORE_DIR}/style/values/motion"
     "${WEBCORE_DIR}/style/values/primitives"
+    "${WEBCORE_DIR}/style/values/scroll-snap"
     "${WEBCORE_DIR}/style/values/shapes"
     "${WEBCORE_DIR}/style/values/text-decoration"
     "${WEBCORE_DIR}/svg"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2671,6 +2671,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StylePrimitiveNumericTypes.h
     style/values/primitives/StyleUnevaluatedCalculation.h
 
+    style/values/scroll-snap/StyleScrollMargin.h
+    style/values/scroll-snap/StyleScrollPadding.h
+
     style/values/shapes/StyleBasicShape.h
     style/values/shapes/StyleCircleFunction.h
     style/values/shapes/StyleEllipseFunction.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3167,6 +3167,8 @@ style/values/images/StyleGradient.cpp
 style/values/primitives/StyleLengthResolution.cpp
 style/values/primitives/StylePosition.cpp
 style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+style/values/scroll-snap/StyleScrollMargin.cpp
+style/values/scroll-snap/StyleScrollPadding.cpp
 style/values/shapes/StyleBasicShape.cpp
 style/values/shapes/StyleCircleFunction.cpp
 style/values/shapes/StyleEllipseFunction.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4819,6 +4819,8 @@
 		BC2B41252733600500A2D191 /* DummyModelPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B412327335E1F00A2D191 /* DummyModelPlayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2B41312734A08600A2D191 /* DummyModelPlayerProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2B412027335CB900A2D191 /* DummyModelPlayerProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2C0BEC2D284F7B00FCFBA0 /* CSSValueConcepts.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0BEB2D284F7B00FCFBA0 /* CSSValueConcepts.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2C0C2B2D2C6A4700FCFBA0 /* StyleScrollPadding.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0C242D2C5D2B00FCFBA0 /* StyleScrollPadding.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2C0C2C2D2C6A5600FCFBA0 /* StyleScrollMargin.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0C222D2C5D2B00FCFBA0 /* StyleScrollMargin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2CBF4E140F1ABD003879BE /* JSWebGLContextEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2CBF4B140F1A65003879BE /* JSWebGLContextEvent.h */; };
 		BC2CCA102655DDB200B8C035 /* DestinationColorSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2CCA0E2655DDB200B8C035 /* DestinationColorSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2EE8EA2765943A0077768B /* ColorInterpolationMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2EE8E82765942A0077768B /* ColorInterpolationMethod.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -17796,6 +17798,10 @@
 		BC2B412327335E1F00A2D191 /* DummyModelPlayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DummyModelPlayer.h; sourceTree = "<group>"; };
 		BC2B412427335E1F00A2D191 /* DummyModelPlayer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DummyModelPlayer.cpp; sourceTree = "<group>"; };
 		BC2C0BEB2D284F7B00FCFBA0 /* CSSValueConcepts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSValueConcepts.h; sourceTree = "<group>"; };
+		BC2C0C222D2C5D2B00FCFBA0 /* StyleScrollMargin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleScrollMargin.h; sourceTree = "<group>"; };
+		BC2C0C232D2C5D2B00FCFBA0 /* StyleScrollMargin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleScrollMargin.cpp; sourceTree = "<group>"; };
+		BC2C0C242D2C5D2B00FCFBA0 /* StyleScrollPadding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleScrollPadding.h; sourceTree = "<group>"; };
+		BC2C0C252D2C5D2B00FCFBA0 /* StyleScrollPadding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleScrollPadding.cpp; sourceTree = "<group>"; };
 		BC2CBF4B140F1A65003879BE /* JSWebGLContextEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebGLContextEvent.h; sourceTree = "<group>"; };
 		BC2CBF7A140F1D58003879BE /* JSWebGLContextEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLContextEvent.cpp; sourceTree = "<group>"; };
 		BC2CCA0E2655DDB200B8C035 /* DestinationColorSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DestinationColorSpace.h; sourceTree = "<group>"; };
@@ -34396,6 +34402,17 @@
 			path = dummy;
 			sourceTree = "<group>";
 		};
+		BC2C0C262D2C5D2B00FCFBA0 /* scroll-snap */ = {
+			isa = PBXGroup;
+			children = (
+				BC2C0C232D2C5D2B00FCFBA0 /* StyleScrollMargin.cpp */,
+				BC2C0C222D2C5D2B00FCFBA0 /* StyleScrollMargin.h */,
+				BC2C0C252D2C5D2B00FCFBA0 /* StyleScrollPadding.cpp */,
+				BC2C0C242D2C5D2B00FCFBA0 /* StyleScrollPadding.h */,
+			);
+			path = "scroll-snap";
+			sourceTree = "<group>";
+		};
 		BC3078982CFFF06800630D75 /* filter-effects */ = {
 			isa = PBXGroup;
 			children = (
@@ -34820,6 +34837,7 @@
 				BCB271B52CBD7D6B00265123 /* images */,
 				BCEA07322CC5EBBA000AC148 /* motion */,
 				BCB271F22CC0156E00265123 /* primitives */,
+				BC2C0C262D2C5D2B00FCFBA0 /* scroll-snap */,
 				BCB271C62CBD7D6B00265123 /* shapes */,
 				BC3078E42D02884200630D75 /* text-decoration */,
 				BCA407F02C9F2140006B037F /* StyleValueTypes.h */,
@@ -44151,6 +44169,8 @@
 				E4D86E6D2640394C00B62425 /* StyleScopeOrdinal.h in Headers */,
 				4A4F48AA16B0DFC000EDBB29 /* StyleScopeRuleSets.h in Headers */,
 				4989734B2B663C6700720679 /* StyleScrollbarState.h in Headers */,
+				BC2C0C2C2D2C6A5600FCFBA0 /* StyleScrollMargin.h in Headers */,
+				BC2C0C2B2D2C6A4700FCFBA0 /* StyleScrollPadding.h in Headers */,
 				F47A5E3E195B8C8A00483100 /* StyleScrollSnapPoints.h in Headers */,
 				9D6380101AF173220031A15C /* StyleSelfAlignmentData.h in Headers */,
 				BCB272082CC1F1DB00265123 /* StyleShapeFunction.h in Headers */,

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -39,6 +39,7 @@
 #include "RenderSVGModelObject.h"
 #include "ScrollAnchoringController.h"
 #include "StyleBuilderConverter.h"
+#include "StyleScrollPadding.h"
 #include "WebAnimation.h"
 
 namespace WebCore {
@@ -257,11 +258,24 @@ void ViewTimeline::cacheCurrentTime()
             return scrollDirection->isVertical ? style.scrollPaddingBottom() : style.scrollPaddingRight();
         };
 
-        auto hasAutoStartInset = !m_insets.start;
-        auto insetStartLength = hasAutoStartInset ? scrollPadding(PaddingEdge::Start) : *m_insets.start;
-        auto insetEndLength = m_insets.end.value_or(hasAutoStartInset ? scrollPadding(PaddingEdge::End) : insetStartLength);
-        auto insetStart = floatValueForOffset(insetStartLength, scrollContainerSize);
-        auto insetEnd = floatValueForOffset(insetEndLength, scrollContainerSize);
+        bool hasInsetsStart = m_insets.start.has_value();
+        bool hasInsetsEnd = m_insets.end.has_value();
+
+        float insetStart = 0;
+        float insetEnd = 0;
+        if (hasInsetsStart && hasInsetsEnd) {
+            insetStart = floatValueForOffset(*m_insets.start, scrollContainerSize);
+            insetEnd = floatValueForOffset(*m_insets.end, scrollContainerSize);
+        } else if (hasInsetsStart) {
+            insetStart = floatValueForOffset(*m_insets.start, scrollContainerSize);
+            insetEnd = insetStart;
+        } else if (hasInsetsEnd) {
+            insetStart = Style::evaluate(scrollPadding(PaddingEdge::Start), scrollContainerSize);
+            insetEnd = floatValueForOffset(*m_insets.end, scrollContainerSize);
+        } else {
+            insetStart = Style::evaluate(scrollPadding(PaddingEdge::Start), scrollContainerSize);
+            insetEnd = Style::evaluate(scrollPadding(PaddingEdge::End), scrollContainerSize);
+        }
 
         return {
             scrollOffset,

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8930,7 +8930,7 @@
         "scroll-margin-bottom": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-bottom"
                 ],
@@ -8948,7 +8948,7 @@
         "scroll-margin-left": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-left"
                 ],
@@ -8966,7 +8966,7 @@
         "scroll-margin-right": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-right"
                 ],
@@ -8984,7 +8984,7 @@
         "scroll-margin-top": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-top"
                 ],
@@ -9096,7 +9096,7 @@
         "scroll-padding-bottom": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "bottom"
@@ -9111,7 +9111,7 @@
         "scroll-padding-left": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "left"
@@ -9126,7 +9126,7 @@
         "scroll-padding-right": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "right"
@@ -9141,7 +9141,7 @@
         "scroll-padding-top": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "top"

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -97,6 +97,8 @@
 #include "StyleReflection.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include "StyleScrollMargin.h"
+#include "StyleScrollPadding.h"
 #include "StyleTextShadow.h"
 #include "Styleable.h"
 #include "TimelineRange.h"
@@ -4710,13 +4712,13 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyScrollMargin:
         return getCSSPropertyValuesFor4SidesShorthand(scrollMarginShorthand());
     case CSSPropertyScrollMarginBottom:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginBottom(), style);
+        return style.scrollMarginBottom().toCSS(style);
     case CSSPropertyScrollMarginTop:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginTop(), style);
+        return style.scrollMarginTop().toCSS(style);
     case CSSPropertyScrollMarginRight:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginRight(), style);
+        return style.scrollMarginRight().toCSS(style);
     case CSSPropertyScrollMarginLeft:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginLeft(), style);
+        return style.scrollMarginLeft().toCSS(style);
     case CSSPropertyScrollMarginBlock:
         return getCSSPropertyValuesFor2SidesShorthand(scrollMarginBlockShorthand());
     case CSSPropertyScrollMarginInline:
@@ -4724,13 +4726,13 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyScrollPadding:
         return getCSSPropertyValuesFor4SidesShorthand(scrollPaddingShorthand());
     case CSSPropertyScrollPaddingBottom:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingBottom(), style);
+        return style.scrollPaddingBottom().toCSS(style);
     case CSSPropertyScrollPaddingTop:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingTop(), style);
+        return style.scrollPaddingTop().toCSS(style);
     case CSSPropertyScrollPaddingRight:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingRight(), style);
+        return style.scrollPaddingRight().toCSS(style);
     case CSSPropertyScrollPaddingLeft:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingLeft(), style);
+        return style.scrollPaddingLeft().toCSS(style);
     case CSSPropertyScrollPaddingBlock:
         return getCSSPropertyValuesFor2SidesShorthand(scrollPaddingBlockShorthand());
     case CSSPropertyScrollPaddingInline:

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -457,6 +457,11 @@ template<typename T> inline constexpr auto SerializationSeparator<SpaceSeparated
 template<typename T> struct SpaceSeparatedRectEdges {
     using value_type = T;
 
+    constexpr SpaceSeparatedRectEdges(T value)
+        : value { value, value, value, value }
+    {
+    }
+
     constexpr SpaceSeparatedRectEdges(T top, T right, T bottom, T left)
         : value { WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left) }
     {
@@ -469,10 +474,21 @@ template<typename T> struct SpaceSeparatedRectEdges {
 
     constexpr bool operator==(const SpaceSeparatedRectEdges<T>&) const = default;
 
-    const T& top() const { return value.top(); }
-    const T& right() const { return value.right(); }
+    const T& top() const    { return value.top(); }
+    const T& right() const  { return value.right(); }
     const T& bottom() const { return value.bottom(); }
-    const T& left() const { return value.left(); }
+    const T& left() const   { return value.left(); }
+
+    T& top()                { return value.top(); }
+    T& right()              { return value.right(); }
+    T& bottom()             { return value.bottom(); }
+    T& left()               { return value.left(); }
+
+    bool isZero() const
+        requires HasIsZero<T>
+    {
+        return top().isZero() && right().isZero() && bottom().isZero() && left().isZero();
+    }
 
     RectEdges<T> value;
 };
@@ -506,6 +522,11 @@ template<typename T> inline constexpr auto SerializationSeparator<SpaceSeparated
 template<typename T> struct MinimallySerializingSpaceSeparatedRectEdges {
     using value_type = T;
 
+    constexpr MinimallySerializingSpaceSeparatedRectEdges(T value)
+        : value { value, value, value, value }
+    {
+    }
+
     constexpr MinimallySerializingSpaceSeparatedRectEdges(T top, T right, T bottom, T left)
         : value { WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left) }
     {
@@ -516,12 +537,23 @@ template<typename T> struct MinimallySerializingSpaceSeparatedRectEdges {
     {
     }
 
+    constexpr bool operator==(const MinimallySerializingSpaceSeparatedRectEdges<T>&) const = default;
+
     const T& top() const    { return value.top(); }
     const T& right() const  { return value.right(); }
     const T& bottom() const { return value.bottom(); }
     const T& left() const   { return value.left(); }
 
-    constexpr bool operator==(const MinimallySerializingSpaceSeparatedRectEdges<T>&) const = default;
+    T& top()                { return value.top(); }
+    T& right()              { return value.right(); }
+    T& bottom()             { return value.bottom(); }
+    T& left()               { return value.left(); }
+
+    bool isZero() const
+        requires HasIsZero<T>
+    {
+        return top().isZero() && right().isZero() && bottom().isZero() && left().isZero();
+    }
 
     RectEdges<T> value;
 };

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5809,12 +5809,7 @@ LayoutUnit RenderBox::offsetFromLogicalTopOfFirstPage() const
 
 LayoutBoxExtent RenderBox::scrollPaddingForViewportRect(const LayoutRect& viewportRect)
 {
-    // We are using minimumValueForLength here, because scroll-padding values might be "auto". WebKit currently
-    // interprets "auto" as 0. See: https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding
-    const auto& padding = style().scrollPadding();
-    return LayoutBoxExtent(
-        minimumValueForLength(padding.top(), viewportRect.height()), minimumValueForLength(padding.right(), viewportRect.width()),
-        minimumValueForLength(padding.bottom(), viewportRect.height()), minimumValueForLength(padding.left(), viewportRect.width()));
+    return Style::extentForRect(style().scrollPadding(), viewportRect);
 }
 
 LayoutUnit synthesizedBaseline(const RenderBox& box, const RenderStyle& parentStyle, LineDirectionMode direction, BaselineSynthesisEdge edge)

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2018,8 +2018,9 @@ LayoutRect RenderElement::absoluteAnchorRect(bool* insideFixed) const
 
 MarginRect RenderElement::absoluteAnchorRectWithScrollMargin(bool* insideFixed) const
 {
-    LayoutRect anchorRect = absoluteAnchorRect(insideFixed);
-    const LengthBox& scrollMargin = style().scrollMargin();
+    auto anchorRect = absoluteAnchorRect(insideFixed);
+
+    const auto& scrollMargin = style().scrollMargin();
     if (scrollMargin.isZero())
         return { anchorRect, anchorRect };
 
@@ -2027,13 +2028,8 @@ MarginRect RenderElement::absoluteAnchorRectWithScrollMargin(bool* insideFixed) 
     // coordinate system of the scroll container and applied to the rectangular bounding
     // box of the transformed border box of the target element.
     // See https://www.w3.org/TR/css-scroll-snap-1/#scroll-margin.
-    const LayoutBoxExtent margin(
-        valueForLength(scrollMargin.top(), anchorRect.height()),
-        valueForLength(scrollMargin.right(), anchorRect.width()),
-        valueForLength(scrollMargin.bottom(), anchorRect.height()),
-        valueForLength(scrollMargin.left(), anchorRect.width()));
     auto marginRect = anchorRect;
-    marginRect.expand(margin);
+    marginRect.expand(Style::extentForRect(scrollMargin, anchorRect));
     return { marginRect, anchorRect };
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3553,94 +3553,94 @@ bool RenderStyle::customPropertiesEqual(const RenderStyle& other) const
         && m_rareInheritedData->customProperties == other.m_rareInheritedData->customProperties;
 }
 
-const LengthBox& RenderStyle::scrollMargin() const
+const Style::ScrollMargin& RenderStyle::scrollMargin() const
 {
     return m_nonInheritedData->rareData->scrollMargin;
 }
 
-const Length& RenderStyle::scrollMarginTop() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginTop() const
 {
     return scrollMargin().top();
 }
 
-const Length& RenderStyle::scrollMarginBottom() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginBottom() const
 {
     return scrollMargin().bottom();
 }
 
-const Length& RenderStyle::scrollMarginLeft() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginLeft() const
 {
     return scrollMargin().left();
 }
 
-const Length& RenderStyle::scrollMarginRight() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginRight() const
 {
     return scrollMargin().right();
 }
 
-void RenderStyle::setScrollMarginTop(Length&& length)
+void RenderStyle::setScrollMarginTop(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.top(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.top(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollMarginBottom(Length&& length)
+void RenderStyle::setScrollMarginBottom(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.bottom(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.bottom(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollMarginLeft(Length&& length)
+void RenderStyle::setScrollMarginLeft(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.left(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.left(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollMarginRight(Length&& length)
+void RenderStyle::setScrollMarginRight(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.right(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.right(), WTFMove(edge));
 }
 
-const LengthBox& RenderStyle::scrollPadding() const
+const Style::ScrollPadding& RenderStyle::scrollPadding() const
 {
     return m_nonInheritedData->rareData->scrollPadding;
 }
 
-const Length& RenderStyle::scrollPaddingTop() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingTop() const
 {
     return scrollPadding().top();
 }
 
-const Length& RenderStyle::scrollPaddingBottom() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingBottom() const
 {
     return scrollPadding().bottom();
 }
 
-const Length& RenderStyle::scrollPaddingLeft() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingLeft() const
 {
     return scrollPadding().left();
 }
 
-const Length& RenderStyle::scrollPaddingRight() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingRight() const
 {
     return scrollPadding().right();
 }
 
-void RenderStyle::setScrollPaddingTop(Length&& length)
+void RenderStyle::setScrollPaddingTop(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.top(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.top(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollPaddingBottom(Length&& length)
+void RenderStyle::setScrollPaddingBottom(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.bottom(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.bottom(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollPaddingLeft(Length&& length)
+void RenderStyle::setScrollPaddingLeft(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.left(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.left(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollPaddingRight(Length&& length)
+void RenderStyle::setScrollPaddingRight(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.right(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.right(), WTFMove(edge));
 }
 
 ScrollSnapType RenderStyle::initialScrollSnapType()

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -293,6 +293,10 @@ class ViewTransitionName;
 struct Color;
 struct ColorScheme;
 struct ScopedName;
+struct ScrollMargin;
+struct ScrollMarginEdge;
+struct ScrollPadding;
+struct ScrollPaddingEdge;
 
 enum class PositionTryOrder : uint8_t;
 }
@@ -1062,17 +1066,17 @@ public:
 
     inline bool effectiveInert() const;
 
-    const LengthBox& scrollMargin() const;
-    const Length& scrollMarginTop() const;
-    const Length& scrollMarginBottom() const;
-    const Length& scrollMarginLeft() const;
-    const Length& scrollMarginRight() const;
+    const Style::ScrollMargin& scrollMargin() const;
+    const Style::ScrollMarginEdge& scrollMarginTop() const;
+    const Style::ScrollMarginEdge& scrollMarginBottom() const;
+    const Style::ScrollMarginEdge& scrollMarginLeft() const;
+    const Style::ScrollMarginEdge& scrollMarginRight() const;
 
-    const LengthBox& scrollPadding() const;
-    const Length& scrollPaddingTop() const;
-    const Length& scrollPaddingBottom() const;
-    const Length& scrollPaddingLeft() const;
-    const Length& scrollPaddingRight() const;
+    const Style::ScrollPadding& scrollPadding() const;
+    const Style::ScrollPaddingEdge& scrollPaddingTop() const;
+    const Style::ScrollPaddingEdge& scrollPaddingBottom() const;
+    const Style::ScrollPaddingEdge& scrollPaddingLeft() const;
+    const Style::ScrollPaddingEdge& scrollPaddingRight() const;
 
     bool hasSnapPosition() const;
     ScrollSnapType scrollSnapType() const;
@@ -1620,15 +1624,15 @@ public:
 
     inline void setEffectiveInert(bool);
 
-    void setScrollMarginTop(Length&&);
-    void setScrollMarginBottom(Length&&);
-    void setScrollMarginLeft(Length&&);
-    void setScrollMarginRight(Length&&);
+    void setScrollMarginTop(Style::ScrollMarginEdge&&);
+    void setScrollMarginBottom(Style::ScrollMarginEdge&&);
+    void setScrollMarginLeft(Style::ScrollMarginEdge&&);
+    void setScrollMarginRight(Style::ScrollMarginEdge&&);
 
-    void setScrollPaddingTop(Length&&);
-    void setScrollPaddingBottom(Length&&);
-    void setScrollPaddingLeft(Length&&);
-    void setScrollPaddingRight(Length&&);
+    void setScrollPaddingTop(Style::ScrollPaddingEdge&&);
+    void setScrollPaddingBottom(Style::ScrollPaddingEdge&&);
+    void setScrollPaddingLeft(Style::ScrollPaddingEdge&&);
+    void setScrollPaddingRight(Style::ScrollPaddingEdge&&);
 
     void setScrollSnapType(ScrollSnapType);
     void setScrollSnapAlign(const ScrollSnapAlign&);
@@ -2096,8 +2100,8 @@ public:
 
     static constexpr FieldSizing initialFieldSizing();
 
-    static inline Length initialScrollMargin();
-    static inline Length initialScrollPadding();
+    static inline Style::ScrollMarginEdge initialScrollMargin();
+    static inline Style::ScrollPaddingEdge initialScrollPadding();
 
     static ScrollSnapType initialScrollSnapType();
     static ScrollSnapAlign initialScrollSnapAlign();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -70,6 +70,8 @@
 
 namespace WebCore {
 
+using namespace CSS::Literals;
+
 inline const Style::Color& RenderStyle::accentColor() const { return m_rareInheritedData->accentColor; }
 inline bool RenderStyle::affectsTransform() const { return hasTransform() || offsetPath() || rotate() || scale() || translate(); }
 inline const StyleContentAlignmentData& RenderStyle::alignContent() const { return m_nonInheritedData->miscData->alignContent; }
@@ -480,8 +482,8 @@ inline GapLength RenderStyle::initialRowGap() { return { }; }
 constexpr RubyPosition RenderStyle::initialRubyPosition() { return RubyPosition::Over; }
 constexpr RubyAlign RenderStyle::initialRubyAlign() { return RubyAlign::SpaceAround; }
 constexpr RubyOverhang RenderStyle::initialRubyOverhang() { return RubyOverhang::Auto; }
-inline Length RenderStyle::initialScrollMargin() { return zeroLength(); }
-inline Length RenderStyle::initialScrollPadding() { return { }; }
+inline Style::ScrollMarginEdge RenderStyle::initialScrollMargin() { return Style::ScrollMarginEdge { 0_css_px }; }
+inline Style::ScrollPaddingEdge RenderStyle::initialScrollPadding() { return Style::ScrollPaddingEdge { CSS::Keyword::Auto { } }; }
 inline std::optional<ScrollbarColor> RenderStyle::initialScrollbarColor() { return std::nullopt; }
 constexpr ScrollbarWidth RenderStyle::initialScrollbarWidth() { return ScrollbarWidth::Auto; }
 constexpr StyleSelfAlignmentData RenderStyle::initialSelfAlignment() { return { ItemPosition::Auto, OverflowAlignment::Default }; }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -44,6 +44,9 @@
 #include "ShapeValue.h"
 #include "StyleColor.h"
 #include "StyleContentAlignmentData.h"
+#include "StylePrimitiveNumericTypes.h"
+#include "StyleScrollMargin.h"
+#include "StyleScrollPadding.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleSelfAlignmentData.h"
 #include "StyleTextEdge.h"
@@ -66,6 +69,8 @@ class TextStream;
 }
 
 namespace WebCore {
+
+using namespace CSS::Literals;
 
 class AnimationList;
 class ContentData;
@@ -144,9 +149,11 @@ public:
     DataRef<StyleGridData> grid;
     DataRef<StyleGridItemData> gridItem;
 
+    // Only meaningful when `hasClip` is true.
     LengthBox clip;
-    LengthBox scrollMargin { 0, 0, 0, 0 };
-    LengthBox scrollPadding { Length(LengthType::Auto), Length(LengthType::Auto), Length(LengthType::Auto), Length(LengthType::Auto) };
+
+    Style::ScrollMargin scrollMargin { Style::ScrollMarginEdge { 0_css_px } };
+    Style::ScrollPadding scrollPadding { Style::ScrollPaddingEdge { CSS::Keyword::Auto { } } };
 
     CounterDirectiveMap counterDirectives;
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -83,6 +83,8 @@
 #include "StyleRayFunction.h"
 #include "StyleReflection.h"
 #include "StyleResolveForFont.h"
+#include "StyleScrollMargin.h"
+#include "StyleScrollPadding.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleTextEdge.h"
 #include "TabSize.h"
@@ -256,6 +258,9 @@ public:
     static Vector<PositionTryFallback> convertPositionTryFallbacks(const BuilderState&, const CSSValue&);
 
     template<CSSValueID, CSSValueID> static WebCore::Length convertPositionComponent(const BuilderState&, const CSSValue&);
+
+    static Style::ScrollPaddingEdge convertScrollPaddingEdge(const BuilderState&, const CSSValue&);
+    static Style::ScrollMarginEdge convertScrollMarginEdge(const BuilderState&, const CSSValue&);
 
 private:
     friend class BuilderCustom;
@@ -2232,6 +2237,16 @@ inline Vector<PositionTryFallback> BuilderConverter::convertPositionTryFallbacks
         auto fallback = fallbackForValueList(*itemList);
         return fallback ? *fallback : PositionTryFallback { };
     });
+}
+
+inline Style::ScrollPaddingEdge BuilderConverter::convertScrollPaddingEdge(const BuilderState& builderState, const CSSValue& value)
+{
+    return Style::scrollPaddingEdgeFromCSSValue(value, builderState);
+}
+
+inline Style::ScrollMarginEdge BuilderConverter::convertScrollMarginEdge(const BuilderState& builderState, const CSSValue& value)
+{
+    return Style::scrollMarginEdgeFromCSSValue(value, builderState);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -77,6 +77,8 @@ inline LengthBox forwardInheritedValue(const LengthBox& value) { auto copy = val
 inline GapLength forwardInheritedValue(const GapLength& value) { auto copy = value; return copy; }
 inline FilterOperations forwardInheritedValue(const FilterOperations& value) { auto copy = value; return copy; }
 inline TransformOperations forwardInheritedValue(const TransformOperations& value) { auto copy = value; return copy; }
+inline ScrollMarginEdge forwardInheritedValue(const ScrollMarginEdge& value) { auto copy = value; return copy; }
+inline ScrollPaddingEdge forwardInheritedValue(const ScrollPaddingEdge& value) { auto copy = value; return copy; }
 
 // Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleScrollMargin.h"
+
+#include "ComputedStyleExtractor.h"
+#include "LayoutRect.h"
+#include "StyleBuilderConverter.h"
+#include "StyleBuilderState.h"
+
+namespace WebCore {
+namespace Style {
+
+LayoutUnit ScrollMarginEdge::evaluate(LayoutUnit referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return LayoutUnit(m_value.value());
+
+    case LengthType::Percent:
+        return LayoutUnit(static_cast<float>(referenceLength * m_value.percent() / 100.0f));
+
+    case LengthType::Calculated:
+        return LayoutUnit(m_value.nonNanCalculatedValue(referenceLength));
+
+    case LengthType::FillAvailable:
+    case LengthType::Auto:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0_lu;
+}
+
+float ScrollMarginEdge::evaluate(float referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return m_value.value();
+
+    case LengthType::Percent:
+        return referenceLength * m_value.percent() / 100.0f;
+
+    case LengthType::Calculated:
+        return m_value.nonNanCalculatedValue(referenceLength);
+
+    case LengthType::FillAvailable:
+    case LengthType::Auto:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0.0f;
+}
+
+Ref<CSSValue> ScrollMarginEdge::toCSS(const RenderStyle& style) const
+{
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(m_value, style);
+}
+
+ScrollMarginEdge scrollMarginEdgeFromCSSValue(const CSSValue& value, const BuilderState& state)
+{
+    return ScrollMarginEdge { BuilderConverter::convertLength(state, value) };
+}
+
+LayoutBoxExtent extentForRect(const ScrollMargin& margin, const LayoutRect& rect)
+{
+    return LayoutBoxExtent {
+        Style::evaluate(margin.top(), rect.height()),
+        Style::evaluate(margin.right(), rect.width()),
+        Style::evaluate(margin.bottom(), rect.height()),
+        Style::evaluate(margin.left(), rect.width()),
+    };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Length.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+
+class CSSValue;
+class LayoutRect;
+class LayoutUnit;
+class RenderStyle;
+using LayoutBoxExtent = RectEdges<LayoutUnit>;
+
+namespace Style {
+
+class BuilderState;
+
+// <'scroll-margin-*'> = <length>
+// https://drafts.csswg.org/css-scroll-snap-1/#margin-longhands-physical
+struct ScrollMarginEdge {
+    ScrollMarginEdge(WebCore::Length&& value)
+        : m_value { WTFMove(value) }
+    {
+        RELEASE_ASSERT(m_value.isSpecified());
+    }
+
+    ScrollMarginEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> pixels)
+        : m_value { pixels.value, WebCore::LengthType::Fixed }
+    {
+    }
+
+    ScrollMarginEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> percentage)
+        : m_value { percentage.value, WebCore::LengthType::Percent }
+    {
+    }
+
+    LayoutUnit evaluate(LayoutUnit referenceLength) const;
+    float evaluate(float referenceLength) const;
+
+    Ref<CSSValue> toCSS(const RenderStyle&) const;
+
+    bool isZero() const { return m_value.isZero(); }
+
+    bool operator==(const ScrollMarginEdge&) const = default;
+
+private:
+    WebCore::Length m_value;
+};
+
+// <'scroll-margin'> = <length>{1,4}
+// https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin
+struct ScrollMargin : SpaceSeparatedRectEdges<ScrollMarginEdge> {
+    using Wrapped = SpaceSeparatedRectEdges<ScrollMarginEdge>;
+    using Wrapped::Wrapped;
+    using Wrapped::operator=;
+
+    template<size_t I> friend const auto& get(const ScrollMargin& self)
+    {
+        return get<I>(static_cast<const Wrapped&>(self));
+    }
+
+    bool operator==(const ScrollMargin&) const = default;
+};
+
+// MARK: - Conversion
+
+ScrollMarginEdge scrollMarginEdgeFromCSSValue(const CSSValue&, const BuilderState&);
+
+// MARK: - Evaluation
+
+template<typename T> T evaluate(const ScrollMarginEdge& edge, T referenceLength)
+{
+    return edge.evaluate(referenceLength);
+}
+
+// MARK: - Extent
+
+LayoutBoxExtent extentForRect(const ScrollMargin&, const LayoutRect&);
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleScrollPadding.h"
+
+#include "ComputedStyleExtractor.h"
+#include "LayoutRect.h"
+#include "StyleBuilderConverter.h"
+#include "StyleBuilderState.h"
+
+namespace WebCore {
+namespace Style {
+
+LayoutUnit ScrollPaddingEdge::evaluate(LayoutUnit referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return LayoutUnit(m_value.value());
+
+    case LengthType::Percent:
+        return LayoutUnit(static_cast<float>(referenceLength * m_value.percent() / 100.0f));
+
+    case LengthType::Calculated:
+        return LayoutUnit(m_value.nonNanCalculatedValue(referenceLength));
+
+    case LengthType::Auto:
+            return 0_lu;
+
+    case LengthType::FillAvailable:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0_lu;
+}
+
+float ScrollPaddingEdge::evaluate(float referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return m_value.value();
+
+    case LengthType::Percent:
+        return referenceLength * m_value.percent() / 100.0f;
+
+    case LengthType::Calculated:
+        return m_value.nonNanCalculatedValue(referenceLength);
+
+    case LengthType::Auto:
+            return 0;
+
+    case LengthType::FillAvailable:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0;
+}
+
+Ref<CSSValue> ScrollPaddingEdge::toCSS(const RenderStyle& style) const
+{
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(m_value, style);
+}
+
+ScrollPaddingEdge scrollPaddingEdgeFromCSSValue(const CSSValue& value, const BuilderState& state)
+{
+    if (value.valueID() == CSSValueAuto)
+        return ScrollPaddingEdge { CSS::Keyword::Auto { } };
+    return ScrollPaddingEdge { BuilderConverter::convertLength(state, value) };
+}
+
+LayoutBoxExtent extentForRect(const ScrollPadding& padding, const LayoutRect& rect)
+{
+    return LayoutBoxExtent {
+        Style::evaluate(padding.top(), rect.height()),
+        Style::evaluate(padding.right(), rect.width()),
+        Style::evaluate(padding.bottom(), rect.height()),
+        Style::evaluate(padding.left(), rect.width()),
+    };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Length.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+
+class CSSValue;
+class LayoutRect;
+class LayoutUnit;
+class RenderStyle;
+using LayoutBoxExtent = RectEdges<LayoutUnit>;
+
+namespace Style {
+
+class BuilderState;
+
+// <'scroll-padding-*'> = auto | <length-percentage [0,∞]>
+// https://drafts.csswg.org/css-scroll-snap-1/#padding-longhands-physical
+struct ScrollPaddingEdge {
+    ScrollPaddingEdge(WebCore::Length&& value)
+        : m_value { WTFMove(value) }
+    {
+        RELEASE_ASSERT(m_value.isSpecified());
+    }
+
+    ScrollPaddingEdge(CSS::Keyword::Auto)
+        : m_value { WebCore::LengthType::Auto }
+    {
+    }
+
+    ScrollPaddingEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> pixels)
+        : m_value { pixels.value, WebCore::LengthType::Fixed }
+    {
+    }
+
+    ScrollPaddingEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> percentage)
+        : m_value { percentage.value, WebCore::LengthType::Percent }
+    {
+    }
+
+    LayoutUnit evaluate(LayoutUnit referenceLength) const;
+    float evaluate(float referenceLength) const;
+
+    Ref<CSSValue> toCSS(const RenderStyle&) const;
+
+    bool isZero() const { return m_value.isZero(); }
+
+    bool operator==(const ScrollPaddingEdge&) const = default;
+
+private:
+    WebCore::Length m_value;
+};
+
+// <'scroll-padding'> = [ auto | <length-percentage [0,∞]> ]{1,4}
+// https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding
+struct ScrollPadding : SpaceSeparatedRectEdges<ScrollPaddingEdge> {
+    using Wrapped = SpaceSeparatedRectEdges<ScrollPaddingEdge>;
+    using Wrapped::Wrapped;
+    using Wrapped::operator=;
+
+    template<size_t I> friend const auto& get(const ScrollPadding& self)
+    {
+        return get<I>(static_cast<const Wrapped&>(self));
+    }
+
+    bool operator==(const ScrollPadding&) const = default;
+};
+
+// MARK: - Conversion
+
+ScrollPaddingEdge scrollPaddingEdgeFromCSSValue(const CSSValue&, const BuilderState&);
+
+// MARK: - Evaluation
+
+template<typename T> T evaluate(const ScrollPaddingEdge& edge, T referenceLength)
+{
+    return edge.evaluate(referenceLength);
+}
+
+// MARK: - Extent
+
+LayoutBoxExtent extentForRect(const ScrollPadding&, const LayoutRect&);
+
+} // namespace Style
+} // namespace WebCore


### PR DESCRIPTION
#### a3f67be7afd4daff5f81e12d7dbcca2fb17f890a
<pre>
[Test 2] Partially re-apply other half of 288829@main to test if that part is a Speedometer 3 regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=286485">https://bugs.webkit.org/show_bug.cgi?id=286485</a>

Reviewed by NOBODY (OOPS!).

WIP - Test 2

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3f67be7afd4daff5f81e12d7dbcca2fb17f890a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86660 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67016 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24804 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32798 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93386 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74999 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6598 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13836 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19096 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->