### PR TITLE
AX: AXIsolatedObject::relativeFrame should try to use the frame of associated labels as a fallback for controls that have not been painted

### DIFF
--- a/LayoutTests/accessibility/mac/clipped-radio-input-frame-expected.txt
+++ b/LayoutTests/accessibility/mac/clipped-radio-input-frame-expected.txt
@@ -1,0 +1,31 @@
+This test ensures we compute a valid frame for a radio button that is visually clipped out of the viewport.
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ Foo
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bar

--- a/LayoutTests/accessibility/mac/clipped-radio-input-frame.html
+++ b/LayoutTests/accessibility/mac/clipped-radio-input-frame.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true -->
+<!-- runSingly because of the usage of accessibilityController.setForceInitialFrameCaching, which sets a process-global static. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+.sr-only {
+    position: absolute;
+    clip: rect(1px, 1px, 1px, 1px);
+    border: 0;
+    clip-path: inset(0 0 99.9% 99.9%);
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    width: 1px;
+}
+</style>
+</head>
+<body>
+
+<div style="margin-left: 300px">
+    <!-- Does not have .sr-only, so the radio should be visible and thus painted as part of the accessibility paint. -->
+    <input type="radio" name="radio1" id="radio1">
+    <label for="radio1">Foo</label>
+
+    <!-- Add tons of space to greatly separate the .sr-only radio from the "normal" radio, allowing us to expect a
+         large y-distance between the two. -->
+    <br/><br/><br/><br/><br/><br/><br/><br/>
+    <br/><br/><br/><br/><br/><br/><br/><br/>
+    <br/><br/><br/><br/><br/><br/><br/><br/>
+
+    <input type="radio" name="radio2" id="radio2" class="sr-only">
+    <label for="radio2">Bar</label>
+</div>
+
+<script>
+function absoluteDifference(num1, num2) {
+    if (num1 > num2)
+        return num1 - num2;
+    return num2 - num1;
+}
+
+// This is a relatively common pattern where "default" style controls will be used for accessibility semantics, but visually
+// clipped, with a label overlapping the area to provide a custom visual appearance for the control.
+var output = "This test ensures we compute a valid frame for a radio button that is visually clipped out of the viewport.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setForceInitialFrameCaching(true);
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var radio1 = accessibilityController.accessibleElementById("radio1");
+    var radio2 = accessibilityController.accessibleElementById("radio2");
+
+    setTimeout(async function() {
+        // If we return the right frame for #radio2, it will have the margin-left:300px baked into its position.
+        await waitFor(() => absoluteDifference(webArea.x, radio2.x) >= 300);
+        // If we return the right frame for #radio2, it will be below #radio1.
+        await waitFor(() => {
+            const yRadio1 = radio1.y;
+            const yRadio2 = radio2.y;
+            return yRadio2 < yRadio1 && absoluteDifference(yRadio1, yRadio2) >= 300;
+        });
+        accessibilityController.setForceInitialFrameCaching(false);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -895,6 +895,9 @@ accessibility/datalist.html [ WontFix ]
 fast/forms/datalist [ WontFix ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-datalist-element [ WontFix ]
 
+# Missing AccessibilityController::setForceInitialFrameCaching implementation.
+accessibility/mac/clipped-radio-input-frame.html [ WontFix ]
+
 accessibility/range-input-increment-decrement-fires-input-event.html [ WontFix ]
 
 # Default ARIA for custom elements are not yet enabled

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -235,7 +235,7 @@ private:
     FloatPoint screenRelativePosition() const final;
     IntPoint remoteFrameOffset() const final;
     FloatRect relativeFrame() const final;
-    bool hasCachedRelativeFrame() const { return optionalAttributeValue<IntRect>(AXProperty::RelativeFrame).has_value(); }
+    std::optional<IntRect> cachedRelativeFrame() const { return optionalAttributeValue<IntRect>(AXProperty::RelativeFrame); }
 #if PLATFORM(MAC)
     FloatRect primaryScreenRect() const final;
 #endif


### PR DESCRIPTION
#### 18e61b9a78ee75505477966caafa0a440b48ce98
<pre>
AX: AXIsolatedObject::relativeFrame should try to use the frame of associated labels as a fallback for controls that have not been painted
<a href="https://bugs.webkit.org/show_bug.cgi?id=286581">https://bugs.webkit.org/show_bug.cgi?id=286581</a>
<a href="https://rdar.apple.com/143706179">rdar://143706179</a>

Reviewed by Chris Fleizach.

A very common pattern in web development is to have a &quot;sr-only&quot; (screenreader only) CSS class, which uses CSS clipping
to prevent an element from being visually rendered but still available to assistive technologies. This causes problems
for us right now, as the clipping will prevent the element from being painted, which means we won&apos;t cache any bounds
for it during the accessibility paint (i.e. AccessibilityRegionContext). A popular online web store using this pattern
to represent radio buttons, and because we compute a frame that is way off-screen, VoiceOver cannot select these radio
buttons.

In a future patch, we probably want some more general solution for handling this type of clipped content — maybe
unconditionally not respecting clipping when doing an accessibility paint, or having some heuristic for respecting
clipping.

But for now, this commit detects the case where we couldn&apos;t compute a cached frame for a control, and computes a relative
frame based on the sum rects of any associated labels. This is strictly better than returning a position that is likely
completely incorrect. This also covers in the case where a control will be painted, but hasn&apos;t yet, while its labels
have been painted and can provide reasonable geometry to use in the meantime.

This patch adds another heuristic to AXIsolatedObject::relativeFrame, where if we can&apos;t compute a cached frame, we at
least prevent the x,y from being reported as negative, as chances are if an AT is requesting the bounds for something,
it is somewhere on screen.

* LayoutTests/accessibility/clipped-radio-input-frame-expected.txt: Added.
* LayoutTests/accessibility/clipped-radio-input-frame.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::relativeFrame const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:

Canonical link: <a href="https://commits.webkit.org/289513@main">https://commits.webkit.org/289513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b04158387ae74a179f6bf0736feceeb1950c8211

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91993 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67341 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25079 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5062 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33240 "Found 2 new test failures: editing/undo/redo-reapply-edit-command-crash.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36984 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76139 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75340 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19681 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18119 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7207 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19602 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14054 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->