### PR TITLE
[iOS] [Visual Bidi Selection] Selection sometimes shrinks when selecting a paragraph that ends with RLE character

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-6-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-6-expected.txt
@@ -1,0 +1,12 @@
+Verifies that the selection does not unnecessarily clamp to LTR text when selecting the entire RTL paragraph from the start
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS initialBounds.left + initialBounds.width is finalBounds.left + finalBounds.width
+PASS initialSelectedText is "أُرسلت"
+PASS finalSelectedText is "‫أُرسلت من الـ iPhone‬"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+‫أُرسلت من الـ iPhone‬

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-6.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-6.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    font-size: 20px;
+    font-family: system-ui;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection does not unnecessarily clamp to LTR text when selecting the entire RTL paragraph from the start");
+
+    target = document.getElementById("target");
+    bounds = target.getBoundingClientRect();
+
+    await UIHelper.longPressAtPoint(bounds.left + bounds.width - 10, bounds.top + bounds.height / 2);
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.waitForSelectionToAppear();
+    initialBounds = await UIHelper.selectionBounds();
+    initialSelectedText = getSelection().toString();
+
+    const {x, y} = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(x, y)
+        .move(bounds.left - 1, y, 0.5)
+        .end()
+        .takeResult());
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.waitForSelectionToAppear();
+    finalSelectedText = getSelection().toString();
+    finalBounds = await UIHelper.selectionBounds();
+
+    shouldBe("initialBounds.left + initialBounds.width", "finalBounds.left + finalBounds.width");
+    shouldBeEqualToString("initialSelectedText", "أُرسلت");
+    shouldBeEqualToString("finalSelectedText", target.textContent);
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p dir="rtl"><span id="target">&#x202b;أُرسلت من الـ iPhone&#x202c;</span></p>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1022,6 +1022,27 @@ window.UIHelper = class UIHelper {
         return true;
     }
 
+    static async selectionBounds()
+    {
+        const rects = await this.getUISelectionViewRects();
+        if (!rects?.length)
+            return null;
+
+        let minTop = Infinity;
+        let minLeft = Infinity;
+        let maxTop = -Infinity;
+        let maxLeft = -Infinity;
+
+        for (const rect of rects) {
+            minTop = Math.min(minTop, rect.top);
+            minLeft = Math.min(minLeft, rect.left);
+            maxTop = Math.max(maxTop, rect.left + rect.width);
+            maxLeft = Math.max(maxLeft, rect.top + rect.height);
+        }
+
+        return { left: minLeft, top: minTop, width: maxLeft - minLeft, height: maxTop - minTop };
+    }
+
     static getSelectionStartGrabberViewRect()
     {
         if (!this.isWebKit2() || !this.isIOSFamily())


### PR DESCRIPTION
#### 08a51bcc0dfde7f741158d1705b202e1da805339
<pre>
[iOS] [Visual Bidi Selection] Selection sometimes shrinks when selecting a paragraph that ends with RLE character
<a href="https://bugs.webkit.org/show_bug.cgi?id=286582">https://bugs.webkit.org/show_bug.cgi?id=286582</a>
<a href="https://rdar.apple.com/143265072">rdar://143265072</a>

Reviewed by Abrar Rahman Protyasha.

Fix a corner case in how we select the closest bidi text boundary when making a selected text range
both visually and logically contiguous, which causes the selection to snap to the (visually)
farthest boundary instead of the closer one. See below (`findBidiBoundary`) for more details.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-6-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-6.html: Added.

Add a layout test to exercise this change by selecting from the first Arabic word in the paragraph,
to the end of `iPhone`; verify that the entire paragraph remains selected.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async selectionBounds):

Add a `UIHelper` method to compute the overall bounding rect of the selection.

* Source/WebCore/editing/Editing.cpp:
(WebCore::findBidiBoundary):

Implement the main fix here — if the left boundary point is visually closer, we currently choose the
right boundary point and vice versa. This works for the most part, where the selection direction is
opposite of the direction of the bidi text run that contains the new boundaries (since selecting the
left boundary will have the effect of visually selecting to the right boundary and vice versa).
However, in the case where the direction *matches* the direction of the bidi text run containing the
extent, this reversal doesn&apos;t happen, so moving the selection extent to the left/right boundaries
will actually visually select to the left/right boundaries, respectively.

To account for this, we consider the selection direction when determining which bidi boundary point
to snap to after ending range adjustment.

(WebCore::makeVisuallyContiguousIfNeeded):

Pass in the direction of the selected text on the first and/or last line (see above).

Canonical link: <a href="https://commits.webkit.org/289452@main">https://commits.webkit.org/289452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18f86c86ee8457eb941e5dffbf9169281ad64d51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67230 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24997 "Failed to checkout and rebase branch from PR 39611") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33095 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93720 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14136 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10281 "Failed to checkout and rebase branch from PR 39611") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76034 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18515 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19561 "Failed to checkout and rebase branch from PR 39611") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7023 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19446 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13900 "Failed to checkout and rebase branch from PR 39611") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->