### PR TITLE
A page with `overflow-y: hidden` can sometimes still be scrolled

### DIFF
--- a/LayoutTests/fast/scrolling/mac/unscrollable-root-overflow-hidden-on-one-axis-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/unscrollable-root-overflow-hidden-on-one-axis-expected.txt
@@ -1,0 +1,10 @@
+Tests that a 100% height root with hidden on one axis does not scroll.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS windowScrollEventCount is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/unscrollable-root-overflow-hidden-on-one-axis.html
+++ b/LayoutTests/fast/scrolling/mac/unscrollable-root-overflow-hidden-on-one-axis.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+    body {
+        overflow-y: hidden;
+        height: 100%;
+    }
+    
+    .filler {
+        background: gray;
+        width: 100px;
+        height: 5000px;
+    }
+    </style>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+    jsTestIsAsync = true;
+
+    var windowScrollEventCount = 0;
+
+    function checkForScroll()
+    {
+        shouldBe('windowScrollEventCount', '0');
+        finishJSTest();
+    }
+
+    async function scrollTest()
+    {
+        const events = [
+            {
+                type : "wheel",
+                viewX : 100,
+                viewY : 100,
+                deltaY : -10,
+                phase : "began"
+            },
+            {
+                type : "wheel",
+                deltaY : -100,
+                phase : "changed"
+            },
+            {
+                type : "wheel",
+                phase : "ended"
+            },
+            {
+                type : "wheel",
+                deltaY : -100,
+                momentumPhase : "began"
+            },
+            {
+                type : "wheel",
+                deltaY : -100,
+                momentumPhase : "changed"
+            },
+            {
+                type : "wheel",
+                momentumPhase : "ended"
+            }
+        ];
+
+        await UIHelper.mouseWheelSequence({ events });
+        checkForScroll();
+    }
+
+    function setupTopLevel()
+    {
+        description("Tests that a 100% height root with hidden on one axis does not scroll.");
+
+        window.addEventListener('scroll', () => {
+            ++windowScrollEventCount;
+        }, false);
+
+        if (window.eventSender) {
+            setTimeout(scrollTest, 0);
+            return;
+        }
+
+        finishJSTest();
+    }
+
+    window.addEventListener('load', () => {
+        setupTopLevel();
+    }, false);
+</script>
+</head>
+<body>
+    <div class="filler"></div>
+<div id="console"></div>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/WheelEventTestMonitor.cpp
+++ b/Source/WebCore/page/WheelEventTestMonitor.cpp
@@ -176,6 +176,7 @@ void WheelEventTestMonitor::checkShouldFireCallbacks()
 TextStream& operator<<(TextStream& ts, WheelEventTestMonitor::DeferReason reason)
 {
     switch (reason) {
+    case WheelEventTestMonitor::DeferReason::None: ts << "none"; break;
     case WheelEventTestMonitor::DeferReason::HandlingWheelEvent: ts << "handling wheel event"; break;
     case WheelEventTestMonitor::DeferReason::HandlingWheelEventOnMainThread: ts << "handling wheel event on main thread"; break;
     case WheelEventTestMonitor::DeferReason::PostMainThreadWheelEventHandling: ts << "post-main thread event handling"; break;

--- a/Source/WebCore/page/WheelEventTestMonitor.h
+++ b/Source/WebCore/page/WheelEventTestMonitor.h
@@ -42,16 +42,17 @@ namespace WebCore {
 class Page;
 
 enum class WheelEventTestMonitorDeferReason : uint16_t {
-    HandlingWheelEvent                  = 1 << 0,
-    HandlingWheelEventOnMainThread      = 1 << 1,
-    PostMainThreadWheelEventHandling    = 1 << 2,
-    RubberbandInProgress                = 1 << 3,
-    ScrollSnapInProgress                = 1 << 4,
-    ScrollAnimationInProgress           = 1 << 5,
-    ScrollingThreadSyncNeeded           = 1 << 6,
-    ContentScrollInProgress             = 1 << 7,
-    RequestedScrollPosition             = 1 << 8,
-    CommittingTransientZoom             = 1 << 9,
+    None                                = 1 << 0,
+    HandlingWheelEvent                  = 1 << 1,
+    HandlingWheelEventOnMainThread      = 1 << 2,
+    PostMainThreadWheelEventHandling    = 1 << 3,
+    RubberbandInProgress                = 1 << 4,
+    ScrollSnapInProgress                = 1 << 5,
+    ScrollAnimationInProgress           = 1 << 6,
+    ScrollingThreadSyncNeeded           = 1 << 7,
+    ContentScrollInProgress             = 1 << 8,
+    RequestedScrollPosition             = 1 << 9,
+    CommittingTransientZoom             = 1 << 10,
 };
 
 class WheelEventTestMonitor : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WheelEventTestMonitor> {

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -140,7 +140,7 @@ OptionSet<WheelEventProcessingSteps> ScrollingTree::determineWheelEventProcessin
 
     auto latchedNodeAndSteps = m_latchingController.latchingDataForEvent(wheelEvent, m_allowLatching);
     if (latchedNodeAndSteps) {
-        LOG_WITH_STREAM(ScrollLatching, stream << "ScrollingTree::determineWheelEventProcessing " << wheelEvent << " have latched node " << latchedNodeAndSteps->scrollingNodeID << " steps " << latchedNodeAndSteps->processingSteps << " gesture state " << m_treeState.gestureState);
+        LOG_WITH_STREAM(ScrollLatching, stream << "\nScrollingTree::determineWheelEventProcessing " << wheelEvent << " have latched node " << latchedNodeAndSteps->scrollingNodeID << " steps " << latchedNodeAndSteps->processingSteps << " gesture state " << m_treeState.gestureState);
         return latchedNodeAndSteps->processingSteps;
     }
     if (wheelEvent.isGestureStart() || wheelEvent.isNonGestureEvent())
@@ -150,14 +150,14 @@ OptionSet<WheelEventProcessingSteps> ScrollingTree::determineWheelEventProcessin
 
     m_latchingController.receivedWheelEvent(wheelEvent, processingSteps, m_allowLatching);
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::determineWheelEventProcessing: " << wheelEvent << " processingSteps " << processingSteps);
+    LOG_WITH_STREAM(Scrolling, stream << "\nScrollingTree::determineWheelEventProcessing: " << wheelEvent << " processingSteps " << processingSteps);
 
     return processingSteps;
 }
 
 WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "\nScrollingTree " << this << " handleWheelEvent " << wheelEvent);
+    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree " << this << " handleWheelEvent " << wheelEvent);
 
     Locker locker { m_treeLock };
 
@@ -232,8 +232,10 @@ WheelEventHandlingResult ScrollingTree::handleWheelEventWithNode(const PlatformW
             
             auto scrollPropagationInfo = scrollingNode->computeScrollPropagation(adjustedWheelEvent.delta());
             if (scrollPropagationInfo.shouldBlockScrollPropagation) {
-                if (!scrollPropagationInfo.isHandled)
+                if (!scrollPropagationInfo.isHandled) {
+                    auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *this, scrollingNode->scrollingNodeID(), WheelEventTestMonitor::DeferReason::None };
                     return WheelEventHandlingResult::unhandled();
+                }
                 m_latchingController.nodeDidHandleEvent(scrollingNode->scrollingNodeID(), processingSteps, adjustedWheelEvent, m_allowLatching);
                 m_gestureState.nodeDidHandleEvent(scrollingNode->scrollingNodeID(), adjustedWheelEvent);
                 return WheelEventHandlingResult::handled();

--- a/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
@@ -28,11 +28,12 @@
 
 #if ENABLE(ASYNC_SCROLLING)
 
+#include "Logging.h"
 #include "PlatformWheelEvent.h"
 #include "ScrollingTree.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
-
 
 ScrollingTreeGestureState::ScrollingTreeGestureState(ScrollingTree& scrollingTree)
     : m_scrollingTree(scrollingTree)
@@ -60,6 +61,7 @@ bool ScrollingTreeGestureState::handleGestureCancel(const PlatformWheelEvent& ev
 
 void ScrollingTreeGestureState::nodeDidHandleEvent(ScrollingNodeID nodeID, const PlatformWheelEvent& event)
 {
+    LOG_WITH_STREAM(OverlayScrollbars, stream << "ScrollingTreeGestureState::nodeDidHandleEvent " << nodeID << " " << event.phase());
     switch (event.phase()) {
     case PlatformWheelEventPhase::MayBegin:
         m_mayBeginNodeID = nodeID;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -182,12 +182,20 @@ protected:
 
     bool allowsHorizontalScrolling() const { return m_scrollableAreaParameters.allowsHorizontalScrolling; }
     bool allowsVerticalScrolling() const { return m_scrollableAreaParameters.allowsVerticalScrolling; }
+
     bool horizontalOverscrollBehaviorPreventsPropagation() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior != OverscrollBehavior::Auto; }
     bool verticalOverscrollBehaviorPreventsPropagation() const { return m_scrollableAreaParameters.verticalOverscrollBehavior != OverscrollBehavior::Auto; }
+
+    bool overscrollBehaviorAllowsHorizontalRubberBand() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior != OverscrollBehavior::None; }
+    bool overscrollBehaviorAllowsVerticalRubberBand() const { return m_scrollableAreaParameters.verticalOverscrollBehavior != OverscrollBehavior::None; }
+
     PlatformWheelEvent eventForPropagation(const PlatformWheelEvent&) const;
     ScrollPropagationInfo computeScrollPropagation(const FloatSize&) const;
     bool overscrollBehaviorAllowsRubberBand() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior != OverscrollBehavior::None ||  m_scrollableAreaParameters.verticalOverscrollBehavior != OverscrollBehavior::None; }
+
     bool shouldRubberBand(const PlatformWheelEvent&, EventTargeting) const;
+    bool shouldRubberBandOnSide(BoxSide, RectEdges<bool> pinnedEdges) const;
+
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     std::unique_ptr<ScrollingTreeScrollingNodeDelegate> m_delegate;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -291,18 +291,7 @@ RectEdges<bool> ScrollingTreeScrollingNodeDelegateMac::edgePinnedState() const
 
 bool ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide(BoxSide side) const
 {
-    if (scrollingNode().isRootNode())
-        return scrollingTree()->clientAllowsMainFrameRubberBandingOnSide(side);
-
-    switch (side) {
-    case BoxSide::Top:
-    case BoxSide::Bottom:
-        return allowsVerticalScrolling();
-    case BoxSide::Left:
-    case BoxSide::Right:
-        return allowsHorizontalScrolling();
-    }
-    return true;
+    return scrollingNode().shouldRubberBandOnSide(side, edgePinnedState());
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::didStopRubberBandAnimation()

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -241,6 +241,8 @@ private:
 
     void adjustDeltaForSnappingIfNeeded(float& deltaX, float& deltaY);
 
+    void clampDeltaForAllowedAxes(const PlatformWheelEvent&, FloatSize&);
+
 #if ENABLE(KINETIC_SCROLLING) && !PLATFORM(MAC)
     // Returns true if handled.
     bool processWheelEventForKineticScrolling(const PlatformWheelEvent&);

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -666,7 +666,7 @@ IntSize TileController::computeTileSize()
     } else if (m_scrollability == Scrollability::VerticallyScrollable)
         tileSize.setWidth(std::min(std::max<int>(ceilf(boundsWithoutMargin().width() * tileGrid().scale()), kDefaultTileSize), maxTileSize.width()));
 
-    LOG_WITH_STREAM(Scrolling, stream << "TileController::tileSize newSize=" << tileSize);
+    LOG_WITH_STREAM(Tiling, stream << "TileController::tileSize newSize=" << tileSize);
 
     m_tileSizeLocked = true;
     return tileSize;

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -248,6 +248,15 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
     return handled;
 }
 
+void ScrollingEffectsController::clampDeltaForAllowedAxes(const PlatformWheelEvent& wheelEvent, FloatSize& delta)
+{
+    if (!m_client.allowsHorizontalStretching(wheelEvent))
+        delta.setWidth(0);
+
+    if (!m_client.allowsVerticalStretching(wheelEvent))
+        delta.setHeight(0);
+}
+
 bool ScrollingEffectsController::modifyScrollDeltaForStretching(const PlatformWheelEvent& wheelEvent, FloatSize& delta, bool isHorizontallyStretched, bool isVerticallyStretched)
 {
     auto affectedSide = affectedSideOnDominantAxis(delta);
@@ -291,11 +300,7 @@ bool ScrollingEffectsController::modifyScrollDeltaForStretching(const PlatformWh
                 m_unappliedOverscrollDelta.expand(delta.width(), 0);
         }
 
-        if (!m_client.allowsHorizontalStretching(wheelEvent))
-            delta.setWidth(0);
-
-        if (!m_client.allowsVerticalStretching(wheelEvent))
-            delta.setHeight(0);
+        clampDeltaForAllowedAxes(wheelEvent, delta);
 
         return !delta.isZero();
     }
@@ -347,6 +352,8 @@ bool ScrollingEffectsController::applyScrollDeltaWithStretching(const PlatformWh
         ceilf(elasticDeltaForReboundDelta(m_stretchScrollForce.width())),
         ceilf(elasticDeltaForReboundDelta(m_stretchScrollForce.height()))
     };
+
+    clampDeltaForAllowedAxes(wheelEvent, dampedDelta);
 
     LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::applyScrollDeltaWithStretching() - stretchScrollForce " << m_stretchScrollForce << " move delta " << delta << " dampedDelta " << dampedDelta);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7585,6 +7585,7 @@ class WebCore::FilterOperations {
 
 header: <WebCore/WheelEventTestMonitor.h>
 [OptionSet] enum class WebCore::WheelEventTestMonitorDeferReason : uint16_t {
+    None,
     HandlingWheelEvent,
     HandlingWheelEventOnMainThread,
     PostMainThreadWheelEventHandling,


### PR DESCRIPTION
#### 618e0c9aab19d67ea3a915dd3fbaa62617004e88
<pre>
A page with `overflow-y: hidden` can sometimes still be scrolled
<a href="https://bugs.webkit.org/show_bug.cgi?id=286554">https://bugs.webkit.org/show_bug.cgi?id=286554</a>
<a href="https://rdar.apple.com/143660753">rdar://143660753</a>

Reviewed by Matt Woodrow.

A page with `body { overflow-y: hidden; }` can still be partially scrolled (without
momentum). This happens because the `shouldRubberBand()` logic says that we can rubberband
vertically, so we allow the event through and apply the scroll delta.

The bug falls out of some complexity around when we actually allow rubberbanding on the
root, which has some surprising behaviors. We allow rubberbanding on an unscrollable root
to give the user a feeling of responsiveness, but only &quot;unscrollable&quot; in the sense of &quot;not
enough content to scroll&quot;, not &quot;scrolling disallowed by the web content (i.e. `overflow:
hidden`). The bug was that we didn&apos;t strictly evaluate this per axis, so if the horizontal
axis allowed rubberbanding, we&apos;d also allow it on the vertical axis.

Fix by expanding out the logic in `ScrollingTreeScrollingNode::shouldRubberBand()` to
check each axis independently. Also have
`ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide()` share the same code.

Fixing `shouldRubberBand()` is not strictly enough though; there are cases where a
rubberband can be started on the horizontal axis, then, with a circular gesture on the
trackpad, the vertical axis can be stretched. This PR partially fixes this with the
changes in ScrollingEffectsController, but a full fix for this rare edge case requires
more work.

Because `ScrollingTree::handleWheelEventWithNode()` now more accurately predicts whether
an event will trigger any event handling, some tests[1] timed out because `WheelEventTestMonitor`
never received any deferral reasons. Rather than require tests to know if an event will
cause any scrolling, introduce a &quot;None&quot; deferral reason purely to allow a test that uses
`eventSender.monitorWheelEvents()` to not time out when an event simply doesn&apos;t trigger any
scrolling, for example because of `overscroll-behavior: none`.

[1] imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html

* LayoutTests/fast/scrolling/mac/unscrollable-root-overflow-hidden-on-one-axis-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/unscrollable-root-overflow-hidden-on-one-axis.html: Added.
* Source/WebCore/page/WheelEventTestMonitor.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/WheelEventTestMonitor.h:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::determineWheelEventProcessing):
(WebCore::ScrollingTree::handleWheelEvent):
(WebCore::ScrollingTree::handleWheelEventWithNode):
* Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp:
(WebCore::ScrollingTreeGestureState::nodeDidHandleEvent):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::shouldRubberBandOnSide const):
(WebCore::ScrollingTreeScrollingNode::shouldRubberBand const):
(WebCore::ScrollingTreeScrollingNode::canHandleWheelEvent const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide const):
* Source/WebCore/platform/ScrollingEffectsController.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::computeTileSize):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::clampDeltaForAllowedAxes):
(WebCore::ScrollingEffectsController::modifyScrollDeltaForStretching):
(WebCore::ScrollingEffectsController::applyScrollDeltaWithStretching):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/289750@main">https://commits.webkit.org/289750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1f12aefdfd8030dfc4925a759c855426d5d3ed0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87668 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67688 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25434 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94419 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14836 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10878 "Found 7 new test failures: fast/canvas/check-stale-putImageData.html fast/dom/gc-dom-tree-async-node-deletion-queue-limit.html fast/table/table-section-split2.html ipc/create-media-source-with-invalid-constraints-crash.html js/exception-with-handler-inside-eval-with-dynamic-scope.html media/media-session/actionHandler-no-document-leak.html webgl/2.0.y/conformance/rendering/many-draw-calls.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75769 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18671 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7787 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20153 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18040 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->