### PR TITLE
Sample panels on https://colorsublime.github.io are missing the black background until click

### DIFF
--- a/LayoutTests/fast/css/fast-path-explicit-inherit-expected.html
+++ b/LayoutTests/fast/css/fast-path-explicit-inherit-expected.html
@@ -1,0 +1,5 @@
+<style>
+.c { background-color: green; color: blue; }
+.t { background-color: green }
+</style>
+<div id=c class=c><div id=t class=t>Text</div></div>

--- a/LayoutTests/fast/css/fast-path-explicit-inherit.html
+++ b/LayoutTests/fast/css/fast-path-explicit-inherit.html
@@ -1,0 +1,10 @@
+<style>
+.c { background-color: red; color: yellow; }
+.t { background-color: inherit }
+.fastpath-mutation { background-color: green; color: blue; }
+</style>
+<div id=c class=c><div id=t class=t>Text</div></div>
+<script>
+document.body.offsetLeft;
+c.classList.add("fastpath-mutation");
+</script>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -496,6 +496,12 @@ bool RenderStyle::inheritedEqual(const RenderStyle& other) const
         && m_rareInheritedData == other.m_rareInheritedData;
 }
 
+bool RenderStyle::nonInheritedEqual(const RenderStyle& other) const
+{
+    return m_nonInheritedFlags == other.m_nonInheritedFlags
+        && m_nonInheritedData == other.m_nonInheritedData
+        && (m_svgStyle.ptr() == other.m_svgStyle.ptr() || m_svgStyle->nonInheritedEqual(other.m_svgStyle));
+}
 
 bool RenderStyle::fastPathInheritedEqual(const RenderStyle& other) const
 {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1823,6 +1823,7 @@ public:
     const AtomString& hyphenString() const;
 
     bool inheritedEqual(const RenderStyle&) const;
+    bool nonInheritedEqual(const RenderStyle&) const;
     bool fastPathInheritedEqual(const RenderStyle&) const;
     bool nonFastPathInheritedEqual(const RenderStyle&) const;
 

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -97,14 +97,7 @@ SVGRenderStyle::~SVGRenderStyle() = default;
 
 bool SVGRenderStyle::operator==(const SVGRenderStyle& other) const
 {
-    return m_fillData == other.m_fillData
-        && m_strokeData == other.m_strokeData
-        && m_stopData == other.m_stopData
-        && m_miscData == other.m_miscData
-        && m_layoutData == other.m_layoutData
-        && m_inheritedResourceData == other.m_inheritedResourceData
-        && m_inheritedFlags == other.m_inheritedFlags
-        && m_nonInheritedFlags == other.m_nonInheritedFlags;
+    return inheritedEqual(other) && nonInheritedEqual(other);
 }
 
 bool SVGRenderStyle::inheritedEqual(const SVGRenderStyle& other) const
@@ -113,6 +106,14 @@ bool SVGRenderStyle::inheritedEqual(const SVGRenderStyle& other) const
         && m_strokeData == other.m_strokeData
         && m_inheritedResourceData == other.m_inheritedResourceData
         && m_inheritedFlags == other.m_inheritedFlags;
+}
+
+bool SVGRenderStyle::nonInheritedEqual(const SVGRenderStyle& other) const
+{
+    return m_stopData == other.m_stopData
+        && m_miscData == other.m_miscData
+        && m_layoutData == other.m_layoutData
+        && m_nonInheritedFlags == other.m_nonInheritedFlags;
 }
 
 void SVGRenderStyle::inheritFrom(const SVGRenderStyle& other)

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -45,6 +45,8 @@ public:
     ~SVGRenderStyle();
 
     bool inheritedEqual(const SVGRenderStyle&) const;
+    bool nonInheritedEqual(const SVGRenderStyle&) const;
+
     void inheritFrom(const SVGRenderStyle&);
     void copyNonInheritedFrom(const SVGRenderStyle&);
 

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -69,10 +69,11 @@ Change determineChange(const RenderStyle& s1, const RenderStyle& s2)
     if (!s1.nonFastPathInheritedEqual(s2))
         return Change::Inherited;
 
+    bool nonInheritedEqual = s1.nonInheritedEqual(s2);
     if (!s1.fastPathInheritedEqual(s2))
-        return Change::FastPathInherited;
+        return nonInheritedEqual ? Change::FastPathInherited : Change::NonInheritedAndFastPathInherited;
 
-    if (s1 != s2)
+    if (!nonInheritedEqual)
         return Change::NonInherited;
 
     return Change::None;

--- a/Source/WebCore/style/StyleChange.h
+++ b/Source/WebCore/style/StyleChange.h
@@ -35,6 +35,7 @@ enum class Change : uint8_t {
     None,
     NonInherited,
     FastPathInherited,
+    NonInheritedAndFastPathInherited,
     Inherited,
     Descendants,
     Renderer


### PR DESCRIPTION
#### 431aa8dced21476808597782a920f664355508d9
<pre>
Sample panels on <a href="https://colorsublime.github.io">https://colorsublime.github.io</a> are missing the black background until click
<a href="https://bugs.webkit.org/show_bug.cgi?id=286365">https://bugs.webkit.org/show_bug.cgi?id=286365</a>
<a href="https://rdar.apple.com/137988602">rdar://137988602</a>

Reviewed by Simon Fraser.

Fast-path inheritance can not be used if the current style has explicitly inherited properties.

* LayoutTests/fast/css/fast-path-explicit-inherit-expected.html: Added.
* LayoutTests/fast/css/fast-path-explicit-inherit.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::nonInheritedEqual const):

Add comparison for non-inherited properties.

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::operator== const):
(WebCore::SVGRenderStyle::nonInheritedEqual const):
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChange):
* Source/WebCore/style/StyleChange.h:

Add a new style change type for when a fast-path property and a non-inherited property both change.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::computeDescendantsToResolve const):
(WebCore::Style::TreeResolver::determineResolutionType):

In that case we also need to check if the style has had any explicitly inherited properties applied and
not use the fast path if so.

Canonical link: <a href="https://commits.webkit.org/289457@main">https://commits.webkit.org/289457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5f9eef49602f16fc8ee3bf2e800aa0ff2cf2dc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25017 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47576 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33136 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10314 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75263 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19486 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->