### PR TITLE
Introduce SAFE_PRINTF

### DIFF
--- a/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
+++ b/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
@@ -83,9 +83,7 @@ int testFunctionOverrides()
     JSC::Options::functionOverrides() = oldFunctionOverrides;
     JSC::FunctionOverrides::reinstallOverrides();
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("%s: function override tests.\n", failed ? "FAIL" : "PASS");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("%s: function override tests.\n", failed ? "FAIL"_s : "PASS"_s);
 
     return failed;
 }

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1078,6 +1078,40 @@ void secureMemsetSpan(std::span<T, Extent> destination, uint8_t byte)
 #endif
 }
 
+/* WTF_FOR_EACH */
+
+// https://www.scs.stanford.edu/~dm/blog/va-opt.html
+#define WTF_PARENS ()
+#define WTF_EXPAND(...) WTF_EXPAND4(WTF_EXPAND4(WTF_EXPAND4(WTF_EXPAND4(__VA_ARGS__))))
+#define WTF_EXPAND4(...) WTF_EXPAND3(WTF_EXPAND3(WTF_EXPAND3(WTF_EXPAND3(__VA_ARGS__))))
+#define WTF_EXPAND3(...) WTF_EXPAND2(WTF_EXPAND2(WTF_EXPAND2(WTF_EXPAND2(__VA_ARGS__))))
+#define WTF_EXPAND2(...) WTF_EXPAND1(WTF_EXPAND1(WTF_EXPAND1(WTF_EXPAND1(__VA_ARGS__))))
+#define WTF_EXPAND1(...) __VA_ARGS__
+#define WTF_FOR_EACH_HELPER(macro, a1, ...) macro(a1) __VA_OPT__(WTF_FOR_EACH_AGAIN PARENS (macro, __VA_ARGS__))
+#define WTF_FOR_EACH_AGAIN() WTF_FOR_EACH_HELPER
+#define WTF_FOR_EACH(macro, ...) __VA_OPT__(WTF_EXPAND(WTF_FOR_EACH_HELPER(macro, __VA_ARGS__)))
+
+/* SAFE_PRINTF */
+
+// https://gist.github.com/sehe/3374327
+template <class T> inline typename std::enable_if<std::is_integral<T>::value, T>::type safePrintfType(T arg) { return arg; }
+template <class T> inline typename std::enable_if<std::is_floating_point<T>::value, T>::type safePrintfType(T arg) { return arg; }
+template <class T> inline typename std::enable_if<std::is_pointer<T>::value, T>::type safePrintfType(T arg) {
+    static_assert(!std::is_same_v<std::remove_cv_t<std::remove_pointer_t<T>>, char>, "char* is not bounds safe; please use a null terminated string type");
+    return arg;
+}
+
+// This version of printf rejects char* but accepts known null terminated
+// string types, like ASCIILiteral and CString. A type can specialize
+// 'safePrintfType' to advertise conversion to null terminated string.
+
+// We do this as a macro so that we still get compile-time checking that our
+// arguments match our format string.
+
+#define SAFE_PRINTF_TYPE(...) WTF_FOR_EACH(WTF::safePrintfType, __VA_ARGS__)
+
+#define SAFE_PRINTF(format, ...) printf(format, SAFE_PRINTF_TYPE(__VA_ARGS__))
+
 template<typename T> concept ByteType = sizeof(T) == 1 && ((std::is_integral_v<T> && !std::same_as<T, bool>) || std::same_as<T, std::byte>) && !std::is_const_v<T>;
 
 template<typename> struct ByteCastTraits;

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -900,9 +900,7 @@ bool protocolIs(StringView string, ASCIILiteral protocol)
 
 void URL::print() const
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("%s\n", m_string.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("%s\n", m_string.utf8());
 }
 
 #endif

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -173,6 +173,9 @@ constexpr std::span<const LChar> operator""_span8(const char* characters, size_t
 
 } // inline StringLiterals
 
+// ASCIILiteral is null terminated
+inline const char* safePrintfType(const ASCIILiteral& asciiLiteral) { return asciiLiteral.characters(); }
+
 } // namespace WTF
 
 using namespace WTF::StringLiterals;

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -151,6 +151,9 @@ inline size_t CString::length() const
     return m_buffer ? m_buffer->length() : 0;
 }
 
+// CString is null terminated
+inline const char* safePrintfType(const CString& cstring) { return cstring.data(); }
+
 } // namespace WTF
 
 using WTF::CString;


### PR DESCRIPTION
#### ea4f9860bf2fcd7ca8d6c16eb534c71525527bc3
<pre>
Introduce SAFE_PRINTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=286503">https://bugs.webkit.org/show_bug.cgi?id=286503</a>
<a href="https://rdar.apple.com/143589997">rdar://143589997</a>

Reviewed by Chris Dumez.

printf() is not bounds safe because %s arguments might not be null terminated.

This patch introduces SAFE_PRINTF, which checks its arguments for null
termination at compile time.

* Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp:
(testFunctionOverrides):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::safePrintfType):
* Source/WTF/wtf/URL.cpp:
(WTF::URL::print const):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::safePrintfType):
* Source/WTF/wtf/text/CString.h:
(WTF::safePrintfType):

Canonical link: <a href="https://commits.webkit.org/289409@main">https://commits.webkit.org/289409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e84fd4c3d4e1cdc3bd20524d236f8cb8e98b53e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37439 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67051 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32839 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36557 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79490 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93447 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85479 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75839 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75027 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6645 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13499 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13883 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19143 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107972 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13621 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25986 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->