### PR TITLE
Return error when storing blobs in IndexedDB for ephemeral session

### DIFF
--- a/LayoutTests/storage/indexeddb/modern/blob-simple-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/blob-simple-private-expected.txt
@@ -1,0 +1,17 @@
+This tests basic operations putting blobs into an object store and then retrieving them.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+Initial upgrade needed: Old version - 0 New version - 1
+Let's create a blob and store it in IndexedDB twice.
+FAIL Failed to add blob with error: Error preparing Blob/File data to be stored in object store
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/blob-simple-private.html
+++ b/LayoutTests/storage/indexeddb/modern/blob-simple-private.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+
+<script src="resources/blob-simple.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/blob-simple-workers-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/blob-simple-workers-private-expected.txt
@@ -1,0 +1,18 @@
+[Worker] This tests basic operations putting blobs into an object store and then retrieving them.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Starting worker: resources/blob-simple-workers.js
+[Worker] indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+[Worker]
+[Worker] indexedDB.deleteDatabase(dbname)
+[Worker] indexedDB.open(dbname)
+[Worker] Initial upgrade needed: Old version - 0 New version - 1
+[Worker] Let's create a blob and store it in IndexedDB twice.
+FAIL [Worker] Failed to add blob with error: Error preparing Blob/File data to be stored in object store
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/blob-simple-workers-private.html
+++ b/LayoutTests/storage/indexeddb/modern/blob-simple-workers-private.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+<script>
+worker = startWorker('resources/blob-simple-workers.js');</script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/resources/blob-simple-workers.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/blob-simple-workers.js
@@ -68,6 +68,11 @@ function* testSteps()
     
     idbRequest(objectStore.add(data));
     event = yield;
+    if (event.type == 'error') {
+        testFailed("Failed to add blob with error: " + event.target.error.message);
+        finishJSTest();
+        return;
+    }
     
     debug("Added blob to database once");
 

--- a/LayoutTests/storage/indexeddb/modern/resources/blob-simple.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/blob-simple.js
@@ -63,7 +63,12 @@ function* testSteps()
     
     idbRequest(objectStore.add(data));
     event = yield;
-    
+    if (event.type == 'error') {
+        testFailed("Failed to add blob with error: " + event.target.error.message);
+        finishJSTest();
+        return;
+    }
+
     debug("Added blob to database once");
 
     let key1 = event.target.result;

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -351,17 +351,6 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::putOrAdd(JSGlobalObject& state, JSV
     if (UNLIKELY(scope.exception()))
         return Exception { ExceptionCode::DataCloneError, "Failed to store record in an IDBObjectStore: An object could not be cloned."_s };
 
-    bool privateBrowsingEnabled = false;
-    if (auto* document = dynamicDowncast<Document>(*context)) {
-        if (auto* page = document->page())
-            privateBrowsingEnabled = page->sessionID().isEphemeral();
-    }
-
-    if (serializedValue->hasBlobURLs() && privateBrowsingEnabled) {
-        // https://bugs.webkit.org/show_bug.cgi?id=156347 - Support Blobs in private browsing.
-        return Exception { ExceptionCode::DataCloneError, "Failed to store record in an IDBObjectStore: BlobURLs are not yet supported."_s };
-    }
-
     if (key && !key->isValid())
         return Exception { ExceptionCode::DataError, "Failed to store record in an IDBObjectStore: The parameter is not a valid key."_s };
 

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -1270,11 +1270,12 @@ void IDBTransaction::putOrAddOnServer(IDBClient::TransactionOperation& operation
         return;
     }
 
+    bool isEphemeral = database().connectionProxy().sessionID().isEphemeral();
     // Due to current limitations on our ability to post tasks back to a worker thread,
     // workers currently write blobs to disk synchronously.
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=157958 - Make this asynchronous after refactoring allows it.
     if (!isMainThread()) {
-        auto idbValue = value->writeBlobsToDiskForIndexedDBSynchronously();
+        auto idbValue = value->writeBlobsToDiskForIndexedDBSynchronously(isEphemeral);
         if (idbValue.data().data())
             m_database->connectionProxy().putOrAdd(operation, key.get(), idbValue, overwriteMode);
         else {
@@ -1293,7 +1294,7 @@ void IDBTransaction::putOrAddOnServer(IDBClient::TransactionOperation& operation
     // stop future requests from going to the server ahead of it.
     operation.setNextRequestCanGoToServer(false);
 
-    value->writeBlobsToDiskForIndexedDB([protectedThis = Ref { *this }, this, protectedOperation = Ref<IDBClient::TransactionOperation>(operation), keyData = IDBKeyData(key.get()).isolatedCopy(), overwriteMode](IDBValue&& idbValue) mutable {
+    value->writeBlobsToDiskForIndexedDB(isEphemeral, [protectedThis = Ref { *this }, this, protectedOperation = Ref<IDBClient::TransactionOperation>(operation), keyData = IDBKeyData(key.get()).isolatedCopy(), overwriteMode](IDBValue&& idbValue) mutable {
         ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
         ASSERT(isMainThread());
         if (idbValue.data().data()) {

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -47,9 +47,10 @@ namespace IDBClient {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(IDBConnectionProxy);
 
-IDBConnectionProxy::IDBConnectionProxy(IDBConnectionToServer& connection)
+IDBConnectionProxy::IDBConnectionProxy(IDBConnectionToServer& connection, PAL::SessionID sessionID)
     : m_connectionToServer(connection)
     , m_serverConnectionIdentifier(connection.identifier())
+    , m_sessionID(sessionID)
 {
     ASSERT(isMainThread());
 }
@@ -62,6 +63,11 @@ void IDBConnectionProxy::ref()
 void IDBConnectionProxy::deref()
 {
     m_connectionToServer->deref();
+}
+
+PAL::SessionID IDBConnectionProxy::sessionID() const
+{
+    return m_sessionID;
 }
 
 Ref<IDBOpenDBRequest> IDBConnectionProxy::openDatabase(ScriptExecutionContext& context, const IDBDatabaseIdentifier& databaseIdentifier, uint64_t version)

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -64,7 +64,7 @@ class IDBConnectionToServer;
 class WEBCORE_EXPORT IDBConnectionProxy final {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(IDBConnectionProxy, WEBCORE_EXPORT);
 public:
-    IDBConnectionProxy(IDBConnectionToServer&);
+    IDBConnectionProxy(IDBConnectionToServer&, PAL::SessionID);
 
     Ref<IDBOpenDBRequest> openDatabase(ScriptExecutionContext&, const IDBDatabaseIdentifier&, uint64_t version);
     void didOpenDatabase(const IDBResultData&);
@@ -129,6 +129,8 @@ public:
     void abortActivitiesForCurrentThread();
     void setContextSuspended(ScriptExecutionContext& currentContext, bool isContextSuspended);
 
+    PAL::SessionID sessionID() const;
+
 private:
     void completeOpenDBRequest(const IDBResultData&);
     bool hasRecordOfTransaction(const IDBTransaction&) const WTF_REQUIRES_LOCK(m_transactionMapLock);
@@ -176,6 +178,7 @@ private:
 
     CrossThreadQueue<CrossThreadTask> m_mainThreadQueue;
     RefPtr<IDBConnectionToServer> m_mainThreadProtector WTF_GUARDED_BY_LOCK(m_mainThreadTaskLock);
+    PAL::SessionID m_sessionID;
 };
 
 } // namespace IDBClient

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -46,14 +46,14 @@ namespace IDBClient {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(IDBConnectionToServer);
 
-Ref<IDBConnectionToServer> IDBConnectionToServer::create(IDBConnectionToServerDelegate& delegate)
+Ref<IDBConnectionToServer> IDBConnectionToServer::create(IDBConnectionToServerDelegate& delegate, PAL::SessionID sessionID)
 {
-    return adoptRef(*new IDBConnectionToServer(delegate));
+    return adoptRef(*new IDBConnectionToServer(delegate, sessionID));
 }
 
-IDBConnectionToServer::IDBConnectionToServer(IDBConnectionToServerDelegate& delegate)
+IDBConnectionToServer::IDBConnectionToServer(IDBConnectionToServerDelegate& delegate, PAL::SessionID sessionID)
     : m_delegate(delegate)
-    , m_proxy(makeUniqueWithoutRefCountedCheck<IDBConnectionProxy>(*this))
+    , m_proxy(makeUniqueWithoutRefCountedCheck<IDBConnectionProxy>(*this, sessionID))
 {
 }
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -31,6 +31,7 @@
 #include "IDBIndexIdentifier.h"
 #include "IDBObjectStoreIdentifier.h"
 #include "IDBResourceIdentifier.h"
+#include <pal/SessionID.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
@@ -60,7 +61,7 @@ class IDBConnectionToServer final : public ThreadSafeRefCounted<IDBConnectionToS
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(IDBConnectionToServer, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBConnectionToServer);
 public:
-    WEBCORE_EXPORT static Ref<IDBConnectionToServer> create(IDBConnectionToServerDelegate&);
+    WEBCORE_EXPORT static Ref<IDBConnectionToServer> create(IDBConnectionToServerDelegate&, PAL::SessionID);
     WEBCORE_EXPORT ~IDBConnectionToServer();
 
     WEBCORE_EXPORT IDBConnectionIdentifier identifier() const;
@@ -148,7 +149,7 @@ public:
     WEBCORE_EXPORT void didGetAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, Vector<IDBDatabaseNameAndVersion>&&);
 
 private:
-    IDBConnectionToServer(IDBConnectionToServerDelegate&);
+    IDBConnectionToServer(IDBConnectionToServerDelegate&, PAL::SessionID);
 
     typedef void (IDBConnectionToServer::*ResultFunction)(const IDBResultData&);
     void callResultFunctionWithErrorLater(ResultFunction, const IDBResourceIdentifier& requestIdentifier);

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -128,8 +128,8 @@ public:
 
     Vector<String> blobURLs() const;
     Vector<URLKeepingBlobAlive> blobHandles() const { return crossThreadCopy(m_internals.blobHandles); }
-    void writeBlobsToDiskForIndexedDB(CompletionHandler<void(IDBValue&&)>&&);
-    IDBValue writeBlobsToDiskForIndexedDBSynchronously();
+    void writeBlobsToDiskForIndexedDB(bool isEphemeral, CompletionHandler<void(IDBValue&&)>&&);
+    IDBValue writeBlobsToDiskForIndexedDBSynchronously(bool isEphemeral);
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
         return adoptRef(*new SerializedScriptValue(WTFMove(data)));

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -232,10 +232,10 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
         ~EmptyIDBConnectionToServerDeletegate() { }
     };
 
-    IDBClient::IDBConnectionToServer& idbConnectionToServerForSession(PAL::SessionID) final
+    IDBClient::IDBConnectionToServer& idbConnectionToServerForSession(PAL::SessionID sessionID) final
     {
         static NeverDestroyed<EmptyIDBConnectionToServerDeletegate> emptyDelegate;
-        static auto& emptyConnection = IDBClient::IDBConnectionToServer::create(emptyDelegate.get()).leakRef();
+        static auto& emptyConnection = IDBClient::IDBConnectionToServer::create(emptyDelegate.get(), sessionID).leakRef();
         return emptyConnection;
     }
 };

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1159,9 +1159,11 @@ void NetworkConnectionToWebProcess::blobSize(const URL& url, CompletionHandler<v
 
 void NetworkConnectionToWebProcess::writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
-    auto* session = networkSession();
+    CheckedPtr session = networkSession();
     if (!session)
         return completionHandler({ });
+
+    MESSAGE_CHECK_COMPLETION(!session->sessionID().isEphemeral(), completionHandler({ }));
 
     Vector<RefPtr<BlobDataFileReference>> fileReferences;
     for (auto& url : blobURLs)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -50,13 +50,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<WebIDBConnectionToServer> WebIDBConnectionToServer::create()
+Ref<WebIDBConnectionToServer> WebIDBConnectionToServer::create(PAL::SessionID sessionID)
 {
-    return adoptRef(*new WebIDBConnectionToServer());
+    return adoptRef(*new WebIDBConnectionToServer(sessionID));
 }
 
-WebIDBConnectionToServer::WebIDBConnectionToServer()
-    : m_connectionToServer(IDBClient::IDBConnectionToServer::create(*this))
+WebIDBConnectionToServer::WebIDBConnectionToServer(PAL::SessionID sessionID)
+    : m_connectionToServer(IDBClient::IDBConnectionToServer::create(*this, sessionID))
 {
 }
 

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -39,7 +39,7 @@ class WebIDBResult;
 
 class WebIDBConnectionToServer final : private WebCore::IDBClient::IDBConnectionToServerDelegate, private IPC::MessageSender, public RefCounted<WebIDBConnectionToServer> {
 public:
-    static Ref<WebIDBConnectionToServer> create();
+    static Ref<WebIDBConnectionToServer> create(PAL::SessionID);
     virtual ~WebIDBConnectionToServer();
 
     WebCore::IDBClient::IDBConnectionToServer& coreConnectionToServer();
@@ -49,7 +49,7 @@ public:
     void connectionToServerLost();
 
 private:
-    WebIDBConnectionToServer();
+    WebIDBConnectionToServer(PAL::SessionID);
 
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final { return 0; }

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -297,7 +297,8 @@ void NetworkProcessConnection::didCacheResource(const ResourceRequest& request, 
 WebIDBConnectionToServer& NetworkProcessConnection::idbConnectionToServer()
 {
     if (!m_webIDBConnection)
-        m_webIDBConnection = WebIDBConnectionToServer::create();
+        m_webIDBConnection = WebIDBConnectionToServer::create(WebProcess::singleton().sessionID());
+
     return *m_webIDBConnection;
 }
 

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -74,7 +74,7 @@ InProcessIDBServer::InProcessIDBServer(PAL::SessionID sessionID, const String& d
     : m_queue(WorkQueue::create("com.apple.WebKit.IndexedDBServer"_s))
 {
     ASSERT(isMainThread());
-    m_connectionToServer = IDBClient::IDBConnectionToServer::create(*this);
+    m_connectionToServer = IDBClient::IDBConnectionToServer::create(*this, sessionID);
     dispatchTask([this, protectedThis = Ref { *this }, directory = databaseDirectoryPath.isolatedCopy()] () mutable {
         m_connectionToClient = IDBServer::IDBConnectionToClient::create(*this);
 


### PR DESCRIPTION
#### 6e23f71b34e62d50b9f18e59b928570712c7c143
<pre>
Return error when storing blobs in IndexedDB for ephemeral session
<a href="https://bugs.webkit.org/show_bug.cgi?id=286561">https://bugs.webkit.org/show_bug.cgi?id=286561</a>
<a href="https://rdar.apple.com/143668397">rdar://143668397</a>

Reviewed by Brady Eidson.

Currently error is only returned for Window context but not Worker, and this makes it look like blobs can be stored in
Workers. To fix it, this patch ensures SerializedScriptValue::writeBlobsToDiskForIndexedDB checks whether it&apos;s ephemeral
session before storing blobs to disk. Also, add a message check in network proccess for corresponding message for
safety.

* LayoutTests/storage/indexeddb/modern/blob-simple-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/blob-simple-private.html: Added.
* LayoutTests/storage/indexeddb/modern/blob-simple-workers-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/blob-simple-workers-private.html: Added.
* LayoutTests/storage/indexeddb/modern/resources/blob-simple-workers.js:
* LayoutTests/storage/indexeddb/modern/resources/blob-simple.js:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::putOrAdd):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::putOrAddOnServer):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::IDBConnectionProxy):
(WebCore::IDBClient::IDBConnectionProxy::sessionID const):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::create):
(WebCore::IDBClient::IDBConnectionToServer::IDBConnectionToServer):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::SerializedScriptValue::writeBlobsToDiskForIndexedDB):
(WebCore::SerializedScriptValue::writeBlobsToDiskForIndexedDBSynchronously):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::writeBlobsToTemporaryFilesForIndexedDB):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp:
(WebKit::WebIDBConnectionToServer::create):
(WebKit::WebIDBConnectionToServer::WebIDBConnectionToServer):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::idbConnectionToServer):
* Source/WebKitLegacy/Storage/InProcessIDBServer.cpp:
(InProcessIDBServer::InProcessIDBServer):

Canonical link: <a href="https://commits.webkit.org/289628@main">https://commits.webkit.org/289628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49ee9911923d384da5f4abfab448129b81421fad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15236 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25375 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47979 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94303 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14721 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7672 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14737 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14481 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->