### PR TITLE
AX: AXTextMarker::findMarker doesn't move to the right offset when encountering a non-ASCII character

### DIFF
--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -82,12 +82,20 @@ struct AXTextRuns {
     // Do not de-reference. Use for comparison purposes only.
     void* containingBlock { nullptr };
     Vector<AXTextRun> runs;
+    bool containsOnlyASCII { true };
 
     AXTextRuns() = default;
-    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& runs)
+    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns)
         : containingBlock(containingBlock)
-        , runs(WTFMove(runs))
-    { }
+        , runs(WTFMove(textRuns))
+    {
+        for (const auto& run : runs) {
+            if (!run.text.containsOnlyASCII()) {
+                containsOnlyASCII = false;
+                break;
+            }
+        }
+    }
     String debugDescription() const;
 
     size_t size() const { return runs.size(); }


### PR DESCRIPTION
#### fc04b09d028ce6cb51c6b16e98b994fa81567307
<pre>
AX: AXTextMarker::findMarker doesn&apos;t move to the right offset when encountering a non-ASCII character
<a href="https://bugs.webkit.org/show_bug.cgi?id=286522">https://bugs.webkit.org/show_bug.cgi?id=286522</a>
<a href="https://rdar.apple.com/143609336">rdar://143609336</a>

Reviewed by Chris Fleizach.

With this commit, we use CachedTextBreakIterator::{preceding, following} to determine how many offsets to move when
encountering non-ASCII characters, preventing AXTextMarker::findMarker from moving to an offset in the middle of a
non-ASCII character (e.g. an emoji).

This partially fixes accessibility/text-marker/text-marker-previous-next.html in ENABLE(AX_THREAD_TEXT_APIS) mode,
which includes an emoji testcase.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::findMarker const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::AXTextRuns):

Canonical link: <a href="https://commits.webkit.org/289402@main">https://commits.webkit.org/289402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfda9e28339f1fa9be255debff2a764a93a19544

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37544 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67101 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24875 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47420 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36662 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93553 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75098 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17832 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6760 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13726 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->