### PR TITLE
Reduce use of strlen() in the codebase

### DIFF
--- a/Source/WTF/wtf/StringPrintStream.cpp
+++ b/Source/WTF/wtf/StringPrintStream.cpp
@@ -85,7 +85,7 @@ void StringPrintStream::vprintf(const char* format, va_list argList)
 
 CString StringPrintStream::toCString() const
 {
-    ASSERT(m_length == strlen(m_buffer.data()));
+    ASSERT(m_length == strlenSpan(m_buffer));
     return CString(m_buffer.first(m_length));
 }
 
@@ -97,7 +97,7 @@ void StringPrintStream::reset()
 
 Expected<String, UTF8ConversionError> StringPrintStream::tryToString() const
 {
-    ASSERT(m_length == strlen(m_buffer.data()));
+    ASSERT(m_length == strlenSpan(m_buffer));
     if (m_length > String::MaxLength)
         return makeUnexpected(UTF8ConversionError::OutOfMemory);
     return String::fromUTF8(m_buffer.first(m_length));
@@ -105,13 +105,13 @@ Expected<String, UTF8ConversionError> StringPrintStream::tryToString() const
 
 String StringPrintStream::toString() const
 {
-    ASSERT(m_length == strlen(m_buffer.data()));
+    ASSERT(m_length == strlenSpan(m_buffer));
     return String::fromUTF8(m_buffer.first(m_length));
 }
 
 String StringPrintStream::toStringWithLatin1Fallback() const
 {
-    ASSERT(m_length == strlen(m_buffer.data()));
+    ASSERT(m_length == strlenSpan(m_buffer));
     return String::fromUTF8WithLatin1Fallback(m_buffer.first(m_length));
 }
 

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -138,10 +138,8 @@ std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, Strin
     if (!confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryFilePath.data(), temporaryFilePath.size()))
         return { String(), invalidPlatformFileHandle };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Shrink the vector.
-    temporaryFilePath.shrink(strlen(temporaryFilePath.data()));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    temporaryFilePath.shrink(strlenSpan(temporaryFilePath.span()));
 
     ASSERT(temporaryFilePath.last() == '/');
 

--- a/Source/WTF/wtf/dtoa/utils.h
+++ b/Source/WTF/wtf/dtoa/utils.h
@@ -32,6 +32,7 @@
 #include <cstring>
 #include <wtf/Assertions.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/StringCommon.h>
 
 #ifndef UNIMPLEMENTED
 #define UNIMPLEMENTED() ASSERT_NOT_REACHED()
@@ -307,9 +308,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     buffer_[length] = '\0';
     // Make sure nobody managed to add a 0-character to the
     // buffer while building the string.
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    ASSERT(strlen(buffer_.start().data()) == length);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    ASSERT(strlenSpan(buffer_.start()) == length);
     position_ = -1;
     ASSERT(is_finalized());
     return buffer_.start().first(length);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -106,6 +106,15 @@ inline std::span<const char8_t> span(const std::u8string& string)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
+template<typename T, std::size_t Extent>
+size_t strlenSpan(std::span<T, Extent> span) requires(sizeof(T) == 1)
+{
+    size_t i = 0;
+    while (span[i] != '\0')
+        ++i;
+    return i;
+}
+
 template<typename CharacterType> inline constexpr bool isLatin1(CharacterType character)
 {
     using UnsignedCharacterType = typename std::make_unsigned<CharacterType>::type;
@@ -1247,6 +1256,7 @@ using WTF::equalLettersIgnoringASCIICaseWithLength;
 using WTF::isLatin1;
 using WTF::span;
 using WTF::spanHasPrefixIgnoringASCIICase;
+using WTF::strlenSpan;
 using WTF::unsafeSpan;
 using WTF::unsafeSpan8;
 using WTF::unsafeSpanIncludingNullTerminator;

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -136,9 +136,7 @@ static bool isUndesiredAlias(ASCIILiteral alias)
 
 static void addToTextEncodingNameMap(ASCIILiteral alias, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    ASSERT(strlen(alias) <= maxEncodingNameLength);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    ASSERT(alias.length() <= maxEncodingNameLength);
     if (isUndesiredAlias(alias))
         return;
     ASCIILiteral atomName = textEncodingNameMap->get(name);

--- a/Source/WebCore/platform/ios/LegacyTileCache.mm
+++ b/Source/WebCore/platform/ios/LegacyTileCache.mm
@@ -568,8 +568,7 @@ void LegacyTileCache::drawLayer(LegacyTileLayer* layer, CGContextRef context, Dr
 
     ++layer.paintCount;
     if (m_tilePaintCountersVisible) {
-        char text[16];
-        snprintf(text, sizeof(text), "%d", layer.paintCount);
+        auto string = adoptCF(CFStringCreateWithFormat(0, 0, CFSTR("%d"), layer.paintCount));
 
         CGContextSaveGState(context);
 
@@ -577,7 +576,7 @@ void LegacyTileCache::drawLayer(LegacyTileLayer* layer, CGContextRef context, Dr
         CGContextSetFillColorWithColor(context, cachedCGColor(colorForGridTileBorder([layer tileGrid])).get());
         
         CGRect labelBounds = [layer bounds];
-        labelBounds.size.width = 10 + 12 * strlen(text);
+        labelBounds.size.width = 10 + 12 * CFStringGetLength(string.get());
         labelBounds.size.height = 25;
         CGContextFillRect(context, labelBounds);
 
@@ -591,7 +590,6 @@ void LegacyTileCache::drawLayer(LegacyTileLayer* layer, CGContextRef context, Dr
         CFTypeRef keys[] = { kCTFontAttributeName, kCTForegroundColorFromContextAttributeName };
         CFTypeRef values[] = { font.get(), kCFBooleanTrue };
         auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-        auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, reinterpret_cast<const UInt8*>(text), strlen(text), kCFStringEncodingUTF8, false, kCFAllocatorNull));
         auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
         auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
         CGContextSetTextPosition(context, labelBounds.origin.x + 3, labelBounds.origin.y + 20);

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -245,10 +245,8 @@ auto SandboxExtension::createHandleForTemporaryFile(StringView prefix, Type type
     if (!confstr(_CS_DARWIN_USER_TEMP_DIR, path.data(), path.size()))
         return std::nullopt;
     
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Shrink the vector.   
-    path.shrink(strlen(path.data()));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    path.shrink(strlenSpan(path.span()));
 
     ASSERT(path.last() == '/');
 

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -859,11 +859,10 @@ static void createGlobalWebViewAndOffscreenWindow()
 
 static NSString *libraryPathForDumpRenderTree()
 {
-    char* dumpRenderTreeTemp = getenv("DUMPRENDERTREE_TEMP");
-    if (dumpRenderTreeTemp)
-        return [[NSFileManager defaultManager] stringWithFileSystemRepresentation:dumpRenderTreeTemp length:strlen(dumpRenderTreeTemp)];
-    else
-        return [@"~/Library/Application Support/DumpRenderTree" stringByExpandingTildeInPath];
+    auto dumpRenderTreeTemp = unsafeSpan(getenv("DUMPRENDERTREE_TEMP"));
+    if (dumpRenderTreeTemp.data())
+        return [[NSFileManager defaultManager] stringWithFileSystemRepresentation:dumpRenderTreeTemp.data() length:dumpRenderTreeTemp.size()];
+    return [@"~/Library/Application Support/DumpRenderTree" stringByExpandingTildeInPath];
 }
 
 static void setWebPreferencesForTestOptions(WebPreferences *preferences, const WTR::TestOptions& options)
@@ -1094,7 +1093,7 @@ static void runTestingServerLoop()
         if (size_t newLineCharacterIndex = find(std::span<const char> { filenameBuffer }, '\n'); newLineCharacterIndex != notFound)
             filenameBuffer[newLineCharacterIndex] = '\0';
 
-        if (!strlen(filenameBuffer.data()))
+        if (!strlenSpan(std::span { filenameBuffer }))
             continue;
 
         if (handleControlCommand(std::span { filenameBuffer }))


### PR DESCRIPTION
#### 4dda9081d58ad072836beddaf27a8823ef52b7b1
<pre>
Reduce use of strlen() in the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=286559">https://bugs.webkit.org/show_bug.cgi?id=286559</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/DataLog.cpp:
(WTF::initializeLogFileOnce):
* Source/WTF/wtf/StringPrintStream.cpp:
(WTF::StringPrintStream::toCString const):
(WTF::StringPrintStream::tryToString const):
(WTF::StringPrintStream::toString const):
(WTF::StringPrintStream::toStringWithLatin1Fallback const):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/dtoa/utils.h:
(WTF::double_conversion::StringBuilder::Finalize):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::requires):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::WTF_REQUIRES_LOCK):
* Source/WebCore/platform/ios/LegacyTileCache.mm:
(WebCore::LegacyTileCache::drawLayer):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtension::createHandleForTemporaryFile):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(libraryPathForDumpRenderTree):
(runTestingServerLoop):

Canonical link: <a href="https://commits.webkit.org/289462@main">https://commits.webkit.org/289462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad4a0bc95082a758ca79b69d1732c655983f76d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67227 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24994 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78722 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47549 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36821 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79753 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93713 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85741 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76032 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75229 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18524 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7008 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19439 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108235 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13893 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26048 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->