### PR TITLE
Update WTF::HashTable to be compatible with ranges

### DIFF
--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -62,7 +62,7 @@ namespace WTF {
     }
 
     // Thomas Wang's 32 Bit Mix Function: http://www.cris.com/~Ttwang/tech/inthash.htm
-    inline unsigned intHash(uint32_t key) 
+    inline unsigned intHash(uint32_t key)
     {
         key += ~(key << 15);
         key ^= (key >> 10);
@@ -72,7 +72,7 @@ namespace WTF {
         key ^= (key >> 16);
         return key;
     }
-    
+
     // Thomas Wang's 64 bit Mix Function: http://www.cris.com/~Ttwang/tech/inthash.htm
     inline unsigned intHash(uint64_t key)
     {
@@ -120,12 +120,12 @@ namespace WTF {
 
     // pointer identity hash function
 
-    template<typename T, bool isSmartPointer> 
+    template<typename T, bool isSmartPointer>
     struct PtrHashBase;
 
     template <typename T>
     struct PtrHashBase<T, false /* isSmartPtr */> {
-        typedef T PtrType; 
+        typedef T PtrType;
 
         static unsigned hash(PtrType key) { return IntHash<uintptr_t>::hash(reinterpret_cast<uintptr_t>(key)); }
         static bool equal(PtrType a, PtrType b) { return a == b; }

--- a/Source/WTF/wtf/HashIterators.h
+++ b/Source/WTF/wtf/HashIterators.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -118,7 +118,7 @@ namespace WTF {
 
     public:
         HashTableConstKeysIterator(const ConstIterator& impl) : m_impl(impl) {}
-        
+
         const KeyType* get() const { return &(m_impl.get()->key); }
         const KeyType& operator*() const { return *get(); }
         const KeyType* operator->() const { return get(); }
@@ -142,7 +142,7 @@ namespace WTF {
 
     public:
         HashTableConstValuesIterator(const ConstIterator& impl) : m_impl(impl) {}
-        
+
         const MappedType* get() const { return std::addressof(m_impl.get()->value); }
         const MappedType& operator*() const { return *get(); }
         const MappedType* operator->() const { return get(); }
@@ -167,7 +167,7 @@ namespace WTF {
 
     public:
         HashTableKeysIterator(const Iterator& impl) : m_impl(impl) {}
-        
+
         KeyType* get() const { return &(m_impl.get()->key); }
         KeyType& operator*() const { return *get(); }
         KeyType* operator->() const { return get(); }
@@ -197,7 +197,7 @@ namespace WTF {
 
     public:
         HashTableValuesIterator(const Iterator& impl) : m_impl(impl) {}
-        
+
         MappedType* get() const { return std::addressof(m_impl.get()->value); }
         MappedType& operator*() const { return *get(); }
         MappedType* operator->() const { return get(); }

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -95,7 +95,7 @@ public:
         for (const auto& keyValuePair : initializerList)
             add(keyValuePair.key, keyValuePair.value);
     }
-    
+
     template<typename... Items>
     static HashMap from(Items&&... items)
     {
@@ -119,7 +119,7 @@ public:
     iterator end();
     const_iterator begin() const;
     const_iterator end() const;
-    
+
     iterator random() { return m_impl.random(); }
     const_iterator random() const { return m_impl.random(); }
 
@@ -290,13 +290,13 @@ inline void HashMap<T, U, V, W, X, Y, shouldValidateKey>::swap(HashMap& other)
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey>::size() const
 {
-    return m_impl.size(); 
+    return m_impl.size();
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 inline unsigned HashMap<T, U, V, W, X, Y, shouldValidateKey>::capacity() const
-{ 
-    return m_impl.capacity(); 
+{
+    return m_impl.capacity();
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
@@ -498,7 +498,7 @@ auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTra
 {
     return inlineEnsure(std::forward<KeyType>(key), functor);
 }
-    
+
 template<typename T, typename U, typename V, typename W, typename X, typename Y, ShouldValidateKey shouldValidateKey>
 inline auto HashMap<T, U, V, W, X, Y, shouldValidateKey>::get(const KeyType& key) const -> MappedPeekType
 {

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -108,7 +108,7 @@ public:
     //   static bool equal(const ValueType&, const T&);
     //   static translate(ValueType&, const T&, unsigned hashCode);
     template<typename HashTranslator, typename T> AddResult add(const T&);
-    
+
     // An alternate version of translated add(), ensure() will still do translation
     // by hashing and comparing with some other type, to avoid the cost of type
     // conversion if the object is already in the table, but rather than a static
@@ -221,7 +221,7 @@ struct HashSetTranslator {
     static unsigned hash(const auto& key) { return HashFunctions::hash(key); }
     static bool equal(const auto& a, const auto& b) { return HashFunctions::equal(a, b); }
     static void translate(auto& location, auto&&, NOESCAPE const Invocable<typename ValueTraits::TraitType()> auto& functor)
-    { 
+    {
         ValueTraits::assignToEmpty(location, functor());
     }
 };
@@ -249,19 +249,19 @@ struct HashSetEnsureTranslatorAdaptor {
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline void HashSet<T, U, V, W, shouldValidateKey>::swap(HashSet& other)
 {
-    m_impl.swap(other.m_impl); 
+    m_impl.swap(other.m_impl);
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline unsigned HashSet<T, U, V, W, shouldValidateKey>::size() const
 {
-    return m_impl.size(); 
+    return m_impl.size();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline unsigned HashSet<T, U, V, W, shouldValidateKey>::capacity() const
 {
-    return m_impl.capacity(); 
+    return m_impl.capacity();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
@@ -273,31 +273,31 @@ inline unsigned HashSet<T, U, V, W, shouldValidateKey>::memoryUse() const
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline bool HashSet<T, U, V, W, shouldValidateKey>::isEmpty() const
 {
-    return m_impl.isEmpty(); 
+    return m_impl.isEmpty();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline auto HashSet<T, U, V, W, shouldValidateKey>::begin() const -> iterator
 {
-    return m_impl.begin(); 
+    return m_impl.begin();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline auto HashSet<T, U, V, W, shouldValidateKey>::end() const -> iterator
 {
-    return m_impl.end(); 
+    return m_impl.end();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline auto HashSet<T, U, V, W, shouldValidateKey>::find(const ValueType& value) const -> iterator
 {
-    return m_impl.find(value); 
+    return m_impl.find(value);
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline bool HashSet<T, U, V, W, shouldValidateKey>::contains(const ValueType& value) const
 {
-    return m_impl.contains(value); 
+    return m_impl.contains(value);
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
@@ -397,7 +397,7 @@ inline bool HashSet<T, U, V, W, shouldValidateKey>::removeIf(NOESCAPE const Invo
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 inline void HashSet<T, U, V, W, shouldValidateKey>::clear()
 {
-    m_impl.clear(); 
+    m_impl.clear();
 }
 
 template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -421,9 +421,9 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 #endif
 
         HashTable();
-        ~HashTable() 
+        ~HashTable()
         {
-            invalidateIterators(this); 
+            invalidateIterators(this);
             if (m_table)
                 deallocateTable(m_table);
 #if CHECK_HASHTABLE_USE_AFTER_DESTRUCTION
@@ -558,7 +558,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         ValueType* expand(ValueType* entry = nullptr);
         void shrink() { rehash(tableSize() / 2, nullptr); }
         void shrinkToBestSize();
-    
+
         void deleteReleasedWeakBuckets();
 
         ValueType* rehash(unsigned newTableSize, ValueType* entry);
@@ -693,18 +693,18 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         while (true) {
             ValueType* entry = table + i;
-                
+
             // we count on the compiler to optimize out this branch
             if (HashFunctions::safeToCompareToEmptyOrDeleted) {
                 if (HashTranslator::equal(Extractor::extract(*entry), key))
                     return entry;
-                
+
                 if (isEmptyBucket(*entry))
                     return nullptr;
             } else {
                 if (isEmptyBucket(*entry))
                     return nullptr;
-                
+
                 if (!isDeletedBucket(*entry) && HashTranslator::equal(Extractor::extract(*entry), key))
                     return entry;
             }
@@ -789,21 +789,21 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         while (true) {
             ValueType* entry = table + i;
-            
+
             // we count on the compiler to optimize out this branch
             if (HashFunctions::safeToCompareToEmptyOrDeleted) {
                 if (isEmptyBucket(*entry))
                     return makeLookupResult(deletedEntry ? deletedEntry : entry, false, h);
-                
+
                 if (HashTranslator::equal(Extractor::extract(*entry), key))
                     return makeLookupResult(entry, true, h);
-                
+
                 if (isDeletedBucket(*entry))
                     deletedEntry = entry;
             } else {
                 if (isEmptyBucket(*entry))
                     return makeLookupResult(deletedEntry ? deletedEntry : entry, false, h);
-            
+
                 if (isDeletedBucket(*entry))
                     deletedEntry = entry;
                 else if (HashTranslator::equal(Extractor::extract(*entry), key))
@@ -858,7 +858,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             zeroBytes(bucket);
         }
     };
-    
+
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
     inline void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::initializeBucket(ValueType& bucket)
     {
@@ -897,21 +897,21 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         ValueType* entry;
         while (true) {
             entry = table + i;
-            
+
             // we count on the compiler to optimize out this branch
             if (HashFunctions::safeToCompareToEmptyOrDeleted) {
                 if (isEmptyBucket(*entry))
                     break;
-                
+
                 if (HashTranslator::equal(Extractor::extract(*entry), key))
                     return AddResult(makeKnownGoodIterator(entry), false);
-                
+
                 if (isDeletedBucket(*entry))
                     deletedEntry = entry;
             } else {
                 if (isEmptyBucket(*entry))
                     break;
-            
+
                 if (isDeletedBucket(*entry))
                     deletedEntry = entry;
                 else if (HashTranslator::equal(Extractor::extract(*entry), key))
@@ -939,12 +939,12 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         HashTranslator::translate(*entry, std::forward<T>(key), functor);
         setKeyCount(keyCount() + 1);
-        
+
         if (shouldExpand())
             entry = expand(entry);
 
         internalCheckTableConsistency();
-        
+
         return AddResult(makeKnownGoodIterator(entry), true);
     }
 
@@ -966,10 +966,10 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         ValueType* entry = lookupResult.first.first;
         bool found = lookupResult.first.second;
         unsigned h = lookupResult.second;
-        
+
         if (found)
             return AddResult(makeKnownGoodIterator(entry), false);
-        
+
         if (isDeletedBucket(*entry)) {
             initializeBucket(*entry);
             setDeletedCount(deletedCount() - 1);
@@ -1007,7 +1007,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
-    template <typename HashTranslator, typename T> 
+    template <typename HashTranslator, typename T>
     auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::find(const T& key) -> iterator
     {
         if (!m_table)
@@ -1021,7 +1021,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
-    template <typename HashTranslator, typename T> 
+    template <typename HashTranslator, typename T>
     auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::find(const T& key) const -> const_iterator
     {
         if (!m_table)
@@ -1035,7 +1035,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, ShouldValidateKey shouldValidateKey>
-    template <typename HashTranslator, typename T> 
+    template <typename HashTranslator, typename T>
     bool HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, shouldValidateKey>::contains(const T& key) const
     {
         if (!m_table)
@@ -1125,10 +1125,10 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             ValueType& bucket = table[i];
             if (isEmptyOrDeletedBucket(bucket))
                 continue;
-            
+
             if (!functor(bucket))
                 continue;
-            
+
             deleteBucket(bucket);
             ++removedBucketCount;
         }
@@ -1139,7 +1139,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
 
         if (shouldShrink())
             shrinkToBestSize();
-        
+
         internalCheckTableConsistency();
         return removedBucketCount;
     }
@@ -1558,7 +1558,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         const ValueType* operator->() const { return get(); }
 
         HashTableConstIteratorAdapter& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableConstIteratorAdapter& operator++(int) { auto prev = *this; ++m_impl; return prev; }
 
         typename HashTableType::const_iterator m_impl;
     };
@@ -1578,7 +1578,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         ValueType* operator->() const { return get(); }
 
         HashTableIteratorAdapter& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableIteratorAdapter& operator++(int) { auto prev = *this; ++m_impl; return prev; }
 
         operator HashTableConstIteratorAdapter<HashTableType, ValueType>() {
             typename HashTableType::const_iterator i = m_impl;

--- a/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp
@@ -209,7 +209,7 @@ TEST(WTF_HashSet, UniquePtrKey_TakeUsingRawPointer)
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
     EXPECT_EQ(0u, ConstructorDestructorCounter::destructionCount);
-    
+
     result = nullptr;
 
     EXPECT_EQ(1u, ConstructorDestructorCounter::constructionCount);
@@ -437,7 +437,7 @@ TEST(WTF_HashSet, Ref)
 
         Ref<RefLogger> ref(a);
         set.add(WTFMove(ref));
-        
+
         ASSERT_TRUE(set.contains(&a));
     }
 
@@ -941,6 +941,20 @@ TEST(WTF_HashSet, FormSymmetricDifference)
         result.formSymmetricDifference(sequence);
         EXPECT_EQ(result, set3);
     }
+}
+
+TEST(WTF_HashSet, RangesAllAnyNoneOf)
+{
+    HashSet<int> set1 { 1, 2, 3 };
+    EXPECT_TRUE(std::ranges::all_of(set1, [] (int el) {
+        return el < 4;
+    }));
+    EXPECT_TRUE(std::ranges::none_of(set1, [] (int el) {
+        return el > 4;
+    }));
+    EXPECT_TRUE(std::ranges::any_of(set1, [] (int el) {
+        return el < 2;
+    }));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### e64756fa250d3a4b1ac977eb7a184872cb219a7e
<pre>
Update WTF::HashTable to be compatible with ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=286548">https://bugs.webkit.org/show_bug.cgi?id=286548</a>

Reviewed by NOBODY (OOPS!).

I tried replacing `WTF::anyOf` with `std::ranges::any_of`, but encountered
numerous compiler errors, many of which were related to `WTF::HashTable`. The
issue was that, in order to be compatible with ranges, the iterator needed to
satisfy `std::weakly_incrementable`. This patch resolves the issue and includes
related tests.

* Source/WTF/wtf/HashTable.h:
(WTF::HashTableConstIteratorAdapter::operator++):
(WTF::HashTableIteratorAdapter::operator++):
* Tools/TestWebKitAPI/Tests/WTF/HashSet.cpp:
(TestWebKitAPI::TEST(WTF_HashSet, RangesAllAnyNoneOf)):
</pre>