### PR TITLE
Remove CORS restriction on mixed content upgrades

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt
@@ -1,5 +1,6 @@
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for img-tag to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for img-tag to same-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for img-tag to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt
@@ -1,10 +1,13 @@
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=keep-scheme&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=swap-scheme&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for img-tag to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for img-tag to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects allowed for img-tag to same-http origin and swap-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt
@@ -1,9 +1,11 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt
@@ -1,9 +1,11 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt
@@ -1,9 +1,11 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -175,7 +175,7 @@ static bool destinationIsImageAndInitiatorIsImageset(FetchOptions::Destination d
     return destination == FetchOptions::Destination::Image && initiator == Initiator::Imageset;
 }
 
-bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Mode mode, FetchOptions::Destination destination, Initiator initiator)
+bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Destination destination, Initiator initiator)
 {
     RefPtr document = frame.document();
     if (!document || !isUpgradeMixedContentEnabled(*document) || isUpgradable != IsUpgradable::Yes)
@@ -194,9 +194,6 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
 
     // 4.1 The request's URL is not upgraded in the following cases.
     if (!canModifyRequest(url, destination, initiator, shouldUpgradeIPAddressAndLocalhostForTesting))
-        return false;
-    // or CORS is excluded
-    if (mode == FetchOptions::Mode::Cors && !(document->quirks().needsRelaxedCorsMixedContentCheckQuirk() && destinationIsImageAudioOrVideo(destination)))
         return false;
 
     logConsoleWarningForUpgrade(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -51,7 +51,7 @@ enum class ShouldLogWarning { No, Yes };
 enum class IsUpgradable : bool { No, Yes, };
 
 bool frameAndAncestorsCanRunInsecureContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
-bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Mode, FetchOptions::Destination, Initiator);
+bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Destination, Initiator);
 bool shouldBlockRequestForDisplayableContent(LocalFrame&, const URL&, ContentType, IsUpgradable = IsUpgradable::No);
 bool shouldBlockRequestForRunnableContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
 void checkFormForMixedContent(LocalFrame&, const URL&);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -263,7 +263,7 @@ ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::request
         if (frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None) {
             bool isRequestUpgradable { false };
             if (RefPtr document = frame->document()) {
-                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().mode, request.options().destination, request.options().initiator);
+                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().destination, request.options().initiator);
                 request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
             }
             URL requestURL = request.resourceRequest().url();
@@ -817,7 +817,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         return true;
 
     if (RefPtr document = m_documentLoader->cachedResourceLoader().document()) {
-        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(*document->frame(), isUpgradableTypeFromResourceType(type), request.url(), options.mode, options.destination, options.initiator) : false;
+        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(*document->frame(), isUpgradableTypeFromResourceType(type), request.url(), options.destination, options.initiator) : false;
         upgradeInsecureResourceRequestIfNeeded(request, *document, alwaysUpgradeMixedContent ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
     }
 
@@ -1122,7 +1122,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
 
     bool isRequestUpgradable { false };
     if (RefPtr document = this->document()) {
-        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().mode, request.options().destination, request.options().initiator);
+        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator);
         request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
         url = request.resourceRequest().url();
     }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1516,13 +1516,6 @@ bool Quirks::needsGetElementsByNameQuirk() const
 #endif
 }
 
-// tripadvisor.com: rdar://112851939
-// FIXME: Remove this quirk when <rdar://127247321> is complete
-bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
-{
-    return needsQuirks() && m_quirksData.needsRelaxedCorsMixedContentCheckQuirk;
-}
-
 // rdar://127398734
 bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 {
@@ -2500,17 +2493,6 @@ static void handleSpotifyQuirks(QuirksData& quirksData, const URL& quirksURL, co
 #endif
 }
 
-static void handleTripAdvisorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
-{
-    if (quirksDomainString != "tripadvisor.com"_s)
-        return;
-
-    UNUSED_PARAM(quirksURL);
-    UNUSED_PARAM(documentURL);
-    // tripadvisor.com: rdar://112851939
-    quirksData.needsRelaxedCorsMixedContentCheckQuirk = true;
-}
-
 static void handleVictoriasSecretQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
 {
     if (quirksDomainString != "victoriassecret.com"_s)
@@ -2798,7 +2780,6 @@ void Quirks::determineRelevantQuirks()
 #if PLATFORM(IOS_FAMILY)
         { "thesaurus"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
 #endif
-        { "tripadvisor"_s, &handleTripAdvisorQuirks },
 #if PLATFORM(MAC)
         { "trix-editor"_s, &handleTrixEditorQuirks },
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -215,7 +215,6 @@ public:
     WEBCORE_EXPORT bool shouldUseEphemeralPartitionedStorageForDOMCookies(const URL&) const;
 
     bool needsGetElementsByNameQuirk() const;
-    bool needsRelaxedCorsMixedContentCheckQuirk() const;
     bool needsLaxSameSiteCookieQuirk(const URL&) const;
 
     String scriptToEvaluateBeforeRunningScriptFromURL(const URL&);

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -53,7 +53,6 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsCanPlayAfterSeekedQuirk { false };
     bool needsChromeMediaControlsPseudoElementQuirk { false };
     bool needsMozillaFileTypeForDataTransferQuirk { false };
-    bool needsRelaxedCorsMixedContentCheckQuirk { false };
     bool needsResettingTransitionCancelsRunningTransitionQuirk { false };
     bool needsScrollbarWidthThinDisabledQuirk { false };
     bool needsSeekingSupportDisabledQuirk { false };


### PR DESCRIPTION
#### fc53eacf6a68602a99d29ed1a160f9b1c3a13697
<pre>
Remove CORS restriction on mixed content upgrades
<a href="https://bugs.webkit.org/show_bug.cgi?id=286624">https://bugs.webkit.org/show_bug.cgi?id=286624</a>
<a href="https://rdar.apple.com/124531208">rdar://124531208</a>

Reviewed by Anne van Kesteren.

It turns out that we&apos;re not actually spec-compliant by requiring that requests
are non-CORS. This requirement is mentioned in the spec, but it is not actually
specified in any of the algorithms and was removed in
<a href="https://github.com/w3c/webappsec-mixed-content/pull/67.">https://github.com/w3c/webappsec-mixed-content/pull/67.</a> The spec still needs to
be cleaned up.

This change brings WebKit in-line with Chromium and Gecko on a few
upgrade-insecure-request WPT tests. We now begin failing a few
block-all-mixed-content tests because it is deprecated.

* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
* Source/WebCore/loader/MixedContentChecker.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestImage):
(WebCore::CachedResourceLoader::updateRequestAfterRedirection):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::determineRelevantQuirks):
(WebCore::Quirks::needsRelaxedCorsMixedContentCheckQuirk const): Deleted.
(WebCore::handleTripAdvisorQuirks): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/289639@main">https://commits.webkit.org/289639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f98b5805707d00e2a2f4cfaccf9689e9c5a7e312

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92466 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15285 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90603 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48014 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33665 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37458 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/34529 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94352 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14769 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75724 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20095 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18524 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13644 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14785 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->