### PR TITLE
Document leak occurs when dragging cursor over Hebrew characters

### DIFF
--- a/LayoutTests/fast/text/international/hebrew-selection-does-not-leak-expected.txt
+++ b/LayoutTests/fast/text/international/hebrew-selection-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that LayoutTests/fast/text/international/hebrew-selection.html does not leak the document object when dragging cursor over the Hebrew characters
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text/international/hebrew-selection-does-not-leak.html
+++ b/LayoutTests/fast/text/international/hebrew-selection-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/document-leak-test.js"></script>
+<script>
+    description("Tests that LayoutTests/fast/text/international/hebrew-selection.html does not leak the document object when dragging cursor over the Hebrew characters");
+    onload = () => runDocumentLeakTest({ frameURL: "hebrew-selection.html", framesToCreate: 20 });
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text/international/hebrew-selection.html
+++ b/LayoutTests/fast/text/international/hebrew-selection.html
@@ -17,11 +17,14 @@ var width = document.getElementById("reference").offsetWidth;
 var target = document.getElementById("target");
 
 if (window.eventSender) {
+    if (window.frameElement)
+        window.frameElement.scrollIntoView(true);
     window.eventSender.mouseMoveTo(target.offsetLeft + 5, target.offsetTop + 5);
     window.eventSender.mouseDown();
     window.eventSender.mouseMoveTo(target.offsetLeft + 5 + width / 2, target.offsetTop + 5);
     window.eventSender.mouseUp();
 }
+onload = () => parent.postMessage("iframeLoaded");
 </script>
 </body>
 </html>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1784,6 +1784,7 @@ void FrameSelection::willBeRemovedFromFrame()
         CursorAlignOnScroll::IfNeeded, TextGranularity::CharacterGranularity);
     m_previousCaretNode = nullptr;
     m_typingStyle = nullptr;
+    m_originalBase = { };
 }
 
 void FrameSelection::setStart(const VisiblePosition& position, UserTriggered trigger)


### PR DESCRIPTION
#### 23db017c981845a994f0fe2355286a896292aea1
<pre>
Document leak occurs when dragging cursor over Hebrew characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=286509">https://bugs.webkit.org/show_bug.cgi?id=286509</a>
<a href="https://rdar.apple.com/143597148">rdar://143597148</a>

Reviewed by Ryan Reno.

A document leak occurs when dragging over Hebrew characters in a layout test fast/text/international/hebrew-selection.html.
The leak isn&apos;t specific to Hebrew but also other Unicode represented characters.

The leak occurs due to the FrameSelection&apos;s member m_originalBase
keeping a RefPtr to a Node in m_originalBase&apos;s Position member. It is used to keep track of positions between characters at a boundary for certain kinds of text during character selection.
m_originalBase can be reset to null upon the next mouse selection such as on a mouse click.

A user can cause this leak if they highlight this text, not perform another mouse selection anywhere else on the page, then either navigate away from the page or navigate to another document by pressing on an
anchor link. The document where the text selection happened on would then be stuck in a reference cycle.

The document owns the FrameSelection, which is the reason why this leak occurs because Document -&gt; FrameSelection -&gt; VisiblePosition -&gt; Position -&gt; Node-&gt; Document.
Fix this by resetting m_originalBase when the Document calls FrameSelection::willBeRemovedFromFrame. This is called when the document itself is being removed from the frame.

* LayoutTests/fast/text/international/hebrew-selection-does-not-leak-expected.txt: Added.
* LayoutTests/fast/text/international/hebrew-selection-does-not-leak.html: Added.
* LayoutTests/fast/text/international/hebrew-selection.html:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::willBeRemovedFromFrame):

Canonical link: <a href="https://commits.webkit.org/291804@main">https://commits.webkit.org/291804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55edd0b1bd3e57a122bc57a184cd6a8237322b9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71589 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28963 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96793 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10160 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84753 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9842 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15203 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80606 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79950 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19970 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14000 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26005 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->