### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in FTPDirectoryParser.cpp

### DIFF
--- a/Source/WTF/wtf/text/ParsingUtilities.h
+++ b/Source/WTF/wtf/text/ParsingUtilities.h
@@ -76,7 +76,7 @@ template<typename CharacterType, typename DelimiterType> bool skipExactly(const 
     return false;
 }
 
-template<typename CharacterType, typename DelimiterType> bool skipExactly(std::span<const CharacterType>& data, DelimiterType delimiter)
+template<typename CharacterType, typename DelimiterType> bool skipExactly(std::span<CharacterType>& data, DelimiterType delimiter)
 {
     if (!data.empty() && data.front() == delimiter) {
         skip(data, 1);
@@ -112,7 +112,7 @@ template<bool characterPredicate(UChar)> bool skipExactly(StringParsingBuffer<UC
     return false;
 }
 
-template<bool characterPredicate(LChar)> bool skipExactly(std::span<const LChar>& buffer)
+template<bool characterPredicate(LChar), typename CharacterType> bool skipExactly(std::span<CharacterType>& buffer) requires(std::is_same_v<std::remove_const_t<CharacterType>, LChar>)
 {
     if (!buffer.empty() && characterPredicate(buffer[0])) {
         skip(buffer, 1);
@@ -121,7 +121,7 @@ template<bool characterPredicate(LChar)> bool skipExactly(std::span<const LChar>
     return false;
 }
 
-template<bool characterPredicate(UChar)> bool skipExactly(std::span<const UChar>& buffer)
+template<bool characterPredicate(UChar), typename CharacterType> bool skipExactly(std::span<CharacterType>& buffer) requires(std::is_same_v<std::remove_const_t<CharacterType>, UChar>)
 {
     if (!buffer.empty() && characterPredicate(buffer[0])) {
         skip(buffer, 1);
@@ -136,7 +136,7 @@ template<typename CharacterType, typename DelimiterType> void skipUntil(StringPa
         ++buffer;
 }
 
-template<typename CharacterType, typename DelimiterType> void skipUntil(std::span<const CharacterType>& buffer, DelimiterType delimiter)
+template<typename CharacterType, typename DelimiterType> void skipUntil(std::span<CharacterType>& buffer, DelimiterType delimiter)
 {
     size_t index = 0;
     while (index < buffer.size() && buffer[index] != delimiter)
@@ -144,7 +144,7 @@ template<typename CharacterType, typename DelimiterType> void skipUntil(std::spa
     skip(buffer, index);
 }
 
-template<bool characterPredicate(LChar)> void skipUntil(std::span<const LChar>& data)
+template<bool characterPredicate(LChar), typename CharacterType> void skipUntil(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, LChar>)
 {
     size_t index = 0;
     while (index < data.size() && !characterPredicate(data[index]))
@@ -152,7 +152,7 @@ template<bool characterPredicate(LChar)> void skipUntil(std::span<const LChar>& 
     skip(data, index);
 }
 
-template<bool characterPredicate(UChar)> void skipUntil(std::span<const UChar>& data)
+template<bool characterPredicate(UChar), typename CharacterType> void skipUntil(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, UChar>)
 {
     size_t index = 0;
     while (index < data.size() && !characterPredicate(data[index]))
@@ -178,7 +178,7 @@ template<typename CharacterType, typename DelimiterType> void skipWhile(StringPa
         ++buffer;
 }
 
-template<typename CharacterType, typename DelimiterType> void skipWhile(std::span<const CharacterType>& buffer, DelimiterType delimiter)
+template<typename CharacterType, typename DelimiterType> void skipWhile(std::span<CharacterType>& buffer, DelimiterType delimiter)
 {
     size_t index = 0;
     while (index < buffer.size() && buffer[index] == delimiter)
@@ -186,7 +186,7 @@ template<typename CharacterType, typename DelimiterType> void skipWhile(std::spa
     skip(buffer, index);
 }
 
-template<bool characterPredicate(LChar)> void skipWhile(std::span<const LChar>& data)
+template<bool characterPredicate(LChar), typename CharacterType> void skipWhile(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, LChar>)
 {
     size_t index = 0;
     while (index < data.size() && characterPredicate(data[index]))
@@ -194,7 +194,7 @@ template<bool characterPredicate(LChar)> void skipWhile(std::span<const LChar>& 
     skip(data, index);
 }
 
-template<bool characterPredicate(UChar)> void skipWhile(std::span<const UChar>& data)
+template<bool characterPredicate(UChar), typename CharacterType> void skipWhile(std::span<CharacterType>& data) requires(std::is_same_v<std::remove_const_t<CharacterType>, UChar>)
 {
     size_t index = 0;
     while (index < data.size() && characterPredicate(data[index]))

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -254,7 +254,7 @@ void FTPDirectoryDocumentParser::parseAndAppendOneLine(const String& inputLine)
     ListResult result;
     CString latin1Input = inputLine.latin1();
 
-    FTPEntryType typeResult = parseOneFTPLine(latin1Input.span(), m_listState, result);
+    FTPEntryType typeResult = parseOneFTPLine(byteCast<LChar>(latin1Input.mutableSpan()), m_listState, result);
 
     // FTPMiscEntry is a comment or usage statistic which we don't care about, and junk is invalid data - bail in these 2 cases
     if (typeResult == FTPMiscEntry || typeResult == FTPJunkEntry)

--- a/Source/WebCore/loader/FTPDirectoryParser.h
+++ b/Source/WebCore/loader/FTPDirectoryParser.h
@@ -137,14 +137,14 @@ struct ListResult
     bool valid;
     FTPEntryType type;        
     
-    std::span<const LChar> filename;
-    std::span<const LChar> linkname;
+    std::span<LChar> filename;
+    std::span<LChar> linkname;
     
     String fileSize;      
     FTPTime modifiedTime; 
     bool caseSensitive; // file system is definitely case insensitive
 };
 
-FTPEntryType parseOneFTPLine(std::span<const LChar> inputLine, ListState&, ListResult&);
+FTPEntryType parseOneFTPLine(std::span<LChar> inputLine, ListState&, ListResult&);
                  
 } // namespace WebCore


### PR DESCRIPTION
#### 5706bb10341e030f91d3bb6cf103b18cf09e075c
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in FTPDirectoryParser.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286589">https://bugs.webkit.org/show_bug.cgi?id=286589</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/text/ParsingUtilities.h:
(WTF::skipExactly):
(WTF::requires):
(WTF::skipUntil):
(WTF::skipWhile):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::parseAndAppendOneLine):
* Source/WebCore/loader/FTPDirectoryParser.cpp:
(WebCore::parseOneFTPLine):
* Source/WebCore/loader/FTPDirectoryParser.h:

Canonical link: <a href="https://commits.webkit.org/289464@main">https://commits.webkit.org/289464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d208b0431a9c01f9214686fe62afae22ea5d787b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86952 "Failed to checkout and rebase branch from PR 39601") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14525 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25034 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78809 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/47614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33185 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36802 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79736 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93696 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85835 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76026 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75223 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19540 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6985 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13557 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19422 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108218 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/13988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26067 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17317 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->