### PR TITLE
Instagram video doesn't replay

### DIFF
--- a/LayoutTests/media/media-source/media-source-reopen-expected.txt
+++ b/LayoutTests/media/media-source/media-source-reopen-expected.txt
@@ -1,0 +1,20 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(audiosb = source.addSourceBuffer("audio/mp4; codecs=mp4a.40.2"))
+RUN(videosb = source.addSourceBuffer("video/mp4; codecs=avc1.4d401e"))
+RUN(audiosb.appendWindowEnd = 0.4)
+RUN(videosb.appendWindowEnd = 0.5)
+EXPECTED (video.buffered.end(video.buffered.length-1) == Math.min(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1)) == 'true') OK
+RUN(source.endOfStream())
+EXPECTED (source.readyState == 'ended') OK
+EXPECTED (video.buffered.end(video.buffered.length-1) == Math.max(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1)) == 'true') OK
+EXPECTED (video.duration == Math.max(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1)) == 'true') OK
+EVENT(sourceended)
+EXPECTED (source.readyState == 'open') OK
+EXPECTED (video.buffered.end(video.buffered.length-1) == Math.min(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1)) == 'true') OK
+EVENT(update)
+RUN(source.endOfStream())
+EVENT(ended)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-reopen.html
+++ b/LayoutTests/media/media-source/media-source-reopen.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>media-source-reopen</title>
+        <script src="../video-test.js"></script>
+        <script>
+var loader;
+var source;
+var audiosb;
+var videosb;
+var audiodata;
+var videodata;
+
+async function startTest()
+{
+    findMediaElement();
+    video.disableRemotePlayback = true;
+    video.muted = true;
+    
+    const MediaSource = self.ManagedMediaSource || self.MediaSource;
+
+    source = new MediaSource();
+    run('video.src = URL.createObjectURL(source)');
+    await waitFor(source, 'sourceopen');
+    waitFor(video, 'error').then(failTest);
+
+    run('audiosb = source.addSourceBuffer("audio/mp4; codecs=mp4a.40.2")');
+    run('videosb = source.addSourceBuffer("video/mp4; codecs=avc1.4d401e")');
+
+    let audioResponse = await fetch('content/test-48kHz.m4a');
+    let audiodata = await audioResponse.arrayBuffer();
+    let videoResponse = await fetch('content/test-fragmented-video.mp4');
+    let videodata = await videoResponse.arrayBuffer();
+
+    run('audiosb.appendWindowEnd = 0.4');
+    run('videosb.appendWindowEnd = 0.5');
+
+    audiosb.appendBuffer(audiodata);
+    videosb.appendBuffer(videodata);
+    await Promise.all([waitFor(audiosb, 'update', true), waitFor(videosb, 'update', true)]);
+
+    testExpected('video.buffered.end(video.buffered.length-1) == Math.min(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1))', true);
+    run('source.endOfStream()');
+    testExpected('source.readyState', "ended");
+    testExpected('video.buffered.end(video.buffered.length-1) == Math.max(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1))', true);
+    testExpected('video.duration == Math.max(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1))', true);
+    await waitFor(source, 'sourceended');
+
+    audiosb.appendBuffer(audiodata);
+    testExpected('source.readyState', "open");
+    testExpected('video.buffered.end(video.buffered.length-1) == Math.min(audiosb.buffered.end(audiosb.buffered.length-1), videosb.buffered.end(videosb.buffered.length-1))', true);
+    await waitFor(audiosb, 'update');
+    run('source.endOfStream()');
+
+    await video.play();
+    waitForEventAndEnd('ended');
+}
+        </script>
+    </head>
+    <body onload="startTest()">
+        <video controls></video>
+    </body>
+</html>

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1419,8 +1419,9 @@ void MediaSource::onReadyStateChange(ReadyState oldState, ReadyState newState)
         // https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered
         for (auto& sourceBuffer : m_sourceBuffers.get())
             sourceBuffer->setMediaSourceEnded(true);
-        updateBufferedIfNeeded(true /* force */);
     }
+    if (newState == ReadyState::Ended || (newState == ReadyState::Open && oldState == ReadyState::Ended))
+        updateBufferedIfNeeded(true /* force */);
 
     // MediaSource's readyState transitions from "open" to "closed" or "ended" to "closed".
     if (oldState > ReadyState::Closed && newState == ReadyState::Closed) {


### PR DESCRIPTION
#### f1c1197adbc419004979c177898bed371a018c56
<pre>
Instagram video doesn&apos;t replay
<a href="https://bugs.webkit.org/show_bug.cgi?id=286475">https://bugs.webkit.org/show_bug.cgi?id=286475</a>
<a href="https://rdar.apple.com/141590278">rdar://141590278</a>

Reviewed by Eric Carlson.

The video&apos;s buffered ranges weren&apos;t recalculated when the MediaSource was
re-opened (its readyState moved from &quot;ended&quot; to &quot;open&quot;). The calculation
of the buffered ranges depends on the MediaSource&apos;s readyState.

Whenever the video&apos;s buffered attribute change, a message is sent to the GPU
process with the new final value.
In parallel, the GPU&apos;s MediaSourcePrivate will recalculate the playable buffered
ranges whenever new data were added.

Instagram when playing a MSE video, append all the data then calls MediaSource.endOfStream()
to then totally unnecessarily re-append once again all the data followed by endOfStream()
several times.
As the video&apos;s buffered attribute wasn&apos;t updated with the appendBuffer that followed
(which reopened the MediaSource) the GPU process buffered range mirror was
now incorrectly assuming the MediaSource wasn&apos;t ended and kept waiting
for more data to come, never reaching the player&apos;s ended state.

We now correctly recalculate the buffered ranges whenever the MediaSource is closed
or re-opened.

Added test that ensures:
1- the buffered range gets updated when the MediaSource move back to &quot;open&quot; state
2- we will fire the ended event when playback reaches the end.

* LayoutTests/media/media-source/media-source-reopen-expected.txt: Added.
* LayoutTests/media/media-source/media-source-reopen.html: Added.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::onReadyStateChange):

Canonical link: <a href="https://commits.webkit.org/289401@main">https://commits.webkit.org/289401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea3dc89985a3138c368d51e2fd1a7805d195089

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67062 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24835 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75858 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75052 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17773 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6680 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13918 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19178 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13656 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->