### PR TITLE
Fix SVGElement.ownerSVGElement on outermost <svg> in foreignObject

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/SVGElement.ownerSVGElement-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/SVGElement.ownerSVGElement-01-expected.txt
@@ -4,16 +4,14 @@ PASS non-<svg> child of outer <svg> element (in document)
 PASS non-<svg> descendant of outer <svg> element (in document)
 PASS inner <svg> descendant of outer <svg> element (in document)
 PASS non-<svg> descendant of inner <svg> element (in document)
-FAIL outer <svg> in foreignObject (in document) assert_equals: expected null but got Element node <svg id="top-svg">
-      <rect width="10" height="10"></r...
+PASS outer <svg> in foreignObject (in document)
 PASS inner <svg> child of outer <svg> in foreignObject (in document)
 PASS outer <svg> element (not in document)
 PASS non-<svg> child of outer <svg> element (not in document)
 PASS non-<svg> descendant of outer <svg> element (not in document)
 PASS inner <svg> descendant of outer <svg> element (not in document)
 PASS non-<svg> descendant of inner <svg> element (not in document)
-FAIL outer <svg> in foreignObject (not in document) assert_equals: expected null but got Element node <svg id="top-svg">
-      <rect width="10" height="10"></r...
+PASS outer <svg> in foreignObject (not in document)
 PASS inner <svg> child of outer <svg> in foreignObject (not in document)
 PASS non-svg element with no parent
 PASS svg element with no parent

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2008 Rob Buis <buis@kde.org>
- * Copyright (C) 2008-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Google Inc. All rights reserved.
  * Copyright (C) 2008 Alp Toker <alp@atoker.com>
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
  * Copyright (C) 2013 Samsung Electronics. All rights reserved.
@@ -207,6 +208,9 @@ void SVGElement::removedFromAncestor(RemovalType removalType, ContainerNode& old
 
 SVGSVGElement* SVGElement::ownerSVGElement() const
 {
+    if (isOutermostSVGSVGElement())
+        return nullptr;
+
     SUPPRESS_UNCOUNTED_LOCAL auto* node = parentNode();
     while (node) {
         if (auto* svg = dynamicDowncast<SVGSVGElement>(*node))


### PR DESCRIPTION
#### 6ce660df8e73f74edf12a52a65d8325dca9f96bd
<pre>
Fix SVGElement.ownerSVGElement on outermost &lt;svg&gt; in foreignObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=286531">https://bugs.webkit.org/show_bug.cgi?id=286531</a>
<a href="https://rdar.apple.com/143625675">rdar://143625675</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/232437a403a0dfa9a0ef8006bf77f4549ab84d78">https://source.chromium.org/chromium/chromium/src/+/232437a403a0dfa9a0ef8006bf77f4549ab84d78</a>

If an &lt;svg&gt; element was a child of a &lt;foreignObject&gt;, it would
incorrectly continue past it while searching for the owner &lt;svg&gt;
element. Check if the element is an outermost root first, and return
nullptr if it is per [1].

[1] <a href="https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement">https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/types/SVGElement.ownerSVGElement-01-expected.txt:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::ownerSVGElement const):

Canonical link: <a href="https://commits.webkit.org/289388@main">https://commits.webkit.org/289388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c0c7dcb00e457f17fec9ae5ef1e98e60d089936

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67095 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24866 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5001 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32922 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36648 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93539 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75897 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75092 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18466 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6742 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13974 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19234 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->