### PR TITLE
RenderTable::BottomSection() should return the last rendered table section

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>CSS Test: Table border is correct even with out of order tbody, thead, tfoot</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/tables.html#forming-a-table">
+<style>
+table {
+    border: 3px solid blue;
+    border-collapse:collapse;}
+td, th {height: 20px; width:20px;}
+tbody {background-color: gold;}
+thead {background-color: pink;}
+tfoot {background-color: lightgreen;}
+</style>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+</table>
+<table>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border-ref.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>CSS Test: Table border is correct even with out of order tbody, thead, tfoot</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/tables.html#forming-a-table">
+<style>
+table {
+    border: 3px solid blue;
+    border-collapse:collapse;}
+td, th {height: 20px; width:20px;}
+tbody {background-color: gold;}
+thead {background-color: pink;}
+tfoot {background-color: lightgreen;}
+</style>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+</table>
+<table>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>
+<table>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<title>CSS Test: Table border is correct even with out of order tbody, thead, tfoot</title>
+<link rel="author" title="Karl Dubost" href="mailto:karlcow@apple.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/tables.html#forming-a-table">
+<link rel="match" href="out-of-order-elements-collapsed-border-ref.html">
+<style>
+table {
+    border: 3px solid blue;
+    border-collapse:collapse;}
+td, th {height: 20px; width:20px;}
+tbody {background-color: gold;}
+thead {background-color: pink;}
+tfoot {background-color: lightgreen;}
+</style>
+<table>
+    <tbody><tr><td></td></tr></tbody>
+    <thead><tr><th></th></tr></thead>
+</table>
+<table>
+    <tfoot><tr><th></th></tr></tfoot>
+    <tbody><tr><td></td></tr></tbody>
+</table>
+<table>
+    <tfoot><tr><th></th></tr></tfoot>
+    <tbody><tr><td></td></tr></tbody>
+    <thead><tr><th></th></tr></thead>
+</table>
+<table>
+    <tfoot><tr><th></th></tr></tfoot>
+    <thead><tr><th></th></tr></thead>
+    <tbody><tr><td></td></tr></tbody>
+</table>
+<table>
+    <tbody><tr><td></td></tr></tbody>
+    <tfoot><tr><th></th></tr></tfoot>
+    <thead><tr><th></th></tr></thead>
+</table>
+<table>
+    <tbody><tr><td></td></tr></tbody>
+    <thead><tr><th></th></tr></thead>
+    <tfoot><tr><th></th></tr></tfoot>
+</table>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -133,6 +133,20 @@ RenderTableSection* RenderTable::topSection() const
     return m_foot.get();
 }
 
+RenderTableSection* RenderTable::bottomSection() const
+{
+    recalcSectionsIfNeeded();
+    if (m_foot)
+        return m_foot.get();
+    for (CheckedPtr child = lastChild(); child; child = child->previousSibling()) {
+        if (child.get() == m_head.get())
+            continue;
+        if (auto* tableSection = dynamicDowncast<RenderTableSection>(*child))
+            return tableSection;
+    }
+    return m_head.get();
+}
+
 void RenderTable::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBlock::styleDidChange(diff, oldStyle);
@@ -1466,18 +1480,6 @@ RenderTableSection* RenderTable::sectionBelow(const RenderTableSection* section,
     }
     if (!nextSection && m_foot && (skipEmptySections == DoNotSkipEmptySections || m_foot->numRows()))
         return m_foot.get();
-    return nullptr;
-}
-
-RenderTableSection* RenderTable::bottomSection() const
-{
-    recalcSectionsIfNeeded();
-    if (m_foot)
-        return m_foot.get();
-    for (RenderObject* child = lastChild(); child; child = child->previousSibling()) {
-        if (auto* tableSection = dynamicDowncast<RenderTableSection>(*child))
-            return tableSection;
-    }
     return nullptr;
 }
 


### PR DESCRIPTION
#### 1d539b1ae929bb6062b9501cc61c97d57c0108b1
<pre>
RenderTable::BottomSection() should return the last rendered table section
<a href="https://bugs.webkit.org/show_bug.cgi?id=257575">https://bugs.webkit.org/show_bug.cgi?id=257575</a>
<a href="https://rdar.apple.com/110430887">rdar://110430887</a>

Reviewed by Alan Baradlay.

BottomSection() was not necessary returning the last rendered section.
In return it had an impact on drawing the border of the table element
when the borders are collapsed.
See <a href="https://searchfox.org/wubkat/rev/47b66cb0dc7c2146fa7576555c720080708667f3/Source/WebCore/rendering/RenderTable.cpp#1358-1378">https://searchfox.org/wubkat/rev/47b66cb0dc7c2146fa7576555c720080708667f3/Source/WebCore/rendering/RenderTable.cpp#1358-1378</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/out-of-order-elements-collapsed-border.html: Added.
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::bottomSection const):

Canonical link: <a href="https://commits.webkit.org/289434@main">https://commits.webkit.org/289434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dbb451b1b890005ebe61b561bc8cd777529e403

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67224 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24991 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89970 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5155 "Failed to checkout and rebase branch from PR 39589") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78717 "Failed to checkout and rebase branch from PR 39589") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47546 "Failed to checkout and rebase branch from PR 39589") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33089 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10273 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76029 "Failed to checkout and rebase branch from PR 39589") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74570 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75226 "Failed to checkout and rebase branch from PR 39589") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19552 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17977 "Failed to checkout and rebase branch from PR 39589") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7007 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14147 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19438 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->