### PR TITLE
[JSC] Fix stale assertion in Loop Unrolling

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -292,9 +292,14 @@ public:
         // Determine if the condition should be inverted based on whether the "not taken" branch points into the loop.
         Node* terminal = tail->terminal();
         ASSERT(terminal->op() == Branch);
-        bool needToInverseCondition = data.loop->contains(terminal->branchData()->notTaken.block);
-        data.inverseCondition = needToInverseCondition;
-        ASSERT(data.loop->contains(terminal->branchData()->taken.block) == !needToInverseCondition);
+        if (data.loop->contains(terminal->branchData()->notTaken.block)) {
+            // If tail's branch is both jumping into the loop, then it is not a tail.
+            // This happens when we already unrolled this loop before.
+            if (data.loop->contains(terminal->branchData()->taken.block))
+                return false;
+            data.inverseCondition = true;
+        } else
+            data.inverseCondition = false;
 
         return true;
     }


### PR DESCRIPTION
#### 617664a6c6902140a6ccf69f832c7dba23f45645
<pre>
[JSC] Fix stale assertion in Loop Unrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=286601">https://bugs.webkit.org/show_bug.cgi?id=286601</a>
<a href="https://rdar.apple.com/143723904">rdar://143723904</a>

Reviewed by Yijia Huang.

If tail&apos;s branch is both jumping to the loop, then we should fail loop
unrolling. This condition is only met when we already unrolled this loop
before, and in the following condition check, we always fail already
because condition will be just jsBoolean(true) (so loop unrolling fails
with this). But debug assertion hits here.

* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::locateTail):

Canonical link: <a href="https://commits.webkit.org/289436@main">https://commits.webkit.org/289436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98d69c26e8bf808f87b4ba73b4ed8011b5a36d31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91832 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37711 "Failed to checkout and rebase branch from PR 39610") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67229 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/37711 "Failed to checkout and rebase branch from PR 39610") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89976 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5160 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4940 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33092 "Found 1 new test failure: editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36826 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79758 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93718 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85746 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75228 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19554 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17980 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7017 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/13548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19444 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108240 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13898 "Failed to checkout and rebase branch from PR 39610") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26051 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->