### PR TITLE
Reduce use of strcmp() / strncmp() in the codebase

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -27,6 +27,7 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreGraphics/CoreGraphics.h>
+#include <wtf/text/WTFString.h>
 
 #if HAVE(IOSURFACE)
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
@@ -449,3 +450,10 @@ CG_EXTERN void CGEnterLockdownModeForFonts();
 #endif
 
 WTF_EXTERN_C_END
+
+inline String CGPDFDictionaryGetNameString(CGPDFDictionaryRef dictionary, ASCIILiteral key)
+{
+    const char* value = nullptr;
+    CGPDFDictionaryGetName(dictionary, key.characters(), &value);
+    return value ? String::fromUTF8(value) : String();
+}

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -162,12 +162,10 @@ void TextCodecICU::createICUConverter() const
     if (cachedConverter) {
         UErrorCode error = U_ZERO_ERROR;
         const char* cachedConverterName = ucnv_getName(cachedConverter.get(), &error);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (U_SUCCESS(error) && !strcmp(m_canonicalConverterName, cachedConverterName)) {
+        if (U_SUCCESS(error) && m_canonicalConverterName == cachedConverterName) {
             m_converter = WTFMove(cachedConverter);
             return;
         }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     UErrorCode error = U_ZERO_ERROR;

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -52,6 +52,7 @@
 #include "ExceptionOr.h"
 #include <wtf/Algorithms.h>
 #include <wtf/FixedVector.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -403,7 +404,7 @@ ExceptionOr<Ref<CSSMathSum>> CSSNumericValue::toSum(FixedVector<String>&& units)
 
     if (parsedUnits.isEmpty()) {
         std::sort(values.begin(), values.end(), [](auto& a, auto& b) {
-            return strcmp(downcast<CSSUnitValue>(a)->unitSerialization().characters(), downcast<CSSUnitValue>(b)->unitSerialization().characters()) < 0;
+            return compareSpans(downcast<CSSUnitValue>(a)->unitSerialization().span(), downcast<CSSUnitValue>(b)->unitSerialization().span()) < 0;
         });
         return CSSMathSum::create(WTFMove(values));
     }

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -46,10 +46,8 @@ ExceptionOr<Ref<TextDecoder>> TextDecoder::create(const String& label, Options o
     if (trimmedLabel.contains(nullCharacter))
         return Exception { ExceptionCode::RangeError };
     auto decoder = adoptRef(*new TextDecoder(trimmedLabel, options));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (!decoder->m_textEncoding.isValid() || !strcmp(decoder->m_textEncoding.name(), "replacement"))
+    if (!decoder->m_textEncoding.isValid() || decoder->m_textEncoding.name() == "replacement"_s)
         return Exception { ExceptionCode::RangeError };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return decoder;
 }
 

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -360,7 +360,7 @@ void PrintContext::outputLinkedDestinations(GraphicsContext& graphicsContext, Do
     }
 }
 
-String PrintContext::pageProperty(LocalFrame* frame, const char* propertyName, int pageNumber)
+String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName, int pageNumber)
 {
     ASSERT(frame);
     ASSERT(frame->document());
@@ -373,26 +373,22 @@ String PrintContext::pageProperty(LocalFrame* frame, const char* propertyName, i
     document->updateLayout();
     auto style = document->styleScope().resolver().styleForPage(pageNumber);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
     // Implement formatters for properties we care about.
-    if (!strcmp(propertyName, "margin-left")) {
+    if (propertyName == "margin-left"_s) {
         if (style->marginLeft().isAuto())
             return autoAtom();
         return String::number(style->marginLeft().value());
     }
-    if (!strcmp(propertyName, "line-height"))
+    if (propertyName == "line-height"_s)
         return String::number(style->lineHeight().value());
-    if (!strcmp(propertyName, "font-size"))
+    if (propertyName == "font-size"_s)
         return String::number(style->fontDescription().computedSize());
-    if (!strcmp(propertyName, "font-family"))
+    if (propertyName == "font-family"_s)
         return style->fontDescription().firstFamily();
-    if (!strcmp(propertyName, "size"))
+    if (propertyName == "size"_s)
         return makeString(style->pageSize().width.value(), ' ', style->pageSize().height.value());
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-    return makeString("pageProperty() unimplemented for: "_s, unsafeSpan(propertyName));
+    return makeString("pageProperty() unimplemented for: "_s, propertyName);
 }
 
 bool PrintContext::isPageBoxVisible(LocalFrame* frame, int pageNumber)

--- a/Source/WebCore/page/PrintContext.h
+++ b/Source/WebCore/page/PrintContext.h
@@ -77,7 +77,7 @@ public:
 
     // Used by layout tests.
     WEBCORE_EXPORT static int pageNumberForElement(Element*, const FloatSize& pageSizeInPixels); // Returns -1 if page isn't found.
-    WEBCORE_EXPORT static String pageProperty(LocalFrame*, const char* propertyName, int pageNumber);
+    WEBCORE_EXPORT static String pageProperty(LocalFrame*, const String& propertyName, int pageNumber);
     WEBCORE_EXPORT static bool isPageBoxVisible(LocalFrame*, int pageNumber);
     WEBCORE_EXPORT static String pageSizeAndMarginsInPixels(LocalFrame*, int pageNumber, int width, int height, int marginTop, int marginRight, int marginBottom, int marginLeft);
     WEBCORE_EXPORT static int numberOfPages(LocalFrame&, const FloatSize& pageSizeInPixels);

--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -35,12 +35,10 @@ namespace WebCore {
 bool isMemoryAttributionDisabled()
 {
     static bool result = []() {
-        const char* value = getenv("WEBKIT_DISABLE_MEMORY_ATTRIBUTION");
-        if (!value)
+        auto value = unsafeSpan(getenv("WEBKIT_DISABLE_MEMORY_ATTRIBUTION"));
+        if (!value.data())
             return false;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        return !strcmp(value, "1");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        return equalSpans(value, "1"_span);
     }();
     return result;
 }

--- a/Source/WebCore/platform/cocoa/AGXCompilerService.cpp
+++ b/Source/WebCore/platform/cocoa/AGXCompilerService.cpp
@@ -49,8 +49,8 @@ bool deviceHasAGXCompilerService()
             hasAGXCompilerService = false;
             return *hasAGXCompilerService;
         }
-        const char* machine = systemInfo.machine;
-        if (!strcmp(machine, "iPad5,1") || !strcmp(machine, "iPad5,2") || !strcmp(machine, "iPad5,3") || !strcmp(machine, "iPad5,4"))
+        auto machine = unsafeSpan(systemInfo.machine);
+        if (equalSpans(machine, "iPad5,1"_span) || equalSpans(machine, "iPad5,2"_span) || equalSpans(machine, "iPad5,3"_span) || equalSpans(machine, "iPad5,4"_span))
             hasAGXCompilerService = true;
         else
             hasAGXCompilerService = false;

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -291,10 +291,8 @@ std::optional<OpusCookieContents> parseOpusPrivateData(std::span<const uint8_t> 
     //
     //     This is an 8-octet (64-bit) field that allows codec
     //     identification and is human readable.
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (strncmp("OpusHead", byteCast<char>(codecPrivateData.data()), 8))
+    if (!spanHasPrefix(codecPrivateData, "OpusHead"_span8))
         return { };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     OpusCookieContents cookie;
 

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
@@ -435,9 +435,9 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
 
         case GIFType: {
             // All GIF files begin with "GIF87a" or "GIF89a".
-            if (!strncmp((char*)currentComponent.data(), "GIF89a", 6))
+            if (spanHasPrefix(currentComponent, "GIF89a"_span))
                 m_version = 89;
-            else if (!strncmp((char*)currentComponent.data(), "GIF87a", 6))
+            else if (spanHasPrefix(currentComponent, "GIF87a"_span))
                 m_version = 87;
             else
                 return false;
@@ -608,8 +608,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         case GIFApplicationExtension: {
             // Check for netscape application extension.
-            if (m_bytesToConsume == 11 
-                && (!strncmp(reinterpret_cast<const char*>(currentComponent.data()), "NETSCAPE2.0", 11) || !strncmp(reinterpret_cast<const char*>(currentComponent.data()), "ANIMEXTS1.0", 11)))
+            if (m_bytesToConsume == 11 && (spanHasPrefix(currentComponent, "NETSCAPE2.0"_span) || spanHasPrefix(currentComponent, "ANIMEXTS1.0"_span)))
                 GETN(1, GIFNetscapeExtensionBlock);
             else
                 GETN(1, GIFConsumeBlock);

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
@@ -83,7 +83,7 @@ static void PNGAPI decodingWarning(png_structp png, png_const_charp warningMsg)
     // Mozilla did this, so we will too.
     // Convert a tRNS warning to be an error (see
     // http://bugzilla.mozilla.org/show_bug.cgi?id=251381 )
-    if (!strncmp(warningMsg, "Missing PLTE before tRNS", 24))
+    if (spanHasPrefix(unsafeSpan(warningMsg), "Missing PLTE before tRNS"_span))
         png_error(png, warningMsg);
 }
 

--- a/Source/WebCore/platform/mac/CursorMac.mm
+++ b/Source/WebCore/platform/mac/CursorMac.mm
@@ -129,48 +129,47 @@ static Class coreCursorClass()
     return coreCursorClass;
 }
 
-static NSCursor *cursor(const char *name)
+static NSCursor *cursor(ASCIILiteral name)
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     __strong NSCursor **slot = nullptr;
     
-    if (!strcmp(name, "BusyButClickable"))
+    if (name == "BusyButClickable"_s)
         slot = &busyButClickableNSCursor;
-    else if (!strcmp(name, "MakeAlias"))
+    else if (name == "MakeAlias"_s)
         slot = &makeAliasNSCursor;
-    else if (!strcmp(name, "Move"))
+    else if (name == "Move"_s)
         slot = &moveNSCursor;
-    else if (!strcmp(name, "ResizeEast"))
+    else if (name == "ResizeEast"_s)
         slot = &resizeEastNSCursor;
-    else if (!strcmp(name, "ResizeEastWest"))
+    else if (name == "ResizeEastWest"_s)
         slot = &resizeEastWestNSCursor;
-    else if (!strcmp(name, "ResizeNorth"))
+    else if (name == "ResizeNorth"_s)
         slot = &resizeNorthNSCursor;
-    else if (!strcmp(name, "ResizeNorthSouth"))
+    else if (name == "ResizeNorthSouth"_s)
         slot = &resizeNorthSouthNSCursor;
-    else if (!strcmp(name, "ResizeNortheast"))
+    else if (name == "ResizeNortheast"_s)
         slot = &resizeNortheastNSCursor;
-    else if (!strcmp(name, "ResizeNortheastSouthwest"))
+    else if (name == "ResizeNortheastSouthwest"_s)
         slot = &resizeNortheastSouthwestNSCursor;
-    else if (!strcmp(name, "ResizeNorthwest"))
+    else if (name == "ResizeNorthwest"_s)
         slot = &resizeNorthwestNSCursor;
-    else if (!strcmp(name, "ResizeNorthwestSoutheast"))
+    else if (name == "ResizeNorthwestSoutheast"_s)
         slot = &resizeNorthwestSoutheastNSCursor;
-    else if (!strcmp(name, "ResizeSouth"))
+    else if (name == "ResizeSouth"_s)
         slot = &resizeSouthNSCursor;
-    else if (!strcmp(name, "ResizeSoutheast"))
+    else if (name == "ResizeSoutheast"_s)
         slot = &resizeSoutheastNSCursor;
-    else if (!strcmp(name, "ResizeSouthwest"))
+    else if (name == "ResizeSouthwest"_s)
         slot = &resizeSouthwestNSCursor;
-    else if (!strcmp(name, "ResizeWest"))
+    else if (name == "ResizeWest"_s)
         slot = &resizeWestNSCursor;
-    else if (!strcmp(name, "Cell"))
+    else if (name == "Cell"_s)
         slot = &cellNSCursor;
-    else if (!strcmp(name, "Help"))
+    else if (name == "Help"_s)
         slot = &helpNSCursor;
-    else if (!strcmp(name, "ZoomIn"))
+    else if (name == "ZoomIn"_s)
         slot = &zoomInNSCursor;
-    else if (!strcmp(name, "ZoomOut"))
+    else if (name == "ZoomOut"_s)
         slot = &zoomOutNSCursor;
     
     if (!slot)
@@ -179,12 +178,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (!*slot)
         *slot = [[coreCursorClass() alloc] init];
     return *slot;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #else
 
-static NSCursor *cursor(const char *)
+static NSCursor *cursor(ASCIILiteral)
 {
     return [NSCursor arrowCursor];
 }
@@ -258,72 +256,72 @@ void Cursor::ensurePlatformCursor() const
         break;
 
     case Type::Wait:
-        m_platformCursor = cursor("BusyButClickable");
+        m_platformCursor = cursor("BusyButClickable"_s);
         break;
 
     case Type::Help:
-        m_platformCursor = cursor("Help");
+        m_platformCursor = cursor("Help"_s);
         break;
 
     case Type::Move:
     case Type::MiddlePanning:
-        m_platformCursor = cursor("Move");
+        m_platformCursor = cursor("Move"_s);
         break;
 
     case Type::EastResize:
     case Type::EastPanning:
-        m_platformCursor = cursor("ResizeEast");
+        m_platformCursor = cursor("ResizeEast"_s);
         break;
 
     case Type::NorthResize:
     case Type::NorthPanning:
-        m_platformCursor = cursor("ResizeNorth");
+        m_platformCursor = cursor("ResizeNorth"_s);
         break;
 
     case Type::NorthEastResize:
     case Type::NorthEastPanning:
-        m_platformCursor = cursor("ResizeNortheast");
+        m_platformCursor = cursor("ResizeNortheast"_s);
         break;
 
     case Type::NorthWestResize:
     case Type::NorthWestPanning:
-        m_platformCursor = cursor("ResizeNorthwest");
+        m_platformCursor = cursor("ResizeNorthwest"_s);
         break;
 
     case Type::SouthResize:
     case Type::SouthPanning:
-        m_platformCursor = cursor("ResizeSouth");
+        m_platformCursor = cursor("ResizeSouth"_s);
         break;
 
     case Type::SouthEastResize:
     case Type::SouthEastPanning:
-        m_platformCursor = cursor("ResizeSoutheast");
+        m_platformCursor = cursor("ResizeSoutheast"_s);
         break;
 
     case Type::SouthWestResize:
     case Type::SouthWestPanning:
-        m_platformCursor = cursor("ResizeSouthwest");
+        m_platformCursor = cursor("ResizeSouthwest"_s);
         break;
 
     case Type::WestResize:
     case Type::WestPanning:
-        m_platformCursor = cursor("ResizeWest");
+        m_platformCursor = cursor("ResizeWest"_s);
         break;
 
     case Type::NorthSouthResize:
-        m_platformCursor = cursor("ResizeNorthSouth");
+        m_platformCursor = cursor("ResizeNorthSouth"_s);
         break;
 
     case Type::EastWestResize:
-        m_platformCursor = cursor("ResizeEastWest");
+        m_platformCursor = cursor("ResizeEastWest"_s);
         break;
 
     case Type::NorthEastSouthWestResize:
-        m_platformCursor = cursor("ResizeNortheastSouthwest");
+        m_platformCursor = cursor("ResizeNortheastSouthwest"_s);
         break;
 
     case Type::NorthWestSouthEastResize:
-        m_platformCursor = cursor("ResizeNorthwestSoutheast");
+        m_platformCursor = cursor("ResizeNorthwestSoutheast"_s);
         break;
 
     case Type::ColumnResize:
@@ -339,7 +337,7 @@ void Cursor::ensurePlatformCursor() const
         break;
 
     case Type::Cell:
-        m_platformCursor = cursor("Cell");
+        m_platformCursor = cursor("Cell"_s);
         break;
 
     case Type::ContextMenu:
@@ -347,11 +345,11 @@ void Cursor::ensurePlatformCursor() const
         break;
 
     case Type::Alias:
-        m_platformCursor = cursor("MakeAlias");
+        m_platformCursor = cursor("MakeAlias"_s);
         break;
 
     case Type::Progress:
-        m_platformCursor = cursor("BusyButClickable");
+        m_platformCursor = cursor("BusyButClickable"_s);
         break;
 
     case Type::NoDrop:
@@ -375,11 +373,11 @@ void Cursor::ensurePlatformCursor() const
         break;
 
     case Type::ZoomIn:
-        m_platformCursor = cursor("ZoomIn");
+        m_platformCursor = cursor("ZoomIn"_s);
         break;
 
     case Type::ZoomOut:
-        m_platformCursor = cursor("ZoomOut");
+        m_platformCursor = cursor("ZoomOut"_s);
         break;
 
     case Type::Grab:

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -103,9 +103,7 @@ void SQLiteFileSystem::setCanSuspendLockedFileAttribute(const String& filePath)
         auto path = makeString(filePath, suffix);
         char excluded = 0xff;
         auto result = setxattr(FileSystem::fileSystemRepresentation(path).data(), "com.apple.runningboard.can-suspend-locked", &excluded, sizeof(excluded), 0, 0);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (result < 0 && !strcmp(suffix, ""))
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        if (result < 0 && suffix == ""_s)
             RELEASE_LOG_ERROR(SQLDatabase, "SQLiteFileSystem::setCanSuspendLockedFileAttribute: setxattr failed: %" PUBLIC_LOG_STRING, strerror(errno));
     }
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3816,7 +3816,7 @@ ExceptionOr<String> Internals::pageProperty(const String& propertyName, int page
     if (!frame())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    return PrintContext::pageProperty(frame(), propertyName.utf8().data(), pageNumber);
+    return PrintContext::pageProperty(frame(), propertyName, pageNumber);
 }
 
 ExceptionOr<String> Internals::pageSizeAndMarginsInPixels(int pageNumber, int width, int height, int marginTop, int marginRight, int marginBottom, int marginLeft) const

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1502,7 +1502,7 @@ using AttributeParseState = std::optional<HashMap<String, String>>;
 
 static void attributesStartElementNsHandler(void* closure, const xmlChar* xmlLocalName, const xmlChar* /*xmlPrefix*/, const xmlChar* /*xmlURI*/, int /*numNamespaces*/, const xmlChar** /*namespaces*/, int numAttributes, int /*numDefaulted*/, const xmlChar** libxmlAttributes)
 {
-    if (strcmp(byteCast<char>(xmlLocalName), "attrs"))
+    if (!equalSpans(unsafeSpan(byteCast<char>(xmlLocalName)), "attrs"_span))
         return;
 
     auto& state = *static_cast<AttributeParseState*>(static_cast<xmlParserCtxtPtr>(closure)->_private);

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -98,13 +98,13 @@ int WebDriverService::run(int argc, char** argv)
     if (const char* targetEnvVar = getenv("WEBDRIVER_TARGET_ADDR"))
         targetString = String::fromLatin1(targetEnvVar);
     for (int i = 1 ; i < argc; ++i) {
-        const char* arg = argv[i];
-        if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
+        auto arg = unsafeSpan(argv[i]);
+        if (equalSpans(arg, "-h"_span) || equalSpans(arg, "--help"_span)) {
             printUsageStatement(argv[0]);
             return EXIT_SUCCESS;
         }
 
-        if (!strcmp(arg, "-p") && portString.isNull()) {
+        if (equalSpans(arg, "-p"_span) && portString.isNull()) {
             if (++i == argc) {
                 printUsageStatement(argv[0]);
                 return EXIT_FAILURE;
@@ -113,27 +113,27 @@ int WebDriverService::run(int argc, char** argv)
             continue;
         }
 
-        static const unsigned portStrLength = strlen("--port=");
-        if (!strncmp(arg, "--port=", portStrLength) && portString.isNull()) {
-            portString = String::fromLatin1(arg + portStrLength);
+        static constexpr auto portArgument = "--port="_span;
+        if (spanHasPrefix(arg, portArgument) && portString.isNull()) {
+            portString = arg.subspan(portArgument.size());
             continue;
         }
 
-        static const unsigned hostStrLength = strlen("--host=");
-        if (!strncmp(arg, "--host=", hostStrLength) && !host) {
-            host = String::fromLatin1(arg + hostStrLength);
+        static constexpr auto hostArgument = "--host="_span;
+        if (spanHasPrefix(arg, hostArgument) && !host) {
+            host = arg.subspan(hostArgument.size());
             continue;
         }
 
 #if ENABLE(WEBDRIVER_BIDI)
-        static const unsigned bidiPortStrLength = strlen("--bidi-port=");
-        if (!strncmp(arg, "--bidi-port=", bidiPortStrLength) && bidiPortString.isNull()) {
-            bidiPortString = String::fromLatin1(arg + bidiPortStrLength);
+        static constexpr auto bidiPortArgument = "--bidi-port="_span;
+        if (spanHasPrefix(arg, bidiPortArgument) && bidiPortString.isNull()) {
+            bidiPortString = arg.subspan(bidiPortArgument.size());
             continue;
         }
 #endif
 
-        if (!strcmp(arg, "-t") && targetString.isNull()) {
+        if (equalSpans(arg, "-t"_span) && targetString.isNull()) {
             if (++i == argc) {
                 printUsageStatement(argv[0]);
                 return EXIT_FAILURE;
@@ -142,9 +142,9 @@ int WebDriverService::run(int argc, char** argv)
             continue;
         }
 
-        static const unsigned targetStrLength = strlen("--target=");
-        if (!strncmp(arg, "--target=", targetStrLength) && targetString.isNull()) {
-            targetString = String::fromLatin1(arg + targetStrLength);
+        static constexpr auto targetArgument = "--target="_span;
+        if (spanHasPrefix(arg, targetArgument) && targetString.isNull()) {
+            targetString = arg.subspan(targetArgument.size());
             continue;
         }
     }

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -143,12 +143,10 @@ static uint64_t generateReplyIdentifier()
 
     NSMethodSignature *methodSignature = invocation.methodSignature;
     for (NSUInteger i = 0, count = methodSignature.numberOfArguments; i < count; ++i) {
-        const char *type = [methodSignature getArgumentTypeAtIndex:i];
+        auto type = unsafeSpan([methodSignature getArgumentTypeAtIndex:i]);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (strcmp(type, "@?"))
+        if (!equalSpans(type, "@?"_span))
             continue;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         if (replyInfo)
             [NSException raise:NSInvalidArgumentException format:@"Only one reply block is allowed per message send. (%s)", sel_getName(invocation.selector)];
@@ -233,12 +231,10 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
 
     // Look for the block argument (if any).
     for (NSUInteger i = 0, count = methodSignature.numberOfArguments; i < count; ++i) {
-        const char *type = [methodSignature getArgumentTypeAtIndex:i];
+        auto type = unsafeSpan([methodSignature getArgumentTypeAtIndex:i]);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (strcmp(type, "@?"))
+        if (!equalSpans(type, "@?"_span))
             continue;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         // We found the block.
         // If the wire had no block signature but we expect one, we drop the message.

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm
@@ -30,6 +30,7 @@
 
 #import <CoreGraphics/CGPDFDocument.h>
 #import <JavaScriptCore/RegularExpression.h>
+#import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/OptionSet.h>
 #import <wtf/text/ASCIILiteral.h>
@@ -100,11 +101,8 @@ static bool pdfDocumentContainsPrintScript(RetainPtr<CGPDFDocumentRef> pdfDocume
             continue;
 
         // A JavaScript action must have an action type of "JavaScript".
-        const char* actionType = nullptr;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (!CGPDFDictionaryGetName(javaScriptAction, "S", &actionType) || strcmp(actionType, "JavaScript"))
+        if (CGPDFDictionaryGetNameString(javaScriptAction, "S"_s) != "JavaScript"_s)
             continue;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         auto scriptFromBytes = [](std::span<const uint8_t> bytes) {
             CFStringEncoding encoding = (bytes.size() > 1 && bytes[0] == 0xFE && bytes[1] == 0xFF) ? kCFStringEncodingUnicode : kCFStringEncodingUTF8;

--- a/Source/WebKitLegacy/mac/WebView/WebPDFDocumentExtras.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFDocumentExtras.mm
@@ -25,6 +25,7 @@
 
 #import "WebPDFDocumentExtras.h"
 
+#import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/Vector.h>
 #import <wtf/RetainPtr.h>
 
@@ -94,8 +95,7 @@ NSArray *allScriptsInPDFDocument(CGPDFDocumentRef pdfDocument)
             continue;
 
         // A JavaScript action must have an action type of "JavaScript".
-        const char* actionType;
-        if (!CGPDFDictionaryGetName(javaScriptAction, "S", &actionType) || strcmp(actionType, "JavaScript"))
+        if (CGPDFDictionaryGetNameString(javaScriptAction, "S"_s) != "JavaScript"_s)
             continue;
 
         const UInt8* bytes = nullptr;

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3539,6 +3539,14 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_strstr:
         error(line_number, 'safercpp/strstr', 4, "Use WTF::find() or WTF::contains() instead of strstr().")
 
+    uses_strcmp = search(r'strcmp\(', line)
+    if uses_strcmp:
+        error(line_number, 'safercpp/strcmp', 4, "strcmp() is unsafe.")
+
+    uses_strncmp = search(r'strncmp\(', line)
+    if uses_strncmp:
+        error(line_number, 'safercpp/strncmp', 4, "strncmp() is unsafe.")
+
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
     """Checks rules from the 'C++ style rules' section of cppguide.html.
@@ -4887,6 +4895,8 @@ class CppChecker(object):
         'safercpp/memset',
         'safercpp/memset_s',
         'safercpp/weak_ref_exception',
+        'safercpp/strcmp',
+        'safercpp/strncmp',
         'safercpp/strchr',
         'safercpp/strstr',
         'safercpp/timer_exception',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6318,6 +6318,16 @@ class WebKitStyleTest(CppStyleTestBase):
             'Use WTF::find() or WTF::contains() instead of strstr().  [safercpp/strstr] [4]',
             'foo.cpp')
 
+        self.assert_lint(
+            'int result = strcmp(a, "foo");',
+            'strcmp() is unsafe.  [safercpp/strcmp] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'int result = strncmp(a, "foo", 3);',
+            'strncmp() is unsafe.  [safercpp/strncmp] [4]',
+            'foo.cpp')
+
     def test_ctype_fucntion(self):
         self.assert_lint(
             'int i = isascii(8);',


### PR DESCRIPTION
#### cd22602acd1a62f94e7f60245d6332f2f15f1078
<pre>
Reduce use of strcmp() / strncmp() in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=286519">https://bugs.webkit.org/show_bug.cgi?id=286519</a>

Reviewed by Geoffrey Garen.

Reduce use of strcmp() / strncmp() in the codebase as they are considered unsafe.

* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
(CGPDFDictionaryGetNameString):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::createICUConverter const):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::CSSNumericValue::toSum):
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::create):
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::pageProperty):
* Source/WebCore/page/PrintContext.h:
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::isMemoryAttributionDisabled):
* Source/WebCore/platform/cocoa/AGXCompilerService.cpp:
(WebCore::deviceHasAGXCompilerService):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::parseOpusPrivateData):
* Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp:
(GIFImageReader::parse):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::decodingWarning):
* Source/WebCore/platform/mac/CursorMac.mm:
(WebCore::cursor):
(WebCore::Cursor::ensurePlatformCursor const):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::setCanSuspendLockedFileAttribute):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::pageProperty const):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::attributesStartElementNsHandler):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::run):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _sendInvocation:interface:]):
(-[_WKRemoteObjectRegistry _invokeMethod:]):
* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluation.mm:
(WebKit::PDFScriptEvaluation::pdfDocumentContainsPrintScript):
* Source/WebKitLegacy/mac/WebView/WebPDFDocumentExtras.mm:
(allScriptsInPDFDocument):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):

Canonical link: <a href="https://commits.webkit.org/289399@main">https://commits.webkit.org/289399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3755148a12e2b1247dbc4aace6c57f426bd6627

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86818 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91666 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67106 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24879 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47425 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/86316 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32935 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36668 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93559 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75102 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6769 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13494 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19254 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13732 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->