### PR TITLE
REGRESSION(289357@main): [macOS iOS] 10 TestWebKitAPI tests are failing/crashing (failure in EWS)

### DIFF
--- a/Tools/TestWebKitAPI/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/NetworkConnection.mm
@@ -72,7 +72,7 @@ void Connection::receiveHTTPRequest(CompletionHandler<void(Vector<char>&&)>&& co
         buffer.appendVector(WTFMove(bytes));
         if (auto* doubleNewline = strnstr(buffer.data(), "\r\n\r\n", buffer.size())) {
             if (auto* contentLengthBegin = strnstr(buffer.data(), "Content-Length", buffer.size())) {
-                size_t contentLength = parseInteger<int>(buffer.span().subspan(contentLengthBegin - buffer.data() + strlen("Content-Length: "))).value_or(0);
+                size_t contentLength = parseIntegerAllowingTrailingJunk<int>(buffer.span().subspan(contentLengthBegin - buffer.data() + strlen("Content-Length: "))).value_or(0);
                 size_t headerLength = doubleNewline - buffer.data() + strlen("\r\n\r\n");
                 if (buffer.size() - headerLength < contentLength)
                     return connection.receiveHTTPRequest(WTFMove(completionHandler), WTFMove(buffer));


### PR DESCRIPTION
#### 18ac23068497fbfab7cff86d31eb67ce0df999da
<pre>
REGRESSION(289357@main): [macOS iOS] 10 TestWebKitAPI tests are failing/crashing (failure in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286579">https://bugs.webkit.org/show_bug.cgi?id=286579</a>
<a href="https://rdar.apple.com/143703766">rdar://143703766</a>

Reviewed by Per Arne Vollan and Alex Christensen.

In 289357@main, I replaced the call to `atoi()` in Connection::receiveHTTPRequest()
with a call to parseInteger&lt;int&gt;(). This is normally identical except if there junk
at the end of the string. In this case, there is `\r\n` at the end of the string,
which `atoi()` used to ignore. As a result, call `parseIntegerAllowingTrailingJunk&lt;int&gt;()`
to maintain pre-existing behavior.

* Tools/TestWebKitAPI/NetworkConnection.mm:
(TestWebKitAPI::Connection::receiveHTTPRequest const):

Canonical link: <a href="https://commits.webkit.org/289433@main">https://commits.webkit.org/289433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2081a31593dd2bfac95f486ee0cdeac3a1ca4bca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86947 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6457 "Failed to checkout and rebase branch from PR 39600") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41300 "Failed to checkout and rebase branch from PR 39600") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91799 "Failed to checkout and rebase branch from PR 39600") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37684 "Failed to checkout and rebase branch from PR 39600") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88996 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6727 "Failed to checkout and rebase branch from PR 39600") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14520 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/91799 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/37684 "Failed to checkout and rebase branch from PR 39600") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89950 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/6727 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/41300 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/91799 "Failed to checkout and rebase branch from PR 39600") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/6727 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/41300 "Failed to checkout and rebase branch from PR 39600") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36799 "Failed to checkout and rebase branch from PR 39600") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/6727 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/41300 "Failed to checkout and rebase branch from PR 39600") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93693 "Failed to checkout and rebase branch from PR 39600") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14100 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10256 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/93693 "Failed to checkout and rebase branch from PR 39600") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14309 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/41300 "Failed to checkout and rebase branch from PR 39600") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/93693 "Failed to checkout and rebase branch from PR 39600") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/41300 "Failed to checkout and rebase branch from PR 39600") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6981 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/13541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14123 "Failed to checkout and rebase branch from PR 39600") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13868 "Failed to checkout and rebase branch from PR 39600") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17309 "Failed to checkout and rebase branch from PR 39600") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15651 "Failed to checkout and rebase branch from PR 39600") | | | 
<!--EWS-Status-Bubble-End-->