### PR TITLE
[iOS] [Visual Bidi Selection] Selection sometimes unnecessarily expands when selecting bidi text

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-5-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-5-expected.txt
@@ -1,0 +1,12 @@
+Verifies that the selection does not unnecessarily expand to the entire paragraph when selecting bidi text surrounded by bidi embedding characters.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 1
+PASS selectionRects[0].width is <= bounds.width - 1
+PASS getSelection().toString() is "iPhone"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-5.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-5.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    font-size: 20px;
+    font-family: system-ui;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection does not unnecessarily expand to the entire paragraph when selecting bidi text surrounded by bidi embedding characters.");
+
+    bounds = document.getElementById("target").getBoundingClientRect();
+
+    await UIHelper.longPressAtPoint(bounds.left + 20, bounds.top + (bounds.height / 2));
+    selectionRects = await UIHelper.waitForSelectionToAppear();
+    await UIHelper.ensurePresentationUpdate();
+
+    shouldBe("selectionRects.length", "1");
+    shouldBeLessThanOrEqual("selectionRects[0].width", "bounds.width - 1");
+    shouldBeEqualToString("getSelection().toString()", "iPhone");
+
+    document.querySelector("p[dir='rtl']").remove();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p dir="rtl"><span id="target">&#x202b;أُرسلت من الـ iPhone&#x202c;</span></p>
+</body>
+</html>

--- a/Source/WebCore/editing/RenderedPosition.h
+++ b/Source/WebCore/editing/RenderedPosition.h
@@ -72,6 +72,9 @@ public:
     Position positionAtLeftBoundaryOfBiDiRun() const;
     Position positionAtRightBoundaryOfBiDiRun() const;
 
+    bool atLeftmostOffsetInBox() const { return m_box && m_offset == m_box->leftmostCaretOffset(); }
+    bool atRightmostOffsetInBox() const { return m_box && m_offset == m_box->rightmostCaretOffset(); }
+
     IntRect absoluteRect(CaretRectMode = CaretRectMode::Normal) const;
 
     std::optional<BoundaryPoint> boundaryPoint() const;
@@ -82,8 +85,6 @@ private:
 
     InlineIterator::LeafBoxIterator previousLeafOnLine() const;
     InlineIterator::LeafBoxIterator nextLeafOnLine() const;
-    bool atLeftmostOffsetInBox() const { return m_box && m_offset == m_box->leftmostCaretOffset(); }
-    bool atRightmostOffsetInBox() const { return m_box && m_offset == m_box->rightmostCaretOffset(); }
     bool atLeftBoundaryOfBidiRun(ShouldMatchBidiLevel, unsigned char bidiLevelOfRun) const;
     bool atRightBoundaryOfBidiRun(ShouldMatchBidiLevel, unsigned char bidiLevelOfRun) const;
 


### PR DESCRIPTION
#### 667eb43d06b329ab64f51ed61d42777ae0b00057
<pre>
[iOS] [Visual Bidi Selection] Selection sometimes unnecessarily expands when selecting bidi text
<a href="https://bugs.webkit.org/show_bug.cgi?id=286556">https://bugs.webkit.org/show_bug.cgi?id=286556</a>
<a href="https://rdar.apple.com/143264840">rdar://143264840</a>

Reviewed by Richard Robinson.

When selecting the word &quot;iPhone&quot; in the following paragraph when visual bidi selection is enabled:

&gt; ‫أُرسلت من الـ iPhone‬

…we currently (incorrectly) expand the selection to include the entire paragraph, in an attempt to
make the (already-visually-contiguous) selection visually contiguous. This is due to the fact that,
when finding the base (minimum) bidi level in between the selection endpoints using the helper
function `forEachRenderedBoxBetween(start, end)`, the `start` offset is after the end of the `e` in
`&quot;iPhone&quot;` (LTR), but the end offset is at the beginning of the unrendered `U+202c` (pop directional
formatting — i.e. PDF) character at the end of the paragraph.

When iterating boxes on the line from left to right, we end up first visiting the box containing
`U+202c` on the right edge (offset 21), followed by &quot;iPhone&quot; (from offset 15 to 21). The problem
with this is that the contents of the `U+202c` PDF character isn&apos;t itself contained in the selection
range, but because we include it as an inline box in between the selection endpoints, we end up
trying to force visual contiguity by selecting all the content in the paragraph.

To fix this, when iterating leaf boxes, we detect cases where either:

1.  The first endpoint we encounter (in left-to-right order) has a position that is the rightmost
    offset in the bidi run, or

2.  The last endpoint we encounter has a position that is the leftmost offset in the bidi run

…and subsequently avoid applying the iteration callback for these collapsed ranges.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-5-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-5.html: Added.

Add a layout test to exercise the change.

* Source/WebCore/editing/Editing.cpp:
(WebCore::forEachRenderedBoxBetween):
(WebCore::makeVisuallyContiguousIfNeeded):

Drive-by fix: also avoid making the selection &quot;visually contiguous&quot; by collapsing the range.

* Source/WebCore/editing/RenderedPosition.h:
(WebCore::RenderedPosition::atLeftmostOffsetInBox const):
(WebCore::RenderedPosition::atRightmostOffsetInBox const):

Canonical link: <a href="https://commits.webkit.org/289410@main">https://commits.webkit.org/289410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c3107dd7f8e05bbee272864ae260fabdf8670db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24921 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36717 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93608 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18476 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6853 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14043 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19304 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->