### PR TITLE
Imperative invokers for popover don't fix focus order

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -2,11 +2,16 @@ Button1  Button2  Invoker0  Invoker1  Button3  Button4
 Invoker  after
 Show popover
 Toggle popover Other focusable element
-Toggle popover Popover with focusable element Nested popover with focusable element
+Toggle popover
 
-PASS Popover focus navigation
-PASS Circular reference tab navigation
-PASS Popover focus returns when popover is hidden by invoker
-PASS Popover focus only returns to invoker when focus is within the popover
-PASS Cases where the next focus candidate isn't in the direct parent scope
+PASS Popover focus navigation with declarative invocation
+PASS Popover focus navigation with imperative invocation
+PASS Circular reference tab navigation with declarative invocation
+PASS Circular reference tab navigation with imperative invocation
+PASS Popover focus returns when popover is hidden by invoker with declarative invocation
+PASS Popover focus returns when popover is hidden by invoker with imperative invocation
+PASS Popover focus only returns to invoker when focus is within the popover with declarative invocation
+PASS Popover focus only returns to invoker when focus is within the popover with imperative invocation
+PASS Cases where the next focus candidate isn't in the direct parent scope with declarative invocation
+PASS Cases where the next focus candidate isn't in the direct parent scope with imperative invocation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html
@@ -17,17 +17,17 @@
   </div>
   <div popover id=popover1 style="top:100px">
     <button id=inside_popover1 tabindex="0">Inside1</button>
-    <button id=invoker2 popovertarget=popover2 tabindex="0">Nested Invoker 2</button>
+    <button id=invoker2 tabindex="0">Nested Invoker 2</button>
     <button id=inside_popover2 tabindex="0">Inside2</button>
   </div>
   <button id=button2 tabindex="0">Button2</button>
   <div popover id=popover_no_invoker tabindex="0" style="top:300px"></div>
-  <button popovertarget=popover0 id=invoker0 tabindex="0">Invoker0</button>
-  <button popovertarget=popover1 id=invoker1 tabindex="0">Invoker1</button>
+  <button id=invoker0 tabindex="0">Invoker0</button>
+  <button id=invoker1 tabindex="0">Invoker1</button>
   <button id=button3 tabindex="0">Button3</button>
   <div popover id=popover2 style="top:200px">
     <button id=inside_popover3 tabindex="0">Inside3</button>
-    <button id=invoker3 popovertarget=popover3 tabindex="0">Nested Invoker 3</button>
+    <button id=invoker3 tabindex="0">Nested Invoker 3</button>
   </div>
   <div popover id=popover3 style="top:300px">
     Non-focusable popover
@@ -53,7 +53,7 @@ async function verifyFocusOrder(order,description) {
     assert_equals(document.activeElement,control,`${description}: Step ${i+1} (backwards)`);
   }
 }
-promise_test(async t => {
+async function testPopoverFocusNavigation() {
   button1.focus();
   assert_equals(document.activeElement,button1);
   await sendTab();
@@ -108,33 +108,110 @@ promise_test(async t => {
   assert_equals(document.activeElement,button4,'Focus should skip popovers');
   button1.focus();
   await verifyFocusOrder([button1, button2, invoker0, invoker1, inside_popover1, invoker2, inside_popover3, invoker3, inside_popover2, button3, button4],'set 2');
-}, "Popover focus navigation");
+}
+promise_test(async t => {
+  invoker0.setAttribute('popovertarget', 'popover0');
+  invoker1.setAttribute('popovertarget', 'popover1');
+  invoker2.setAttribute('popovertarget', 'popover2');
+  invoker3.setAttribute('popovertarget', 'popover3');
+  t.add_cleanup(() => {
+    invoker0.removeAttribute('popovertarget');
+    invoker1.removeAttribute('popovertarget');
+    invoker2.removeAttribute('popovertarget');
+    invoker3.removeAttribute('popovertarget');
+  });
+  await testPopoverFocusNavigation();
+}, "Popover focus navigation with declarative invocation");
+
+promise_test(async t => {
+  const invoker0Click = () => {
+    popover0.togglePopover({ source: invoker0 });
+  };
+  invoker0.addEventListener('click', invoker0Click);
+  const invoker1Click = () => {
+    popover1.togglePopover({ source: invoker1 });
+  };
+  invoker1.addEventListener('click', invoker1Click);
+  const invoker2Click = () => {
+    popover2.togglePopover({ source: invoker2 });
+  };
+  invoker2.addEventListener('click', invoker2Click);
+  const invoker3Click = () => {
+    popover3.togglePopover({ source: invoker3 });
+  };
+  invoker3.addEventListener('click', invoker3Click);
+  t.add_cleanup(() => {
+    invoker0.removeEventListener('click', invoker0Click);
+    invoker1.removeEventListener('click', invoker1Click);
+    invoker2.removeEventListener('click', invoker2Click);
+    invoker3.removeEventListener('click', invoker3Click);
+  });
+  await testPopoverFocusNavigation()
+}, "Popover focus navigation with imperative invocation");
 </script>
 
-<button id=circular0 popovertarget=popover4 tabindex="0">Invoker</button>
+<button id=circular0 tabindex="0">Invoker</button>
 <div id=popover4 popover>
-  <button id=circular1 autofocus popovertarget=popover4 popovertargetaction=hide tabindex="0"></button>
-  <button id=circular2 popovertarget=popover4 popovertargetaction=show tabindex="0"></button>
-  <button id=circular3 popovertarget=popover4 tabindex="0"></button>
+  <button id=circular1 autofocus popovertargetaction=hide tabindex="0"></button>
+  <button id=circular2 popovertargetaction=show tabindex="0"></button>
+  <button id=circular3 tabindex="0"></button>
 </div>
 <button id=circular4 tabindex="0">after</button>
 <script>
-promise_test(async t => {
+async function testCircularReferenceTabNavigation() {
   circular0.focus();
   await sendEnter(); // Activate the invoker
   await verifyFocusOrder([circular0, circular1, circular2, circular3, circular4],'circular reference');
   popover4.hidePopover();
-}, "Circular reference tab navigation");
+}
+promise_test(async t => {
+  circular0.setAttribute('popovertarget', 'popover4');
+  circular1.setAttribute('popovertarget', 'popover4');
+  circular2.setAttribute('popovertarget', 'popover4');
+  circular3.setAttribute('popovertarget', 'popover4');
+  t.add_cleanup(() => {
+    circular0.removeAttribute('popovertarget');
+    circular1.removeAttribute('popovertarget');
+    circular2.removeAttribute('popovertarget');
+    circular3.removeAttribute('popovertarget');
+  });
+  await testCircularReferenceTabNavigation();
+}, "Circular reference tab navigation with declarative invocation");
+promise_test(async t => {
+  const circular0Click = () => {
+    popover4.togglePopover({ source: circular0 });
+  };
+  circular0.addEventListener('click', circular0Click);
+  const circular1Click = () => {
+    popover4.hidePopover();
+  };
+  circular1.addEventListener('click', circular1Click);
+  const circular2Click = () => {
+    popover4.showPopover({ source: circular2 });
+  };
+  circular2.addEventListener('click', circular2Click);
+  const circular3Click = () => {
+    popover4.togglePopover({ source: circular3 });
+  };
+  circular3.addEventListener('click', circular3Click);
+  t.add_cleanup(() => {
+    circular0.removeEventListener('click', circular0Click);
+    circular1.removeEventListener('click', circular1Click);
+    circular2.removeEventListener('click', circular2Click);
+    circular3.removeEventListener('click', circular3Click);
+  });
+  await testCircularReferenceTabNavigation();
+}, "Circular reference tab navigation with imperative invocation");
 </script>
 
 <div id=focus-return1>
-  <button popovertarget=focus-return1-p popovertargetaction=show tabindex="0">Show popover</button>
+  <button popovertargetaction=show tabindex="0">Show popover</button>
   <div popover id=focus-return1-p>
-    <button popovertarget=focus-return1-p popovertargetaction=hide autofocus tabindex="0">Hide popover</button>
+    <button popovertargetaction=hide autofocus tabindex="0">Hide popover</button>
   </div>
 </div>
 <script>
-promise_test(async t => {
+async function testPopoverFocusReturn1() {
   const invoker = document.querySelector('#focus-return1>button');
   const popover = document.querySelector('#focus-return1>[popover]');
   const hideButton = popover.querySelector('[popovertargetaction=hide]');
@@ -146,16 +223,46 @@ promise_test(async t => {
   await sendEnter(); // Activate the hide invoker
   assert_false(popover.matches(':popover-open'), 'popover should be hidden by invoker');
   assert_equals(document.activeElement,invoker,'Focus should be returned to the invoker');
-}, "Popover focus returns when popover is hidden by invoker");
+}
+promise_test(async t => {
+  const invoker = document.querySelector('#focus-return1>button');
+  const popover = document.querySelector('#focus-return1>[popover]');
+  const hideButton = popover.querySelector('button');
+  invoker.setAttribute('popovertarget', 'focus-return1-p');
+  hideButton.setAttribute('popovertarget', 'focus-return1-p');
+  t.add_cleanup(() => {
+    invoker.removeAttribute('popovertarget');
+    hideButton.removeAttribute('popovertarget');
+  });
+  await testPopoverFocusReturn1();
+}, "Popover focus returns when popover is hidden by invoker with declarative invocation");
+promise_test(async t => {
+  const invoker = document.querySelector('#focus-return1>button');
+  const popover = document.querySelector('#focus-return1>[popover]');
+  const hideButton = popover.querySelector('button');
+  const invokerClick = () => {
+    popover.showPopover({ source: invoker });
+  };
+  invoker.addEventListener('click', invokerClick);
+  const hideButtonClick = () => {
+    popover.hidePopover();
+  };
+  hideButton.addEventListener('click', hideButtonClick);
+  t.add_cleanup(() => {
+    invoker.removeEventListener('click', invokerClick);
+    hideButton.removeEventListener('click', hideButtonClick);
+  });
+  await testPopoverFocusReturn1();
+}, "Popover focus returns when popover is hidden by invoker with imperative invocation");
 </script>
 
 <div id=focus-return2>
-  <button popovertarget=focus-return2-p tabindex="0">Toggle popover</button>
+  <button tabindex="0">Toggle popover</button>
   <div popover id=focus-return2-p>Popover with <button tabindex="0">focusable element</button></div>
   <span tabindex=0>Other focusable element</span>
 </div>
 <script>
-promise_test(async t => {
+async function testPopoverFocusReturn2() {
   const invoker = document.querySelector('#focus-return2>button');
   const popover = document.querySelector('#focus-return2>[popover]');
   const otherElement = document.querySelector('#focus-return2>span');
@@ -171,18 +278,38 @@ promise_test(async t => {
   await sendEscape(); // Close the popover via ESC
   assert_false(popover.matches(':popover-open'), 'popover should be hidden');
   assert_equals(document.activeElement,otherElement,'focus does not move because it was not inside the popover');
-}, "Popover focus only returns to invoker when focus is within the popover");
+}
+promise_test(async t => {
+  const invoker = document.querySelector('#focus-return2>button');
+  invoker.setAttribute('popovertarget', 'focus-return2-p');
+  t.add_cleanup(() => {
+    invoker.removeAttribute('popovertarget');
+  });
+  await testPopoverFocusReturn2();
+}, "Popover focus only returns to invoker when focus is within the popover with declarative invocation");
+promise_test(async t => {
+  const invoker = document.querySelector('#focus-return2>button');
+  const popover = document.querySelector('#focus-return2>[popover]');
+  const invokerClick = () => {
+    popover.togglePopover({ source: invoker });
+  };
+  invoker.addEventListener('click', invokerClick);
+  t.add_cleanup(() => {
+    invoker.removeEventListener('click', invokerClick);
+  });
+  await testPopoverFocusReturn2();
+}, "Popover focus only returns to invoker when focus is within the popover with imperative invocation");
 </script>
 
 <div id=no-focus-candidate>
-  <button popovertarget=no-focus-candidate-p tabindex="0">Toggle popover</button>
+  <button tabindex="0">Toggle popover</button>
   <div popover id=no-focus-candidate-p>
-    Popover with <button tabindex="0" popovertarget=no-focus-candidate-p2>focusable element</button>
+    Popover with <button tabindex="0">focusable element</button>
     <div popover id=no-focus-candidate-p2>Nested popover with <button tabindex="0">focusable element</button></div>
   </div>
 </div>
 <script>
-promise_test(async t => {
+async function testNoFocusCandidate() {
   const invoker = document.querySelector('#no-focus-candidate>button');
   const popover = document.querySelector('#no-focus-candidate>[popover]');
   const nestedPopover = document.querySelector('#no-focus-candidate>[popover]>[popover]');
@@ -203,5 +330,43 @@ promise_test(async t => {
   nestedPopover.querySelector('button').focus();
   await sendTab();
   assert_equals(document.activeElement, document.body, 'no more focusable elements after the button');
-}, "Cases where the next focus candidate isn't in the direct parent scope");
+}
+promise_test(async t => {
+  const invoker = document.querySelector('#no-focus-candidate>button');
+  const popover = document.querySelector('#no-focus-candidate>[popover]');
+  const nestedButton = popover.querySelector('button');
+  const nestedPopover = document.querySelector('#no-focus-candidate>[popover]>[popover]');
+  invoker.setAttribute('popovertarget', 'no-focus-candidate-p');
+  nestedButton.setAttribute('popovertarget', 'no-focus-candidate-p2');
+  t.add_cleanup(() => {
+    invoker.removeAttribute('popovertarget');
+    nestedButton.removeAttribute('popovertarget');
+    nestedButton.disabled = false;
+    popover.hidePopover();
+    nestedPopover.hidePopover();
+  });
+  await testNoFocusCandidate();
+}, "Cases where the next focus candidate isn't in the direct parent scope with declarative invocation");
+promise_test(async t => {
+  const invoker = document.querySelector('#no-focus-candidate>button');
+  const popover = document.querySelector('#no-focus-candidate>[popover]');
+  const nestedButton = popover.querySelector('button');
+  const nestedPopover = document.querySelector('#no-focus-candidate>[popover]>[popover]');
+  const invokerClick = () => {
+    popover.togglePopover({ source: invoker });
+  };
+  invoker.addEventListener('click', invokerClick);
+  const nestedButtonClick = () => {
+    nestedPopover.togglePopover({ source: nestedButton });
+  };
+  nestedButton.addEventListener('click', nestedButtonClick);
+  t.add_cleanup(() => {
+    invoker.removeEventListener('click', invokerClick);
+    nestedButton.removeEventListener('click', nestedButtonClick);
+    nestedButton.disabled = false;
+    popover.hidePopover();
+    nestedPopover.hidePopover();
+  });
+  await testNoFocusCandidate();
+}, "Cases where the next focus candidate isn't in the direct parent scope with imperative invocation");
 </script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3157,6 +3157,17 @@ void Element::clearPopoverData()
         elementRareData()->setPopoverData(nullptr);
 }
 
+Element* Element::invokedPopover() const
+{
+    return hasRareData() ? elementRareData()->invokedPopover() : nullptr;
+}
+
+void Element::setInvokedPopover(RefPtr<Element>&& element)
+{
+    auto& data = ensureElementRareData();
+    data.setInvokedPopover(WTFMove(element));
+}
+
 void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
 {
     ASSERT(!newShadowRoot->hasChildNodes());

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -676,8 +676,11 @@ public:
     void clearPopoverData();
     bool isPopoverShowing() const;
 
+    Element* invokedPopover() const;
+    void setInvokedPopover(RefPtr<Element>&&);
+
     virtual bool isValidCommandType(const CommandType) { return false; }
-    virtual bool handleCommandInternal(const HTMLButtonElement&, const CommandType&) { return false; }
+    virtual bool handleCommandInternal(HTMLButtonElement&, const CommandType&) { return false; }
 
     ExceptionOr<void> setPointerCapture(int32_t);
     ExceptionOr<void> releasePointerCapture(int32_t);

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -48,6 +48,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     ExplicitlySetAttrElementsMap explicitlySetAttrElementsMap;
     uint8_t visibilityAdjustment;
     HashMap<std::optional<Style::PseudoElementIdentifier>, Ref<Calculation::RandomKeyMap>> randomKeyMap;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> invokedPopoverWeakPtr;
 };
 
 static_assert(sizeof(ElementRareData) == sizeof(SameSizeAsElementRareData), "ElementRareData should stay small");

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -27,7 +27,9 @@
 #include "CustomStateSet.h"
 #include "DOMTokenList.h"
 #include "DatasetDOMStringMap.h"
+#include "Element.h"
 #include "ElementAnimationRareData.h"
+#include "EventTarget.h"
 #include "FormAssociatedCustomElement.h"
 #include "IntersectionObserver.h"
 #include "KeyframeEffectStack.h"
@@ -156,6 +158,9 @@ public:
     PopoverData* popoverData() { return m_popoverData.get(); }
     void setPopoverData(std::unique_ptr<PopoverData>&& popoverData) { m_popoverData = WTFMove(popoverData); }
 
+    Element* invokedPopover() const { return m_invokedPopover.get(); }
+    void setInvokedPopover(RefPtr<Element>&& element) { m_invokedPopover = WTFMove(element); }
+
     const std::optional<OptionSet<ContentRelevancy>>& contentRelevancy() const { return m_contentRelevancy; }
     void setContentRelevancy(OptionSet<ContentRelevancy>& contentRelevancy) { m_contentRelevancy = contentRelevancy; }
 
@@ -224,6 +229,8 @@ public:
             result.add(UseType::CustomStateSet);
         if (m_userInfo)
             result.add(UseType::UserInfo);
+        if (m_invokedPopover)
+            result.add(UseType::InvokedPopover);
         return result;
     }
 #endif
@@ -274,6 +281,8 @@ private:
     ExplicitlySetAttrElementsMap m_explicitlySetAttrElementsMap;
 
     std::unique_ptr<PopoverData> m_popoverData;
+
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_invokedPopover;
 
     RefPtr<CustomStateSet> m_customStateSet;
 

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -259,6 +259,7 @@ public:
         DisplayContentsOrNoneStyle = 1 << 26,
         CustomStateSet = 1 << 27,
         UserInfo = 1 << 28,
+        InvokedPopover = 1 << 29,
     };
 #endif
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -200,7 +200,7 @@ bool HTMLDialogElement::isValidCommandType(const CommandType command)
     return HTMLElement::isValidCommandType(command) || command == CommandType::ShowModal || command == CommandType::Close;
 }
 
-bool HTMLDialogElement::handleCommandInternal(const HTMLButtonElement& invoker, const CommandType& command)
+bool HTMLDialogElement::handleCommandInternal(HTMLButtonElement& invoker, const CommandType& command)
 {
     if (HTMLElement::handleCommandInternal(invoker, command))
         return true;

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -55,7 +55,7 @@ public:
     void runFocusingSteps();
 
     bool isValidCommandType(const CommandType) final;
-    bool handleCommandInternal(const HTMLButtonElement& invoker, const CommandType&) final;
+    bool handleCommandInternal(HTMLButtonElement& invoker, const CommandType&) final;
 
     void queueDialogToggleEventTask(ToggleState oldState, ToggleState newState);
 

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -158,7 +158,7 @@ public:
 
     void queuePopoverToggleEventTask(ToggleState oldState, ToggleState newState);
     ExceptionOr<void> showPopover(const ShowPopoverOptions&);
-    ExceptionOr<void> showPopoverInternal(const HTMLElement* = nullptr);
+    ExceptionOr<void> showPopoverInternal(HTMLElement* = nullptr);
     ExceptionOr<void> hidePopover();
     ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);
     ExceptionOr<bool> togglePopover(std::optional<std::variant<WebCore::HTMLElement::TogglePopoverOptions, bool>>);
@@ -169,7 +169,7 @@ public:
     void popoverAttributeChanged(const AtomString& value);
 
     bool isValidCommandType(const CommandType) override;
-    bool handleCommandInternal(const HTMLButtonElement& invoker, const CommandType&) override;
+    bool handleCommandInternal(HTMLButtonElement& invoker, const CommandType&) override;
 
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);
@@ -208,6 +208,8 @@ protected:
     static const AtomString& eventNameForEventHandlerAttribute(const QualifiedName& attributeName, const EventHandlerNameMap&);
 
 private:
+    void setInvoker(HTMLElement*);
+
     String nodeName() const final;
 
     void mapLanguageAttributeToLocale(const AtomString&, MutableStyleProperties&);

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -394,7 +394,7 @@ void HTMLFormControlElement::setPopoverTargetAction(const AtomString& value)
 }
 
 // https://html.spec.whatwg.org/#popover-target-attribute-activation-behavior
-void HTMLFormControlElement::handlePopoverTargetAction(const EventTarget* eventTarget) const
+void HTMLFormControlElement::handlePopoverTargetAction(const EventTarget* eventTarget)
 {
     RefPtr popover = popoverTargetElement();
     if (!popover)

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -128,7 +128,7 @@ protected:
 
     void dispatchBlurEvent(RefPtr<Element>&& newFocusedElement) override;
 
-    void handlePopoverTargetAction(const EventTarget*) const;
+    void handlePopoverTargetAction(const EventTarget*);
 
 private:
     void refFormAssociatedElement() const final { ref(); }

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -83,10 +83,10 @@ static HTMLElement* invokerForOpenPopover(const Node* candidatePopover)
 
 static Element* openPopoverForInvoker(const Node* candidateInvoker)
 {
-    RefPtr invoker = dynamicDowncast<HTMLFormControlElement>(candidateInvoker);
+    RefPtr invoker = dynamicDowncast<HTMLElement>(candidateInvoker);
     if (!invoker)
         return nullptr;
-    RefPtr popover = invoker->popoverTargetElement();
+    RefPtr popover = invoker->invokedPopover();
     if (popover && popover->isPopoverShowing() && popover->popoverData()->invoker() == invoker)
         return popover.get();
     return nullptr;


### PR DESCRIPTION
#### b46f59f1c06a8d2f0562fee7c42472c99d7dee85
<pre>
Imperative invokers for popover don&apos;t fix focus order
<a href="https://bugs.webkit.org/show_bug.cgi?id=286575">https://bugs.webkit.org/show_bug.cgi?id=286575</a>

Reviewed by Tim Nguyen.

The FocusController currently still relies on the popoverTargetElement of buttons, to look for popovers
to move to the new focus order.

This patch stores the invoked popover on the provided invoking element&apos;s rare data,
and then updates FocusController to use this instead.

This way both declarative and imperative popover relationships correctly fix focus order.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2.html:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invokedPopover const):
(WebCore::Element::setInvokedPopover):
* Source/WebCore/dom/Element.h:
(WebCore::Element::handleCommandInternal):
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::invokedPopover const):
(WebCore::ElementRareData::setInvokedPopover):
(WebCore::ElementRareData::useTypes const):
* Source/WebCore/dom/NodeRareData.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::handleCommandInternal):
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::showPopoverInternal):
(WebCore::HTMLElement::setInvoker):
(WebCore::HTMLElement::hidePopoverInternal):
(WebCore::HTMLElement::handleCommandInternal):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::handlePopoverTargetAction):
(WebCore::HTMLFormControlElement::handlePopoverTargetAction const): Deleted.
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::openPopoverForInvoker):

Canonical link: <a href="https://commits.webkit.org/291719@main">https://commits.webkit.org/291719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb277c6bfd623d1aca25f3e4f2416556c7e6b71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71567 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28942 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15177 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80591 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79931 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19898 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1829 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13954 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20781 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->