### PR TITLE
[JSC] Use singleton WorkQueue for SignalSender

### DIFF
--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -41,6 +41,7 @@
 #include "WaiterListManager.h"
 #include "Watchdog.h"
 #include <wtf/ProcessID.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/ThreadMessage.h>
 #include <wtf/threads/Signals.h>
 
@@ -194,14 +195,24 @@ void VMTraps::invalidateCodeBlocksOnStack(Locker<Lock>&, CallFrame* topCallFrame
     }
 }
 
-class VMTraps::SignalSender final : public AutomaticThread {
+class VMTraps::SignalSender final : public ThreadSafeRefCounted<VMTraps::SignalSender> {
 public:
-    using Base = AutomaticThread;
-    SignalSender(const AbstractLocker& locker, VM& vm)
-        : Base(locker, vm.traps().m_lock, vm.traps().m_condition.copyRef())
-        , m_vm(vm)
+    SignalSender(const AbstractLocker&, VM& vm)
+        : m_vm(vm)
+        , m_lock(vm.traps().m_lock)
+        , m_condition(vm.traps().m_condition)
     {
         activateSignalHandlersFor(Signal::AccessFault);
+    }
+
+    static WorkQueue& queue()
+    {
+        static LazyNeverDestroyed<Ref<WorkQueue>> workQueue;
+        static std::once_flag onceKey;
+        std::call_once(onceKey, [&] {
+            workQueue.construct(WorkQueue::create("JSC VMTraps Signal Sender"_s));
+        });
+        return workQueue.get();
     }
 
     static void initializeSignals()
@@ -257,31 +268,47 @@ public:
         });
     }
 
-    ASCIILiteral name() const final
-    {
-        return "JSC VMTraps Signal Sender Thread"_s;
-    }
-
     VMTraps& traps() { return m_vm.traps(); }
 
-private:
-    PollResult poll(const AbstractLocker&) final
+
+    void notify(AbstractLocker&)
     {
-        if (traps().m_isShuttingDown)
-            return PollResult::Stop;
-
-        if (!traps().needHandling(VMTraps::AsyncEvents))
-            return PollResult::Wait;
-
-        // We know that no trap could have been processed and re-added because we are holding the lock.
-        if (vmIsInactive(m_vm))
-            return PollResult::Wait;
-        return PollResult::Work;
+        if (m_scheduled)
+            return;
+        m_scheduled = true;
+        queue().dispatch([protectedThis = Ref { *this }] {
+            protectedThis->work();
+        });
     }
 
-    WorkResult work() final
+    bool isStopped(AbstractLocker&)
+    {
+        return !m_scheduled;
+    }
+
+private:
+    void work()
     {
         VM& vm = m_vm;
+
+        auto workDone = [&](AbstractLocker&) {
+            m_scheduled = false;
+            m_condition->notifyAll(); // let work queue service next SignalSender if needed.
+        };
+
+        {
+            Locker locker { *m_lock };
+            ASSERT(m_scheduled);
+            if (traps().m_isShuttingDown)
+                return workDone(locker);
+
+            if (!traps().needHandling(VMTraps::AsyncEvents))
+                return workDone(locker);
+
+            // We know that no trap could have been processed and re-added because we are holding the lock.
+            if (vmIsInactive(m_vm))
+                return workDone(locker);
+        }
 
         auto optionalOwnerThread = vm.ownerThread();
         if (optionalOwnerThread) {
@@ -301,21 +328,26 @@ private:
             });
         }
 
-        {
-            if (vm.traps().hasTrapBit(NeedTermination))
-                vm.syncWaiter()->condition().notifyOne();
-        }
+        if (vm.traps().hasTrapBit(NeedTermination))
+            vm.syncWaiter()->condition().notifyOne();
 
         {
-            Locker locker { *traps().m_lock };
+            Locker locker { *m_lock };
+            ASSERT(m_scheduled);
             if (traps().m_isShuttingDown)
-                return WorkResult::Stop;
-            traps().m_condition->waitFor(*traps().m_lock, 1_ms);
+                return workDone(locker);
+            ASSERT(m_scheduled);
         }
-        return WorkResult::Continue;
+
+        queue().dispatchAfter(1_ms, [protectedThis = Ref { *this }] {
+            protectedThis->work();
+        });
     }
 
     VM& m_vm;
+    Box<Lock> m_lock;
+    Box<Condition> m_condition;
+    bool m_scheduled { false };
 };
 
 #endif // ENABLE(SIGNAL_BASED_VM_TRAPS)
@@ -337,10 +369,9 @@ void VMTraps::willDestroyVM()
     if (m_signalSender) {
         {
             Locker locker { *m_lock };
-            if (!m_signalSender->tryStop(locker))
-                m_condition->notifyAll(locker);
+            while (!m_signalSender->isStopped(locker))
+                m_condition->wait(*m_lock);
         }
-        m_signalSender->join();
         m_signalSender = nullptr;
     }
 #endif
@@ -365,7 +396,7 @@ void VMTraps::fireTrap(VMTraps::Event event)
         Locker locker { *m_lock };
         if (!m_signalSender)
             m_signalSender = adoptRef(new SignalSender(locker, vm()));
-        m_condition->notifyAll(locker);
+        m_signalSender->notify(locker);
     }
 #endif
 
@@ -471,7 +502,7 @@ void VMTraps::undoDeferTerminationSlow(DeferAction deferAction)
 
 VMTraps::VMTraps()
     : m_lock(Box<Lock>::create())
-    , m_condition(AutomaticThreadCondition::create())
+    , m_condition(Box<Condition>::create())
 {
 }
 

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -271,7 +271,7 @@ private:
     static constexpr BitField NeedExceptionHandlingMask = ~(1 << NeedExceptionHandling);
 
     Box<Lock> m_lock;
-    Ref<AutomaticThreadCondition> m_condition;
+    Box<Condition> m_condition;
     Atomic<BitField> m_trapBits { 0 };
     bool m_needToInvalidatedCodeBlocks { false };
     bool m_isShuttingDown { false };


### PR DESCRIPTION
#### 737376a68f94d330ed35bfa05ceaa3dd901a078f
<pre>
[JSC] Use singleton WorkQueue for SignalSender
<a href="https://bugs.webkit.org/show_bug.cgi?id=286529">https://bugs.webkit.org/show_bug.cgi?id=286529</a>
<a href="https://rdar.apple.com/143619084">rdar://143619084</a>

Reviewed by Mark Lam.

Let&apos;s not launch a new thread for each VM&apos;s teardown (for workers).
Use singleton WorkQueue and emit stop signals from that.

* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::willDestroyVM):
(JSC::VMTraps::fireTrap):
(JSC::VMTraps::VMTraps):
* Source/JavaScriptCore/runtime/VMTraps.h:

Canonical link: <a href="https://commits.webkit.org/289416@main">https://commits.webkit.org/289416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b98459dd6449e0e6d8e0db441d0d1de3dd8a3dbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86825 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91673 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37557 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67115 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24889 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47434 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32946 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36675 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79608 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93566 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85598 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75917 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75113 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19434 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17846 "Build is in progress. Recent messages:OS: Ventura (13.6.9), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 16 flakes 1 failures; Uploaded test results; 10 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6785 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13504 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19261 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108090 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13739 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26008 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->