### PR TITLE
REGRESSION (285925@main): [iOS] Selection highlights for non-editable content sometimes disappear

### DIFF
--- a/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-expected.txt
+++ b/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-expected.txt
@@ -1,0 +1,13 @@
+START Hello
+
+world END
+
+Verifies that native selection UI is not suppressed when selecting visible content. To manually run the test, select from START to END and verify that the selection highlight is visible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS selectionRects.length is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container.html
+++ b/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+}
+
+em {
+    color: orange;
+    font-weight: bold;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that native selection UI is not suppressed when selecting visible content. To manually run the test, select from START to END and verify that the selection highlight is visible.");
+
+    if (!window.testRunner)
+        return;
+
+    const start = document.getElementById("start");
+    const end = document.getElementById("end");
+
+    await UIHelper.longPressElement(start);
+    await UIHelper.waitForSelectionToAppear();
+
+    getSelection().setBaseAndExtent(start, 0, end, 1);
+    await UIHelper.ensurePresentationUpdate();
+
+    selectionRects = await UIHelper.waitForSelectionToAppear();
+
+    shouldBe("selectionRects.length", "2");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <font face="sans-serif">
+        <p><em id="start">START</em> Hello</p>
+        <p>world <em id="end">END</em></p>
+    </font>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2236,7 +2236,7 @@ void RenderObject::removeRareData()
 RenderObject::RenderObjectRareData::RenderObjectRareData() = default;
 RenderObject::RenderObjectRareData::~RenderObjectRareData() = default;
 
-bool RenderObject::hasNonEmptyVisibleRectRespectingParentFrames() const
+bool RenderObject::hasEmptyVisibleRectRespectingParentFrames() const
 {
     auto enclosingFrameRenderer = [] (const RenderObject& renderer) {
         auto* ownerElement = renderer.document().ownerElement();

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -769,7 +769,7 @@ public:
     // Returns the object containing this one. Can be different from parent for positioned elements.
     // If repaintContainer and repaintContainerSkipped are not null, on return *repaintContainerSkipped
     // is true if the renderer returned is an ancestor of repaintContainer.
-    RenderElement* container() const;
+    WEBCORE_EXPORT RenderElement* container() const;
     RenderElement* container(const RenderLayerModelObject* repaintContainer, bool& repaintContainerSkipped) const;
 
     RenderBoxModelObject* offsetParent() const;
@@ -1054,7 +1054,7 @@ public:
     virtual std::optional<RepaintRects> computeVisibleRectsInContainer(const RepaintRects&, const RenderLayerModelObject* repaintContainer, VisibleRectContext) const;
     virtual std::optional<FloatRect> computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject* repaintContainer, VisibleRectContext) const;
 
-    WEBCORE_EXPORT bool hasNonEmptyVisibleRectRespectingParentFrames() const;
+    WEBCORE_EXPORT bool hasEmptyVisibleRectRespectingParentFrames() const;
 
     virtual unsigned length() const { return 1; }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -205,6 +205,7 @@ class PrintContext;
 class Range;
 class RegistrableDomain;
 class RenderImage;
+class RenderObject;
 class Report;
 class ResourceRequest;
 class ResourceResponse;
@@ -875,6 +876,7 @@ public:
     void updateHeaderAndFooterLayersForDeviceScaleChange(float scaleFactor);
 
     bool isTransparentOrFullyClipped(const WebCore::Node&) const;
+    bool isTransparentOrFullyClipped(const WebCore::RenderObject&) const;
 #endif
 
     void didUpdateRendering();


### PR DESCRIPTION
#### 4aac13b0792324cd39da9b593980e2c79c11e5ce
<pre>
REGRESSION (285925@main): [iOS] Selection highlights for non-editable content sometimes disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=286490">https://bugs.webkit.org/show_bug.cgi?id=286490</a>
<a href="https://rdar.apple.com/143296175">rdar://143296175</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in <a href="https://commits.webkit.org/285925@main">https://commits.webkit.org/285925@main</a>, we now apply the &quot;hidden selection
container&quot; heuristic to non-editable, non-collapsed selection ranges as well as editable selections
(e.g. Google Docs). This worked by first finding the common ancestor `Node` that contains both
selection endpoints, and then checking if that container&apos;s renderer is either in a completely- or
nearly-transparent layer, or is otherwise completely clipped out (based on visible repaint rects).

However, this logic breaks in the case where the selection endpoints&apos; common ancestor in the render
tree is _not_ the same as the common ancestor in the DOM — for example, when using the inline `font`
element like so:

```
&lt;font face=&quot;…&quot;&gt;
    &lt;p&gt;abc&lt;/p&gt; &lt;!-- selection starts here --&gt;
    …
    &lt;p&gt;def&lt;/p&gt; &lt;!-- selection ends here --&gt;
&lt;/font&gt;
```

In this case, the `font` element is common ancestor in the DOM, but an anonymous block renderer is
the common ancestor in the actual render tree. This causes us to incorrectly treat this selection as
fully clipped, based on the fact that the inline `font` element renderer is empty. To fix this, we
adjust the heuristic to find the common ancestor in the render tree that contains both selection
endpoints, and then check if that common ancestor is hidden.

* LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-expected.txt: Added.
* LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container.html: Added.

Add a new layout test to exercise this fix.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::hasEmptyVisibleRectRespectingParentFrames const):
(WebCore::RenderObject::hasNonEmptyVisibleRectRespectingParentFrames const): Deleted.

Drive-by fix: remove the `Non` from this method, which returns true if and only if the renderer&apos;s
(or one of its parent frames&apos;) visible rect is empty. Note that the only call site expects this
behavior, so the resulting behavior is correct (the method name is just misleading).

* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::isTransparentOrFullyClipped const):
(WebKit::closestCommonContainerInRenderTree):

Add a helper method to return the deepest common renderer that contains both selection endpoints.

(WebKit::WebPage::getPlatformEditorStateCommon const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/289369@main">https://commits.webkit.org/289369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d491e33129ab6051580679e6b263fd32b3a82d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67027 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24814 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4916 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4711 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32822 "Found 5 new test failures: editing/undo/redo-reapply-edit-command-crash.html http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36537 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13840 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10035 "Found 1 new test failure: swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/75829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17727 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6625 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13863 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->