### PR TITLE
Add layout tests for ResourceMonitor

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7674,3 +7674,6 @@ imported/w3c/web-platform-tests/css/selectors/featureless-005.html [ ImageOnlyFa
 # Skip large regular expression tests on Debug to avoid timeout.
 [ Debug ] fast/regex/slow.html [ Skip ]
 [ Debug ] imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html [ Skip ]
+
+# Cocoa-only test.
+webkit.org/b/286318 http/tests/iframe-monitor [ Skip ]

--- a/LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+Test resource monitor.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.querySelector('iframe[name=frame1]').srcdoc is ""
+PASS document.querySelector('iframe[name=frame2]').srcdoc is ""
+PASS document.querySelector('iframe[name=frame3]').srcdoc is not ""
+PASS document.querySelector('iframe[name=frame4]').srcdoc is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/eligibility.html
+++ b/LayoutTests/http/tests/iframe-monitor/eligibility.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="./resources/monitor-setup.js"></script>
+</head>
+<body>
+<script>
+
+description("Test resource monitor.");
+window.jsTestIsAsync = true;
+
+onload = async () => {
+    if (!await setup()) {
+        finishJSTest();
+        return;
+    }
+
+    // Make sure iframe load is done after rule is set correctly.
+    const stage = document.querySelector('#stage');
+    const base = 'http://localhost:8080/iframe-monitor/resources';
+
+    stage.innerHTML = `
+        <!-- these frames are not elegible for resource monitoring -->
+        <iframe name="frame1" src="${base}/iframe-not-eligible.html"></iframe>
+        <iframe name="frame2" src="${base}/iframe-not-eligible2.html"></iframe>
+
+        <!-- these frames are elegible for resource monitoring -->
+        <iframe name="frame3" src="${base}/iframe--eligible--.html"></iframe>
+        <iframe name="frame4" src="${base}/iframe--eligible--2.html"></iframe>
+    `;
+
+    await waitUntilUnload('frame3');
+
+    shouldBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+    shouldBe(`document.querySelector('iframe[name=frame2]').srcdoc`, '""');
+    shouldNotBe(`document.querySelector('iframe[name=frame3]').srcdoc`, '""');
+    shouldBe(`document.querySelector('iframe[name=frame4]').srcdoc`, '""');
+
+    finishJSTest();
+}
+</script>
+
+<div id="stage"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+Test iframe with huge resource usage is unloaded.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.querySelector('iframe[name=frame1]').srcdoc is not ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/iframe-unload.html
+++ b/LayoutTests/http/tests/iframe-monitor/iframe-unload.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="./resources/monitor-setup.js"></script>
+</head>
+<body>
+<script>
+
+description("Test iframe with huge resource usage is unloaded.");
+window.jsTestIsAsync = true;
+
+onload = async () => {
+    if (!await setup()) {
+        finishJSTest();
+        return;
+    }
+
+    // Make sure iframe load is done after rule is set correctly.
+    const stage = document.querySelector('#stage');
+    const base = 'http://localhost:8080/iframe-monitor/resources';
+
+    stage.innerHTML = `
+        <iframe name="frame1" src="http://localhost:8080/iframe-monitor/resources/iframe--eligible--.html"></iframe>
+    `;
+
+    await waitUntilUnload('frame1');
+
+    shouldNotBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+
+    finishJSTest();
+}
+</script>
+
+<div id="stage"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/iframe-monitor/resources/generate-byte.py
+++ b/LayoutTests/http/tests/iframe-monitor/resources/generate-byte.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import random
+import string
+from urllib.parse import parse_qs
+
+query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
+size = int(query.get('size', ['0'])[0])
+
+sys.stdout.write('Content-Type: application/octet-stream\r\n')
+sys.stdout.write(f'Content-Length: {size}\r\n')
+sys.stdout.write('\r\n')
+
+random_string = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(size))
+sys.stdout.write(random_string)

--- a/LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--.html
@@ -1,0 +1,11 @@
+Using significant resources and eligible for resource monitoring.
+
+<script>
+    window.unload = () => {
+        console.log('Should not be run');
+        window.parent.postMessage({ message: 'Bye from iframe 3!' }, '*');
+    };
+
+    const size = 20 * 1024;
+    fetch(`./generate-byte.py?size=${size}`);
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--2.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--2.html
@@ -1,0 +1,11 @@
+Using very little resources but still eligible for resource monitoring.
+
+<script>
+    window.unload = () => {
+        console.log('Should not be run');
+        window.parent.postMessage({ message: 'Bye from iframe 4!' }, '*');
+    };
+
+    const size = 1 * 1024;
+    fetch(`./generate-byte.py?size=${size}`);
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/iframe-not-eligible.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/iframe-not-eligible.html
@@ -1,0 +1,8 @@
+Not using significant resources and not eligible for resource monitoring.
+
+<script>
+    window.unload = () => {
+        console.log('Should not be run');
+        window.parent.postMessage({ message: 'Bye from iframe 1!' }, '*');
+    };
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/iframe-not-eligible2.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/iframe-not-eligible2.html
@@ -1,0 +1,11 @@
+Using significant resources but not eligible for resource monitoring.
+
+<script>
+    window.unload = () => {
+        console.log('Should not be run');
+        window.parent.postMessage({ message: 'Bye from iframe 2!' }, '*');
+    };
+
+    const size = 20 * 1024;
+    fetch(`./generate-byte.py?size=${size}`);
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
+++ b/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
@@ -1,0 +1,45 @@
+async function setup() {
+    if (window.testRunner && 'canModifyResourceMonitorList' in testRunner && testRunner.canModifyResourceMonitorList) {
+        const rules = [
+            rule('--eligible--'),
+        ];
+
+        await testRunner.setResourceMonitorList(JSON.stringify(rules));
+
+        // Lower the threshold to 10k
+        internals.setResourceMonitorNetworkUsageThreshold(10 * 1024, 0.001);
+
+        // Skip throttling of unloading.
+        internals.shouldSkipResourceMonitorThrottling = true;
+
+        return true;
+    } else {
+        console.error('ResourceMonitor is not available or cannot modify rules.');
+        return false;
+    }
+}
+
+function rule(filter, action = 'block') {
+    const trigger = { "url-filter": filter };
+
+    return { action: { type: action }, trigger };
+}
+
+async function pause(ms) {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(), ms);
+    });
+}
+
+async function waitUntilUnload(name) {
+    const iframe = document.querySelector(`iframe[name=${name}]`);
+    if (!iframe)
+        throw new Error("iframe dosn't exist");
+
+    while (!iframe.srcdoc) {
+        await pause(10);
+    }
+
+    // extra wait time
+    await pause(100);
+}

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7676,3 +7676,5 @@ webkit.org/b/286507 compositing/geometry/fixed-position-composited-page-scale-sm
 webkit.org/b/286515 fast/forms/datalist/datalist-show-hide.html [ Timeout ]
 
 webkit.org/b/286594 http/wpt/cache-storage/quota-third-party.https.html [ Pass Failure Slow ]
+
+webkit.org/b/286318 http/tests/iframe-monitor [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1949,3 +1949,5 @@ imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-t
 webkit.org/b/286080 fast/webgpu/nocrash/fuzz-284937.html [ Failure Timeout Crash ]
 
 webkit.org/b/286371 [ Sequoia Release x86_64 ] webrtc/captureCanvas-webrtc-software-h264-high.html [ Failure ]
+
+webkit.org/b/286318 http/tests/iframe-monitor [ Pass ]

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1975,6 +1975,9 @@ public:
     ResourceMonitor& resourceMonitor();
     Ref<ResourceMonitor> protectedResourceMonitor();
     ResourceMonitor* parentResourceMonitorIfExists();
+
+    bool shouldSkipResourceMonitorThrottling() const { return m_shouldSkipResourceMonitorThrottling; }
+    void setShouldSkipResourceMonitorThrottling(bool flag) { m_shouldSkipResourceMonitorThrottling = flag; }
 #endif
 
     Ref<Calculation::RandomKeyMap> randomKeyMap() const;
@@ -2689,6 +2692,7 @@ private:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     RefPtr<ResourceMonitor> m_resourceMonitor;
+    bool m_shouldSkipResourceMonitorThrottling { false };
 #endif
 
     mutable RefPtr<Calculation::RandomKeyMap> m_randomKeyMap;

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
+#include "ResourceMonitorChecker.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
@@ -36,7 +37,7 @@ class LocalFrame;
 
 class ResourceMonitor final : public RefCountedAndCanMakeWeakPtr<ResourceMonitor> {
 public:
-    enum class Eligibility : uint8_t { Unsure, NotEligible, Eligible };
+    using Eligibility = ResourceMonitorEligibility;
 
     static Ref<ResourceMonitor> create(LocalFrame&);
 
@@ -57,7 +58,6 @@ private:
     URL m_frameURL;
     Eligibility m_eligibility { Eligibility::Unsure };
     bool m_networkUsageExceed { false };
-    size_t m_networkUsageThreshold { 0 };
     CheckedSize m_networkUsage;
 };
 

--- a/Source/WebCore/loader/ResourceMonitorChecker.cpp
+++ b/Source/WebCore/loader/ResourceMonitorChecker.cpp
@@ -36,8 +36,10 @@
 
 namespace WebCore {
 
-static constexpr Seconds ruleListPreparationTimeout = 10_s;
-static constexpr auto defaultEligibility = ResourceMonitor::Eligibility::NotEligible;
+static size_t networkUsageThresholdWithRandomNoise(size_t threshold, double randomness)
+{
+    return static_cast<size_t>(threshold * (1 + randomness * cryptographicallyRandomUnitInterval()));
+}
 
 ResourceMonitorChecker& ResourceMonitorChecker::singleton()
 {
@@ -47,6 +49,7 @@ ResourceMonitorChecker& ResourceMonitorChecker::singleton()
 
 ResourceMonitorChecker::ResourceMonitorChecker()
     : m_workQueue { WorkQueue::create("ResourceMonitorChecker Work Queue"_s) }
+    , m_networkUsageThreshold { networkUsageThresholdWithRandomNoise(networkUsageThreshold, networkUsageThresholdRandomness) }
 {
     protectedWorkQueue()->dispatchAfter(ruleListPreparationTimeout, [this] mutable {
         if (m_ruleList)
@@ -91,6 +94,8 @@ ResourceMonitor::Eligibility ResourceMonitorChecker::checkEligibility(const Cont
     ASSERT(m_ruleList);
 
     auto matched = m_ruleList->processContentRuleListsForResourceMonitoring(info.resourceURL, info.mainDocumentURL, info.frameURL, info.type);
+    RESOURCEMONITOR_RELEASE_LOG("The url is %" PUBLIC_LOG_STRING ": %" SENSITIVE_LOG_STRING, (matched ? "eligible" : "not eligible"), info.resourceURL.string().utf8().data());
+
     return matched ? Eligibility::Eligible : Eligibility::NotEligible;
 }
 
@@ -126,6 +131,11 @@ void ResourceMonitorChecker::finishPendingQueries(Function<Eligibility(const Con
         });
     }
     m_pendingQueries.clear();
+}
+
+void ResourceMonitorChecker::setNetworkUsageThreshold(size_t threshold, double randomness)
+{
+    m_networkUsageThreshold = networkUsageThresholdWithRandomNoise(threshold, randomness);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ResourceMonitorThrottler.cpp
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.cpp
@@ -130,6 +130,12 @@ bool ResourceMonitorThrottler::AccessThrottler::tryExpire(ApproximateTime time, 
     return true;
 }
 
+void ResourceMonitorThrottler::setCountPerDuration(size_t count, Seconds duration)
+{
+    m_config.count = count;
+    m_config.duration = duration;
+}
+
 } // namespace WebCore
 
 #undef RESOURCEMONITOR_RELEASE_LOG

--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -41,6 +41,8 @@ public:
 
     WEBCORE_EXPORT bool tryAccess(const String& host, ApproximateTime = ApproximateTime::now());
 
+    WEBCORE_EXPORT void setCountPerDuration(size_t, Seconds);
+
 private:
     struct Config {
         size_t count;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7815,4 +7815,25 @@ void Internals::setTopDocumentURLForQuirks(const String& urlString)
     document->quirks().setTopDocumentURLForTesting(URL { urlString });
 }
 
+#if ENABLE(CONTENT_EXTENSIONS)
+void Internals::setResourceMonitorNetworkUsageThreshold(size_t threshold, double randomness)
+{
+    ResourceMonitorChecker::singleton().setNetworkUsageThreshold(threshold, randomness);
+}
+
+bool Internals::shouldSkipResourceMonitorThrottling() const
+{
+    if (RefPtr document = contextDocument())
+        return document->shouldSkipResourceMonitorThrottling();
+
+    return false;
+}
+
+void Internals::setShouldSkipResourceMonitorThrottling(bool flag)
+{
+    if (RefPtr document = contextDocument())
+        document->setShouldSkipResourceMonitorThrottling(flag);
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -42,6 +42,7 @@
 #include "PageConsoleClient.h"
 #include "RealtimeMediaSource.h"
 #include "RenderingMode.h"
+#include "ResourceMonitorChecker.h"
 #include "SleepDisabler.h"
 #include "TextIndicator.h"
 #include "VP9Utilities.h"
@@ -1550,6 +1551,12 @@ public:
     void getImageBufferResourceLimits(ImageBufferResourceLimitsPromise&&);
 
     void setResourceCachingDisabledByWebInspector(bool);
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    void setResourceMonitorNetworkUsageThreshold(size_t threshold, double randomness = ResourceMonitorChecker::networkUsageThresholdRandomness);
+    bool shouldSkipResourceMonitorThrottling() const;
+    void setShouldSkipResourceMonitorThrottling(bool);
+#endif
 
 private:
     explicit Internals(Document&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1423,4 +1423,9 @@ enum RenderingMode {
     Promise<ImageBufferResourceLimits> getImageBufferResourceLimits();
 
     undefined setTopDocumentURLForQuirks(DOMString urlString);
+
+#if defined(ENABLE_CONTENT_EXTENSIONS) && ENABLE_CONTENT_EXTENSIONS
+    undefined setResourceMonitorNetworkUsageThreshold(unsigned long threshold, double randomness);
+    attribute boolean shouldSkipResourceMonitorThrottling;
+#endif
 };

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -588,3 +588,16 @@ void WKContextClearMockGamepadsForTesting(WKContextRef)
         WebCore::GamepadProvider::singleton().clearGamepadsForTesting();
 #endif
 }
+
+void WKContextSetResourceMonitorURLsForTesting(WKContextRef contextRef, WKStringRef rulesText, void* context, WKContextSetResourceMonitorURLsFunction callback)
+{
+#if ENABLE(CONTENT_EXTENSIONS) && PLATFORM(COCOA)
+    WebKit::toImpl(contextRef)->setResourceMonitorURLsForTesting(WebKit::toWTFString(rulesText), [context, callback] {
+        if (callback)
+            callback(context);
+    });
+#else
+    if (callback)
+        callback(context);
+#endif
+}

--- a/Source/WebKit/UIProcess/API/C/WKContext.h
+++ b/Source/WebKit/UIProcess/API/C/WKContext.h
@@ -215,6 +215,9 @@ WK_EXPORT void WKContextSetCustomWebContentServiceBundleIdentifier(WKContextRef 
 
 WK_EXPORT void WKContextClearMockGamepadsForTesting(WKContextRef contextRef);
 
+typedef void (*WKContextSetResourceMonitorURLsFunction)(void* functionContext);
+WK_EXPORT void WKContextSetResourceMonitorURLsForTesting(WKContextRef contextRef, WKStringRef rulesText, void* context, WKContextSetResourceMonitorURLsFunction callback);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -615,6 +615,7 @@ public:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WebCompiledContentRuleList* cachedResourceMonitorRuleList();
+    void setResourceMonitorURLsForTesting(const String& rulesText, CompletionHandler<void()>&&);
 #endif
 
 #if PLATFORM(COCOA)
@@ -738,7 +739,8 @@ private:
 #if ENABLE(CONTENT_EXTENSIONS)
     void loadOrUpdateResourceMonitorRuleList();
 
-    void platformLoadResourceMonitorRuleList(CompletionHandler<void()>&&);
+    void platformLoadResourceMonitorRuleList(CompletionHandler<void(RefPtr<WebCompiledContentRuleList>)>&&);
+    void platformCompileResourceMonitorRuleList(const String& rulesText, CompletionHandler<void(RefPtr<WebCompiledContentRuleList>)>&&);
 #endif
 
     Ref<API::ProcessPoolConfiguration> m_configuration;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -542,7 +542,8 @@ public:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void requestResourceMonitorRuleLists();
-    void setResourceMonitorRuleListsIfRequired(WebCompiledContentRuleList*);
+    void setResourceMonitorRuleListsIfRequired(RefPtr<WebCompiledContentRuleList>);
+    void setResourceMonitorRuleLists(RefPtr<WebCompiledContentRuleList>, CompletionHandler<void()>&&);
 #endif
 
 private:

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2527,6 +2527,12 @@ void WebProcess::setResourceMonitorContentRuleList(WebCompiledContentRuleListDat
 
     WebCore::ResourceMonitorChecker::singleton().setContentRuleList(WTFMove(backend));
 }
+
+void WebProcess::setResourceMonitorContentRuleListAsync(WebCompiledContentRuleListData&& ruleListData, CompletionHandler<void()>&& completionHandler)
+{
+    setResourceMonitorContentRuleList(WTFMove(ruleListData));
+    completionHandler();
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -405,6 +405,7 @@ public:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void setResourceMonitorContentRuleList(WebCompiledContentRuleListData&&);
+    void setResourceMonitorContentRuleListAsync(WebCompiledContentRuleListData&&, CompletionHandler<void()>&&);
 #endif
 
     bool areAllPagesThrottleable() const;

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -235,6 +235,7 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
 #if ENABLE(CONTENT_EXTENSIONS)
     [DeferSendingIfSuspended] SetResourceMonitorContentRuleList(WebKit::WebCompiledContentRuleListData ruleListData)
+    SetResourceMonitorContentRuleListAsync(WebKit::WebCompiledContentRuleListData ruleListData) -> ()
 #endif
 
 #if PLATFORM(COCOA)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -465,4 +465,8 @@ interface TestRunner {
 
     Promise<undefined> setTopContentInset(double contentInset);
     Promise<undefined> setPageScaleFactor(unrestricted double scaleFactor, long x, long y);
+
+    // ResourceMonitor
+    readonly attribute boolean canModifyResourceMonitorList;
+    Promise<undefined> setResourceMonitorList(DOMString rulesText);
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2142,6 +2142,11 @@ void TestRunner::setTopContentInset(JSContextRef context, double contentInset, J
     postMessageWithAsyncReply(context, "SetTopContentInset", adoptWK(WKDoubleCreate(contentInset)), callback);
 }
 
+void TestRunner::setResourceMonitorList(JSContextRef context, JSStringRef rulesText, JSValueRef callback)
+{
+    postMessageWithAsyncReply(context, "SetResourceMonitorList", toWK(rulesText), callback);
+}
+
 ALLOW_DEPRECATED_DECLARATIONS_END
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -564,6 +564,16 @@ public:
 
     void setPageScaleFactor(JSContextRef, double scaleFactor, long x, long y, JSValueRef callback);
 
+    bool canModifyResourceMonitorList() const
+    {
+#if PLATFORM(COCOA)
+        return true;
+#else
+        return false;
+#endif
+    }
+    void setResourceMonitorList(JSContextRef, JSStringRef rulesText, JSValueRef callback);
+
 private:
     TestRunner();
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2188,6 +2188,9 @@ void TestController::didReceiveAsyncMessageFromInjectedBundle(WKStringRef messag
     if (WKStringIsEqualToUTF8CString(messageName, "DisplayAndTrackRepaints"))
         return WKPageDisplayAndTrackRepaintsForTesting(TestController::singleton().mainWebView()->page(), completionHandler.leak(), adoptAndCallCompletionHandler);
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetResourceMonitorList"))
+        return setResourceMonitorList(stringValue(messageBody), WTFMove(completionHandler));
+
     ASSERT_NOT_REACHED();
 }
 
@@ -4457,6 +4460,11 @@ void TestController::setRequestStorageAccessThrowsExceptionUntilReload(bool enab
     auto configuration = adoptWK(WKPageCopyPageConfiguration(m_mainWebView->page()));
     auto preferences = WKPageConfigurationGetPreferences(configuration.get());
     WKPreferencesSetBoolValueForKeyForTesting(preferences, enabled, toWK("RequestStorageAccessThrowsExceptionUntilReload").get());
+}
+
+void TestController::setResourceMonitorList(WKStringRef rulesText, CompletionHandler<void(WKTypeRef)>&& completionHandler)
+{
+    WKContextSetResourceMonitorURLsForTesting(m_context.get(), rulesText, completionHandler.leak(), adoptAndCallCompletionHandler);
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -357,6 +357,8 @@ public:
     void cleanUpKeychain(const String& attrLabel, const String& applicationLabelBase64);
     bool keyExistsInKeychain(const String& attrLabel, const String& applicationLabelBase64);
 
+    void setResourceMonitorList(WKStringRef rulesText, CompletionHandler<void(WKTypeRef)>&&);
+
 #if PLATFORM(COCOA)
     NSString *overriddenCalendarIdentifier() const;
     NSString *overriddenCalendarLocaleIdentifier() const;


### PR DESCRIPTION
#### dcd18c28da6d7a531587b1646dad132a02b55284
<pre>
Add layout tests for ResourceMonitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=286318">https://bugs.webkit.org/show_bug.cgi?id=286318</a>
<a href="https://rdar.apple.com/141840408">rdar://141840408</a>

Reviewed by Ben Nham.

Add minimum layout tests for ResourceMonitor. This covers following basic cases for iframes:
- Not be eligible for monitoring and uses small amount of load.
- Not be eligible for monitoring and uses big amount of load.
- Be eligible for monitoring and uses big amount of load.
- Be eligible for monitoring and uses small amount of load.

For easy and consistent testing, add functions to set various conditions for monitoring and
connect them to Internals and TestRunner. Also needs to

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/eligibility.html: Added.
* LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/iframe-unload.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/generate-byte.py: Added.
* LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--2.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/iframe-not-eligible.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/iframe-not-eligible2.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/Document.h:
(WebCore::Document::shouldSkipResourceMonitorThrottling const):
(WebCore::Document::setShouldSkipResourceMonitorThrottling):
* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::ResourceMonitor):
(WebCore::ResourceMonitor::setEligibility):
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
(WebCore::networkUsageThresholdWithRandomNoise): Deleted.
* Source/WebCore/loader/ResourceMonitor.h:
* Source/WebCore/loader/ResourceMonitorChecker.cpp:
(WebCore::networkUsageThresholdWithRandomNoise):
(WebCore::ResourceMonitorChecker::checkEligibility):
(WebCore::ResourceMonitorChecker::setNetworkUsageThreshold):
* Source/WebCore/loader/ResourceMonitorChecker.h:
* Source/WebCore/loader/ResourceMonitorThrottler.cpp:
(WebCore::ResourceMonitorThrottler::setCountPerDuration):
* Source/WebCore/loader/ResourceMonitorThrottler.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setResourceMonitorNetworkUsageThreshold):
(WebCore::Internals::shouldSkipResourceMonitorThrottling const):
(WebCore::Internals::setShouldSkipResourceMonitorThrottling):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetResourceMonitorURLsForTesting):
* Source/WebKit/UIProcess/API/C/WKContext.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::createCompiledContentRuleList):
(WebKit::WebProcessPool::platformLoadResourceMonitorRuleList):
(WebKit::WebProcessPool::platformCompileResourceMonitorRuleList):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::loadOrUpdateResourceMonitorRuleList):
(WebKit::WebProcessPool::setResourceMonitorURLsForTesting):
(WebKit::WebProcessPool::platformLoadResourceMonitorRuleList):
(WebKit::WebProcessPool::platformCompileResourceMonitorRuleList):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::requestResourceMonitorRuleLists):
(WebKit::WebProcessProxy::setResourceMonitorRuleListsIfRequired):
(WebKit::WebProcessProxy::setResourceMonitorRuleLists):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setResourceMonitorContentRuleListAsync):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setResourceMonitorList):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::canModifyResourceMonitorList const):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::TestController::setResourceMonitorList):
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/289467@main">https://commits.webkit.org/289467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0edf43798ea6a91d9cb05f320a2bbec3a696411

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41437 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89129 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/6865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14657 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/91938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90081 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/6865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78820 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/91938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/6865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33196 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/6865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34075 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/14241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/93825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/14445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74676 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/93825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18527 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/14260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/17447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->