### PR TITLE
[cssom] Fix the serialization of the text-decoration shorthand

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-serialization.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-serialization.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL text-decoration shorthand serialization assert_equals: expected "underline rgb(0, 0, 0)" but got "underline"
+PASS text-decoration shorthand serialization
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4136,7 +4136,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyTextAlignLast:
         return createConvertingToCSSValueID(style.textAlignLast());
     case CSSPropertyTextDecoration:
-        return renderTextDecorationLineFlagsToCSSValue(style.textDecorationLine());
+        return CSSValuePair::create(renderTextDecorationLineFlagsToCSSValue(style.textDecorationLine()), currentColorOrValidColor(style, style.textDecorationColor()));
     case CSSPropertyTextJustify:
         return createConvertingToCSSValueID(style.textJustify());
     case CSSPropertyWebkitTextDecoration:


### PR DESCRIPTION
#### ba1e6401c8e064da3d104a41bb11b5addc8db5b3
<pre>
[cssom] Fix the serialization of the text-decoration shorthand.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

When serializing the `text-decoration` shorthand, we should include the color value.
This omission caused the WPT test to fail.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-serialization.tentative-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba1e6401c8e064da3d104a41bb11b5addc8db5b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86972 "Failed to checkout and rebase branch from PR 39609") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37709 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89021 "Failed to checkout and rebase branch from PR 39609") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14549 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67226 "Found 10 new test failures: fast/css/getComputedStyle/getComputedStyle-text-decoration.html fast/css/link-alternate-stylesheet-2.html fast/css/link-disabled-attr.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-computed.html imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002.html media/track/webvtt-inline.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24993 "Found 8 new test failures: fast/css/getComputedStyle/getComputedStyle-text-decoration.html fast/css/link-alternate-stylesheet-1.html fast/css/link-alternate-stylesheet-2.html fast/css/link-alternate-stylesheet-3.html fast/css/link-alternate-stylesheet-4.html fast/css/link-alternate-stylesheet-5.html fast/css/link-disabled-attr.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89974 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5156 "Found 9 new test failures: fast/css/getComputedStyle/getComputedStyle-text-decoration.html fast/css/link-alternate-stylesheet-1.html fast/css/link-alternate-stylesheet-2.html fast/css/link-alternate-stylesheet-3.html fast/css/link-alternate-stylesheet-4.html fast/css/link-alternate-stylesheet-5.html fast/css/link-disabled-attr.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html media/track/webvtt-inline.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78719 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4936 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33091 "Found 16 new test failures: fast/css/getComputedStyle/getComputedStyle-text-decoration.html fast/css/link-alternate-stylesheet-1.html fast/css/link-alternate-stylesheet-2.html fast/css/link-alternate-stylesheet-3.html fast/css/link-alternate-stylesheet-4.html fast/css/link-alternate-stylesheet-5.html fast/css/link-disabled-attr.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36824 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75431 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33970 "Found 16 new test failures: fast/css/getComputedStyle/getComputedStyle-text-decoration.html fast/css/link-alternate-stylesheet-1.html fast/css/link-alternate-stylesheet-2.html fast/css/link-alternate-stylesheet-3.html fast/css/link-alternate-stylesheet-4.html fast/css/link-alternate-stylesheet-5.html fast/css/link-disabled-attr.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93716 "Failed to checkout and rebase branch from PR 39609") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14132 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10277 "Found 16 new test failures: fast/css/getComputedStyle/getComputedStyle-text-decoration.html fast/css/link-alternate-stylesheet-1.html fast/css/link-alternate-stylesheet-2.html fast/css/link-alternate-stylesheet-3.html fast/css/link-alternate-stylesheet-4.html fast/css/link-alternate-stylesheet-5.html fast/css/link-disabled-attr.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/93716 "Failed to checkout and rebase branch from PR 39609") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74572 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/93716 "Failed to checkout and rebase branch from PR 39609") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19553 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17979 "Found 16 new test failures: fast/css/getComputedStyle/getComputedStyle-text-decoration.html fast/css/link-alternate-stylesheet-1.html fast/css/link-alternate-stylesheet-2.html fast/css/link-alternate-stylesheet-3.html fast/css/link-alternate-stylesheet-4.html fast/css/link-alternate-stylesheet-5.html fast/css/link-disabled-attr.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-shorthand.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html ... (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7014 "Failed to checkout and rebase branch from PR 39609") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19442 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->