### PR TITLE
MediaStreamTrack audio rendering may be broken in case page is capturing with and without echo cancellation

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -120,6 +120,7 @@ public:
     virtual const CAAudioStreamDescription& format() = 0;
     virtual void captureUnitIsStarting() = 0;
     virtual void captureUnitHasStopped() = 0;
+    virtual void canRenderAudioChanged() = 0;
     // Background thread.
     virtual OSStatus produceSpeakerSamples(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) = 0;
 };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedInternalUnit.h
@@ -50,6 +50,7 @@ private:
     OSStatus defaultInputDevice(uint32_t*) final;
     OSStatus defaultOutputDevice(uint32_t*) final;
     bool setVoiceActivityDetection(bool) final;
+    bool canRenderAudio() const final { return m_shouldUseVPIO; }
 
     CoreAudioSharedUnit::StoredAudioUnit m_audioUnit;
     bool m_shouldUseVPIO { false };


### PR DESCRIPTION
#### fafc27995052a8103c0d999576767b746e27722c
<pre>
MediaStreamTrack audio rendering may be broken in case page is capturing with and without echo cancellation
<a href="https://bugs.webkit.org/show_bug.cgi?id=286572">https://bugs.webkit.org/show_bug.cgi?id=286572</a>
<a href="https://rdar.apple.com/143691994">rdar://143691994</a>

Reviewed by Eric Carlson.

Audio rendering through the capture unit is only supported for VPIO.
We need to reevaluate whether using the capture unit for audio rendering everytime a new audio unit is stored.

We add a method to CoreAudioSpeakerSamplesProducer to handle this and we update CoreAudioSharedUnit and RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit to deal with it.
We implement RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::canRenderAudioChanged by asynchronoulsy updating the audio rendering unit to prevent a deadlock.
We do a small refactoring in RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit so that there is a single routine that computes whther audio rendering should go through the capture unit.
We fix CoreAudioSharedInternalUnit::canRenderAudio to properly handle this as well.

* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedInternalUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::setupAudioUnit):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::computeShouldRegisterAsSpeakerSamplesProducer const):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::setShouldRegisterAsSpeakerSamplesProducer):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::start):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::updateShouldRegisterAsSpeakerSamplesProducer):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::canRenderAudioChanged):

Canonical link: <a href="https://commits.webkit.org/289449@main">https://commits.webkit.org/289449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2710f5317a63f4f35776a1799f32a74f626cc07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67192 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47510 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36767 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93658 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14070 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10222 "Found 1 new test failure: accessibility/mac/scrolling-in-pdf-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75188 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18514 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6915 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19358 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13831 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->