### PR TITLE
REGRESSION(Sequoia15.2): [ Sequoia15.2 wk2 ] editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable.html is a constant text failure

### DIFF
--- a/LayoutTests/editing/input/resources/reveal-utilities.js
+++ b/LayoutTests/editing/input/resources/reveal-utilities.js
@@ -65,7 +65,7 @@ function performVerticalScrollingPasteTest()
     }
 }
 
-function performJumpAtTheEdgeTest(useCtrlKeyModifier)
+function performJumpAtTheEdgeTest(insertLineBreak)
 {
     var textArea = document.getElementById("input");
     textArea.focus();
@@ -74,7 +74,8 @@ function performJumpAtTheEdgeTest(useCtrlKeyModifier)
         var jumpDetected = false;
         for (var i = 0; i < 120; ++i) {
             previousScrollTop = document.scrollingElement.scrollTop;
-            eventSender.keyDown("\r", useCtrlKeyModifier ? ["ctrlKey"] : []);
+            const modifierKeys = insertLineBreak && !testRunner.isMac ? ["ctrlKey"] : [];
+            eventSender.keyDown("\r", modifierKeys);
             currentScrollTop = document.scrollingElement.scrollTop;
             // Smooth scrolls are allowed.
             if (Math.abs(previousScrollTop - currentScrollTop) > 24) {

--- a/LayoutTests/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt
+++ b/LayoutTests/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt
@@ -1,4 +1,4 @@
-When the caret is scrolled out and resides at the end of the contenteditable, on pressing "Ctrl+Return" it must be scrolled to the bottom of the view, not to the center to avoid undesirable content view jumping.
+When the caret is scrolled out and resides at the end of the contenteditable, on inserting a line break it must be scrolled to the bottom of the view, not to the center to avoid undesirable content view jumping.
 
 
 

--- a/LayoutTests/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable.html
+++ b/LayoutTests/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 <div>When the caret is scrolled out and resides at the end of the contenteditable,
-on pressing &quot;Ctrl+Return&quot; it must be scrolled to the bottom of the view,
+on inserting a line break it must be scrolled to the bottom of the view,
 not to the center to avoid undesirable content view jumping.</div>
 <div style="height:1000px;">
   <div style="overflow:visible; height:100px;" contenteditable="true" id="input"></div>
@@ -14,6 +14,5 @@ if (window.testRunner)
    testRunner.dumpAsText();
 
 performJumpAtTheEdgeTest(true);
-
 </script>
 </body>

--- a/LayoutTests/platform/gtk/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt
+++ b/LayoutTests/platform/gtk/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt
@@ -1,2 +1,2 @@
-When the caret is scrolled out and resides at the end of the contenteditable, on pressing "Ctrl+Return" it must be scrolled to the bottom of the view, not to the center to avoid undesirable content view jumping.
+When the caret is scrolled out and resides at the end of the contenteditable, on inserting a line break it must be scrolled to the bottom of the view, not to the center to avoid undesirable content view jumping.
 PASS

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1947,5 +1947,3 @@ imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-t
 webkit.org/b/286080 fast/webgpu/nocrash/fuzz-284937.html [ Failure Timeout Crash ]
 
 webkit.org/b/286371 [ Sequoia Release x86_64 ] webrtc/captureCanvas-webrtc-software-h264-high.html [ Failure ]
-
-webkit.org/b/286375 [ Sequoia+ ] editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable.html [ Pass Failure ]

--- a/LayoutTests/platform/win/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt
+++ b/LayoutTests/platform/win/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt
@@ -1,2 +1,2 @@
-When the caret is scrolled out and resides at the end of the contenteditable, on pressing "Ctrl+Return" it must be scrolled to the bottom of the view, not to the center to avoid undesirable content view jumping.
+When the caret is scrolled out and resides at the end of the contenteditable, on inserting a line break it must be scrolled to the bottom of the view, not to the center to avoid undesirable content view jumping.
 PASS


### PR DESCRIPTION
#### 8218a75b98ba2b488ee2f6ca01535028070cc132
<pre>
REGRESSION(Sequoia15.2): [ Sequoia15.2 wk2 ] editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=286375">https://bugs.webkit.org/show_bug.cgi?id=286375</a>
<a href="https://rdar.apple.com/143414632">rdar://143414632</a>

Reviewed by Abrar Rahman Protyasha.

On macOS Sequoia 15.2 and later, `Ctrl-Return` is a system-wide shortcut that brings up the context
menu for the current text selection. This layout test attempts to insert newlines by pressing
`Ctrl-Return` repeatedly, which now fails due to the fact that this now brings up the context menu
for the selection instead. Fix this by avoiding this key combination on macOS, and simply fall back
to just pressing `Return`.

* LayoutTests/editing/input/resources/reveal-utilities.js:
(performJumpAtTheEdgeTest):
* LayoutTests/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt:
* LayoutTests/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable.html:
* LayoutTests/platform/gtk/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/win/editing/input/scroll-to-edge-if-line-break-at-end-of-document-contenteditable-expected.txt:

Canonical link: <a href="https://commits.webkit.org/289393@main">https://commits.webkit.org/289393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecb835b4692ec65ce5ccdc34e07af7a3e4c68bd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37546 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67104 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24877 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89817 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32934 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36664 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13967 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75905 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75100 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18469 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6764 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13990 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->