### PR TITLE
chriskirknielsen.com: Containing blocks not sizing properly when font-variant-caps changes on content.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-caps-invalidation-container-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-caps-invalidation-container-sizing-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+#container {
+  width: min-content;
+  border: 1px solid black;
+  font-size: 100px;
+  font-variant-caps: all-small-caps;
+}
+</style>
+</head>
+<body>
+  <div id="container">
+    X
+  </div>
+</body>
+<script>
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-caps-invalidation-container-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-caps-invalidation-container-sizing.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-variant-caps-prop"
+<link rel="match" href="font-variant-caps-invalidation-container-sizing-ref.html">
+<meta name="assert" content="Block container is sized properly when font-variant-caps is changed from normal to all-small-caps">
+<style>
+#container {
+  width: min-content;
+  border: 1px solid black;
+  font-size: 100px;
+}
+</style>
+</head>
+<body>
+  <div id="container">
+    X
+  </div>
+</body>
+<script>
+document.body.offsetHeight;
+document.getElementById("container").style["font-variant-caps"] = "all-small-caps";
+</script>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -668,6 +668,12 @@ bool TextUtil::canUseSimplifiedTextMeasuring(StringView textContent, const FontC
     if (fontCascade.wordSpacing() || fontCascade.letterSpacing())
         return false;
 
+#if USE(FONT_VARIANT_VIA_FEATURES)
+    auto fontVariantCaps = fontCascade.fontDescription().variantCaps();
+    if (fontVariantCaps == FontVariantCaps::Small || fontVariantCaps == FontVariantCaps::AllSmall || fontVariantCaps ==  FontVariantCaps::Petite || fontVariantCaps == FontVariantCaps::AllPetite)
+        return false;
+#endif
+
     // Additional check on the font codepath.
     auto run = TextRun { textContent };
     run.setCharacterScanForCodePath(false);


### PR DESCRIPTION
#### 62bec285221794fed2fdfb5fdc561a6564edd22b
<pre>
chriskirknielsen.com: Containing blocks not sizing properly when font-variant-caps changes on content.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285264">https://bugs.webkit.org/show_bug.cgi?id=285264</a>
<a href="https://rdar.apple.com/142212550">rdar://142212550</a>

Reviewed by Alan Baradlay.

On a style change, we update the content characteristics of an inline
text box via updateContentCharacteristic, which may add the CanUseSimplifiedContentMeasuring
characteristic on certain pieces of content. We currently allow this
characteristic to be applied for all values of font-variant-caps, but
this is at odds with what we do in RenderText. We should match
RenderText by performing complex content measuring when we see these
values of font-variant-caps.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-caps-invalidation-container-sizing-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-variant-caps-invalidation-container-sizing.html: Added.
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::canUseSimplifiedTextMeasuring):

Canonical link: <a href="https://commits.webkit.org/289486@main">https://commits.webkit.org/289486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c19b6bb6be560ca2398005328ce31a824585793c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6602 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41450 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37831 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25065 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47631 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33205 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36948 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76111 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19651 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18090 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7171 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14273 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19566 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17460 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->