### PR TITLE
[JSC] Use VMTraps' WorkQueue for Watchdog

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -16,7 +16,6 @@
 ./runtime/CachedTypes.cpp
 ./runtime/SamplingProfiler.cpp
 ./runtime/WaiterListManager.h
-./runtime/Watchdog.cpp
 ./wasm/WasmCallee.cpp
 ./wasm/WasmOperations.cpp
 ./wasm/WasmTable.cpp

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -33,6 +33,7 @@
 #include <wtf/Locker.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StackBounds.h>
+#include <wtf/WorkQueue.h>
 
 namespace JSC {
 
@@ -245,6 +246,8 @@ public:
     struct SignalContext;
     void tryInstallTrapBreakpoints(struct VMTraps::SignalContext&, StackBounds);
 #endif
+
+    static WorkQueue& queue();
 
 private:
     VM& vm() const;

--- a/Source/JavaScriptCore/runtime/Watchdog.h
+++ b/Source/JavaScriptCore/runtime/Watchdog.h
@@ -30,7 +30,6 @@
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/WorkQueue.h>
 
 namespace JSC {
 
@@ -38,7 +37,7 @@ class CallFrame;
 class JSGlobalObject;
 class VM;
 
-class Watchdog : public WTF::ThreadSafeRefCounted<Watchdog> {
+class Watchdog : public ThreadSafeRefCounted<Watchdog> {
     WTF_MAKE_TZONE_ALLOCATED(Watchdog);
 public:
     class Scope;
@@ -66,20 +65,15 @@ private:
     bool m_hasEnteredVM { false };
 
     Lock m_lock; // Guards access to m_vm.
-    VM* m_vm;
+    VM* m_vm { nullptr };
 
-    Seconds m_timeLimit;
+    Seconds m_timeLimit { noTimeLimit };
+    Seconds m_cpuDeadline { noTimeLimit };
+    MonotonicTime m_deadline { MonotonicTime::infinity() };
 
-    Seconds m_cpuDeadline;
-    MonotonicTime m_deadline;
-
-    ShouldTerminateCallback m_callback;
-    void* m_callbackData1;
-    void* m_callbackData2;
-
-    Ref<WorkQueue> m_timerQueue;
-
-    friend class LLIntOffsetsExtractor;
+    ShouldTerminateCallback m_callback { nullptr };
+    void* m_callbackData1 { nullptr };
+    void* m_callbackData2 { nullptr };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### d96385b3cddc5dbb90499f6e4ec4bd27762e994e
<pre>
[JSC] Use VMTraps&apos; WorkQueue for Watchdog
<a href="https://bugs.webkit.org/show_bug.cgi?id=286605">https://bugs.webkit.org/show_bug.cgi?id=286605</a>
<a href="https://rdar.apple.com/143731938">rdar://143731938</a>

Reviewed by Keith Miller.

Use VMTraps&apos; WorkQueue for Watchdog too. We do not need to create a new
WorkQueue for Watchdog.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::queue):
* Source/JavaScriptCore/runtime/VMTraps.h:
* Source/JavaScriptCore/runtime/Watchdog.cpp:
(JSC::Watchdog::Watchdog):
(JSC::Watchdog::setTimeLimit):
(JSC::Watchdog::startTimer):
* Source/JavaScriptCore/runtime/Watchdog.h:

Canonical link: <a href="https://commits.webkit.org/289521@main">https://commits.webkit.org/289521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/628c47fe47a983169f8b83c6af0e0cc92b7f0087

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37800 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25047 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33184 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36917 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79845 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93807 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85833 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76097 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74664 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75297 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18070 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7140 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13586 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19535 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108327 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13986 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26069 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->