### PR TITLE
Set logical top and height of table rows and cells in the first layout pass

### DIFF
--- a/LayoutTests/fragmentation/break-in-first-table-row-only-expected.txt
+++ b/LayoutTests/fragmentation/break-in-first-table-row-only-expected.txt
@@ -1,0 +1,12 @@
+There should be a hotpink square below.
+
+
+
+
+
+
+
+
+
+
+PASS

--- a/LayoutTests/fragmentation/break-in-first-table-row-only.html
+++ b/LayoutTests/fragmentation/break-in-first-table-row-only.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+    body { overflow: scroll; }
+</style>
+<p>There should be a hotpink square below.</p>
+<div id="multicol" style="position:relative; columns:2; column-fill:auto; column-gap:0; width:100px; height:90px; line-height:20px; orphans:1; widows:1;">
+    <br>
+    <br>
+    <br>
+    <table data-expected-height="110" cellspacing="0" cellpadding="0">
+        <col style="width:10px;">
+        <col style="width:10px;">
+        <tr data-expected-height="50">
+            <td data-expected-height="50">
+                <br><br>
+            </td>
+        </tr>
+        <tr data-expected-height="60">
+            <td data-expected-height="60">
+                <br>
+                <div data-offset-y="40" style="position:relative; background:hotpink;"><br></div>
+                <br>
+            </td>
+            <td>
+                <div data-offset-y="40" style="position:relative; height:20px; background:hotpink;"><br></div>
+            </td>
+        </tr>
+    </table>
+</div>
+<script src="../resources/check-layout.js"></script>
+<script>
+    checkLayout("#multicol");
+</script>

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -4,8 +4,8 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -150,6 +150,7 @@ void RenderTableRow::layout()
     bool paginated = layoutState->isPaginated();
 
     for (RenderTableCell* cell = firstCell(); cell; cell = cell->nextCell()) {
+        cell->setLogicalTop(logicalTop());
         if (!cell->needsLayout() && paginated && (layoutState->pageLogicalHeightChanged() || (layoutState->pageLogicalHeight() && layoutState->pageLogicalOffset(cell, cell->logicalTop()) != cell->pageLogicalOffset())))
             cell->setChildNeedsLayout(MarkOnlyThis);
 

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -5,6 +5,7 @@
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -340,9 +341,10 @@ void RenderTableSection::layout()
 
     LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
     bool paginated = view().frameView().layoutContext().layoutState()->isPaginated();
-    
+
     const Vector<LayoutUnit>& columnPos = table()->columnPositions();
-    
+
+    LayoutUnit rowLogicalTop;
     for (unsigned r = 0; r < m_grid.size(); ++r) {
         Row& row = m_grid[r].row;
         unsigned cols = row.size();
@@ -366,13 +368,39 @@ void RenderTableSection::layout()
         }
 
         if (RenderTableRow* rowRenderer = m_grid[r].rowRenderer) {
-            if (!rowRenderer->needsLayout() && paginated && view().frameView().layoutContext().layoutState()->pageLogicalHeightChanged())
-                rowRenderer->setChildNeedsLayout(MarkOnlyThis);
-
+            if (paginated) {
+                rowRenderer->setLogicalTop(rowLogicalTop);
+                if (rowRenderer->needsLayout())
+                    rowRenderer->setChildNeedsLayout(MarkOnlyThis);
+            }
             rowRenderer->layoutIfNeeded();
+            if (paginated) {
+                rowRenderer->setLogicalTop(LayoutUnit(logicalHeightForRow(*rowRenderer)));
+                rowLogicalTop = rowRenderer->logicalBottom();
+                rowLogicalTop += LayoutUnit(table()->vBorderSpacing());
+            }
         }
     }
     clearNeedsLayout();
+}
+
+int RenderTableSection::logicalHeightForRow(const RenderTableRow& rowObject) const
+{
+    unsigned rowIndex = rowObject.rowIndex();
+    int logicalHeight = 0;
+    const auto& row = m_grid[rowIndex].row;
+    unsigned cols = row.size();
+    for (unsigned colIndex = 0; colIndex < cols; colIndex++) {
+        const auto& cellStruct = cellAt(rowIndex, colIndex);
+        const auto* cell = cellStruct.primaryCell();
+        if (!cell || cellStruct.inColSpan)
+            continue;
+        // FIXME: Rowspanned cells also need to contribute to row heights
+        // during the first layout pass, in order to get fragmentation right.
+        if (cell->rowSpan() == 1)
+            logicalHeight = std::max<int>(logicalHeight, cell->logicalHeightForRowSizing());
+    }
+    return logicalHeight;
 }
 
 void RenderTableSection::distributeExtraLogicalHeightToPercentRows(LayoutUnit& extraLogicalHeight, int totalPercent)

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -192,7 +192,9 @@ private:
     void ensureRows(unsigned);
 
     void relayoutCellIfFlexed(RenderTableCell&, int rowIndex, int rowHeight);
-    
+
+    int logicalHeightForRow(const RenderTableRow&) const;
+
     void distributeExtraLogicalHeightToPercentRows(LayoutUnit& extraLogicalHeight, int totalPercent);
     void distributeExtraLogicalHeightToAutoRows(LayoutUnit& extraLogicalHeight, unsigned autoRowsCount);
     void distributeRemainingExtraLogicalHeight(LayoutUnit& extraLogicalHeight);


### PR DESCRIPTION
#### d0244c7dd0ed836a2369a0fa285d97c2c0007d53
<pre>
Set logical top and height of table rows and cells in the first layout pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=259576">https://bugs.webkit.org/show_bug.cgi?id=259576</a>
<a href="https://rdar.apple.com/113356300">rdar://113356300</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/0f36142505fcc4bc9b2f3518649befd2b5cbc63f">https://chromium.googlesource.com/chromium/src.git/+/0f36142505fcc4bc9b2f3518649befd2b5cbc63f</a>

This gives the fragmentation machinery an opportunity to insert breaks at the
right places. We previously assumed that all cells were at the top of their
table section, so break insertion was completely bogus. While we&apos;d get a second
chance to break correctly in the second layout pass, this doesn&apos;t always work
too well. There&apos;s currently some code in layoutRows() in RenderTableSection
that attempts to adjust the row height when we change where we break inside a
table cell, but it doesn&apos;t re-align cells vertically after this adjustment.

* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::layout):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::layout):
(WebCore::RenderTableSection::logicalHeightForRow const):
* Source/WebCore/rendering/RenderTableSection.h:
* LayoutTests/fragmentation/break-in-first-table-row-only.html:
* LayoutTests/fragmentation/break-in-first-table-row-only-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0244c7dd0ed836a2369a0fa285d97c2c0007d53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14468 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67174 "Found 6 new test failures: fast/multicol/span/clone-summary.html fast/multicol/table-dynamic-movement.html imported/blink/fast/multicol/span/summary-split.html imported/blink/fast/multicol/table-cell-content-change-with-decorations.html imported/blink/fast/multicol/table-cell-content-change.html imported/w3c/web-platform-tests/css/css-break/table/table-cell-expansion-010.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24948 "Found 2 new test failures: fast/forms/number/number-spinbutton-in-multi-column.html fast/forms/select/listbox-in-multi-column.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89900 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5083 "Found 6 new test failures: fast/forms/switch/click-animation-twice-fast.html fast/multicol/span/clone-summary.html fast/multicol/table-dynamic-movement.html imported/blink/fast/multicol/span/summary-split.html imported/blink/fast/multicol/table-cell-content-change-with-decorations.html imported/blink/fast/multicol/table-cell-content-change.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47492 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4868 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-break/table/table-cell-expansion-010.html imported/w3c/web-platform-tests/css/css-multicol/table/balance-table-with-border-spacing.html imported/w3c/web-platform-tests/css/css-multicol/table/table-cell-content-change-000.html imported/w3c/web-platform-tests/css/css-multicol/table/table-cell-content-change-001.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33014 "Found 14 new test failures: editing/undo/redo-reapply-edit-command-crash.html fast/forms/select/listbox-in-multi-column.html fast/multicol/span/clone-summary.html fast/multicol/table-dynamic-movement.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/blink/fast/multicol/span/summary-split.html imported/blink/fast/multicol/table-cell-content-change-with-decorations.html imported/blink/fast/multicol/table-cell-content-change.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75370 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33893 "Found 11 new test failures: fast/forms/number/number-spinbutton-in-multi-column.html fast/forms/select/listbox-in-multi-column.html fast/multicol/span/clone-summary.html fast/multicol/table-dynamic-movement.html imported/blink/fast/multicol/span/summary-split.html imported/blink/fast/multicol/table-cell-content-change-with-decorations.html imported/blink/fast/multicol/table-cell-content-change.html imported/w3c/web-platform-tests/css/css-break/table/table-cell-expansion-010.html imported/w3c/web-platform-tests/css/css-multicol/table/balance-table-with-border-spacing.html imported/w3c/web-platform-tests/css/css-multicol/table/table-cell-content-change-000.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14050 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10205 "Found 11 new test failures: fast/forms/number/number-spinbutton-in-multi-column.html fast/forms/select/listbox-in-multi-column.html fast/multicol/span/clone-summary.html fast/multicol/table-dynamic-movement.html imported/blink/fast/multicol/span/summary-split.html imported/blink/fast/multicol/table-cell-content-change-with-decorations.html imported/blink/fast/multicol/table-cell-content-change.html imported/w3c/web-platform-tests/css/css-break/table/table-cell-expansion-010.html imported/w3c/web-platform-tests/css/css-multicol/table/balance-table-with-border-spacing.html imported/w3c/web-platform-tests/css/css-multicol/table/table-cell-content-change-000.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75973 "Found 11 new test failures: fast/forms/number/number-spinbutton-in-multi-column.html fast/forms/select/listbox-in-multi-column.html fast/multicol/span/clone-summary.html fast/multicol/table-dynamic-movement.html imported/blink/fast/multicol/span/summary-split.html imported/blink/fast/multicol/table-cell-content-change-with-decorations.html imported/blink/fast/multicol/table-cell-content-change.html imported/w3c/web-platform-tests/css/css-break/table/table-cell-expansion-010.html imported/w3c/web-platform-tests/css/css-multicol/table/balance-table-with-border-spacing.html imported/w3c/web-platform-tests/css/css-multicol/table/table-cell-content-change-000.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75170 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19491 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17908 "Found 11 new test failures: fast/forms/number/number-spinbutton-in-multi-column.html fast/forms/select/listbox-in-multi-column.html fast/multicol/span/clone-summary.html fast/multicol/table-dynamic-movement.html imported/blink/fast/multicol/span/summary-split.html imported/blink/fast/multicol/table-cell-content-change-with-decorations.html imported/blink/fast/multicol/table-cell-content-change.html imported/w3c/web-platform-tests/css/css-break/table/table-cell-expansion-010.html imported/w3c/web-platform-tests/css/css-multicol/table/balance-table-with-border-spacing.html imported/w3c/web-platform-tests/css/css-multicol/table/table-cell-content-change-000.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6884 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13811 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->