### PR TITLE
Use smart pointers to store reference to CanvasBase in CanvasRenderingContext

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -42,7 +42,6 @@ editing/cocoa/HTMLConverter.mm
 html/FormListedElement.cpp
 html/LinkIconCollector.h
 html/MediaElementSession.h
-html/canvas/CanvasRenderingContext.h
 html/parser/HTMLTreeBuilder.h
 html/track/TrackBase.h
 html/track/WebVTTParser.h

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -31,6 +31,7 @@
 #include "PixelBuffer.h"
 #include "TaskSource.h"
 #include <atomic>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
@@ -72,14 +73,9 @@ public:
     virtual void canvasDisplayBufferPrepared(CanvasBase&) = 0;
 };
 
-class CanvasBase {
+class CanvasBase : public AbstractRefCountedAndCanMakeWeakPtr<CanvasBase> {
 public:
     virtual ~CanvasBase();
-
-    virtual void refCanvasBase() const = 0;
-    virtual void derefCanvasBase() const = 0;
-    void ref() const { refCanvasBase(); }
-    void deref() const { derefCanvasBase(); }
 
     virtual bool isHTMLCanvasElement() const { return false; }
     virtual bool isOffscreenCanvas() const { return false; }

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -71,14 +71,12 @@ public:
 
     const CSSParserContext& cssParserContext() const final;
 
-    using RefCounted::ref;
-    using RefCounted::deref;
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     CustomPaintCanvas(ScriptExecutionContext&, unsigned width, unsigned height);
 
-    void refCanvasBase() const final { ref(); }
-    void derefCanvasBase() const final { deref(); }
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
     std::unique_ptr<PaintRenderingContext2D> m_context;

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -65,6 +65,8 @@ class HTMLCanvasElement final : public HTMLElement, public CanvasBase, public Ac
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLCanvasElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLCanvasElement);
 public:
+    USING_CAN_MAKE_WEAKPTR(HTMLElement);
+
     static Ref<HTMLCanvasElement> create(Document&);
     static Ref<HTMLCanvasElement> create(const QualifiedName&, Document&);
     virtual ~HTMLCanvasElement();
@@ -175,9 +177,6 @@ private:
     void setSurfaceSize(const IntSize&);
 
     bool usesContentsAsLayerContents() const;
-
-    void refCanvasBase() const final { HTMLElement::ref(); }
-    void derefCanvasBase() const final { HTMLElement::deref(); }
 
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return HTMLElement::scriptExecutionContext(); }
 

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -162,9 +162,6 @@ private:
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }
 
-    void refCanvasBase() const final { RefCounted::ref(); }
-    void derefCanvasBase() const final { RefCounted::deref(); }
-
     void setSize(const IntSize&) final;
 
     void createImageBuffer() const final;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -84,12 +84,12 @@ CanvasRenderingContext::~CanvasRenderingContext()
 
 void CanvasRenderingContext::ref() const
 {
-    m_canvas.refCanvasBase();
+    m_canvas->ref();
 }
 
 void CanvasRenderingContext::deref() const
 {
-    m_canvas.derefCanvasBase();
+    m_canvas->deref();
 }
 
 RefPtr<ImageBuffer> CanvasRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
@@ -171,9 +171,9 @@ bool CanvasRenderingContext::taintsOrigin(const CachedImage* cachedImage)
     if (cachedImage->isCORSCrossOrigin())
         return true;
 
-    ASSERT(m_canvas.securityOrigin());
+    ASSERT(m_canvas->securityOrigin());
     ASSERT(cachedImage->origin());
-    ASSERT(m_canvas.securityOrigin()->toString() == cachedImage->origin()->toString());
+    ASSERT(m_canvas->securityOrigin()->toString() == cachedImage->origin()->toString());
     return false;
 }
 
@@ -190,7 +190,7 @@ bool CanvasRenderingContext::taintsOrigin(const SVGImageElement* element)
 bool CanvasRenderingContext::taintsOrigin(const HTMLVideoElement* video)
 {
 #if ENABLE(VIDEO)
-    return video && video->taintsOrigin(*m_canvas.securityOrigin());
+    return video && video->taintsOrigin(*m_canvas->securityOrigin());
 #else
     UNUSED_PARAM(video);
     return false;
@@ -204,18 +204,18 @@ bool CanvasRenderingContext::taintsOrigin(const ImageBitmap* imageBitmap)
 
 bool CanvasRenderingContext::taintsOrigin(const URL& url)
 {
-    return !url.protocolIsData() && !m_canvas.securityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton());
+    return !url.protocolIsData() && !m_canvas->securityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton());
 }
 
 void CanvasRenderingContext::checkOrigin(const URL& url)
 {
-    if (m_canvas.originClean() && taintsOrigin(url))
-        m_canvas.setOriginTainted();
+    if (m_canvas->originClean() && taintsOrigin(url))
+        m_canvas->setOriginTainted();
 }
 
 void CanvasRenderingContext::checkOrigin(const CSSStyleImageValue&)
 {
-    m_canvas.setOriginTainted();
+    m_canvas->setOriginTainted();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -145,8 +145,8 @@ protected:
 
     template<class T> void checkOrigin(const T* arg)
     {
-        if (m_canvas.originClean() && taintsOrigin(arg))
-            m_canvas.setOriginTainted();
+        if (m_canvas->originClean() && taintsOrigin(arg))
+            m_canvas->setOriginTainted();
     }
     void checkOrigin(const URL&);
     void checkOrigin(const CSSStyleImageValue&);
@@ -157,7 +157,7 @@ protected:
 private:
     static Lock s_instancesLock;
 
-    CanvasBase& m_canvas;
+    WeakRef<CanvasBase> m_canvas;
     const Type m_type;
 };
 


### PR DESCRIPTION
#### ddfb6b7d179b45962c4a7f15d264417f9601a30f
<pre>
Use smart pointers to store reference to CanvasBase in CanvasRenderingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=286535">https://bugs.webkit.org/show_bug.cgi?id=286535</a>
<a href="https://rdar.apple.com/problem/143630378">rdar://problem/143630378</a>

Reviewed by Chris Dumez and Darin Adler.

Fix a clang static analyzer warning caused by using a raw reference to
store the owning CanvasBase in CanvasRenderingContext. Since CanvasBase
owns CanvasRenderingContext I resorted to using a `WeakRef`.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::ref const):
(WebCore::CanvasRenderingContext::deref const):
(WebCore::CanvasRenderingContext::taintsOrigin):
(WebCore::CanvasRenderingContext::checkOrigin):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::checkOrigin):

Canonical link: <a href="https://commits.webkit.org/289414@main">https://commits.webkit.org/289414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7b5db42b755e9fb445fd79c207d4a5891b884bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67157 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24932 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36727 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93618 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75960 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75157 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18477 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17890 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6864 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14053 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19315 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->