### PR TITLE
[css-anchor-position-1] Fix evaluation of default anchor elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7530,7 +7530,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # -- Anchor Positioning -- #
 
 # general failures
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-offset-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-offset-change-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Anchored initially have the same width as the anchor assert_equals: expected 0 but got 100
-FAIL Increase the height of the anchor to move the anchor-center offset assert_equals: expected 50 but got 200
+PASS Anchored initially have the same width as the anchor
+PASS Increase the height of the anchor to move the anchor-center offset
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9536,7 +9536,8 @@
             "codegen-properties": {
                 "converter": "PositionAnchor",
                 "parser-grammar": "auto | <dashed-ident>",
-                "settings-flag": "cssAnchorPositioningEnabled"
+                "settings-flag": "cssAnchorPositioningEnabled",
+                "high-priority": true
             },
             "specification": {
                 "category": "css-anchor-position",

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -159,7 +159,9 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
         return;
 
     Style::Scope::QueryContainerUpdateContext queryContainerUpdateContext;
-    while (document() && document()->styleScope().updateQueryContainerState(queryContainerUpdateContext)) {
+    // FIXME: its own type
+    Style::Scope::QueryContainerUpdateContext anchorUpdateContext;
+    while (document() && (document()->styleScope().updateQueryContainerState(queryContainerUpdateContext) || document()->styleScope().updateAnchorState(anchorUpdateContext))) {
         document()->updateStyleIfNeeded();
 
         if (!needsLayout())
@@ -170,6 +172,9 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
         if (view().hasOneRef())
             return;
     }
+
+    if (document())
+        Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout(*document());
 }
 
 void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions)
@@ -255,6 +260,9 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
             showRenderTree(renderView());
 #endif
     }
+
+    Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout(*document());
+
     {
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InViewSizeAdjust);
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -142,7 +142,6 @@ inline RenderElement::RenderElement(Type type, ContainerNode& elementOrDocument,
     , m_didContributeToVisuallyNonEmptyPixelCount(false)
     , m_style(WTFMove(style))
 {
-    ASSERT(RenderObject::isRenderElement());
 }
 
 RenderElement::RenderElement(Type type, Element& element, RenderStyle&& style, OptionSet<TypeFlag> baseTypeFlags, TypeSpecificFlags typeSpecificFlags)
@@ -1631,18 +1630,18 @@ const Element* RenderElement::defaultAnchor() const
 {
     if (!element())
         return nullptr;
+
+    const auto& defaultAnchorName = style().positionAnchor();
+    if (!defaultAnchorName)
+        return nullptr;
+
     auto& anchorPositionedStates = document().styleScope().anchorPositionedStates();
-    auto anchoringStateLookupResult = anchorPositionedStates.find(*element());
-    if (anchoringStateLookupResult == anchorPositionedStates.end() || !anchoringStateLookupResult->value)
+    auto anchorPositionedState = anchorPositionedStates.get(*element());
+    if (!anchorPositionedState)
         return nullptr;
-    const auto& anchoringState = *anchoringStateLookupResult->value;
-    const auto& anchorName = style().positionAnchor();
-    if (!anchorName)
-        return nullptr;
-    auto defaultAnchorLookupResult = anchoringState.anchorElements.find(anchorName->name);
-    if (defaultAnchorLookupResult == anchoringState.anchorElements.end())
-        return nullptr;
-    return &defaultAnchorLookupResult->value.get();
+
+    auto defaultAnchor = anchorPositionedState->anchorElements.get(defaultAnchorName->name);
+    return defaultAnchor;
 }
 
 const RenderElement* RenderElement::defaultAnchorRenderer() const

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -395,15 +395,17 @@ RefPtr<Element> AnchorPositionEvaluator::findAnchorAndAttemptResolution(const Bu
     if (!isValid())
         return { };
 
+    if (!elementName)
+        elementName = builderState.style().positionAnchor();
+    if (!elementName)
+        return nullptr;
+
     Ref anchorPositionedElement = *builderState.element();
 
     auto& anchorPositionedStates = anchorPositionedElement->document().styleScope().anchorPositionedStates();
     auto& anchorPositionedState = *anchorPositionedStates.ensure(anchorPositionedElement, [&] {
         return WTF::makeUnique<AnchorPositionedState>();
     }).iterator->value.get();
-
-    if (!elementName)
-        elementName = builderState.style().positionAnchor();
 
     if (elementName) {
         // Collect anchor names that this element refers to in anchor() or anchor-size()
@@ -741,6 +743,7 @@ void AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayou
             state.stage = AnchorPositionResolutionStage::FoundAnchors;
             continue;
         }
+
         if (state.stage == AnchorPositionResolutionStage::Resolved)
             state.stage = AnchorPositionResolutionStage::Positioned;
     }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1682,9 +1682,10 @@ inline String BuilderConverter::convertSVGURIReference(const BuilderState&, cons
     return emptyString();
 }
 
-inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentData(const BuilderState&, const CSSValue& value)
+inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentData(const BuilderState& state, const CSSValue& value)
 {
     auto alignmentData = RenderStyle::initialSelfAlignment();
+
     if (value.isPair()) {
         if (value.first().valueID() == CSSValueLegacy) {
             alignmentData.setPositionType(ItemPositionType::Legacy);
@@ -1699,6 +1700,10 @@ inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentDat
         }
     } else
         alignmentData.setPosition(fromCSSValue<ItemPosition>(value));
+
+    if (alignmentData.position() == ItemPosition::AnchorCenter)
+        Style::AnchorPositionEvaluator::findAnchorAndAttemptResolution(state, { });
+
     return alignmentData;
 }
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -157,6 +157,8 @@ public:
     const CSSCounterStyleRegistry& counterStyleRegistry() const { return m_counterStyleRegistry.get(); }
     CSSCounterStyleRegistry& counterStyleRegistry() { return m_counterStyleRegistry.get(); }
 
+    bool updateAnchorState(QueryContainerUpdateContext&);
+
     AnchorPositionedStates& anchorPositionedStates() { return m_anchorPositionedStates; }
     const AnchorPositionedStates& anchorPositionedStates() const { return m_anchorPositionedStates; }
     void clearAnchorPositioningState();
@@ -256,6 +258,7 @@ private:
     // FIXME: These (and some things above) are only relevant for the root scope.
     UncheckedKeyHashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
 
+    // This stores anchor resolution data for each anchor-positioned element.
     AnchorPositionedStates m_anchorPositionedStates;
 };
 


### PR DESCRIPTION
#### b8c1ab263674c5b492ec0318bec2e407ab2b47c6
<pre>
[css-anchor-position-1] Fix evaluation of default anchor elements
<a href="https://rdar.apple.com/140124449">rdar://140124449</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283295">https://bugs.webkit.org/show_bug.cgi?id=283295</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateForReferencedAnchorsChange):
* Source/WebCore/dom/Element.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layout):
(WebCore::LocalFrameViewLayoutContext::performLayout):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
(WebCore::RenderElement::defaultAnchor const):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertSelfOrDefaultAlignmentData):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::clearAnchorPositioningState):
(WebCore::Style::generateAnchorToAnchorPositionedMap):
(WebCore::Style::Scope::updateAnchorState):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8c1ab263674c5b492ec0318bec2e407ab2b47c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86989 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25004 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4959 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33116 "Found 2 new test failures: editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75451 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76045 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75243 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18003 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7058 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19461 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13913 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->