### PR TITLE
GraphicsContext::drawLinesForText might read out of bounds

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2060,6 +2060,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/FloatQuad.h
     platform/graphics/FloatRect.h
     platform/graphics/FloatRoundedRect.h
+    platform/graphics/FloatSegment.h
     platform/graphics/FloatSize.h
     platform/graphics/Font.h
     platform/graphics/FontBaseline.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2464,6 +2464,7 @@ platform/graphics/FloatPolygon.cpp
 platform/graphics/FloatQuad.cpp
 platform/graphics/FloatRect.cpp
 platform/graphics/FloatRoundedRect.cpp
+platform/graphics/FloatSegment.cpp
 platform/graphics/FloatSize.cpp
 platform/graphics/Font.cpp
 platform/graphics/FontCache.cpp

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -562,10 +562,10 @@ void BifurcatedGraphicsContext::drawBidiText(const FontCascade& cascade, const T
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::drawLinesForText(const FloatPoint& point, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle strokeStyle)
+void BifurcatedGraphicsContext::drawLinesForText(const FloatPoint& point, float thickness, std::span<const FloatSegment> lineSegments, bool printing, bool doubleLines, StrokeStyle strokeStyle)
 {
-    m_primaryContext.drawLinesForText(point, thickness, widths, printing, doubleLines, strokeStyle);
-    m_secondaryContext.drawLinesForText(point, thickness, widths, printing, doubleLines, strokeStyle);
+    m_primaryContext.drawLinesForText(point, thickness, lineSegments, printing, doubleLines, strokeStyle);
+    m_secondaryContext.drawLinesForText(point, thickness, lineSegments, printing, doubleLines, strokeStyle);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -137,7 +137,7 @@ public:
     void drawEmphasisMarks(const FontCascade&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) final;
     void drawBidiText(const FontCascade&, const TextRun&, const FloatPoint&, FontCascade::CustomFontNotReadyAction = FontCascade::CustomFontNotReadyAction::DoNotPaintIfFontNotReady) final;
 
-    void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
+    void drawLinesForText(const FloatPoint&, float thickness, std::span<const FloatSegment>, bool isPrinting, bool doubleLines, StrokeStyle) final;
 
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
 

--- a/Source/WebCore/platform/graphics/DashArray.h
+++ b/Source/WebCore/platform/graphics/DashArray.h
@@ -41,6 +41,8 @@ using DashArrayElement = double;
 using DashArrayElement = float;
 #endif
 
+// DashArray is array of lengths along a path, with elements alternating on, off, on, off state.
+// The array is applied circularly mod path length.
 using DashArray = Vector<DashArrayElement>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FloatSegment.cpp
+++ b/Source/WebCore/platform/graphics/FloatSegment.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FloatSegment.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, FloatSegment floatSegment)
+{
+    TextStream::GroupScope scope(ts);
+    ts.dumpProperty("begin", floatSegment.begin);
+    ts.dumpProperty("end", floatSegment.end);
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/FloatSegment.h
+++ b/Source/WebCore/platform/graphics/FloatSegment.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <wtf/Vector.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+struct FloatSegment {
+    float begin { 0.f };
+    float end { 0.f };
+    bool operator==(const FloatSegment&) const = default;
+    float length() const { return end - begin; }
+    FloatSegment dilate(float length) { return { begin - length, end + length }; }
+};
+
+
+// Computes difference between a line segment `a` and list of line segments `bs` that are dilated by
+// dilationAmount.
+// The difference list is further filtered to only results > dilationAmount.
+//
+// Vector<FloatSegment> intersections = ...;
+// Vector<FloatSegment> solidLine { { 0, totalWidth } };
+// Vector<FloatSegment> diff = difference(solidLine, dilate(intersections, dilationAmount));
+// return filter(diff, [](auto&& s) { return s.length() > dilationAmount });
+// <=>
+// return differenceWithDilation({ 0, totalWidth }, intersections);
+inline Vector<FloatSegment> differenceWithDilation(FloatSegment a, Vector<FloatSegment>&& bs, float dilationAmount)
+{
+    std::sort(bs.begin(), bs.end(), [](auto&& a, auto&& b) {
+        return a.begin < b.begin;
+    });
+
+    auto result = bs.begin();
+    for (auto b : bs) {
+        if (a.begin >= a.end)
+            break;
+        b = b.dilate(dilationAmount);
+        if (b.begin >= a.end)
+            break;
+        FloatSegment candidate { a.begin, b.begin };
+        if (candidate.length() > dilationAmount) {
+            *result = candidate;
+            result = std::next(result);
+        }
+        a.begin = std::max(a.begin, b.end);
+    }
+    bs.shrink(result - bs.begin());
+    if (a.length() > dilationAmount)
+        bs.append(a);
+    return WTFMove(bs);
+}
+
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, FloatSegment);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "DashArray.h"
+#include "FloatSegment.h"
 #include "Font.h"
 #include "FontCascadeDescription.h"
 #include "FontCascadeFonts.h"
@@ -144,7 +144,7 @@ public:
     static void drawGlyphs(GraphicsContext&, const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
     void drawEmphasisMarks(GraphicsContext&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) const;
 
-    DashArray dashesForIntersectionsWithRect(const TextRun&, const FloatPoint& textOrigin, const FloatRect& lineExtents) const;
+    Vector<FloatSegment> lineSegmentsForIntersectionsWithRect(const TextRun&, const FloatPoint& textOrigin, const FloatRect& lineExtents) const;
 
     float widthOfTextRange(const TextRun&, unsigned from, unsigned to, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, float* outWidthBeforeRange = nullptr, float* outWidthAfterRange = nullptr) const;
     WEBCORE_EXPORT float width(const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -87,7 +87,7 @@ private:
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final { }
     void strokeRect(const FloatRect&, float) final { }
     void clipPath(const Path&, WindRule = WindRule::EvenOdd) final { }
-    void drawLinesForText(const FloatPoint&, float, const DashArray&, bool, bool = false, StrokeStyle = StrokeStyle::SolidStroke) final { }
+    void drawLinesForText(const FloatPoint&, float, std::span<const FloatSegment>, bool, bool, StrokeStyle) final { }
     void setLineCap(LineCap) final { }
     void setLineDash(const DashArray&, float) final { }
     void setLineJoin(LineJoin) final { }

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -701,9 +701,9 @@ void OperationRecorder::drawLine(const FloatPoint& point1, const FloatPoint& poi
     append(createCommand<DrawLine>(point1, point2, state.strokeStyle(), state.strokeBrush().color(), state.strokeThickness(), state.shouldAntialias()));
 }
 
-void OperationRecorder::drawLinesForText(const FloatPoint& point, float thickness, const DashArray& widths, bool printing, bool doubleUnderlines, StrokeStyle)
+void OperationRecorder::drawLinesForText(const FloatPoint& point, float thickness, std::span<const FloatSegment> lineSegments, bool printing, bool doubleUnderlines, StrokeStyle)
 {
-    struct DrawLinesForText final : PaintingOperation, OperationData<FloatPoint, float, DashArray, bool, bool, Color> {
+    struct DrawLinesForText final : PaintingOperation, OperationData<FloatPoint, float, Vector<FloatSegment>, bool, bool, Color> {
         virtual ~DrawLinesForText() = default;
 
         void execute(WebCore::GraphicsContextCairo& context) override
@@ -717,11 +717,12 @@ void OperationRecorder::drawLinesForText(const FloatPoint& point, float thicknes
         }
     };
 
-    if (widths.isEmpty())
+    if (lineSegments.empty())
         return;
 
     auto& state = this->state();
-    append(createCommand<DrawLinesForText>(point, thickness, widths, printing, doubleUnderlines, state.strokeBrush().color()));
+    Vector<FloatSegment> segmentVector { WTFMove(lineSegments) };
+    append(createCommand<DrawLinesForText>(point, thickness, WTFMove(segmentVector), printing, doubleUnderlines, state.strokeBrush().color()));
 }
 
 void OperationRecorder::drawDotsForDocumentMarker(const FloatRect& rect, DocumentMarkerLineStyle style)

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -76,7 +76,7 @@ private:
 
     void drawRect(const WebCore::FloatRect&, float) override;
     void drawLine(const WebCore::FloatPoint&, const WebCore::FloatPoint&) override;
-    void drawLinesForText(const WebCore::FloatPoint&, float thickness, const WebCore::DashArray&, bool, bool, WebCore::StrokeStyle) override;
+    void drawLinesForText(const WebCore::FloatPoint&, float thickness, std::span<const WebCore::FloatSegment>, bool, bool, WebCore::StrokeStyle) override;
     void drawDotsForDocumentMarker(const WebCore::FloatRect&, WebCore::DocumentMarkerLineStyle) override;
     void drawEllipse(const WebCore::FloatRect&) override;
 

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.h
@@ -148,7 +148,7 @@ WEBCORE_EXPORT void drawSurface(GraphicsContextCairo&, cairo_surface_t*, const F
 
 void drawRect(GraphicsContextCairo&, const FloatRect&, float, const Color&, StrokeStyle, const Color&);
 void drawLine(GraphicsContextCairo&, const FloatPoint&, const FloatPoint&, StrokeStyle, const Color&, float, bool);
-void drawLinesForText(GraphicsContextCairo&, const FloatPoint&, float thickness, const DashArray&, bool, bool, const Color&);
+void drawLinesForText(GraphicsContextCairo&, const FloatPoint&, float thickness, std::span<const FloatSegment>, bool, bool, const Color&);
 void drawDotsForDocumentMarker(GraphicsContextCairo&, const FloatRect&, DocumentMarkerLineStyle);
 void drawEllipse(GraphicsContextCairo&, const FloatRect&, const Color&, StrokeStyle, const Color&, float);
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -248,11 +248,11 @@ void GraphicsContextCairo::drawFocusRing(const Vector<FloatRect>& rects, float o
 #endif
 }
 
-void GraphicsContextCairo::drawLinesForText(const FloatPoint& point, float thickness, const DashArray& widths, bool printing, bool doubleUnderlines, StrokeStyle)
+void GraphicsContextCairo::drawLinesForText(const FloatPoint& point, float thickness, std::span<const FloatSegment> lineSegments, bool printing, bool doubleUnderlines, StrokeStyle)
 {
-    if (widths.isEmpty())
+    if (lineSegments.empty())
         return;
-    Cairo::drawLinesForText(*this, point, thickness, widths, printing, doubleUnderlines, strokeColor());
+    Cairo::drawLinesForText(*this, point, thickness, lineSegments, printing, doubleUnderlines, strokeColor());
 }
 
 void GraphicsContextCairo::drawDotsForDocumentMarker(const FloatRect& rect, DocumentMarkerLineStyle style)

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -74,7 +74,7 @@ public:
 
     void drawRect(const FloatRect&, float) final;
     void drawLine(const FloatPoint&, const FloatPoint&) final;
-    void drawLinesForText(const FloatPoint&, float thickness, const DashArray&, bool, bool, StrokeStyle) final;
+    void drawLinesForText(const FloatPoint&, float thickness, std::span<const FloatSegment>, bool, bool, StrokeStyle) final;
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
     void drawEllipse(const FloatRect&) final;
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -118,7 +118,7 @@ public:
     void drawFocusRing(const Path&, float outlineWidth, const Color&) final;
     void drawFocusRing(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;
 
-    void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
+    void drawLinesForText(const FloatPoint&, float thickness, std::span<const FloatSegment>, bool isPrinting, bool doubleLines, StrokeStyle) final;
 
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -423,9 +423,9 @@ void DrawLine::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("point-2", point2());
 }
 
-DrawLinesForText::DrawLinesForText(const FloatPoint& point, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle style)
+DrawLinesForText::DrawLinesForText(const FloatPoint& point, std::span<const FloatSegment> lineSegments, float thickness, bool printing, bool doubleLines, StrokeStyle style)
     : m_point(point)
-    , m_widths(widths)
+    , m_lineSegments(lineSegments)
     , m_thickness(thickness)
     , m_printing(printing)
     , m_doubleLines(doubleLines)
@@ -435,7 +435,7 @@ DrawLinesForText::DrawLinesForText(const FloatPoint& point, const DashArray& wid
 
 void DrawLinesForText::apply(GraphicsContext& context) const
 {
-    context.drawLinesForText(m_point, m_thickness, m_widths, m_printing, m_doubleLines, m_style);
+    context.drawLinesForText(m_point, m_thickness, m_lineSegments, m_printing, m_doubleLines, m_style);
 }
 
 void DrawLinesForText::dump(TextStream& ts, OptionSet<AsTextFlag>) const
@@ -443,7 +443,7 @@ void DrawLinesForText::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("point", point());
     ts.dumpProperty("thickness", thickness());
     ts.dumpProperty("double", doubleLines());
-    ts.dumpProperty("widths", widths());
+    ts.dumpProperty("lineSegments", lineSegments());
     ts.dumpProperty("is-printing", isPrinting());
     ts.dumpProperty("double", doubleLines());
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -739,11 +739,11 @@ class DrawLinesForText {
 public:
     static constexpr char name[] = "draw-lines-for-text";
 
-    WEBCORE_EXPORT DrawLinesForText(const FloatPoint&, const DashArray& widths, float thickness, bool printing, bool doubleLines, StrokeStyle);
+    WEBCORE_EXPORT DrawLinesForText(const FloatPoint&, std::span<const FloatSegment> lineSegments, float thickness, bool printing, bool doubleLines, StrokeStyle);
 
     FloatPoint point() const { return m_point; }
     float thickness() const { return m_thickness; }
-    const DashArray& widths() const { return m_widths; }
+    const Vector<FloatSegment>& lineSegments() const { return m_lineSegments; }
     bool isPrinting() const { return m_printing; }
     bool doubleLines() const { return m_doubleLines; }
     StrokeStyle style() const { return m_style; }
@@ -753,7 +753,7 @@ public:
 
 private:
     FloatPoint m_point;
-    DashArray m_widths;
+    Vector<FloatSegment> m_lineSegments;
     float m_thickness;
     bool m_printing;
     bool m_doubleLines;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -260,10 +260,10 @@ void RecorderImpl::drawLine(const FloatPoint& point1, const FloatPoint& point2)
     append(DrawLine(point1, point2));
 }
 
-void RecorderImpl::drawLinesForText(const FloatPoint& point, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle style)
+void RecorderImpl::drawLinesForText(const FloatPoint& point, float thickness, std::span<const FloatSegment> lineSegments, bool printing, bool doubleLines, StrokeStyle style)
 {
     appendStateChangeItemIfNecessary();
-    append(DrawLinesForText(point, widths, thickness, printing, doubleLines, style));
+    append(DrawLinesForText(point, lineSegments, thickness, printing, doubleLines, style));
 }
 
 void RecorderImpl::drawDotsForDocumentMarker(const FloatRect& rect, DocumentMarkerLineStyle style)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -64,7 +64,7 @@ public:
     void endTransparencyLayer() final;
     void drawRect(const FloatRect&, float) final;
     void drawLine(const FloatPoint& point1, const FloatPoint& point2) final;
-    void drawLinesForText(const FloatPoint&, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle) final;
+    void drawLinesForText(const FloatPoint&, float thickness, std::span<const FloatSegment>, bool isPrinting, bool doubleLines, StrokeStyle) final;
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
     void drawEllipse(const FloatRect&) final;
     void drawPath(const Path&) final;

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -70,7 +70,7 @@ public:
 
     void drawRect(const FloatRect&, float) final;
     void drawLine(const FloatPoint&, const FloatPoint&) final;
-    void drawLinesForText(const FloatPoint&, float thickness, const DashArray&, bool, bool, StrokeStyle) final;
+    void drawLinesForText(const FloatPoint&, float thickness, std::span<const FloatSegment>, bool isPrinting, bool doubleLines, StrokeStyle) final;
     void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final;
     void drawEllipse(const FloatRect&) final;
 

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -32,6 +32,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "DashArray.h"
 #include "FontCascade.h"
 #include "ImageBuffer.h"
 #include "MockMediaDevice.h"

--- a/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in
@@ -184,7 +184,7 @@ headers: <WebCore/DisplayListItems.h>
 
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::DisplayList::DrawLinesForText {
     WebCore::FloatPoint point();
-    WebCore::DashArray widths();
+    Vector<WebCore::FloatSegment> lineSegments();
     float thickness();
     bool isPrinting();
     bool doubleLines();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5224,6 +5224,11 @@ header: <WebCore/ImageTypes.h>
     WebCore::Headroom headroom();
 };
 
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::FloatSegment {
+    float begin;
+    float end;
+};
+
 struct WebCore::CanvasActivityRecord {
     HashSet<String> textWritten;
     bool wasDataRead;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -319,10 +319,10 @@ void RemoteDisplayListRecorderProxy::drawLine(const FloatPoint& point1, const Fl
     send(Messages::RemoteDisplayListRecorder::DrawLine(point1, point2));
 }
 
-void RemoteDisplayListRecorderProxy::drawLinesForText(const FloatPoint& point, float thickness, const DashArray& widths, bool printing, bool doubleLines, StrokeStyle style)
+void RemoteDisplayListRecorderProxy::drawLinesForText(const FloatPoint& point, float thickness, std::span<const FloatSegment> lineSegments, bool printing, bool doubleLines, StrokeStyle style)
 {
     appendStateChangeItemIfNecessary();
-    send(Messages::RemoteDisplayListRecorder::DrawLinesForText(DisplayList::DrawLinesForText { point, widths, thickness, printing, doubleLines, style }));
+    send(Messages::RemoteDisplayListRecorder::DrawLinesForText(DisplayList::DrawLinesForText { point, lineSegments, thickness, printing, doubleLines, style }));
 }
 
 void RemoteDisplayListRecorderProxy::drawDotsForDocumentMarker(const FloatRect& rect, DocumentMarkerLineStyle style)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -88,7 +88,7 @@ private:
     void endTransparencyLayer() final;
     void drawRect(const WebCore::FloatRect&, float) final;
     void drawLine(const WebCore::FloatPoint& point1, const WebCore::FloatPoint& point2) final;
-    void drawLinesForText(const WebCore::FloatPoint&, float thickness, const WebCore::DashArray& widths, bool printing, bool doubleLines, WebCore::StrokeStyle) final;
+    void drawLinesForText(const WebCore::FloatPoint&, float thickness, std::span<const WebCore::FloatSegment>, bool isPrinting, bool doubleLines, WebCore::StrokeStyle) final;
     void drawDotsForDocumentMarker(const WebCore::FloatRect&, WebCore::DocumentMarkerLineStyle) final;
     void drawEllipse(const WebCore::FloatRect&) final;
     void drawPath(const WebCore::Path&) final;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -201,6 +201,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/FileMonitor.cpp
         Tests/WebCore/FloatPointTests.cpp
         Tests/WebCore/FloatRectTests.cpp
+        Tests/WebCore/FloatSegmentTest.cpp
         Tests/WebCore/FloatSizeTests.cpp
         Tests/WebCore/GridPosition.cpp
         Tests/WebCore/HTMLParserIdioms.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 		7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */; };
 		7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
 		7B52E86C2A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B52E8642A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp */; };
+		7B588DED2D47B2E600E6FEC4 /* FloatSegmentTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B588DEC2D47B2E600E6FEC4 /* FloatSegmentTest.cpp */; };
 		7B636FC229700F0700F3670F /* StreamConnectionWorkQueueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */; };
 		7B66CFD82D3194B900BD6CB5 /* GraphicsTestUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B66CFD72D3194B900BD6CB5 /* GraphicsTestUtilities.cpp */; };
 		7B6FF89728C22D9400CA76B0 /* WebKit.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 2B648DBA28C1C1F700791F2B /* WebKit.framework */; };
@@ -3042,6 +3043,7 @@
 		7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConnectionTests.cpp; sourceTree = "<group>"; };
 		7B41A8302D08CD9400CE56F9 /* RestoreSessionStorage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RestoreSessionStorage.mm; sourceTree = "<group>"; };
 		7B52E8642A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadSafeObjectHeapTests.cpp; sourceTree = "<group>"; };
+		7B588DEC2D47B2E600E6FEC4 /* FloatSegmentTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FloatSegmentTest.cpp; sourceTree = "<group>"; };
 		7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionWorkQueueTests.cpp; sourceTree = "<group>"; };
 		7B66CFD62D3194B900BD6CB5 /* GraphicsTestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GraphicsTestUtilities.h; sourceTree = "<group>"; };
 		7B66CFD72D3194B900BD6CB5 /* GraphicsTestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GraphicsTestUtilities.cpp; sourceTree = "<group>"; };
@@ -4740,6 +4742,7 @@
 				7A909A701D877475007E10F8 /* FloatPointTests.cpp */,
 				F4AD183725ED791500B1A19F /* FloatQuadTests.cpp */,
 				7A909A711D877475007E10F8 /* FloatRectTests.cpp */,
+				7B588DEC2D47B2E600E6FEC4 /* FloatSegmentTest.cpp */,
 				7A909A721D877475007E10F8 /* FloatSizeTests.cpp */,
 				4C041C6B2C405622002218A4 /* FontCascade.cpp */,
 				95C52728275F35E100DA7E40 /* FontShadowTests.cpp */,
@@ -7068,6 +7071,7 @@
 				7A909A7E1D877480007E10F8 /* FloatPointTests.cpp in Sources */,
 				F4AD183825ED791500B1A19F /* FloatQuadTests.cpp in Sources */,
 				7A909A7F1D877480007E10F8 /* FloatRectTests.cpp in Sources */,
+				7B588DED2D47B2E600E6FEC4 /* FloatSegmentTest.cpp in Sources */,
 				7A909A801D877480007E10F8 /* FloatSizeTests.cpp in Sources */,
 				F4BC0B142146C849002A0478 /* FocusPreservationTests.mm in Sources */,
 				F4A2E64D284541BA0001FEEF /* FocusWebView.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatSegmentTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatSegmentTest.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include "WebCoreTestUtilities.h"
+#include <WebCore/FloatSegment.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+TEST(FloatSegment, DilateWithDifference)
+{
+    // Empty a.
+    {
+        Vector<FloatSegment> intersections { { 77.f, 88.f } };
+        auto result = differenceWithDilation({ 0, 0 }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { };
+        EXPECT_EQ(result, expected);
+    }
+    // Empty bs.
+    {
+        Vector<FloatSegment> intersections { };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 0.f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    // First element removed due to dilation filtering.
+    {
+        Vector<FloatSegment> intersections { { 1.0f, 2.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 2.5f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    // Last element removed due to dilation filtering.
+    {
+        Vector<FloatSegment> intersections { { 66.f, 169.7f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 0.f, 65.5f } };
+        EXPECT_EQ(result, expected);
+    }
+    // All removed.
+    {
+        Vector<FloatSegment> intersections { { 0.5f, 80.f }, { 80.5f, 169.5f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { };
+        EXPECT_EQ(result, expected);
+    }
+    // All removed.
+    {
+        Vector<FloatSegment> intersections { { 0.0f, 80.f }, { 80.f, 180.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.f);
+        Vector<FloatSegment> expected { };
+        EXPECT_EQ(result, expected);
+    }
+    // Normal operation.
+    {
+        Vector<FloatSegment> intersections { { 1.1f, 2.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 0.f, 0.6f }, { 2.5f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    {
+        Vector<FloatSegment> intersections { { 0.f, 1.f }, { 5.f, 77.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 1.5f, 4.5f }, { 77.5f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    {
+        Vector<FloatSegment> intersections { { 0.f, 1.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 1.5f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    {
+        Vector<FloatSegment> intersections { { 2.f, 6.f }, { 8.f, 77.f }, { 3.f, 4.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 0.f, 1.5f }, { 6.5f, 7.5f }, { 77.5f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    {
+        Vector<FloatSegment> intersections { { 2.f, 6.f }, { 8.f, 77.f }, { 3.f, 4.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.f);
+        Vector<FloatSegment> expected { { 0.f, 2.f }, { 6.f, 8.f }, { 77.f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    // Out of range, after end.
+    {
+        Vector<FloatSegment> intersections { { 180.f, 188.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 0.f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+    // Out of range, before begin.
+    {
+        Vector<FloatSegment> intersections { { -188.f, -180.f } };
+        auto result = differenceWithDilation({ 0, 170.f }, WTFMove(intersections), 0.5f);
+        Vector<FloatSegment> expected { { 0.f, 170.f } };
+        EXPECT_EQ(result, expected);
+    }
+}
+
+}

--- a/Tools/TestWebKitAPI/WebCoreTestUtilities.h
+++ b/Tools/TestWebKitAPI/WebCoreTestUtilities.h
@@ -28,6 +28,7 @@
 #include "Test.h"
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/FloatSegment.h>
 #include <WebCore/FloatSize.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/text/TextStream.h>
@@ -99,6 +100,13 @@ inline std::ostream& operator<<(std::ostream& os, const WebCore::IntSize& value)
 }
 
 inline std::ostream& operator<<(std::ostream& os, const WebCore::IntPoint& value)
+{
+    TextStream s { TextStream::LineMode::SingleLine };
+    s << value;
+    return os << s.release();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatSegment& value)
 {
     TextStream s { TextStream::LineMode::SingleLine };
     s << value;


### PR DESCRIPTION
#### 15cc8962394fa5f0ebb029ff188f47f07d841360
<pre>
GraphicsContext::drawLinesForText might read out of bounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=286570">https://bugs.webkit.org/show_bug.cgi?id=286570</a>
<a href="https://rdar.apple.com/143270489">rdar://143270489</a>

Reviewed by Antti Koivisto.

A compromised WCP could send width array with uneven amount of elements
to GraphicsContext::drawLinesForText(). This would cause out-of-bounds
read, as drawLinesForText expects [begin, end] pairs of line segments.

The root cause is that the function used incorrect type DashArray
to pass the line segments. DashArray is a type to pass doubles
that represent lengths relative to previous elements. When used
correctly DashArray [5,6,7] would encode segment list [{0, 5}, {11, 18}].
Note, that the implementation did not use DashArray this way.

Fix by introducing FloatSegment and pass Vector&lt;FloatSegment&gt; instead
of DashArray.

This fixes following issues:
- Avoid passing doubles. The source algorithm works
  with floats, so sending doubles is redundant.
- Avoid conversion from float pair array to float array in the source
  algorithm. The source algorithm already works with float pairs.

Since the change of types touches all of the lines in the source
algorithm, do also following:
- Simplify source algorithm
- Avoid copies of the vectors in the source algorithm

Source algorithm would do following full passes:
 1. Dilate intersection line segments
 2. Sort interections along segment begin
 3. Merge overlapping intersection segments
 4. Compute difference between a solid line and intersections

 Instead, do following full passes:
 1. Sort intersections along segment begin
 2. Compute difference between a solid line and intersections, with
   intersections dilated.

The difference can be computed with overlapping intersections, overlaps
do not affect the result.

For GraphicsContext functions:
- Pass std::span&lt;const FloatSegment&gt; instead of Vector&lt;FloatSegment&gt;,
  as the callee does not need to use Vector functionality anywhere.
- Pass span as value, because it&apos;s small and this prevents pointer
  chasing.
- Fix few .reserveInitialCapacity() size calculations, previously
  tried to always reserve 0.
- Share the rect conversion implementation with Skia port. Skia had
  buggy variant of of the rect conversion algorithm cut-pasted from
  CG variant before CG variant was improved.

Remove all default arguments from GraphicsContext::drawLinesForText().
It is poor style to have default arguments for virtual functions, as
then all overrrides need to replicate them in order to guarantee
consistent invocation through derived type pointer. The callers did
not use the default arguments.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::drawLinesForText):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/DashArray.h:
* Source/WebCore/platform/graphics/FloatSegment.cpp: Copied from Source/WebCore/platform/graphics/DashArray.h.
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FloatSegment.h: Added.
(WebCore::FloatSegment::length const):
(WebCore::FloatSegment::dilate):
(WebCore::differenceWithDilation):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::lineSpansForIntersectionsWithRect const):
(WebCore::FontCascade::dashesForIntersectionsWithRect const): Deleted.
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawLineForText):
(WebCore::GraphicsContext::computeRectsAndStrokeColorForLinesForText):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::OperationRecorder::drawLinesForText):
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawLinesForText):
* Source/WebCore/platform/graphics/cairo/CairoOperations.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::drawLinesForText):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawLinesForText):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawLinesForText::DrawLinesForText):
(WebCore::DisplayList::DrawLinesForText::apply const):
(WebCore::DisplayList::DrawLinesForText::dump const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::DrawLinesForText::lineSegments const):
(WebCore::DisplayList::DrawLinesForText::widths const): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::drawLinesForText):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawLinesForText):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::paintBackgroundDecorations):
(WebCore::compareTuples): Deleted.
(WebCore::translateIntersectionPointsToSkipInkBoundaries): Deleted.
* Source/WebKit/Shared/DisplayListArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::drawLinesForText):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/FloatSegmentTest.cpp: Added.
(TestWebKitAPI::TEST(FloatSegment, DilateWithDifference)):

Canonical link: <a href="https://commits.webkit.org/289737@main">https://commits.webkit.org/289737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d82cf01e7692c52039f99b468e9752f63906900a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25559 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94583 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76661 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18663 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20271 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7997 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20312 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14753 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->