### PR TITLE
[CSS] Top-level & selector has zero specificity

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt
@@ -8,6 +8,6 @@ PASS @scope (#main) { & .b {  } } and #main .b
 PASS @scope (#main) { div .b {  } } and div .b
 PASS @scope (#main) { @scope (.a) { .b {  } } } and .b
 PASS @scope (#main) { :scope .b {  } } and :scope .b
-FAIL @scope { & .b {  } } and :where(:scope) .b assert_equals: unscoped + scoped expected "2" but got "1"
+PASS @scope { & .b {  } } and :where(:scope) .b
 PASS @scope (#main) { > .a {  } } and :where(#main) > .a
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-parent-pseudo-specificity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-parent-pseudo-specificity-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL CSS Nesting: Specificity of top-level '&' assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS CSS Nesting: Specificity of top-level '&'
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -870,6 +870,9 @@ void CSSSelector::replaceNestingParentByPseudoClassScope()
             // Replace by :scope
             selector.setMatch(Match::PseudoClass);
             selector.setPseudoClass(PseudoClass::Scope);
+            // Top-level nesting parent selector acts like :scope with zero specificity.
+            // https://github.com/w3c/csswg-drafts/issues/10196#issuecomment-2161119978
+            selector.setImplicit();
         }
         return false;
     };


### PR DESCRIPTION
#### b5890b75ec8eac1ee8fb335aac5d655dd77a5e73
<pre>
[CSS] Top-level &amp; selector has zero specificity
<a href="https://bugs.webkit.org/show_bug.cgi?id=286600">https://bugs.webkit.org/show_bug.cgi?id=286600</a>

Reviewed by Ryan Reno.

By CSSWG resolution, top-level nesting parent selector has zero specificity.

<a href="https://github.com/w3c/csswg-drafts/issues/10196#issuecomment-2161119978">https://github.com/w3c/csswg-drafts/issues/10196#issuecomment-2161119978</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-specificity-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/top-level-parent-pseudo-specificity-expected.txt:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope):

Canonical link: <a href="https://commits.webkit.org/289455@main">https://commits.webkit.org/289455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a29a7890659804bffd43e416c07a96a560d2fe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91874 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14594 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4982 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93762 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10316 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74617 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18519 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18025 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14197 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19490 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->