### PR TITLE
[Gtk][WPE][Skia] CPU rendering fires an EGL related assertion, when NativeImage/ImageBuffers are drawn

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -213,7 +213,7 @@ struct ApplyItemResult {
 };
 
 enum class ReplayOption : uint8_t {
-    FlushImagesAndWaitForCompletion = 1 << 0,
+    FlushAcceleratedImagesAndWaitForCompletion = 1 << 0,
 };
 
 enum class AsTextFlag : uint8_t {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -503,7 +503,7 @@ void RecorderImpl::setURLForRect(const URL& link, const FloatRect& destRect)
 bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 {
 #if USE(SKIA)
-    if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
+    if (m_displayList.replayOptions().contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion))
         nativeImage.backend().finishAcceleratedRenderingAndCreateFence();
 #endif
 
@@ -514,7 +514,7 @@ bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 bool RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
 {
 #if USE(SKIA)
-    if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
+    if (m_displayList.replayOptions().contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion))
         imageBuffer.finishAcceleratedRenderingAndCreateFence();
 #endif
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -98,7 +98,7 @@ public:
         auto* imageBuffer = get<ImageBuffer>(renderingResourceIdentifier);
 
 #if USE(SKIA)
-        if (imageBuffer && options.contains(ReplayOption::FlushImagesAndWaitForCompletion))
+        if (imageBuffer && options.contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion))
             imageBuffer->waitForAcceleratedRenderingFenceCompletion();
 #else
         UNUSED_PARAM(options);
@@ -113,7 +113,7 @@ public:
         auto* nativeImage = dynamicDowncast<NativeImage>(renderingResource);
 
 #if USE(SKIA)
-        if (nativeImage && options.contains(ReplayOption::FlushImagesAndWaitForCompletion))
+        if (nativeImage && options.contains(ReplayOption::FlushAcceleratedImagesAndWaitForCompletion))
             nativeImage->backend().waitForAcceleratedRenderingFenceCompletion();
 #else
         UNUSED_PARAM(options);

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -60,7 +60,7 @@ public:
 
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
-    std::unique_ptr<DisplayList::DisplayList> recordDisplayList(const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const;
+    std::unique_ptr<DisplayList::DisplayList> recordDisplayList(RenderingMode, const GraphicsLayer&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
 
     static bool paintDisplayListIntoBuffer(Ref<CoordinatedTileBuffer>&, DisplayList::DisplayList&);


### PR DESCRIPTION
#### 5d5c7351cfd8dcda26eb1b1159d750a5e9bbe406
<pre>
[Gtk][WPE][Skia] CPU rendering fires an EGL related assertion, when NativeImage/ImageBuffers are drawn
<a href="https://bugs.webkit.org/show_bug.cgi?id=286566">https://bugs.webkit.org/show_bug.cgi?id=286566</a>

Reviewed by Carlos Garcia Campos.

Visiting e.g. igalia.com, fires an assertion when Skia/CPU rendering is
active. During recording of the displayl ist, we unconditionally create
fences when ImageBuffers/NativeImages are used. This is not correct for
CPU rendering and leads to the assertion, when the Skia/CPU painting
threads attempt to wait for fence completion:

    No provider of eglWaitSync found.  Requires one of:
        EGL 15

The painting threads don&apos;t own a SkiaGLContext in non-GPU painting mode,
therefore we see the EGL error from above. Fix that, by not passing
DisplayList::FlushImagesAndWaitForCompletion as ReplayOption during
display list recording. To clarify, that this option is intended to be
used with accelerated rendering, rename it to
DisplayList::FlushAcceleratedImagesAndWaitForCompletion.

Covered by existing tests, when CPU rendering is chosen.

* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::recordDisplayList const):
(WebCore::SkiaPaintingEngine::postPaintingTask):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:

Canonical link: <a href="https://commits.webkit.org/289419@main">https://commits.webkit.org/289419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/282e3a01adc79830e94decff1e865fa179a48c94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67177 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5084 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4869 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36750 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93641 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75975 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74501 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18478 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6887 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19339 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->