### PR TITLE
[WebDriver][BiDi] run-webdriver-tests: Selenium WebDriver-BiDi tests require extra pytest option

### DIFF
--- a/Tools/Scripts/run-webdriver-tests
+++ b/Tools/Scripts/run-webdriver-tests
@@ -53,6 +53,8 @@ option_parser.add_option('--display-server', choices=['xvfb', 'xorg', 'weston', 
                          help='"xvfb": Use a virtualized X11 server. "xorg": Use the current X11 session. '
                               '"weston": Use a virtualized Weston server. "wayland": Use the current wayland session.'
                               '"headless": Headless mode in current session')
+option_parser.add_option('--enable-webdriver-bidi', action='store_true',
+                         help='Run tests with BiDi enabled')
 
 options, args = option_parser.parse_args()
 

--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -204,6 +204,8 @@ def run(path, args, timeout, env, expectations, ignore_param=None):
 
             if result == ExitCode.INTERNAL_ERROR:
                 harness_recorder.outcome = ('ERROR', None)
+            elif result == ExitCode.USAGE_ERROR:
+                harness_recorder.outcome = ('ERROR', f'Error invoking pytest.main: Arguments: {cmd}')
         except Exception as e:
             harness_recorder.outcome = ('ERROR', str(e))
 

--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner_selenium.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner_selenium.py
@@ -46,7 +46,7 @@ class WebDriverTestRunnerSelenium(object):
 
         skipped = [os.path.join(self._tests_dir, test) for test in self._expectations.skipped_tests()]
         relative_tests_dir = os.path.join('imported', 'selenium', 'py', 'test')
-        executor = WebDriverSeleniumExecutor(self._driver, self._env)
+        executor = WebDriverSeleniumExecutor(self._port, self._driver, self._env)
         # Collected tests are relative to test directory.
         base_dir = os.path.join(self._tests_dir, os.path.dirname(relative_tests_dir))
         collected_tests = {}
@@ -78,7 +78,7 @@ class WebDriverTestRunnerSelenium(object):
         if self._driver.selenium_name() is None:
             return
 
-        executor = WebDriverSeleniumExecutor(self._driver, self._env)
+        executor = WebDriverSeleniumExecutor(self._port, self._driver, self._env)
         timeout = self._port.get_option('timeout')
         for test in tests:
             test_name = os.path.relpath(test.split('::')[0], self._tests_dir)

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2460,7 +2460,7 @@
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/230615"}}
     },
     "imported/w3c/webdriver/tests/bidi/session/status/status.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/230615"}}
+        "expected": { "gtk": { "status": ["SKIP"], "bug": "webkit.org/b/286506"}}
     },
     "imported/w3c/webdriver/tests/bidi/session/subscribe/contexts.py": {
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/230615"}}
@@ -2523,6 +2523,6 @@
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/230615"}}
     },
     "imported/selenium/py/test/selenium/webdriver/common/bidi_script_tests.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/271956"}}
+        "expected": { "gtk": { "status": ["SKIP"], "bug": "webkit.org/b/286506"}}
     }
 }


### PR DESCRIPTION
#### 9a82bd160050b56ded81f734698f1c79ee4fae94
<pre>
[WebDriver][BiDi] run-webdriver-tests: Selenium WebDriver-BiDi tests require extra pytest option
<a href="https://bugs.webkit.org/show_bug.cgi?id=286497">https://bugs.webkit.org/show_bug.cgi?id=286497</a>

Reviewed by Carlos Alberto Lopez Perez.

Add a `--enable-webdriver-bidi` flag to `run-webdriver-tests`. It&apos;ll
forward the required `--bidi=1` to Selenium&apos;s pytest.

Given the plans to control WebDriver-BiDi support behind a feature flag
(bug283517), we skipped trying to figure out whether the build supports
it, opting for a more explicit approach.

During work on this issue, we found a limitation related to a 10-year old
argparse issue[1], which leads to pytest&apos;s failing to load the right
config files[2], which in turn might make it fail to recognize custom
CLI switches added by the expected conftest.py. This happens, for
example, with `--browser-args` if it receives a space-separated list,
as we currently do. So this commit also adds a check for pytest&apos;s
`ExitCode.USAGE_ERROR` when calling `pytest.main` for clarity.

In a follow-up commit, we&apos;ll update the buildbot WebDriver steps to use
the new `--enable-webdriver-bidi` in `run-webdriver-tests`.

Also update some expectations based on recent WebDriver-BiDi commits.

[1] <a href="https://github.com/python/cpython/issues/66623">https://github.com/python/cpython/issues/66623</a>
[2] <a href="https://github.com/pytest-dev/pytest/issues/9749">https://github.com/pytest-dev/pytest/issues/9749</a>

* Tools/Scripts/run-webdriver-tests:
* Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
(run):
* Tools/Scripts/webkitpy/webdriver_tests/webdriver_selenium_executor.py:
(WebDriverSeleniumExecutor.__init__):
* Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner_selenium.py:
(WebDriverTestRunnerSelenium.collect_tests):
(WebDriverTestRunnerSelenium.run):
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/289454@main">https://commits.webkit.org/289454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a11d873a7dc97e735f4346830d30fdd3c52062d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91865 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90009 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5199 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78758 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/47574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/86504 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75468 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/34009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93753 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14169 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14373 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75253 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19591 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18019 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->