### PR TITLE
[CookieStoreAPI] get/getAll should ignore fragments when comparing URLs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
@@ -8,6 +8,6 @@ PASS cookieStore.getAll with absolute url in options
 PASS cookieStore.getAll with relative url in options
 PASS cookieStore.getAll with invalid url path in options
 PASS cookieStore.getAll with invalid url host in options
-FAIL cookieStore.getAll with absolute url with fragment in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
-FAIL cookieStore.getAll with absolute different url in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
+PASS cookieStore.getAll with absolute url with fragment in options
+PASS cookieStore.getAll with absolute different url in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
@@ -8,6 +8,6 @@ PASS cookieStore.get with absolute url in options
 PASS cookieStore.get with relative url in options
 PASS cookieStore.get with invalid url path in options
 PASS cookieStore.get with invalid url host in options
-FAIL cookieStore.get with absolute url with fragment in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
-FAIL cookieStore.get with absolute different url in options promise_test: Unhandled rejection with value: object "TypeError: URL must match the document URL"
+PASS cookieStore.get with absolute url with fragment in options
+PASS cookieStore.get with absolute different url in options
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -272,7 +272,7 @@ void CookieStore::get(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& pr
     auto url = context->cookieURL();
     if (!options.url.isNull()) {
         auto parsed = context->completeURL(options.url);
-        if (context->isDocument() && parsed != url) {
+        if (context->isDocument() && !equalIgnoringFragmentIdentifier(parsed, url)) {
             promise->reject(Exception { ExceptionCode::TypeError, "URL must match the document URL"_s });
             return;
         }
@@ -335,7 +335,7 @@ void CookieStore::getAll(CookieStoreGetOptions&& options, Ref<DeferredPromise>&&
     auto url = context->cookieURL();
     if (!options.url.isNull()) {
         auto parsed = context->completeURL(options.url);
-        if (context->isDocument() && parsed != url) {
+        if (context->isDocument() && !equalIgnoringFragmentIdentifier(parsed, url)) {
             promise->reject(Exception { ExceptionCode::TypeError, "URL must match the document URL"_s });
             return;
         }


### PR DESCRIPTION
#### ad5849d93392a63bc55c9539e3a945aefb76cddf
<pre>
[CookieStoreAPI] get/getAll should ignore fragments when comparing URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=286508">https://bugs.webkit.org/show_bug.cgi?id=286508</a>
<a href="https://rdar.apple.com/143594009">rdar://143594009</a>

Reviewed by Chris Dumez and Sihui Liu.

The get/getAll functions need to compare the url that was passed in
with the context&apos;s url. As per the WPT tests, they should do this
while ignoring the fragments in the urls.

Tested by WPT tests.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):

Canonical link: <a href="https://commits.webkit.org/289390@main">https://commits.webkit.org/289390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb059b6d87b1388c3c8cd2f2371bcddb01a18442

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67048 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89719 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4937 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32843 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93456 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75844 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75033 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19348 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6654 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13487 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13892 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19152 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13630 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->