### PR TITLE
[iPad] scribd.com: Selection handles are missing after selecting text across multiple lines

### DIFF
--- a/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-2-expected.txt
+++ b/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-2-expected.txt
@@ -1,0 +1,10 @@
+STARTEND
+Verifies that native selection UI is not suppressed. To manually run the test, select from START to END and verify that the selection highlight is visible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS selectionRects.length is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-2.html
+++ b/LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-2.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-size: 24px;
+    font-family: system-ui;
+}
+
+.container {
+    position: absolute;
+    width: 0;
+    height: 0;
+    top: 0;
+}
+
+#start, #end {
+    position: absolute;
+    left: 1em;
+}
+
+#start {
+    top: 24px;
+}
+
+#end {
+    top: 64px;
+}
+
+#description {
+    margin-top: 300px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that native selection UI is not suppressed. To manually run the test, select from START to END and verify that the selection highlight is visible.");
+
+    if (!window.testRunner)
+        return;
+
+    const start = document.getElementById("start");
+    const end = document.getElementById("end");
+
+    await UIHelper.longPressElement(start);
+    await UIHelper.waitForSelectionToAppear();
+    getSelection().setBaseAndExtent(start, 0, end, 1);
+    await UIHelper.ensurePresentationUpdate();
+
+    selectionRects = await UIHelper.waitForSelectionToAppear();
+
+    shouldBe("selectionRects.length", "2");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="container">
+        <span id="start">START</span>
+        <span id="end">END</span>
+    </div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -769,7 +769,7 @@ public:
     // Returns the object containing this one. Can be different from parent for positioned elements.
     // If repaintContainer and repaintContainerSkipped are not null, on return *repaintContainerSkipped
     // is true if the renderer returned is an ancestor of repaintContainer.
-    WEBCORE_EXPORT RenderElement* container() const;
+    RenderElement* container() const;
     RenderElement* container(const RenderLayerModelObject* repaintContainer, bool& repaintContainerSkipped) const;
 
     RenderBoxModelObject* offsetParent() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -205,7 +205,6 @@ class PrintContext;
 class Range;
 class RegistrableDomain;
 class RenderImage;
-class RenderObject;
 class Report;
 class ResourceRequest;
 class ResourceResponse;
@@ -876,7 +875,6 @@ public:
     void updateHeaderAndFooterLayersForDeviceScaleChange(float scaleFactor);
 
     bool isTransparentOrFullyClipped(const WebCore::Node&) const;
-    bool isTransparentOrFullyClipped(const WebCore::RenderObject&) const;
 #endif
 
     void didUpdateRendering();


### PR DESCRIPTION
#### 6355462b3a9548b4d9df5a39afc5b4b923b57c95
<pre>
[iPad] scribd.com: Selection handles are missing after selecting text across multiple lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=286595">https://bugs.webkit.org/show_bug.cgi?id=286595</a>
<a href="https://rdar.apple.com/143720155">rdar://143720155</a>

Reviewed by Abrar Rahman Protyasha.

Make another adjustment to the &quot;hidden selection&quot; heuristic after 289369@main. In the case where:

-   There&apos;s a parent renderer that is out-of-flow, empty (zero width or zero height), and the
    nearest common ancestor of both selection endpoints.

-   The selection endpoints are both out-of-flow as well, but are visible (non-zero width and
    height).

…we&apos;ll currently (incorrectly) treat the selection as hidden. Mitigate this by relaxing the
conditions for this heuristic, such that _both_ selection endpoints must be hidden, in order for
this codepath to kick in.

This allows us to keep the native selection in iCloud Pages hidden (285925@main), but still show the
default selection highlight and handles in the case of Scribd.

* LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-2-expected.txt: Added.
* LayoutTests/editing/selection/ios/do-not-hide-selection-in-non-editable-visible-container-2.html: Added.

Add another layout test to exercise this case.

* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::rendererIsTransparentOrFullyClipped):
(WebKit::WebPage::isTransparentOrFullyClipped const):
(WebKit::selectionIsTransparentOrFullyClipped):
(WebKit::WebPage::getPlatformEditorStateCommon const):
(WebKit::closestCommonContainerInRenderTree): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/289453@main">https://commits.webkit.org/289453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12651563d1ad9bae4c9683ceb729817c97101733

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67228 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24996 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33096 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76033 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75230 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18516 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19441 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13895 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->