### PR TITLE
[scroll-animations] Have ScrollTimeline hold a Styleable source

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scroll nearest on pseudo-element attaches to parent scroll container assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 0, 0)"
+PASS scroll nearest on pseudo-element attaches to parent scroll container
 

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -424,7 +424,7 @@ void AnimationTimelinesController::updateTimelineForTimelineScope(const Ref<Scro
     }
 }
 
-void AnimationTimelinesController::registerNamedScrollTimeline(const AtomString& name, const Element& source, ScrollAxis axis)
+void AnimationTimelinesController::registerNamedScrollTimeline(const AtomString& name, Element& source, ScrollAxis axis)
 {
     LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::registerNamedScrollTimeline: " << name << " source: " << source);
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -80,7 +80,7 @@ public:
     WEBCORE_EXPORT void resumeAnimations();
     bool animationsAreSuspended() const { return m_isSuspended; }
 
-    void registerNamedScrollTimeline(const AtomString&, const Element&, ScrollAxis);
+    void registerNamedScrollTimeline(const AtomString&, Element&, ScrollAxis);
     void registerNamedViewTimeline(const AtomString&, const Element&, ScrollAxis, ViewTimelineInsets&&);
     void unregisterNamedTimeline(const AtomString&, const Element&);
     void setTimelineForName(const AtomString&, const Element&, WebAnimation&);

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -160,7 +160,10 @@ void CSSAnimation::syncStyleOriginatedTimeline()
             timelinesController->setTimelineForName(name, target, *this);
         }, [&] (const Animation::AnonymousScrollTimeline& anonymousScrollTimeline) {
             auto scrollTimeline = ScrollTimeline::create(anonymousScrollTimeline.scroller, anonymousScrollTimeline.axis);
-            scrollTimeline->setSource(target.ptr());
+            if (auto owningElement = this->owningElement())
+                scrollTimeline->setSource(*owningElement);
+            else
+                scrollTimeline->setSource(nullptr);
             setTimeline(WTFMove(scrollTimeline));
         }, [&] (const Animation::AnonymousViewTimeline& anonymousViewTimeline) {
             auto insets = anonymousViewTimeline.insets;

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -53,7 +53,8 @@ public:
     static Ref<ScrollTimeline> create(Scroller, ScrollAxis);
 
     virtual Element* source() const;
-    void setSource(const Element*);
+    void setSource(Element*);
+    void setSource(const Styleable&);
 
     ScrollAxis axis() const { return m_axis; }
     void setAxis(ScrollAxis axis) { m_axis = axis; }
@@ -100,6 +101,8 @@ private:
 
     void animationTimingDidChange(WebAnimation&) override;
 
+    void removeTimelineFromDocument(Element*);
+
     struct CurrentTimeData {
         float scrollOffset { 0 };
         float maxScrollOffset { 0 };
@@ -107,7 +110,7 @@ private:
 
     void cacheCurrentTime();
 
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_source;
+    WeakStyleable m_source;
     ScrollAxis m_axis { ScrollAxis::Block };
     AtomString m_name;
     Scroller m_scroller { Scroller::Self };

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -199,11 +199,19 @@ public:
 
     explicit operator bool() const { return !!m_element; }
 
+    bool operator==(const WeakStyleable& other) const = default;
+
     WeakStyleable& operator=(const Styleable& styleable)
     {
         m_element = styleable.element;
         m_pseudoElementIdentifier = styleable.pseudoElementIdentifier;
         return *this;
+    }
+
+    WeakStyleable(const Styleable& styleable)
+    {
+        m_element = styleable.element;
+        m_pseudoElementIdentifier = styleable.pseudoElementIdentifier;
     }
 
     std::optional<Styleable> styleable() const
@@ -212,6 +220,9 @@ public:
             return std::nullopt;
         return Styleable(*m_element, m_pseudoElementIdentifier);
     }
+
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> element() const { return m_element; }
+    std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const { return m_pseudoElementIdentifier; }
 
 private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;


### PR DESCRIPTION
#### 5ab04d6e08be21da84cf0cdc63115faa7702e99d
<pre>
[scroll-animations] Have ScrollTimeline hold a Styleable source
<a href="https://bugs.webkit.org/show_bug.cgi?id=286504">https://bugs.webkit.org/show_bug.cgi?id=286504</a>
<a href="https://rdar.apple.com/143590723">rdar://143590723</a>

Reviewed by Tim Nguyen.

To handle ScrollTimelines associated with pseudo elements, have ScrollTimeline hold a
Styleable source. This will need a follow up for ViewTimeline code as well as the named
timeline code on AnimationTimelinesController.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::source const):
(WebCore::ScrollTimeline::setSource):
(WebCore::ScrollTimeline::controller const):
(WebCore::ScrollTimeline::documentWillUpdateAnimationsAndSendEvents):
(WebCore::ScrollTimeline::animationTimingDidChange):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::applyKeyframeEffects const):
* Source/WebCore/style/Styleable.h:
(WebCore::WeakStyleable::operator== const):
(WebCore::WeakStyleable::WeakStyleable):
(WebCore::WeakStyleable::element const):
(WebCore::WeakStyleable::pseudoElementIdentifier const):
(WebCore::WeakStyleable::updateElement):
(WebCore::Styleable::applyKeyframeEffects const): Deleted.

Canonical link: <a href="https://commits.webkit.org/289523@main">https://commits.webkit.org/289523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ab1c2979ce1eeae7cb7c83888a30a90631074c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37879 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67350 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25088 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47670 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33250 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36996 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93886 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76154 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75355 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18129 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7219 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13588 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14321 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19614 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->