### PR TITLE
Add safe wrapper for xpc_dictionary_get_string()

### DIFF
--- a/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -62,12 +62,10 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
             if (type == XPC_TYPE_ERROR || !weakThis)
                 return;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            if (type != XPC_TYPE_DICTIONARY || strcmp(xpc_dictionary_get_string(event.get(), ClientCertificateAuthentication::XPCMessageNameKey), ClientCertificateAuthentication::XPCMessageNameValue)) {
+            if (type != XPC_TYPE_DICTIONARY || xpc_dictionary_get_wtfstring(event.get(), ClientCertificateAuthentication::XPCMessageNameKey) != ClientCertificateAuthentication::XPCMessageNameValue) {
                 ASSERT_NOT_REACHED();
                 return;
             }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
             auto challengeID = xpc_dictionary_get_uint64(event.get(), ClientCertificateAuthentication::XPCChallengeIDKey);
             if (!challengeID)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -49,14 +49,14 @@ void Connection::connectionReceivedEvent(xpc_object_t request)
 {
     if (xpc_get_type(request) != XPC_TYPE_DICTIONARY)
         return;
-    const char* debugMessage = xpc_dictionary_get_string(request, protocolDebugMessageKey);
+    String debugMessage = xpc_dictionary_get_wtfstring(request, protocolDebugMessageKey);
     if (!debugMessage)
         return;
     auto messageLevel = static_cast<JSC::MessageLevel>(xpc_dictionary_get_uint64(request, protocolDebugMessageLevelKey));
     auto* networkSession = m_networkSession.get();
     if (!networkSession)
         return;
-    m_networkSession->networkProcess().broadcastConsoleMessage(m_networkSession->sessionID(), MessageSource::PrivateClickMeasurement, messageLevel, String::fromUTF8(debugMessage));
+    m_networkSession->networkProcess().broadcastConsoleMessage(m_networkSession->sessionID(), MessageSource::PrivateClickMeasurement, messageLevel, debugMessage);
 }
 
 OSObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -132,8 +132,8 @@ void LaunchServicesDatabaseObserver::handleEvent(xpc_connection_t connection, xp
         return;
     }
     if (xpc_get_type(event) == XPC_TYPE_DICTIONARY) {
-        auto* messageName = xpc_dictionary_get_string(event, xpcMessageNameKey);
-        if (LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName != messageName)
+        String messageName = xpc_dictionary_get_wtfstring(event, xpcMessageNameKey);
+        if (messageName != LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName)
             return;
         startObserving(connection);
     }

--- a/Source/WebKit/Platform/cocoa/MediaCapability.mm
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.mm
@@ -74,7 +74,7 @@ String MediaCapability::environmentIdentifier() const
     xpc_object_t xpcObject = [m_mediaEnvironment createXPCRepresentation];
     if (!xpcObject)
         return emptyString();
-    return String::fromUTF8(xpc_dictionary_get_string(xpcObject, "identifier"));
+    return xpc_dictionary_get_wtfstring(xpcObject, "identifier"_s);
 #endif
 
     return { };

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -65,8 +65,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 void handleXPCExitMessage(xpc_object_t event)
 {
     if (xpc_get_type(event) == XPC_TYPE_DICTIONARY) {
-        auto* messageName = xpc_dictionary_get_string(event, messageNameKey);
-        if (exitProcessMessage == messageName) {
+        String messageName = xpc_dictionary_get_wtfstring(event, messageNameKey);
+        if (messageName == exitProcessMessage) {
             RELEASE_LOG_ERROR(IPC, "Received exit message, exiting now.");
             terminateProcess(EXIT_FAILURE);
         }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.h
@@ -29,6 +29,6 @@
 
 namespace WebKit {
 
-void handleXPCEndpointMessage(xpc_object_t message, const char* messageName);
+void handleXPCEndpointMessage(xpc_object_t message, const String& messageName);
 
 }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
@@ -65,30 +65,26 @@ static void handleVideoReceiverEndpointMessage(xpc_object_t message)
 }
 #endif
 
-void handleXPCEndpointMessage(xpc_object_t message, const char* messageName)
+void handleXPCEndpointMessage(xpc_object_t message, const String& messageName)
 {
     ASSERT_UNUSED(messageName, messageName);
     RELEASE_ASSERT(xpc_get_type(message) == XPC_TYPE_DICTIONARY);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if HAVE(LSDATABASECONTEXT)
-    if (!strcmp(messageName, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName)) {
+    if (messageName == LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName) {
         handleLaunchServiceDatabaseMessage(message);
         return;
     }
 #endif
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-    if (!strcmp(messageName, VideoReceiverEndpointMessage::messageName().characters())) {
+    if (messageName == VideoReceiverEndpointMessage::messageName()) {
         RunLoop::main().dispatch([message = OSObjectPtr(message)] {
             handleVideoReceiverEndpointMessage(message.get());
         });
         return;
     }
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 }
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -79,19 +79,19 @@ bool XPCServiceInitializerDelegate::getConnectionIdentifier(IPC::Connection::Ide
 
 bool XPCServiceInitializerDelegate::getClientIdentifier(String& clientIdentifier)
 {
-    clientIdentifier = String::fromUTF8(xpc_dictionary_get_string(m_initializerMessage, "client-identifier"));
+    clientIdentifier = xpc_dictionary_get_wtfstring(m_initializerMessage, "client-identifier"_s);
     return !clientIdentifier.isEmpty();
 }
 
 bool XPCServiceInitializerDelegate::getClientBundleIdentifier(String& clientBundleIdentifier)
 {
-    clientBundleIdentifier = String::fromLatin1(xpc_dictionary_get_string(m_initializerMessage, "client-bundle-identifier"));
+    clientBundleIdentifier = xpc_dictionary_get_wtfstring(m_initializerMessage, "client-bundle-identifier"_s);
     return !clientBundleIdentifier.isEmpty();
 }
 
 bool XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors(SDKAlignedBehaviors& behaviors)
 {
-    auto behaviorData = xpc_dictionary_get_data_span(m_initializerMessage, "client-sdk-aligned-behaviors");
+    auto behaviorData = xpc_dictionary_get_data_span(m_initializerMessage, "client-sdk-aligned-behaviors"_s);
     if (behaviorData.empty())
         return false;
     memcpySpan(behaviors.storageBytes(), behaviorData);
@@ -100,7 +100,7 @@ bool XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors(SDKAlignedBehav
 
 bool XPCServiceInitializerDelegate::getProcessIdentifier(std::optional<WebCore::ProcessIdentifier>& identifier)
 {
-    auto parsedIdentifier = parseInteger<uint64_t>(StringView::fromLatin1(xpc_dictionary_get_string(m_initializerMessage, "process-identifier")));
+    auto parsedIdentifier = parseInteger<uint64_t>(xpc_dictionary_get_wtfstring(m_initializerMessage, "process-identifier"_s));
     if (!parsedIdentifier)
         return false;
     if (!ObjectIdentifier<WebCore::ProcessIdentifierType>::isValidIdentifier(*parsedIdentifier))
@@ -112,7 +112,7 @@ bool XPCServiceInitializerDelegate::getProcessIdentifier(std::optional<WebCore::
 
 bool XPCServiceInitializerDelegate::getClientProcessName(String& clientProcessName)
 {
-    clientProcessName = String::fromUTF8(xpc_dictionary_get_string(m_initializerMessage, "ui-process-name"));
+    clientProcessName = xpc_dictionary_get_wtfstring(m_initializerMessage, "ui-process-name"_s);
     return !clientProcessName.isEmpty();
 }
 
@@ -120,32 +120,32 @@ bool XPCServiceInitializerDelegate::getExtraInitializationData(HashMap<String, S
 {
     xpc_object_t extraDataInitializationDataObject = xpc_dictionary_get_value(m_initializerMessage, "extra-initialization-data");
 
-    auto inspectorProcess = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "inspector-process"));
+    auto inspectorProcess = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "inspector-process"_s);
     if (!inspectorProcess.isEmpty())
         extraInitializationData.add("inspector-process"_s, inspectorProcess);
 
-    auto serviceWorkerProcess = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "service-worker-process"));
+    auto serviceWorkerProcess = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "service-worker-process"_s);
     if (!serviceWorkerProcess.isEmpty())
         extraInitializationData.add("service-worker-process"_s, WTFMove(serviceWorkerProcess));
-    auto registrableDomain = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "registrable-domain"));
+    auto registrableDomain = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "registrable-domain"_s);
     if (!registrableDomain.isEmpty())
         extraInitializationData.add("registrable-domain"_s, WTFMove(registrableDomain));
 
-    auto isPrewarmedProcess = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "is-prewarmed"));
+    auto isPrewarmedProcess = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "is-prewarmed"_s);
     if (!isPrewarmedProcess.isEmpty())
         extraInitializationData.add("is-prewarmed"_s, isPrewarmedProcess);
 
-    auto isLockdownModeEnabled = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "enable-lockdown-mode"));
+    auto isLockdownModeEnabled = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "enable-lockdown-mode"_s);
     if (!isLockdownModeEnabled.isEmpty())
         extraInitializationData.add("enable-lockdown-mode"_s, isLockdownModeEnabled);
 
     if (!isClientSandboxed()) {
-        auto userDirectorySuffix = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "user-directory-suffix"));
+        auto userDirectorySuffix = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "user-directory-suffix"_s);
         if (!userDirectorySuffix.isEmpty())
             extraInitializationData.add("user-directory-suffix"_s, userDirectorySuffix);
     }
 
-    auto alwaysRunsAtBackgroundPriority = String::fromLatin1(xpc_dictionary_get_string(extraDataInitializationDataObject, "always-runs-at-background-priority"));
+    auto alwaysRunsAtBackgroundPriority = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "always-runs-at-background-priority"_s);
     if (!alwaysRunsAtBackgroundPriority.isEmpty())
         extraInitializationData.add("always-runs-at-background-priority"_s, alwaysRunsAtBackgroundPriority);
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -449,7 +449,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 #endif
 
         if (event)
-            LOG_ERROR("Error while launching %s: %s", logName.data(), xpc_dictionary_get_string(event, XPC_ERROR_KEY_DESCRIPTION));
+            LOG_ERROR("Error while launching %s: %s", logName.data(), xpc_dictionary_get_wtfstring(event, xpcErrorDescriptionKey).utf8().data());
         else
             LOG_ERROR("Error while launching %s: No xpc_object_t event available.", logName.data());
 
@@ -508,9 +508,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
         // launching and we already took care of cleaning things up.
         if (isLaunching() && xpc_get_type(reply) != XPC_TYPE_ERROR) {
             ASSERT(xpc_get_type(reply) == XPC_TYPE_DICTIONARY);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            ASSERT(!strcmp(xpc_dictionary_get_string(reply, "message-name"), "process-finished-launching"));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            ASSERT(xpc_dictionary_get_wtfstring(reply, "message-name"_s) == "process-finished-launching"_s);
 
 #if ASSERT_ENABLED
             mach_port_urefs_t sendRightCount = 0;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -62,11 +62,11 @@ bool NetworkProcessProxy::XPCEventHandler::handleXPCEvent(xpc_object_t event) co
     if (!event || xpc_get_type(event) == XPC_TYPE_ERROR)
         return false;
 
-    auto* messageName = xpc_dictionary_get_string(event, XPCEndpoint::xpcMessageNameKey);
-    if (!messageName || !*messageName)
+    auto messageName = xpc_dictionary_get_wtfstring(event, XPCEndpoint::xpcMessageNameKey);
+    if (messageName.isEmpty())
         return false;
 
-    if (LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName == messageName) {
+    if (messageName == LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointMessageName) {
         networkProcess->m_endpointMessage = event;
         for (auto& processPool : WebProcessPool::allProcessPools()) {
             for (Ref process : processPool->processes())

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -48,8 +48,8 @@ LaunchServicesDatabaseManager& LaunchServicesDatabaseManager::singleton()
 
 void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
 {
-    auto* messageName = xpc_dictionary_get_string(message, XPCEndpoint::xpcMessageNameKey);
-    if (LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName == messageName) {
+    String messageName = xpc_dictionary_get_wtfstring(message, XPCEndpoint::xpcMessageNameKey);
+    if (messageName == LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName) {
 #if HAVE(LSDATABASECONTEXT)
         auto database = xpc_dictionary_get_value(message, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey);
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3547,6 +3547,14 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_strncmp:
         error(line_number, 'safercpp/strncmp', 4, "strncmp() is unsafe.")
 
+    uses_xpc_dictionary_get_data = search(r'xpc_dictionary_get_data\(', line)
+    if uses_xpc_dictionary_get_data:
+        error(line_number, 'safercpp/xpc_dictionary_get_data', 4, "Use xpc_dictionary_get_data_span() instead of xpc_dictionary_get_data().")
+
+    uses_xpc_dictionary_get_string = search(r'xpc_dictionary_get_string\(', line)
+    if uses_xpc_dictionary_get_string:
+        error(line_number, 'safercpp/xpc_dictionary_get_string', 4, "Use xpc_dictionary_get_wtfstring() instead of xpc_dictionary_get_string().")
+
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
     """Checks rules from the 'C++ style rules' section of cppguide.html.
@@ -4900,6 +4908,8 @@ class CppChecker(object):
         'safercpp/strchr',
         'safercpp/strstr',
         'safercpp/timer_exception',
+        'safercpp/xpc_dictionary_get_data',
+        'safercpp/xpc_dictionary_get_string',
         'security/assertion',
         'security/assertion_fallthrough',
         'security/javascriptcore_wtf_blockptr',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6328,6 +6328,16 @@ class WebKitStyleTest(CppStyleTestBase):
             'strncmp() is unsafe.  [safercpp/strncmp] [4]',
             'foo.cpp')
 
+        self.assert_lint(
+            'auto* result = xpc_dictionary_get_data(dictionary, "foo", &size);',
+            'Use xpc_dictionary_get_data_span() instead of xpc_dictionary_get_data().  [safercpp/xpc_dictionary_get_data] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'auto* result = xpc_dictionary_get_string(dictionary, "foo");',
+            'Use xpc_dictionary_get_wtfstring() instead of xpc_dictionary_get_string().  [safercpp/xpc_dictionary_get_string] [4]',
+            'foo.cpp')
+
     def test_ctype_fucntion(self):
         self.assert_lint(
             'int i = isascii(8);',

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -53,8 +53,8 @@ private:
     }
     void handleEvent(xpc_connection_t connection, xpc_object_t event) final
     {
-        auto* messageName = xpc_dictionary_get_string(event, XPCEndpoint::xpcMessageNameKey);
-        if (messageName && !strcmp(messageName, testMessageFromClient)) {
+        String messageName = xpc_dictionary_get_wtfstring(event, XPCEndpoint::xpcMessageNameKey);
+        if (messageName == testMessageFromClient) {
             endpointReceivedMessageFromClient = true;
 
             auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
@@ -68,8 +68,8 @@ class XPCEndpointClient final : public WebKit::XPCEndpointClient {
 private:
     void handleEvent(xpc_object_t event) final
     {
-        auto messageName = xpc_dictionary_get_string(event, XPCEndpoint::xpcMessageNameKey);
-        if (messageName && !strcmp(messageName, testMessageFromEndpoint))
+        String messageName = xpc_dictionary_get_wtfstring(event, XPCEndpoint::xpcMessageNameKey);
+        if (messageName == testMessageFromEndpoint)
             clientReceivedMessageFromEndpoint = true;
     }
     void didConnect() final


### PR DESCRIPTION
#### a69cdc2b13007677cbada1e6d74ca8009a474af1
<pre>
Add safe wrapper for xpc_dictionary_get_string()
<a href="https://bugs.webkit.org/show_bug.cgi?id=286547">https://bugs.webkit.org/show_bug.cgi?id=286547</a>

Reviewed by Per Arne Vollan.

* Source/WTF/wtf/spi/darwin/XPCSPI.h:
(xpc_dictionary_get_data_span):
(xpc_dictionary_get_wtfstring):
* Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm:
(WebKit::PCM::Connection::connectionReceivedEvent):
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::handleEvent):
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::MediaCapability::environmentIdentifier const):
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::handleXPCExitMessage):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm:
(WebKit::handleXPCEndpointMessage):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::XPCServiceInitializerDelegate::getClientIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientBundleIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors):
(WebKit::XPCServiceInitializerDelegate::getProcessIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientProcessName):
(WebKit::XPCServiceInitializerDelegate::getExtraInitializationData):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::checkFrameworkVersion):
(WebKit::XPCServiceEventHandler):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm:
(WebKit::NetworkProcessProxy::XPCEventHandler::handleXPCEvent const):
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm:
(WebKit::LaunchServicesDatabaseManager::handleEvent):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:
* Tools/WebKitTestRunner/WebKitEligibilityUtil/main.cpp:
(main):

Canonical link: <a href="https://commits.webkit.org/289406@main">https://commits.webkit.org/289406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced252866fbe8896b53f05a9a8dbe1b06c6f9c85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67131 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24903 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47450 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/86344 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32961 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36696 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79629 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93587 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85619 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75932 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75128 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6816 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13497 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19282 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108112 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13760 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26017 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->