### PR TITLE
Make an asynchronous version of _WKInputDelegate._webView:focusRequiresStrongPasswordAssistance:

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInputDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInputDelegate.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, _WKFocusStartsInputSessionPolicy) {
 - (void)_webView:(WKWebView *)webView insertTextSuggestion:(UITextSuggestion *)suggestion inInputSession:(id <_WKFormInputSession>)inputSession WK_API_AVAILABLE(ios(10.0));
 - (void)_webView:(WKWebView *)webView willStartInputSession:(id <_WKFormInputSession>)inputSession WK_API_AVAILABLE(ios(12.0));
 - (BOOL)_webView:(WKWebView *)webView focusRequiresStrongPasswordAssistance:(id <_WKFocusedElementInfo>)info WK_API_AVAILABLE(ios(12.0));
+- (void)_webView:(WKWebView *)webView focusRequiresStrongPasswordAssistance:(id <_WKFocusedElementInfo>)info completionHandler:(void (^)(BOOL))completionHandler WK_API_AVAILABLE(ios(WK_IOS_TBA));
 
 - (NSDictionary<id, NSString *> *)_webViewAdditionalContextForStrongPasswordAssistance:(WKWebView *)webView WK_API_AVAILABLE(ios(13.4));
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -458,6 +458,7 @@ struct ImageAnalysisContextMenuActionData {
     WebKit::InteractionInformationAtPosition _positionInformation;
     std::optional<WebCore::TextIndicatorData> _positionInformationLinkIndicator;
     WebKit::FocusedElementInformation _focusedElementInformation;
+    std::optional<WebKit::FocusedElementInformationIdentifier> _pendingFocusedElementIdentifier;
     RetainPtr<NSObject<WKFormPeripheral>> _inputPeripheral;
 
     Vector<WebKit::KeyEventAndCompletionBlock, 1> _keyWebEventHandlers;

--- a/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.h
+++ b/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.h
@@ -36,7 +36,7 @@
 @property (nonatomic, copy) void (^willStartInputSessionHandler)(WKWebView *, id <_WKFormInputSession>);
 @property (nonatomic, copy) void (^didStartInputSessionHandler)(WKWebView *, id <_WKFormInputSession>);
 @property (nonatomic, copy) NSDictionary<id, NSString *> * (^webViewAdditionalContextForStrongPasswordAssistanceHandler)(WKWebView *);
-@property (nonatomic, copy) BOOL (^focusRequiresStrongPasswordAssistanceHandler)(WKWebView *, id <_WKFocusedElementInfo>);
+@property (nonatomic, copy) void (^focusRequiresStrongPasswordAssistanceHandler)(WKWebView *, id <_WKFocusedElementInfo>, void(^)(BOOL));
 @property (nonatomic, copy) void (^insertTextSuggestionHandler)(WKWebView *, UITextSuggestion *, id<_WKFormInputSession>);
 @end
 

--- a/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.mm
@@ -35,7 +35,7 @@
     BlockPtr<void(WKWebView *, id<_WKFormInputSession>)> _willStartInputSessionHandler;
     BlockPtr<void(WKWebView *, id<_WKFormInputSession>)> _didStartInputSessionHandler;
     BlockPtr<NSDictionary<id, NSString *> *(WKWebView *)> _webViewAdditionalContextForStrongPasswordAssistanceHandler;
-    BlockPtr<BOOL(WKWebView *, id<_WKFocusedElementInfo>)> _focusRequiresStrongPasswordAssistanceHandler;
+    BlockPtr<void(WKWebView *, id<_WKFocusedElementInfo>, void(^)(BOOL))> _focusRequiresStrongPasswordAssistanceHandler;
     BlockPtr<void(WKWebView *, UITextSuggestion *, id<_WKFormInputSession>)> _insertTextSuggestionHandler;
 }
 
@@ -113,21 +113,21 @@
     return @{ };
 }
 
-- (void)setFocusRequiresStrongPasswordAssistanceHandler:(BOOL (^)(WKWebView *, id <_WKFocusedElementInfo>))handler
+- (void)setFocusRequiresStrongPasswordAssistanceHandler:(void(^)(WKWebView *, id<_WKFocusedElementInfo>, void(^)(BOOL)))handler
 {
     _focusRequiresStrongPasswordAssistanceHandler = makeBlockPtr(handler);
 }
 
-- (BOOL (^)(WKWebView *, id <_WKFocusedElementInfo>))focusRequiresStrongPasswordAssistanceHandler
+- (void(^)(WKWebView *, id<_WKFocusedElementInfo>, void(^)(BOOL)))focusRequiresStrongPasswordAssistanceHandler
 {
     return _focusRequiresStrongPasswordAssistanceHandler.get();
 }
 
-- (BOOL)_webView:(WKWebView *)webView focusRequiresStrongPasswordAssistance:(id <_WKFocusedElementInfo>)info
+- (void)_webView:(WKWebView *)webView focusRequiresStrongPasswordAssistance:(id<_WKFocusedElementInfo>)info completionHandler:(void(^)(BOOL))completionHandler
 {
     if (_focusRequiresStrongPasswordAssistanceHandler)
-        return _focusRequiresStrongPasswordAssistanceHandler(webView, info);
-    return NO;
+        return _focusRequiresStrongPasswordAssistanceHandler(webView, info, completionHandler);
+    return completionHandler(NO);
 }
 
 - (void)_webView:(WKWebView *)webView insertTextSuggestion:(UITextSuggestion *)suggestion inInputSession:(id<_WKFormInputSession>)inputSession


### PR DESCRIPTION
#### 5ceeaba755e447f42f3cdd36cf7b600dad6b9798
<pre>
Make an asynchronous version of _WKInputDelegate._webView:focusRequiresStrongPasswordAssistance:
<a href="https://bugs.webkit.org/show_bug.cgi?id=286494">https://bugs.webkit.org/show_bug.cgi?id=286494</a>
<a href="https://rdar.apple.com/143579852">rdar://143579852</a>

Reviewed by Wenson Hsieh.

With minimal reordering of when _focusedElementInformation is set, we can call
_continueElementDidFocus synchronously or asynchronously and there should be no
behavior change.  To prevent _continueElementDidFocus from being called after a
blur, I add a check to _focusedElementInformation.identifier after the asynchronous
delegate call to do nothing if we have changed focus during the delegate call.
I changed the SetForScope to a CompletionHandlerCallingScope so I can pass it through
an asynchronous call.

* Source/WebKit/UIProcess/API/Cocoa/_WKInputDelegate.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _continueElementDidFocus:focusedElementInfo:requiresKeyboard:activityStateChanges:]):

Canonical link: <a href="https://commits.webkit.org/289895@main">https://commits.webkit.org/289895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d15f76cd9d053ce76cc0bc49f9993b024d8017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67058 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24828 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47371 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32851 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36574 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75043 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6662 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19160 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->