### PR TITLE
Remove WTF::forEach from the codebase.

### DIFF
--- a/Source/WTF/wtf/Algorithms.h
+++ b/Source/WTF/wtf/Algorithms.h
@@ -32,13 +32,6 @@
 
 namespace WTF {
 
-template<typename ContainerType, typename ForEachFunction>
-void forEach(ContainerType&& container, NOESCAPE ForEachFunction&& forEachFunction)
-{
-    for (auto& value : container)
-        forEachFunction(value);
-}
-
 template<typename ContainerType, typename AnyOfFunction>
 bool anyOf(ContainerType&& container, NOESCAPE AnyOfFunction&& anyOfFunction)
 {

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -607,17 +607,15 @@ GUniquePtr<GstStructure> RealtimeOutgoingMediaSourceGStreamer::stats()
 void RealtimeOutgoingMediaSourceGStreamer::startUpdatingStats()
 {
     GST_DEBUG_OBJECT(m_bin.get(), "Starting buffer monitoring for stats gathering");
-    forEach(m_packetizers, [](auto& packetizer) {
+    for (auto& packetizer : m_packetizers)
         packetizer->startUpdatingStats();
-    });
 }
 
 void RealtimeOutgoingMediaSourceGStreamer::stopUpdatingStats()
 {
     GST_DEBUG_OBJECT(m_bin.get(), "Stopping buffer monitoring for stats gathering");
-    forEach(m_packetizers, [](auto& packetizer) {
+    for (auto& packetizer : m_packetizers)
         packetizer->stopUpdatingStats();
-    });
 }
 
 void RealtimeOutgoingMediaSourceGStreamer::teardown()

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
@@ -342,7 +342,8 @@ struct _WebKitFeatureList {
 
     ~_WebKitFeatureList()
     {
-        forEach(items, webkit_feature_unref);
+        for (auto* item : items)
+            webkit_feature_unref(item);
     }
 
     Vector<WebKitFeature*> items;

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -3019,10 +3019,10 @@ void WebProcessProxy::registerServiceWorkerClients(CompletionHandler<void()>&& c
 HashMap<WebCore::PageIdentifier, CoreIPCAuditToken> WebProcessProxy::presentingApplicationAuditTokens() const
 {
     HashMap<WebCore::PageIdentifier, CoreIPCAuditToken> presentingApplicationAuditTokens;
-    WTF::forEach(pages(), [&] (auto& page) {
+    for (auto& page : pages()) {
         if (page->presentingApplicationAuditToken())
             presentingApplicationAuditTokens.add(page->webPageIDInMainFrameProcess(), page->presentingApplicationAuditToken().value());
-    });
+    }
     return presentingApplicationAuditTokens;
 }
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -247,10 +247,8 @@ void PDFDataDetectorOverlayController::updateDataDetectorHighlightsIfNeeded(PDFD
 
 void PDFDataDetectorOverlayController::updatePlatformHighlightData(PDFDocumentLayout::PageIndex pageIndex)
 {
-    WTF::forEach(m_pdfDataDetectorItemsWithHighlightsMap.get(pageIndex), [&](auto& dataDetectorItemWithHighlight) {
-        auto& [dataDetectorItem, coreHighlight] = dataDetectorItemWithHighlight;
+    for (auto& [dataDetectorItem, coreHighlight] : m_pdfDataDetectorItemsWithHighlightsMap.get(pageIndex))
         coreHighlight->setHighlight(createPlatformDataDetectorHighlight(Ref { dataDetectorItem }).get());
-    });
 }
 
 void PDFDataDetectorOverlayController::hideActiveHighlightOverlay()
@@ -289,9 +287,8 @@ void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(std::o
         return m_pdfDataDetectorItemsWithHighlightsMap.keys();
     }();
 
-    WTF::forEach(pageIndices, [this](auto pageIndex) {
+    for (auto pageIndex : pageIndices)
         updatePlatformHighlightData(pageIndex);
-    });
 }
 
 #pragma mark - PageOverlayClient


### PR DESCRIPTION
#### b80a2ae51aaf378d3d1de94c0a857f48228ee7fb
<pre>
Remove WTF::forEach from the codebase.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286533">https://bugs.webkit.org/show_bug.cgi?id=286533</a>

Reviewed by Sam Weinig.

This API is not necessary with the newer version of STL.

* Source/WTF/wtf/Algorithms.h:
(WTF::forEach): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::startUpdatingStats):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stopUpdatingStats):
* Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp:
(_WebKitFeatureList::~_WebKitFeatureList):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::presentingApplicationAuditTokens const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::updatePlatformHighlightData):
(WebKit::PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects):

Canonical link: <a href="https://commits.webkit.org/289448@main">https://commits.webkit.org/289448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb6363100372aa7dfab1206620a3e68e60dd4874

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67200 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36770 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79703 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93661 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85693 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75997 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19515 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17935 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6921 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19361 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108186 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13834 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26037 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15619 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->