### PR TITLE
[JSC] Remove maxArguments

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -641,6 +641,11 @@ public:
         add32(imm, src, dest);
     }
 
+    void addPtr(TrustedImmPtr imm, RegisterID src, RegisterID dest)
+    {
+        add32(TrustedImm32(imm), src, dest);
+    }
+
     void addPtr(TrustedImm32 imm, AbsoluteAddress address)
     {
         add32(imm, address);
@@ -1012,6 +1017,11 @@ public:
     void addPtr(TrustedImmPtr imm, RegisterID dest)
     {
         add64(TrustedImm64(imm), dest);
+    }
+
+    void addPtr(TrustedImmPtr imm, RegisterID src, RegisterID dest)
+    {
+        add64(TrustedImm64(imm), src, dest);
     }
 
     void addPtr(TrustedImm32 imm, AbsoluteAddress address)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12204,10 +12204,8 @@ IGNORE_CLANG_WARNINGS_END
                     unsigned numUsedSlots = WTF::roundUpToMultipleOf(stackAlignmentRegisters(), originalStackHeight / sizeof(EncodedJSValue));
                     B3::ValueRep argumentCountIncludingThisRep = params[3];
                     getValueFromRep(argumentCountIncludingThisRep, scratchGPR2);
-                    slowCase.append(jit.branch32(CCallHelpers::Above, scratchGPR2, CCallHelpers::TrustedImm32(JSC::maxArguments + 1)));
 
-                    jit.move(scratchGPR2, scratchGPR1);
-                    jit.addPtr(CCallHelpers::TrustedImmPtr(static_cast<size_t>(numUsedSlots + CallFrame::headerSizeInRegisters)), scratchGPR1);
+                    jit.addPtr(CCallHelpers::TrustedImmPtr(static_cast<size_t>(numUsedSlots + CallFrame::headerSizeInRegisters)), scratchGPR2, scratchGPR1);
                     // scratchGPR1 now has the required frame size in Register units
                     // Round scratchGPR1 to next multiple of stackAlignmentRegisters()
                     jit.addPtr(CCallHelpers::TrustedImm32(stackAlignmentRegisters() - 1), scratchGPR1);

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -257,9 +257,6 @@ unsigned sizeOfVarargs(JSGlobalObject* globalObject, JSValue arguments, uint32_t
     }
     RETURN_IF_EXCEPTION(scope, 0);
     
-    if (length > maxArguments)
-        throwStackOverflowError(globalObject, scope);
-
     if (length >= firstVarArgOffset)
         length -= firstVarArgOffset;
     else
@@ -288,7 +285,7 @@ unsigned sizeFrameForVarargs(JSGlobalObject* globalObject, CallFrame* callFrame,
     RETURN_IF_EXCEPTION(scope, 0);
 
     CallFrame* calleeFrame = calleeFrameForVarargs(callFrame, numUsedStackSlots, length + 1);
-    if (UNLIKELY(length > maxArguments || !vm.ensureStackCapacityFor(calleeFrame->registers()))) {
+    if (UNLIKELY(!vm.ensureStackCapacityFor(calleeFrame->registers()))) {
         throwStackOverflowError(globalObject, scope);
         return 0;
     }
@@ -1246,7 +1243,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
     size_t argsCount = 1 + args.size(); // implicit "this" parameter
 
     VMEntryScope entryScope(vm, globalObject);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft() || args.size() > maxArguments))
+    if (UNLIKELY(!vm.isSafeToRecurseSoft()))
         return throwStackOverflowError(globalObject, scope);
 
     if (UNLIKELY(vm.disallowVMEntryCount))
@@ -1341,7 +1338,7 @@ JSObject* Interpreter::executeConstruct(JSObject* constructor, const CallData& c
     }
 
     VMEntryScope entryScope(vm, globalObject);
-    if (UNLIKELY(!vm.isSafeToRecurseSoft() || args.size() > maxArguments)) {
+    if (UNLIKELY(!vm.isSafeToRecurseSoft())) {
         throwStackOverflowError(globalObject, throwScope);
         return nullptr;
     }

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -195,7 +195,6 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
     inline CallFrame* calleeFrameForVarargs(CallFrame*, unsigned numUsedStackSlots, unsigned argumentCountIncludingThis);
 
     unsigned sizeOfVarargs(JSGlobalObject*, JSValue arguments, uint32_t firstVarArgOffset);
-    static constexpr unsigned maxArguments = 0x100000;
     unsigned sizeFrameForVarargs(JSGlobalObject*, CallFrame*, VM&, JSValue arguments, unsigned numUsedStackSlots, uint32_t firstVarArgOffset);
     unsigned sizeFrameForForwardArguments(JSGlobalObject*, CallFrame*, VM&, unsigned numUsedStackSlots);
     void loadVarargs(JSGlobalObject*, JSValue* firstElementDest, JSValue source, uint32_t offset, uint32_t length);

--- a/Source/JavaScriptCore/jit/SetupVarargsFrame.cpp
+++ b/Source/JavaScriptCore/jit/SetupVarargsFrame.cpp
@@ -77,8 +77,6 @@ static void emitSetupVarargsFrameFastCase(VM& vm, CCallHelpers& jit, GPRReg numU
         jit.sub32(CCallHelpers::TrustedImm32(firstVarArgOffset), scratchGPR1);
         endVarArgs.link(&jit);
     }
-    slowCase.append(jit.branch32(CCallHelpers::Above, scratchGPR1, CCallHelpers::TrustedImm32(JSC::maxArguments + 1)));
-    
     emitSetVarargsFrame(jit, scratchGPR1, true, numUsedSlotsGPR, scratchGPR2);
 
     slowCase.append(jit.branchPtr(CCallHelpers::Above, scratchGPR2, GPRInfo::callFrameRegister));

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3241,7 +3241,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSamplingProfilerStackTraces, (JSGlobalObject* g
 JSC_DEFINE_HOST_FUNCTION(functionMaxArguments, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
-    unsigned result = std::min<unsigned>(JSC::maxArguments, static_cast<unsigned>((std::bit_cast<uint8_t*>(Thread::current().stack().origin()) - std::bit_cast<uint8_t*>(vm.softStackLimit())) / sizeof(EncodedJSValue)));
+    unsigned result = static_cast<unsigned>((std::bit_cast<uint8_t*>(Thread::current().stack().origin()) - std::bit_cast<uint8_t*>(vm.softStackLimit())) / sizeof(EncodedJSValue));
     return JSValue::encode(jsNumber(result));
 }
 


### PR DESCRIPTION
#### 1cfb3476bbb9b9d55b71a02fcc84389dcd4d161c
<pre>
[JSC] Remove maxArguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=286518">https://bugs.webkit.org/show_bug.cgi?id=286518</a>
<a href="https://rdar.apple.com/143606019">rdar://143606019</a>

Reviewed by NOBODY (OOPS!).

We are doing check via real stack height, so we do not need this check
additionally.

* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::sizeOfVarargs):
(JSC::sizeFrameForVarargs):
(JSC::Interpreter::executeCallImpl):
(JSC::Interpreter::executeConstruct):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/jit/SetupVarargsFrame.cpp:
(JSC::emitSetupVarargsFrameFastCase):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cfb3476bbb9b9d55b71a02fcc84389dcd4d161c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37494 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14329 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67074 "Found 1 new test failure: js/function-apply.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24845 "Found 1 new test failure: js/function-apply.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89765 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4975 "Found 1 new test failure: js/function-apply.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4761 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32886 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html js/function-apply.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36612 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79545 "Found 11 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-ftl-no-cjit ...") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75271 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33772 "Found 1 new test failure: js/function-apply.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93502 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85535 "Found 11 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-no-llint, stress/regress-179140.js.ftl-no-cjit-no-inline-validate, stress/regress-179140.js.lockdown ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13915 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10089 "Found 2 new test failures: fast/webgpu/type-checker-array-without-argument.html js/function-apply.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75874 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75069 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19380 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17787 "Found 1 new test failure: js/function-apply.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6700 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13938 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19198 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108027 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13676 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25997 "Found 7 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/function-apply.js.layout-no-llint, stress/regress-179140.js.lockdown, stress/regress-179140.js.no-cjit-validate-phases (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->