### PR TITLE
[Intelligence Effects] Rewrite animation is broken in several ways (overlapping text, flickering, temporary missing text, animations may never end)

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -303,6 +303,9 @@ static bool canMergeMarkers(const DocumentMarker& marker, const DocumentMarker& 
         return std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker.data()).suggestionID == std::get<DocumentMarker::WritingToolsTextSuggestionData>(other.data()).suggestionID;
 #endif
 
+    if (marker.type() == DocumentMarkerType::TransparentContent)
+        return std::get<DocumentMarker::TransparentContentData>(marker.data()).uuid == std::get<DocumentMarker::TransparentContentData>(other.data()).uuid;
+
     return true;
 }
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3709,12 +3709,6 @@ RefPtr<TextPlaceholderElement> Editor::insertTextPlaceholder(const IntSize& size
 
     document->selection().setSelection(VisibleSelection { positionInParentBeforeNode(placeholder.ptr()) }, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes));
 
-#if ENABLE(WRITING_TOOLS)
-    // For Writing Tools, we need the snapshot of the last inserted placeholder.
-    if (auto placeholderRange = makeRangeSelectingNode(placeholder.get()))
-        protectedDocument()->page()->chrome().client().saveSnapshotOfTextPlaceholderForAnimation(*placeholderRange);
-#endif
-
     return placeholder;
 }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5388,7 +5388,6 @@ std::optional<SimpleRange> Page::contextRangeForActiveWritingToolsSession() cons
 
 void Page::intelligenceTextAnimationsDidComplete()
 {
-    m_writingToolsController->intelligenceTextAnimationsDidComplete();
 }
 #endif
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -46,9 +46,7 @@ class Page;
 
 struct SimpleRange;
 
-enum class TextAnimationRunMode : uint8_t;
-
-class WritingToolsController final : public CanMakeWeakPtr<WritingToolsController>, public CanMakeCheckedPtr<WritingToolsController> {
+class WritingToolsController final : public CanMakeCheckedPtr<WritingToolsController> {
     WTF_MAKE_TZONE_ALLOCATED(WritingToolsController);
     WTF_MAKE_NONCOPYABLE(WritingToolsController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WritingToolsController);
@@ -80,17 +78,11 @@ public:
     // FIXME: Refactor `TextAnimationController` in such a way so as to not explicitly depend on `WritingToolsController`,
     // and then remove these methods after doing so.
     std::optional<SimpleRange> activeSessionRange() const;
-    void intelligenceTextAnimationsDidComplete();
 
 private:
     struct CompositionState : CanMakeCheckedPtr<CompositionState> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(CompositionState);
-
-        enum class ClearStateDeferralReason : uint8_t {
-            SessionInProgress = 1 << 0,
-            AnimationInProgress = 1 << 1,
-        };
 
         CompositionState(const Vector<Ref<WritingToolsCompositionCommand>>& unappliedCommands, const Vector<Ref<WritingToolsCompositionCommand>>& reappliedCommands, const WritingTools::Session& session)
             : unappliedCommands(unappliedCommands)
@@ -103,11 +95,6 @@ private:
         Vector<Ref<WritingToolsCompositionCommand>> unappliedCommands;
         Vector<Ref<WritingToolsCompositionCommand>> reappliedCommands;
         WritingTools::Session session;
-        OptionSet<ClearStateDeferralReason> clearStateDeferralReasons;
-
-        bool shouldCommitAfterReplacement { false };
-        std::optional<CharacterRange> replacedRange;
-        std::optional<CharacterRange> pendingReplacedRange;
     };
 
     struct ProofreadingState : CanMakeCheckedPtr<ProofreadingState> {
@@ -168,19 +155,12 @@ private:
     void replaceContentsOfRangeInSession(ProofreadingState&, const SimpleRange&, const String&);
     void replaceContentsOfRangeInSession(CompositionState&, const SimpleRange&, const AttributedString&, WritingToolsCompositionCommand::State);
 
-    void compositionSessionDidFinishReplacement();
-    void compositionSessionDidFinishReplacement(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const CharacterRange&, const String&);
-
     void smartReplySessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
-
-    void compositionSessionDidReceiveTextWithReplacementRangeAsync(const WTF::UUID&, const WTF::UUID&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
+    void rewriteSessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
     void showOriginalCompositionForSession();
     void showRewrittenCompositionForSession();
     void restartCompositionForSession();
-
-    template<CompositionState::ClearStateDeferralReason Reason>
-    void removeCompositionClearStateDeferralReason();
 
     template<WritingTools::Session::Type Type>
     void writingToolsSessionDidReceiveAction(WritingTools::Action);
@@ -190,8 +170,6 @@ private:
 
     template<WritingTools::Session::Type Type>
     void didEndWritingToolsSession(bool accepted);
-
-    void commitComposition(CompositionState&, Document&);
 
     RefPtr<Document> document() const;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -264,9 +264,8 @@ struct PerWebProcessState {
     RetainPtr<WTSession> _activeWritingToolsSession;
 
     RetainPtr<id<WKIntelligenceTextEffectCoordinating>> _intelligenceTextEffectCoordinator;
-
-    NSUInteger _partialIntelligenceTextAnimationCount;
-    BOOL _writingToolsTextReplacementsFinished;
+    NSRange _previousProcessedRange;
+    NSInteger _previousStringLength;
 #endif
 
 #if ENABLE(SCREEN_TIME)
@@ -448,9 +447,6 @@ struct PerWebProcessState {
 - (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions;
 - (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
 #endif
-
-- (void)_didEndPartialIntelligenceTextAnimation;
-- (BOOL)_writingToolsTextReplacementsFinished;
 
 - (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)styleData;
 - (void)_removeTextAnimationForAnimationID:(NSUUID *)uuid;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -287,12 +287,11 @@ void PageClientImplCocoa::writingToolsActiveDidChange()
 
 void PageClientImplCocoa::didEndPartialIntelligenceTextAnimation()
 {
-    [m_webView _didEndPartialIntelligenceTextAnimation];
 }
 
 bool PageClientImplCocoa::writingToolsTextReplacementsFinished()
 {
-    return [m_webView _writingToolsTextReplacementsFinished];
+    return false;
 }
 
 void PageClientImplCocoa::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebCore::TextAnimationData& data)

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
@@ -75,8 +75,8 @@ import WebKitSwift
         self.delegate = delegate
     }
 
-    @objc(startAnimationForRange:completion:)
-    public func startAnimation(for range: NSRange) async {
+    @objc(createAnimationForRange:completion:)
+    public func createAnimation(for range: NSRange) async {
         self.reset()
 
         self.viewManager.assertPonderingEffectIsInactive()
@@ -88,8 +88,16 @@ import WebKitSwift
         }
 
         self.contextRange = contextRange
+    }
 
-        let chunk = IntelligenceTextEffectChunk.Pondering(range: contextRange)
+    @objc(startWithCompletion:)
+    public func start() async {
+        self.viewManager.reset()
+
+        self.processedRangeOffset = 0
+        self.replacementQueue = []
+
+        let chunk = IntelligenceTextEffectChunk.Pondering(range: contextRange!)
         let effect = PlatformIntelligencePonderingTextEffect(chunk: chunk as IntelligenceTextEffectChunk)
 
         await self.viewManager.setActivePonderingEffect(effect)
@@ -101,6 +109,9 @@ import WebKitSwift
             assertionFailure("Intelligence text effect coordinator: Unable to create Swift.Range from NSRange \(processedRange)")
             return
         }
+
+        // The Range initializer that takes an NSRange does not do bounds checking.
+        assert(range.upperBound >= range.lowerBound, "Intelligence text effect coordinator: Invalid NSRange \(processedRange)")
 
         let asyncBlock = async(operation)
         let request = Self.ReplacementOperationRequest(processedRange: range, finished: finished, characterDelta: characterDelta, operation: asyncBlock)

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift
@@ -80,8 +80,8 @@ import WebKitSwift
         self.delegate = delegate
     }
 
-    @objc(startAnimationForRange:completion:)
-    public func startAnimation(for range: NSRange) async {
+    @objc(createAnimationForRange:completion:)
+    public func createAnimation(for range: NSRange) async {
         self.viewManager.assertPonderingEffectIsInactive()
         self.viewManager.assertReplacementEffectIsInactive()
 
@@ -94,6 +94,10 @@ import WebKitSwift
         let effect = PlatformIntelligencePonderingTextEffect(chunk: chunk as IntelligenceTextEffectChunk)
 
         await self.viewManager.setActivePonderingEffect(effect)
+    }
+
+    @objc(startWithCompletion:)
+    public func start() async {
     }
 
     @objc(requestReplacementWithProcessedRange:finished:characterDelta:operation:completion:)
@@ -173,7 +177,7 @@ import WebKitSwift
             // This is because in the platform effect view, when a replacement effect gets created, the underlying text becomes hidden
             // for a non-instantaneous amount of time while the replacement is performed. So, a pondering effect has to be ongoing when
             // this happens to avoid the user from seeing the text become briefly hidden.
-            await startAnimation(for: NSRange(request.processedRange))
+            await createAnimation(for: NSRange(request.processedRange))
         }
 
         let chunk = IntelligenceTextEffectChunk.Replacement(

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
@@ -75,7 +75,9 @@ NS_SWIFT_UI_ACTOR
 
 - (instancetype)initWithDelegate:(id<WKIntelligenceTextEffectCoordinatorDelegate>)delegate;
 
-- (void)startAnimationForRange:(NSRange)range completion:(void (^)(void))completion;
+- (void)createAnimationForRange:(NSRange)range completion:(void (^)(void))completion;
+
+- (void)startWithCompletion:(void (^)(void))completion;
 
 - (void)requestReplacementWithProcessedRange:(NSRange)range finished:(BOOL)finished characterDelta:(NSInteger)characterDelta operation:(void (^)(void (^)(void)))operation completion:(void (^)(void))completion;
 


### PR DESCRIPTION
#### 0afd9c050ac5de1e2e8fb086a2b05771b7db0c6a
<pre>
[Intelligence Effects] Rewrite animation is broken in several ways (overlapping text, flickering, temporary missing text, animations may never end)
<a href="https://bugs.webkit.org/show_bug.cgi?id=283782">https://bugs.webkit.org/show_bug.cgi?id=283782</a>
<a href="https://rdar.apple.com/140600971">rdar://140600971</a>

Reviewed by NOBODY (OOPS!).

Draft for now

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::canMergeMarkers):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::insertTextPlaceholder):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::intelligenceTextAnimationsDidComplete):
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::unionRange):
(WebCore::WritingToolsController::smartReplySessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::rewriteSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::willEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::willEndWritingToolsSession):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession):
(WebCore::WritingToolsController::restartCompositionForSession):
(WebCore::WritingToolsController::replaceContentsOfRangeInSession):
(WebCore::isZeroToOneCompositionType): Deleted.
(WebCore::WritingToolsController::removeCompositionClearStateDeferralReason): Deleted.
(WebCore::WritingToolsController::intelligenceTextAnimationsDidComplete): Deleted.
(WebCore::WritingToolsController::compositionSessionDidFinishReplacement): Deleted.
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync): Deleted.
(WebCore::WritingToolsController::commitComposition): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
(-[WKWebView writingToolsSession:didReceiveAction:]):
(-[WKWebView _didEndPartialIntelligenceTextAnimation]): Deleted.
(-[WKWebView _writingToolsTextReplacementsFinished]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didEndPartialIntelligenceTextAnimation):
(WebKit::PageClientImplCocoa::writingToolsTextReplacementsFinished):
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift:
(createAnimation(for:)):
(start):
(requestReplacement(withProcessedRange:finished:characterDelta:operation:)):
(startAnimation(for:)): Deleted.
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceSmartReplyTextEffectCoordinator.swift:
(createAnimation(for:)):
(start):
(startReplacementAnimation(using:)):
(startAnimation(for:)): Deleted.
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0afd9c050ac5de1e2e8fb086a2b05771b7db0c6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86726 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24829 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47374 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32857 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75850 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74348 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75041 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6664 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19162 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13640 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->