### PR TITLE
REGRESSION(289032@main): [Win] ImageBufferCairoSurfaceBackend.cpp(99,33): error: redefinition of 'span(cairo_surface_t*)'

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
@@ -94,6 +94,20 @@ WEBCORE_EXPORT void copyRectFromOneSurfaceToAnother(cairo_surface_t* from, cairo
 IntSize cairoSurfaceSize(cairo_surface_t*);
 void flipImageSurfaceVertically(cairo_surface_t*);
 
+inline std::span<const uint8_t> span(cairo_surface_t* surface)
+{
+    size_t stride = cairo_image_surface_get_stride(surface);
+    size_t height = cairo_image_surface_get_height(surface);
+    return unsafeMakeSpan(cairo_image_surface_get_data(surface), stride * height);
+}
+
+inline std::span<uint8_t> mutableSpan(cairo_surface_t* surface)
+{
+    size_t stride = cairo_image_surface_get_stride(surface);
+    size_t height = cairo_image_surface_get_height(surface);
+    return unsafeMakeSpan(cairo_image_surface_get_data(surface), stride * height);
+}
+
 cairo_matrix_t toCairoMatrix(const AffineTransform&);
 
 void attachSurfaceUniqueID(cairo_surface_t*);

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
@@ -40,13 +40,6 @@
 
 namespace WebCore {
 
-static std::span<const uint8_t> span(cairo_surface_t* surface)
-{
-    size_t stride = cairo_image_surface_get_stride(surface);
-    size_t height = cairo_image_surface_get_height(surface);
-    return unsafeMakeSpan(cairo_image_surface_get_data(surface), stride * height);
-}
-
 GraphicsContextGLImageExtractor::~GraphicsContextGLImageExtractor() = default;
 
 bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool ignoreGammaAndColorProfile, bool)

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -32,6 +32,7 @@
 
 #include "BitmapImage.h"
 #include "CairoOperations.h"
+#include "CairoUtilities.h"
 #include "Color.h"
 #include "GraphicsContext.h"
 #include "ImageBufferUtilitiesCairo.h"
@@ -94,20 +95,6 @@ RefPtr<NativeImage> ImageBufferCairoSurfaceBackend::cairoSurfaceCoerceToImage()
     if (cairo_surface_get_type(m_surface.get()) == CAIRO_SURFACE_TYPE_IMAGE && cairo_surface_get_content(m_surface.get()) == CAIRO_CONTENT_COLOR_ALPHA)
         return createNativeImageReference();
     return copyNativeImage();
-}
-
-static std::span<const uint8_t> span(cairo_surface_t* surface)
-{
-    size_t stride = cairo_image_surface_get_stride(surface);
-    size_t height = cairo_image_surface_get_height(surface);
-    return unsafeMakeSpan(cairo_image_surface_get_data(surface), stride * height);
-}
-
-static std::span<uint8_t> mutableSpan(cairo_surface_t* surface)
-{
-    size_t stride = cairo_image_surface_get_stride(surface);
-    size_t height = cairo_image_surface_get_height(surface);
-    return unsafeMakeSpan(cairo_image_surface_get_data(surface), stride * height);
 }
 
 void ImageBufferCairoSurfaceBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)


### PR DESCRIPTION
#### d55283b7fc9aca5a9e71d551e4d67fc99c786554
<pre>
REGRESSION(289032@main): [Win] ImageBufferCairoSurfaceBackend.cpp(99,33): error: redefinition of &apos;span(cairo_surface_t*)&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=286562">https://bugs.webkit.org/show_bug.cgi?id=286562</a>

Unreviewed build fix for Windows Debug builds.

Moved the duplicated functions to CairoUtilities.h to merge.

* Source/WebCore/platform/graphics/cairo/CairoUtilities.h:
(WebCore::span):
(WebCore::mutableSpan):
* Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp:
(WebCore::span): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::span): Deleted.
(WebCore::mutableSpan): Deleted.

Canonical link: <a href="https://commits.webkit.org/289408@main">https://commits.webkit.org/289408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/723588390c8d10a2ab9be99c85b9a829c3abf37c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5065 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36726 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93617 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75957 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75154 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6863 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13498 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14052 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13790 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->