### PR TITLE
REGRESSION (iPadOS 18): RemoteScrollingCoordinatorProxyIOS Invalid message dispatched virtual void WebKit::RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations.

### DIFF
--- a/LayoutTests/compositing/scrolling/scroller-inside-hidden-layer-expected.html
+++ b/LayoutTests/compositing/scrolling/scroller-inside-hidden-layer-expected.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html>
+<style>
+  ::-webkit-scrollbar {
+    width: 0px;
+  }
+  .outer {
+    position: relative;
+  }
+  .middle {
+    overflow-y: auto;
+    height: 100px;
+  }
+  .inner {
+    position: relative;
+    height: 200px;
+    background: blue;
+  }
+
+</style>
+<body>
+<div class="outer">
+  <div class="middle">
+    <div class="inner"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/compositing/scrolling/scroller-inside-hidden-layer.html
+++ b/LayoutTests/compositing/scrolling/scroller-inside-hidden-layer.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<html>
+<style>
+  ::-webkit-scrollbar {
+    width: 0px;
+  }
+  .outer {
+    position: relative;
+    visibility: hidden;
+  }
+  .middle {
+    overflow-y: auto;
+    visibility: visible;
+    height: 100px;
+  }
+  .inner {
+    position: relative;
+    height: 200px;
+    background: blue;
+  }
+
+</style>
+<body>
+<div class="outer">
+  <div class="middle">
+    <div class="inner"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
+++ b/LayoutTests/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
@@ -31,6 +31,8 @@ layer at (18,10) size 764x144
   RenderBlock (relative positioned) {DIV} at (10,0) size 764x144
 layer at (38,30) size 100x100
   RenderImage {IMG} at (20,20) size 100x100
+layer at (18,164) size 764x144
+  RenderBlock (relative positioned) {DIV} at (10,154) size 764x144
 layer at (38,184) size 100x100
   RenderImage {IMG} at (20,20) size 100x100
 

--- a/LayoutTests/platform/glib/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
+++ b/LayoutTests/platform/glib/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
@@ -31,6 +31,8 @@ layer at (18,10) size 764x144
   RenderBlock (relative positioned) {DIV} at (10,0) size 764x144
 layer at (38,30) size 100x100
   RenderImage {IMG} at (20,20) size 100x100
+layer at (18,164) size 764x144
+  RenderBlock (relative positioned) {DIV} at (10,154) size 764x144
 layer at (38,184) size 100x100
   RenderImage {IMG} at (20,20) size 100x100
 

--- a/LayoutTests/platform/glib/fast/layers/layer-visibility-expected.txt
+++ b/LayoutTests/platform/glib/fast/layers/layer-visibility-expected.txt
@@ -63,6 +63,8 @@ layer at (412,10) size 130x36
       text run at (0,0) width 107: "4 green box with"
       text run at (0,18) width 57: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (412,46) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
 layer at (414,48) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x17
@@ -85,6 +87,8 @@ layer at (10,114) size 130x36
       text run at (0,0) width 107: "6 green box with"
       text run at (0,18) width 57: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (10,150) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
 layer at (12,152) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
     RenderBlock {DIV} at (2,2) size 122x22 [border: (2px solid #008000)]
@@ -96,6 +100,10 @@ layer at (144,114) size 130x36
       text run at (0,0) width 107: "7 green box with"
       text run at (0,18) width 57: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (144,150) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
+layer at (146,152) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (148,154) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x17
@@ -108,6 +116,8 @@ layer at (278,114) size 130x36
     RenderText {#text} at (0,0) size 0x0
 layer at (278,150) size 130x34
   RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #008000)]
+layer at (280,152) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (282,154) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x17
@@ -118,6 +128,10 @@ layer at (412,114) size 130x36
       text run at (0,0) width 107: "9 green box with"
       text run at (0,18) width 57: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (412,150) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
+layer at (414,152) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (416,154) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x17
@@ -127,6 +141,8 @@ layer at (546,114) size 130x18
     RenderText {#text} at (0,0) size 87x17
       text run at (0,0) width 87: "10 green box:"
     RenderText {#text} at (0,0) size 0x0
+layer at (546,132) size 130x34
+  RenderBlock (positioned) {DIV} at (0,18) size 130x34 [border: (2px solid #FF0000)]
 layer at (548,134) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
 layer at (10,218) size 130x36
@@ -181,6 +197,8 @@ layer at (546,218) size 130x36
       text run at (0,0) width 115: "15 green box with"
       text run at (0,18) width 57: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (546,254) size 130x30
+  RenderBlock (positioned) {DIV} at (0,36) size 130x30
 layer at (546,254) size 130x30
   RenderBlock (positioned) {DIV} at (0,0) size 130x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x17
@@ -282,6 +300,8 @@ layer at (144,426) size 130x36
       text run at (0,0) width 115: "22 green box with"
       text run at (0,18) width 57: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (144,462) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
 layer at (146,464) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x17
@@ -294,6 +314,8 @@ layer at (278,426) size 130x36
     RenderText {#text} at (0,0) size 0x0
 layer at (278,462) size 130x34
   RenderBlock (positioned) zI: 1 {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
+layer at (280,464) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (282,466) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x17

--- a/LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
+++ b/LayoutTests/platform/ios/compositing/visibility/visibility-image-layers-dynamic-composited-expected.txt
@@ -31,6 +31,8 @@ layer at (18,10) size 764x145
   RenderBlock (relative positioned) {DIV} at (10,0) size 764x145
 layer at (38,30) size 100x100
   RenderImage {IMG} at (20,20) size 100x100
+layer at (18,165) size 764x145
+  RenderBlock (relative positioned) {DIV} at (10,155) size 764x145
 layer at (38,185) size 100x100
   RenderImage {IMG} at (20,20) size 100x100
 

--- a/LayoutTests/platform/ios/fast/layers/layer-visibility-expected.txt
+++ b/LayoutTests/platform/ios/fast/layers/layer-visibility-expected.txt
@@ -63,6 +63,8 @@ layer at (412,10) size 130x40
       text run at (0,0) width 108: "4 green box with"
       text run at (0,20) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (412,50) size 130x34
+  RenderBlock (positioned) {DIV} at (0,40) size 130x34 [border: (2px solid #FF0000)]
 layer at (414,52) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x19
@@ -85,6 +87,8 @@ layer at (10,114) size 130x40
       text run at (0,0) width 108: "6 green box with"
       text run at (0,20) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (10,154) size 130x34
+  RenderBlock (positioned) {DIV} at (0,40) size 130x34 [border: (2px solid #FF0000)]
 layer at (12,156) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
     RenderBlock {DIV} at (2,2) size 122x24 [border: (2px solid #008000)]
@@ -96,6 +100,10 @@ layer at (144,114) size 130x40
       text run at (0,0) width 108: "7 green box with"
       text run at (0,20) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (144,154) size 130x34
+  RenderBlock (positioned) {DIV} at (0,40) size 130x34 [border: (2px solid #FF0000)]
+layer at (146,156) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (148,158) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x19
@@ -108,6 +116,8 @@ layer at (278,114) size 130x40
     RenderText {#text} at (0,0) size 0x0
 layer at (278,154) size 130x34
   RenderBlock (positioned) {DIV} at (0,40) size 130x34 [border: (2px solid #008000)]
+layer at (280,156) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (282,158) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x19
@@ -118,6 +128,10 @@ layer at (412,114) size 130x40
       text run at (0,0) width 108: "9 green box with"
       text run at (0,20) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (412,154) size 130x34
+  RenderBlock (positioned) {DIV} at (0,40) size 130x34 [border: (2px solid #FF0000)]
+layer at (414,156) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (416,158) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x19
@@ -127,6 +141,8 @@ layer at (546,114) size 130x20
     RenderText {#text} at (0,0) size 88x19
       text run at (0,0) width 88: "10 green box:"
     RenderText {#text} at (0,0) size 0x0
+layer at (546,134) size 130x34
+  RenderBlock (positioned) {DIV} at (0,20) size 130x34 [border: (2px solid #FF0000)]
 layer at (548,136) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
 layer at (10,218) size 130x40
@@ -181,6 +197,8 @@ layer at (546,218) size 130x40
       text run at (0,0) width 116: "15 green box with"
       text run at (0,20) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (546,258) size 130x30
+  RenderBlock (positioned) {DIV} at (0,40) size 130x30
 layer at (546,258) size 130x30
   RenderBlock (positioned) {DIV} at (0,0) size 130x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x19
@@ -282,6 +300,8 @@ layer at (144,426) size 130x40
       text run at (0,0) width 116: "22 green box with"
       text run at (0,20) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (144,466) size 130x34
+  RenderBlock (positioned) {DIV} at (0,40) size 130x34 [border: (2px solid #FF0000)]
 layer at (146,468) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x19
@@ -294,6 +314,8 @@ layer at (278,426) size 130x40
     RenderText {#text} at (0,0) size 0x0
 layer at (278,466) size 130x34
   RenderBlock (positioned) zI: 1 {DIV} at (0,40) size 130x34 [border: (2px solid #FF0000)]
+layer at (280,468) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (282,470) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x19

--- a/LayoutTests/platform/mac/fast/layers/layer-visibility-expected.txt
+++ b/LayoutTests/platform/mac/fast/layers/layer-visibility-expected.txt
@@ -63,6 +63,8 @@ layer at (412,10) size 130x36
       text run at (0,0) width 108: "4 green box with"
       text run at (0,18) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (412,46) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
 layer at (414,48) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x18
@@ -85,6 +87,8 @@ layer at (10,114) size 130x36
       text run at (0,0) width 108: "6 green box with"
       text run at (0,18) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (10,150) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
 layer at (12,152) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
     RenderBlock {DIV} at (2,2) size 122x22 [border: (2px solid #008000)]
@@ -96,6 +100,10 @@ layer at (144,114) size 130x36
       text run at (0,0) width 108: "7 green box with"
       text run at (0,18) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (144,150) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
+layer at (146,152) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (148,154) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x18
@@ -108,6 +116,8 @@ layer at (278,114) size 130x36
     RenderText {#text} at (0,0) size 0x0
 layer at (278,150) size 130x34
   RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #008000)]
+layer at (280,152) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (282,154) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x18
@@ -118,6 +128,10 @@ layer at (412,114) size 130x36
       text run at (0,0) width 108: "9 green box with"
       text run at (0,18) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (412,150) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
+layer at (414,152) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (416,154) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x18
@@ -127,6 +141,8 @@ layer at (546,114) size 130x18
     RenderText {#text} at (0,0) size 88x18
       text run at (0,0) width 88: "10 green box:"
     RenderText {#text} at (0,0) size 0x0
+layer at (546,132) size 130x34
+  RenderBlock (positioned) {DIV} at (0,18) size 130x34 [border: (2px solid #FF0000)]
 layer at (548,134) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
 layer at (10,218) size 130x36
@@ -181,6 +197,8 @@ layer at (546,218) size 130x36
       text run at (0,0) width 116: "15 green box with"
       text run at (0,18) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (546,254) size 130x30
+  RenderBlock (positioned) {DIV} at (0,36) size 130x30
 layer at (546,254) size 130x30
   RenderBlock (positioned) {DIV} at (0,0) size 130x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x18
@@ -282,6 +300,8 @@ layer at (144,426) size 130x36
       text run at (0,0) width 116: "22 green box with"
       text run at (0,18) width 58: "word ok:"
     RenderText {#text} at (0,0) size 0x0
+layer at (144,462) size 130x34
+  RenderBlock (positioned) {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
 layer at (146,464) size 126x30
   RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x18
@@ -294,6 +314,8 @@ layer at (278,426) size 130x36
     RenderText {#text} at (0,0) size 0x0
 layer at (278,462) size 130x34
   RenderBlock (positioned) zI: 1 {DIV} at (0,36) size 130x34 [border: (2px solid #FF0000)]
+layer at (280,464) size 126x30
+  RenderBlock (positioned) {DIV} at (2,2) size 126x30 [border: (2px solid #FF0000)]
 layer at (282,466) size 122x26
   RenderBlock (positioned) {DIV} at (2,2) size 122x26 [border: (2px solid #008000)]
     RenderText {#text} at (2,2) size 16x18

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -874,9 +874,9 @@ void RenderLayer::collectLayers(std::unique_ptr<Vector<RenderLayer*>>& positiveZ
         return;
 
     bool isStacking = isStackingContext();
-    // Overflow layers are just painted by their enclosing layers, so they don't get put in zorder lists.
-    bool layerOrDescendantsAreVisible = (m_hasVisibleContent || m_alwaysIncludedInZOrderLists) || ((m_hasVisibleDescendant || m_hasAlwaysIncludedInZOrderListsDescendants) && isStacking);
+    bool layerOrDescendantsAreVisible = m_hasVisibleContent || m_alwaysIncludedInZOrderLists || m_hasVisibleDescendant || m_hasAlwaysIncludedInZOrderListsDescendants;
     layerOrDescendantsAreVisible |= page().hasEverSetVisibilityAdjustment();
+    // Normal flow layers are just painted by their enclosing layers, so they don't get put in zorder lists.
     if (!isNormalFlowOnly()) {
         if (layerOrDescendantsAreVisible) {
             auto& layerList = (zIndex() >= 0) ? positiveZOrderList : negativeZOrderList;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1175,6 +1175,8 @@ void RenderLayerScrollableArea::computeHasCompositedScrollableOverflow(LayoutUpT
     if (hasCompositedScrollableOverflow == m_hasCompositedScrollableOverflow)
         return;
 
+    m_layer.setSelfAndDescendantsNeedPositionUpdate();
+
     // Whether this layer does composited scrolling affects the configuration of descendant sticky layers. We have to
     // dirty from the enclosing stacking context because overflow scroll doesn't create stacking context so those
     // containing block descendants may not be paint-order descendants, and the compositing dirty bits on RenderLayer act in paint order.


### PR DESCRIPTION
#### 79c73a5e0996c9147a5389341d51641e05e1b455
<pre>
REGRESSION (iPadOS 18): RemoteScrollingCoordinatorProxyIOS Invalid message dispatched virtual void WebKit::RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286356">https://bugs.webkit.org/show_bug.cgi?id=286356</a>
&lt;<a href="https://rdar.apple.com/problem/143435840">rdar://problem/143435840</a>&gt;

Reviewed by Simon Fraser.

layerOrDescendantsAreVisible should not depend on being a stacking context,
positioned layers can have normal-flow children layers that are visible and
require the hidden container to be included in the tree.

* LayoutTests/compositing/scrolling/scroller-inside-hidden-layer-expected.html: Added.
* LayoutTests/compositing/scrolling/scroller-inside-hidden-layer.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::collectLayers):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::computeHasCompositedScrollableOverflow):

Canonical link: <a href="https://commits.webkit.org/289527@main">https://commits.webkit.org/289527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6929336c294cdca51e686c6a05d74ef552fddd80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14808 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25154 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78951 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47738 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37085 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14391 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10479 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76221 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75425 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18554 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7320 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14410 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19703 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14155 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->