### PR TITLE
Reduce use of strchr() in the codebase

### DIFF
--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
@@ -50,11 +50,8 @@ bool WebSocketExtensionParser::parsedSuccessfully()
 
 static bool isSeparator(char character)
 {
-    static constexpr auto separatorCharacters = "()<>@,;:\\\"/[]?={} \t"_s;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    const char* p = strchr(separatorCharacters.characters(), character);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    return p && *p;
+    static constexpr auto separatorCharacters = "()<>@,;:\\\"/[]?={} \t"_span;
+    return contains(separatorCharacters, character);
 }
 
 static bool isSpaceOrTab(LChar character)

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -125,10 +125,8 @@ static constexpr ASCIILiteral textEncodingNameBlocklist[] = { "UTF-7"_s, "BOCU-1
 static bool isUndesiredAlias(ASCIILiteral alias)
 {
     // Reject aliases with version numbers that are supported by some back-ends (such as "ISO_2022,locale=ja,version=0" in ICU).
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (strchr(alias.characters(), ','))
+    if (contains(alias.span(), ','))
         return true;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     // 8859_1 is known to (at least) ICU, but other browsers don't support this name - and having it caused a compatibility
     // problem, see bug 43554.
     if (alias == "8859_1"_s)

--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -29,6 +29,7 @@
 #include <wtf/ASCIICType.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
+#include <wtf/text/StringCommon.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
 // On Windows, use the threadsafe *_r functions provided by pthread.
@@ -83,8 +84,8 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
 
     if (linelen > 0) {
         static const char* monthNames = "JanFebMarAprMayJunJulAugSepOctNovDec";
-        const char* tokens[16]; /* 16 is more than enough */
-        unsigned toklen[std::size(tokens)];
+        std::array<const char*, 16> tokens; /* 16 is more than enough */
+        unsigned toklen[tokens.size()];
         unsigned lineLenSansWsp; // line length sans whitespace
         unsigned numtoks = 0;
         unsigned tokmarker = 0; /* extra info for lstyle handler */
@@ -100,7 +101,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
         }
 
         unsigned pos = 0;
-        while (pos < linelen && numtoks < std::size(tokens)) {
+        while (pos < linelen && numtoks < tokens.size()) {
             while (pos < linelen
                 && (line[pos] == ' ' || line[pos] == '\t' || line[pos] == '\r'))
                 pos++;
@@ -120,7 +121,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
             return ParsingFailed(state);
 
         lineLenSansWsp = &(tokens[numtoks - 1][toklen[numtoks - 1]]) - tokens[0];
-        if (numtoks == std::size(tokens)) {
+        if (numtoks == tokens.size()) {
             pos = linelen;
             while (pos > 0 && (line[pos - 1] == ' ' || line[pos - 1] == '\t'))
                 pos--;
@@ -850,7 +851,7 @@ FTPEntryType parseOneFTPLine(const char* line, ListState& state, ListResult& res
                         }
                     }
                 } else if ((toklen[0] == 10 || toklen[0] == 11)
-                    && strchr("-bcdlpsw?DFam", *tokens[0])) {
+                    && WTF::contains("-bcdlpsw?DFam"_span, *tokens[0])) {
                     p = &(tokens[0][1]);
                     if ((p[0] == 'r' || p[0] == '-') && (p[1] == 'w' || p[1] == '-') && (p[3] == 'r' || p[3] == '-') && (p[4] == 'w' || p[4] == '-') && (p[6] == 'r' || p[6] == '-') && (p[7] == 'w' || p[7] == '-')) {
                     /* 'x'/p[9] can be S|s|x|-|T|t or implementation specific */

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -167,6 +167,7 @@ static bool threadCPUUsage(pid_t id, float period, ThreadInfo& info)
 
     // Skip tid and name.
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
+    // FIXME: Use `find(std::span { buffer }, ')')` instead of `strchr()`.
     char* position = strchr(buffer, ')');
     if (!position)
         return false;

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -92,14 +92,11 @@ static void appendQuoted(Vector<uint8_t>& buffer, const Vector<uint8_t>& string)
 // https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer
 static void appendFormURLEncoded(Vector<uint8_t>& buffer, std::span<const uint8_t> string)
 {
-    static const char safeCharacters[] = "-._*";
+    static constexpr auto safeCharacters = "-._*"_span;
     for (size_t i = 0; i < string.size(); ++i) {
         auto character = string[i];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (isASCIIAlphanumeric(character)
-            || (character != '\0' && strchr(safeCharacters, character)))
+        if (isASCIIAlphanumeric(character) || (character != '\0' && WTF::contains(safeCharacters, character)))
             append(buffer, character);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         else if (character == ' ')
             append(buffer, '+');
         else if (character == '\n' || (character == '\r' && (i + 1 >= string.size() || string[i + 1] != '\n')))

--- a/Source/WebCore/platform/text/SegmentedString.cpp
+++ b/Source/WebCore/platform/text/SegmentedString.cpp
@@ -246,9 +246,7 @@ void SegmentedString::setCurrentPosition(OrdinalNumber line, OrdinalNumber colum
 SegmentedString::AdvancePastResult SegmentedString::advancePastSlowCase(ASCIILiteral literal, bool lettersIgnoringASCIICase)
 {
     constexpr unsigned maxLength = 10;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    ASSERT(!strchr(literal.characters(), '\n'));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    ASSERT(!WTF::contains(literal.span(), '\n'));
     auto length = literal.length();
     ASSERT(length <= maxLength);
     if (length > this->length())

--- a/Source/WebCore/platform/text/SegmentedString.h
+++ b/Source/WebCore/platform/text/SegmentedString.h
@@ -306,9 +306,7 @@ template<bool lettersIgnoringASCIICase> SegmentedString::AdvancePastResult Segme
 {
     unsigned length = literal.length();
     ASSERT(!literal[length]);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    ASSERT(!strchr(literal.characters(), '\n'));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    ASSERT(!WTF::contains(literal.span(), '\n'));
     if (length + 1 < m_currentSubstring.length()) {
         if (m_currentSubstring.is8Bit) {
             for (unsigned i = 0; i < length; ++i) {

--- a/Source/WebKitLegacy/mac/Misc/WebNSObjectExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebNSObjectExtras.mm
@@ -30,6 +30,7 @@
 
 #import <wtf/Assertions.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/StringCommon.h>
 
 @interface WebMainThreadInvoker : NSProxy
 {
@@ -46,7 +47,7 @@ static bool returnTypeIsObject(NSInvocation *invocation)
 {
     // Could use either _C_ID or NSObjCObjectType, but it seems that neither is
     // both available and non-deprecated on all versions of Mac OS X we support.
-    return strchr([[invocation methodSignature] methodReturnType], '@');
+    return contains(unsafeSpan([[invocation methodSignature] methodReturnType]), '@');
 }
 
 @implementation WebMainThreadInvoker

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3529,7 +3529,11 @@ def check_safer_cpp(clean_lines, line_number, error):
 
     uses_memchr = search(r'memchr\(', line)
     if uses_memchr:
-        error(line_number, 'safercpp/memchr', 4, "Use WTF::find() instead of memchr().")
+        error(line_number, 'safercpp/memchr', 4, "Use WTF::find() or WTF::contains() instead of memchr().")
+
+    uses_strchr = search(r'strchr\(', line)
+    if uses_strchr:
+        error(line_number, 'safercpp/strchr', 4, "Use WTF::find() or WTF::contains() instead of strchr().")
 
     uses_strstr = search(r'strstr\(', line)
     if uses_strstr:
@@ -4883,6 +4887,7 @@ class CppChecker(object):
         'safercpp/memset',
         'safercpp/memset_s',
         'safercpp/weak_ref_exception',
+        'safercpp/strchr',
         'safercpp/strstr',
         'safercpp/timer_exception',
         'security/assertion',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6305,7 +6305,12 @@ class WebKitStyleTest(CppStyleTestBase):
 
         self.assert_lint(
             'char* result = memchr(haystack, c, strlen(haystack));',
-            'Use WTF::find() instead of memchr().  [safercpp/memchr] [4]',
+            'Use WTF::find() or WTF::contains() instead of memchr().  [safercpp/memchr] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'char* result = strchr(haystack, c);',
+            'Use WTF::find() or WTF::contains() instead of strchr().  [safercpp/strchr] [4]',
             'foo.cpp')
 
         self.assert_lint(

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -458,7 +458,7 @@ private:
     // Returns false if timed out.
     bool waitForCompletion(const WTF::Function<void ()>&, WTF::Seconds timeout);
 
-    bool handleControlCommand(const char* command);
+    bool handleControlCommand(std::span<const char> command);
 
     void platformInitialize(const Options&);
     void platformInitializeDataStore(WKPageConfigurationRef, const TestOptions&);

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -243,13 +243,13 @@ void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers,
         virtualKeyCode = VK_RMENU;
     else {
         size_t keyLength = WKStringGetLength(keyRef);
-        static const char shiftedUSCharacters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$%^&*()_+{}|:\"<>?";
+        static constexpr auto shiftedUSCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$%^&*()_+{}|:\"<>?"_span;
         wchar_t keyStr[3];
         WKStringGetCharacters(keyRef, keyStr, _countof(keyStr));
         if (keyLength == 1) {
             charCode = keyStr[0];
             virtualKeyCode = LOBYTE(VkKeyScan(charCode));
-            if (strchr(shiftedUSCharacters, charCode))
+            if (contains(shiftedUSCharacters, static_cast<char>(charCode)))
                 needsShiftKeyModifier = true;
         } else if (keyStr[0] == 'F') {
             if (keyLength == 2 && isASCIIDigit(keyStr[1]))


### PR DESCRIPTION
#### 47bb88f5f7e710aae31d46a5225dde4e20607976
<pre>
Reduce use of strchr() in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=286498">https://bugs.webkit.org/show_bug.cgi?id=286498</a>

Reviewed by Michael Catanzaro.

Reduce use of strchr() in the codebase as it is considered unsafe. Use `find()`
or `contains()` instead, which work with spans.

* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::isSeparator):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::isUndesiredAlias):
* Source/WebCore/loader/FTPDirectoryParser.cpp:
(WebCore::parseOneFTPLine):
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::threadCPUUsage):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::appendFormURLEncoded):
* Source/WebCore/platform/text/SegmentedString.cpp:
(WebCore::SegmentedString::advancePastSlowCase):
* Source/WebCore/platform/text/SegmentedString.h:
(WebCore::SegmentedString::advancePast):
* Source/WebKitLegacy/mac/Misc/WebNSObjectExtras.mm:
(returnTypeIsObject):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(handleControlCommand):
(runTestingServerLoop):
(overrideIsInHardwareKeyboardMode): Deleted.
(prepareConsistentTestingEnvironment): Deleted.
(writeCrashedMessageOnFatalError): Deleted.
(dumpRenderTree): Deleted.
(atexitFunction): Deleted.
(DumpRenderTreeMain): Deleted.
(compareHistoryItems): Deleted.
(dumpAudio): Deleted.
(dumpHistoryItem): Deleted.
(dumpFrameScrollPosition): Deleted.
(dumpFramesAsText): Deleted.
(dumpFrameAsPDF): Deleted.
(dumpBackForwardListForWebView): Deleted.
(changeWindowScaleIfNeeded): Deleted.
(sizeWebViewForCurrentTest): Deleted.
(methodNameStringForFailedTest): Deleted.
(dumpBackForwardListForAllWindows): Deleted.
(invalidateAnyPreviousWaitToDumpWatchdog): Deleted.
(setWaitToDumpWatchdog): Deleted.
(shouldSetWaitToDumpWatchdog): Deleted.
(updateDisplay): Deleted.
(dump): Deleted.
(shouldLogFrameLoadDelegates): Deleted.
(shouldLogHistoryDelegates): Deleted.
(shouldDumpAsText): Deleted.
(shouldMakeViewportFlexible): Deleted.
(shouldUseEphemeralSession): Deleted.
(setJSCOptions): Deleted.
(resetWebViewToConsistentState): Deleted.
(WebThreadLockAfterDelegateCallbacksHaveCompleted): Deleted.
(computeTestURL): Deleted.
(testOptionsForTest): Deleted.
(runTest): Deleted.
(displayWebView): Deleted.
(displayAndTrackRepaintsWebView): Deleted.
* Tools/ImageDiff/ImageDiff.cpp:
(main):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm:
(TEST(WebKit, PDFLinkReferrer)):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::handleControlCommand):
(WTR::TestController::runTestingServerLoop):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp:
(WTR::EventSenderProxy::keyDown):

Canonical link: <a href="https://commits.webkit.org/289391@main">https://commits.webkit.org/289391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18db60d101147fa349be2f2701d4b9eb2bad4968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14346 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67081 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24853 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47402 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/86277 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75884 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75079 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19395 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6717 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13955 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19215 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->