### PR TITLE
Subtitles are not displayed in PIP window

### DIFF
--- a/LayoutTests/platform/visionos/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/platform/visionos/interaction-region/paused-video-regions-expected.txt
@@ -1,0 +1,68 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+      )
+      (children 1
+        (GraphicsLayer
+          (bounds 352.00 288.00)
+          (event region
+            (rect (0,0) width=352 height=288)
+          )
+          (children 1
+            (GraphicsLayer
+              (bounds 352.00 288.00)
+              (event region
+                (rect (0,0) width=352 height=288)
+              )
+              (children 1
+                (GraphicsLayer
+                  (bounds 352.00 288.00)
+                  (children 1
+                    (GraphicsLayer
+                      (position 176.00 144.00)
+                      (bounds 51.00 51.00)
+                      (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-25.50 -25.50 0.00 1.00])
+                      (event region
+                        (rect (8,0) width=35 height=8)
+                        (rect (0,8) width=51 height=35)
+                        (rect (8,43) width=35 height=8)
+
+                      (interaction regions [
+                        (interaction (0,0) width=51 height=51)
+                        (cornerRadius 25.50)])
+                      )
+                      (children 1
+                        (GraphicsLayer
+                          (position 10.00 10.00)
+                          (bounds 31.00 31.00)
+                          (contentsOpaque 1)
+                          (transform [0.90 0.00 0.00 0.00] [0.00 0.90 0.00 0.00] [0.00 0.00 1.00 0.00] [2.48 0.00 0.00 1.00])
+                          (mask layer)
+                            (GraphicsLayer
+                              (bounds 31.00 31.00)
+                              (drawsContent 1)
+                            )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+EVENT(canplaythrough)
+

--- a/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
@@ -67,24 +67,28 @@
                                       (layer position [x: 176 y: 176])
                                       (sublayers
                                         (
-                                          (layer bounds [x: 0 y: 0 width: 51 height: 51])
-                                          (layer position [x: 201.5 y: 201.5])
+                                          (layer bounds [x: 0 y: 0 width: 352 height: 288])
+                                          (layer position [x: 176 y: 176])
                                           (sublayers
                                             (
-                                              (layer bounds [x: 0 y: 0 width: 31 height: 31])
-                                              (layer position [x: 25.5 y: 25.5])
+                                              (layer bounds [x: 0 y: 0 width: 51 height: 51])
+                                              (layer position [x: 201.5 y: 201.5])
                                               (sublayers
                                                 (
                                                   (layer bounds [x: 0 y: 0 width: 31 height: 31])
-                                                  (layer anchorPoint [x: 0 y: 0]))))
-                                            (
-                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                              (sublayers
-                                                (
-                                                  (type 0)
-                                                  (layer bounds [x: 0 y: 0 width: 51 height: 51])
                                                   (layer position [x: 25.5 y: 25.5])
-                                                  (layer cornerRadius 25.5))))))))))))))))))))))))
+                                                  (sublayers
+                                                    (
+                                                      (layer bounds [x: 0 y: 0 width: 31 height: 31])
+                                                      (layer anchorPoint [x: 0 y: 0]))))
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                  (sublayers
+                                                    (
+                                                      (type 0)
+                                                      (layer bounds [x: 0 y: 0 width: 51 height: 51])
+                                                      (layer position [x: 25.5 y: 25.5])
+                                                      (layer cornerRadius 25.5))))))))))))))))))))))))))
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0])
       (layer position [x: 400 y: 400]))

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -57,6 +57,7 @@
     -webkit-cursor-visibility: inherit;
     position: relative;
     will-change: z-index;
+    overflow: clip;
 }
 
 .media-controls-container,

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -987,6 +987,7 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
     IntRect initialWindowRect;
     page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
     interface->setupFullscreen(initialWindowRect, page->platformWindow(), videoFullscreenMode, allowsPictureInPicture);
+    interface->setupCaptionsLayer([view layer], initialSize);
 #endif
 }
 


### PR DESCRIPTION
#### ac123bdd1261957f0e6ca233ac8168ab0480b174
<pre>
Subtitles are not displayed in PIP window
<a href="https://bugs.webkit.org/show_bug.cgi?id=286501">https://bugs.webkit.org/show_bug.cgi?id=286501</a>
<a href="https://rdar.apple.com/139626885">rdar://139626885</a>

Reviewed by Jer Noble.

Currently on Mac after returning from pip, all subsequent times
the user enters pip the subtitles do not appear in the pip window,
but are rather outside the pip window on the page. This is caused by two
problems: the first is that we only allocate the captions layer when the
webpage is loaded. So when we destroy the captions layer after returning from
pip, it is never recreated. This patch fixes this issue by adding a call to
VideoFullscreenCaptions::setupCaptionsLayer from
VideoPresentationManagerProxy::setupFullscreenWithID.

The second problem this patch addresses is that overflow needs to hidden
on the media-controls-container div inside the shadow dom. To send the caption to
the pip window, we make an enlarged copy of it, and this needs to be hidden.

Updates baseline for two visionOS layout tests.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(.media-controls-container):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):

Canonical link: <a href="https://commits.webkit.org/289503@main">https://commits.webkit.org/289503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31f5e0558fc9be6cc7a724ac9a1c66971020e2c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14665 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67306 "Found 3 new test failures: fast/css/view-transitions-update-pseudo-element-crash.html fast/multicol/assert-with-nested-columns-and-spanner.html imported/w3c/web-platform-tests/css/css-break/table/repeated-section/special-elements-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33202 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36943 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93833 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14249 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10370 "Found 3 new test failures: fast/css/view-transitions-zoom.html fast/multicol/assert-with-nested-columns-and-spanner.html imported/w3c/web-platform-tests/css/css-break/table/repeated-section/special-elements-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76110 "Found 3 new test failures: fast/css/view-transitions-update-pseudo-element-crash.html fast/multicol/assert-with-nested-columns-and-spanner.html imported/w3c/web-platform-tests/css/css-break/table/repeated-section/special-elements-crash.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75310 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19654 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7166 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14268 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19561 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17455 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->