### PR TITLE
[VisionOS] Add a quirk to preemptively rotate camera frames on zoom web site

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -32,6 +32,7 @@
 
 #include "CommonAtomStrings.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "Event.h"
 #include "EventNames.h"
 #include "ExceptionCode.h"
@@ -54,6 +55,7 @@
 #include "Page.h"
 #include "PhotoCapabilities.h"
 #include "PlatformMediaSessionManager.h"
+#include "Quirks.h"
 #include "RealtimeMediaSourceCenter.h"
 #include "ScriptExecutionContext.h"
 #include "Settings.h"
@@ -98,6 +100,11 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
 
     if (m_private->isAudio())
         PlatformMediaSessionManager::singleton().addAudioCaptureSource(*this);
+    else {
+        Ref document = downcast<Document>(context);
+        if (document->quirks().shouldCameraTracksApplyRotationQuirk())
+            m_private->source().setShouldApplyRotation(true);
+    }
 }
 
 MediaStreamTrack::~MediaStreamTrack()

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -879,6 +879,11 @@ bool Quirks::shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const
 {
     return needsQuirks() && m_quirksData.shouldEnableSpeakerSelectionPermissionsPolicyQuirk;
 }
+
+bool Quirks::shouldCameraTracksApplyRotationQuirk() const
+{
+    return needsQuirks() && m_quirksData.shouldCameraTracksApplyRotationQuirk;
+}
 #endif
 
 // hulu.com rdar://55041979
@@ -2685,6 +2690,10 @@ static void handleZoomQuirks(QuirksData& quirksData, const URL& quirksURL, const
 #if ENABLE(MEDIA_STREAM)
     // zoom.us rdar://118185086
     quirksData.shouldDisableImageCaptureQuirk = true;
+#if PLATFORM(VISION)
+    // zoom.us rdar://143095522
+    quirksData.shouldCameraTracksApplyRotationQuirk = true;
+#endif
 #endif
 }
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -138,6 +138,7 @@ public:
     bool shouldEnableLegacyGetUserMediaQuirk() const;
     bool shouldDisableImageCaptureQuirk() const;
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk() const;
+    bool shouldCameraTracksApplyRotationQuirk() const;
 #endif
 
     bool needsCanPlayAfterSeekedQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -142,6 +142,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldDisableImageCaptureQuirk { false };
     bool shouldEnableLegacyGetUserMediaQuirk { false };
     bool shouldEnableSpeakerSelectionPermissionsPolicyQuirk { false };
+    bool shouldCameraTracksApplyRotationQuirk { false };
 #endif
 
 #if ENABLE(META_VIEWPORT)

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -35,6 +35,7 @@
 #include <wtf/text/StringHash.h>
 
 typedef struct opaqueCMSampleBuffer* CMSampleBufferRef;
+typedef struct __CVBuffer* CVPixelBufferRef;
 
 OBJC_CLASS AVCaptureConnection;
 OBJC_CLASS AVCaptureDevice;
@@ -55,6 +56,7 @@ OBJC_CLASS WebCoreAVVideoCaptureSourceObserver;
 
 namespace WebCore {
 
+class ImageRotationSessionVT;
 class ImageTransferSessionVT;
 
 enum class VideoFrameRotation : uint16_t;
@@ -109,6 +111,11 @@ private:
     void applyFrameRateAndZoomWithPreset(double, double, std::optional<VideoPreset>&&) final;
     void generatePresets() final;
     bool canResizeVideoFrames() const final { return true; }
+    bool setShouldApplyRotation(bool value) final
+    {
+        m_shouldApplyRotation = value;
+        return true;
+    }
 
     void setSessionSizeFrameRateAndZoom();
     bool setPreset(NSString*);
@@ -119,7 +126,6 @@ private:
     // OrientationNotifier::Observer API
     void orientationChanged(IntDegrees orientation) final;
     void rotationAngleForHorizonLevelDisplayChanged(const String&, VideoFrameRotation) final;
-
 
     bool setFrameRateConstraint(double minFrameRate, double maxFrameRate);
     bool areSettingsMatching() const;
@@ -158,6 +164,8 @@ private:
     RetainPtr<AVCapturePhotoSettings> photoConfiguration(const PhotoSettings&);
     IntSize maxPhotoSizeForCurrentPreset(IntSize requestedSize) const;
     AVCapturePhotoOutput* photoOutput();
+
+    RetainPtr<CVPixelBufferRef> rotatePixelBuffer(CVPixelBufferRef, VideoFrameRotation);
 
     RefPtr<VideoFrame> m_buffer;
     RetainPtr<AVCaptureVideoDataOutput> m_videoOutput;
@@ -203,6 +211,13 @@ private:
     int64_t m_defaultTorchMode { 0 };
     OptionSet<RealtimeMediaSourceSettings::Flag> m_pendingSettingsChanges;
     bool m_useSensorAndDeviceOrientation { true };
+
+    bool m_shouldApplyRotation { false };
+    std::unique_ptr<ImageRotationSessionVT> m_rotationSession;
+    VideoFrameRotation m_currentRotationSessionAngle;
+    size_t m_rotatedWidth { 0 };
+    size_t m_rotatedHeight { 0 };
+    OSType m_rotatedFormat { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -30,6 +30,7 @@
 
 #import "FillLightMode.h"
 #import "ImageBuffer.h"
+#import "ImageRotationSessionVT.h"
 #import "ImageTransferSessionVT.h"
 #import "IntRect.h"
 #import "Logging.h"
@@ -250,6 +251,7 @@ AVVideoCaptureSource::AVVideoCaptureSource(AVCaptureDevice* avDevice, const Capt
     , m_device(avDevice)
     , m_zoomScaleFactor(cameraZoomScaleFactor([avDevice deviceType]))
     , m_defaultTorchMode((int64_t)[m_device torchMode])
+    , m_currentRotationSessionAngle(VideoFrameRotation::None)
 {
     [m_device addObserver:m_objcObserver.get() forKeyPath:@"suspended" options:NSKeyValueObservingOptionNew context:(void *)nil];
 }
@@ -1243,12 +1245,28 @@ void AVVideoCaptureSource::captureOutputDidOutputSampleBufferFromConnection(AVCa
     if (++m_framesCount <= framesToDropWhenStarting)
         return;
 
-    auto videoFrame = VideoFrameCV::create(sampleBuffer, [captureConnection isVideoMirrored], m_videoFrameRotation);
-    m_buffer = &videoFrame.get();
+    RefPtr<VideoFrame> videoFrame;
+    if (m_shouldApplyRotation && m_videoFrameRotation != VideoFrameRotation::None) {
+        auto pixelBuffer = static_cast<CVPixelBufferRef>(PAL::CMSampleBufferGetImageBuffer(sampleBuffer));
+
+        RetainPtr rotatedPixelBuffer = rotatePixelBuffer(pixelBuffer, m_videoFrameRotation);
+        if (!pixelBuffer) {
+            ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "failed to apply rotation");
+            return;
+        }
+
+        auto timeStamp = PAL::CMSampleBufferGetOutputPresentationTimeStamp(sampleBuffer);
+        if (CMTIME_IS_INVALID(timeStamp))
+            timeStamp = PAL::CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
+
+        videoFrame = VideoFrameCV::create(PAL::toMediaTime(timeStamp), [captureConnection isVideoMirrored], VideoFrameRotation::None, rotatedPixelBuffer.get());
+    } else
+        videoFrame = VideoFrameCV::create(sampleBuffer, [captureConnection isVideoMirrored], m_videoFrameRotation);
+    m_buffer = videoFrame.get();
     setIntrinsicSize(expandedIntSize(videoFrame->presentationSize()));
     VideoFrameTimeMetadata metadata;
     metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
-    dispatchVideoFrameToObservers(WTFMove(videoFrame), metadata);
+    dispatchVideoFrameToObservers(videoFrame.releaseNonNull(), metadata);
 }
 
 void AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto(RetainPtr<AVCapturePhotoOutput>, RetainPtr<AVCapturePhoto> photo, RetainPtr<NSError> error)
@@ -1399,6 +1417,28 @@ void AVVideoCaptureSource::deviceDisconnected(RetainPtr<NSNotification> notifica
     ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
     if (this->device() == [notification object])
         captureFailed();
+}
+
+RetainPtr<CVPixelBufferRef> AVVideoCaptureSource::rotatePixelBuffer(CVPixelBufferRef pixelBuffer, VideoFrameRotation rotation)
+{
+    ASSERT(rotation != VideoFrameRotation::None);
+    if (rotation == VideoFrameRotation::None)
+        return pixelBuffer;
+
+    auto pixelWidth = CVPixelBufferGetWidth(pixelBuffer);
+    auto pixelHeight = CVPixelBufferGetHeight(pixelBuffer);
+    if (!m_rotationSession || rotation != m_currentRotationSessionAngle || pixelWidth != m_rotatedWidth || pixelHeight != m_rotatedHeight) {
+        RELEASE_LOG_INFO(WebRTC, "RealtimeOutgoingVideoSourceCocoa::rotatePixelBuffer creating rotation session for rotation %hu", rotation);
+        AffineTransform transform;
+        transform.rotate(static_cast<double>(rotation));
+        m_rotationSession = makeUnique<ImageRotationSessionVT>(WTFMove(transform), FloatSize { static_cast<float>(pixelWidth), static_cast<float>(pixelHeight) }, ImageRotationSessionVT::IsCGImageCompatible::No, ImageRotationSessionVT::ShouldUseIOSurface::Yes);
+
+        m_currentRotationSessionAngle = rotation;
+        m_rotatedWidth = pixelWidth;
+        m_rotatedHeight = pixelHeight;
+    }
+
+    return m_rotationSession->rotate(pixelBuffer);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6bc45e4931d4877b3e84843f11d300e96793dd57
<pre>
[VisionOS] Add a quirk to preemptively rotate camera frames on zoom web site
<a href="https://rdar.apple.com/143095522">rdar://143095522</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286551">https://bugs.webkit.org/show_bug.cgi?id=286551</a>

Reviewed by NOBODY (OOPS!).

On VisionOS, camera frames have a native rotation of 90 degrees.
This is not expoected by zoom.us.
Fixing <a href="https://bugs.webkit.org/show_bug.cgi?id=286421">https://bugs.webkit.org/show_bug.cgi?id=286421</a> should help zoom on VisionOS but breaks it on iOS.
For that reason, we introduce a quirk on VisionOS that will rotate camera frames before being exposed to web pages.

Manually tested.

* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldCameraTracksApplyRotationQuirk const):
(WebCore::handleZoomQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::AVVideoCaptureSource):
(WebCore::AVVideoCaptureSource::captureOutputDidOutputSampleBufferFromConnection):
(WebCore::AVVideoCaptureSource::rotatePixelBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5117c8c73b1731ab493fca920411adfe32915ddf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67136 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36702 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93593 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75937 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75133 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6829 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19288 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->