### PR TITLE
Allow specifying a ResolvedValueType for any CSS numeric primitive

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
@@ -36,7 +36,7 @@ struct AngleValidator {
         return CSS::UnitTraits<CSS::AngleUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::AngleRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::AngleRaw<R, V> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
             auto canonicalValue = CSS::canonicalize(raw);
@@ -45,10 +45,10 @@ struct AngleValidator {
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Angle<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Angle<R>>;
-    using DimensionToken = DimensionConsumer<CSS::Angle<R>, AngleValidator>;
-    using NumberToken = NumberConsumerForUnitlessValues<CSS::Angle<R>, AngleValidator, CSS::AngleUnit::Deg>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Angle<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Angle<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::Angle<R, V>, AngleValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::Angle<R, V>, AngleValidator, CSS::AngleUnit::Deg>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentageDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentageDefinitions.h
@@ -40,18 +40,18 @@ struct AnglePercentageValidator {
         return std::nullopt;
     }
 
-    template<auto R> static bool isValid(CSS::AnglePercentageRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::AnglePercentageRaw<R, V> raw, CSSPropertyParserOptions)
     {
         // Values other than 0 and +/-∞ are not supported for <angle-percentage> numeric ranges currently.
         return isValidNonCanonicalizableDimensionValue(raw);
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::AnglePercentage<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::AnglePercentage<R>>;
-    using DimensionToken = DimensionConsumer<CSS::AnglePercentage<R>, AnglePercentageValidator>;
-    using PercentageToken = PercentageConsumer<CSS::AnglePercentage<R>, AnglePercentageValidator>;
-    using NumberToken = NumberConsumerForUnitlessValues<CSS::AnglePercentage<R>, AnglePercentageValidator, CSS::AngleUnit::Deg>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::AnglePercentage<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::AnglePercentage<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::AnglePercentage<R, V>, AnglePercentageValidator>;
+    using PercentageToken = PercentageConsumer<CSS::AnglePercentage<R, V>, AnglePercentageValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::AnglePercentage<R, V>, AnglePercentageValidator, CSS::AngleUnit::Deg>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+FlexDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+FlexDefinitions.h
@@ -35,15 +35,15 @@ struct FlexValidator {
         return CSS::UnitTraits<CSS::FlexUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::FlexRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::FlexRaw<R, V> raw, CSSPropertyParserOptions)
     {
         return isValidCanonicalValue(raw);
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Flex<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Flex<R>>;
-    using DimensionToken = DimensionConsumer<CSS::Flex<R>, FlexValidator>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Flex<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Flex<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::Flex<R, V>, FlexValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
@@ -36,7 +36,7 @@ struct FrequencyValidator {
         return CSS::UnitTraits<CSS::FrequencyUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::FrequencyRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::FrequencyRaw<R, V> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
             auto canonicalValue = CSS::canonicalize(raw);
@@ -45,9 +45,9 @@ struct FrequencyValidator {
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Frequency<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Frequency<R>>;
-    using DimensionToken = DimensionConsumer<CSS::Frequency<R>, FrequencyValidator>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Frequency<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Frequency<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::Frequency<R, V>, FrequencyValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
@@ -37,17 +37,17 @@ struct LengthValidator {
         return CSS::UnitTraits<CSS::LengthUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::LengthRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::LengthRaw<R, V> raw, CSSPropertyParserOptions)
     {
         // Values other than 0 and +/-∞ are not supported for <length> numeric ranges currently.
         return isValidNonCanonicalizableDimensionValue(raw);
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Length<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Length<R>>;
-    using DimensionToken = DimensionConsumer<CSS::Length<R>, LengthValidator>;
-    using NumberToken = NumberConsumerForUnitlessValues<CSS::Length<R>, LengthValidator, CSS::LengthUnit::Px>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Length<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Length<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::Length<R, V>, LengthValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::Length<R, V>, LengthValidator, CSS::LengthUnit::Px>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentageDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentageDefinitions.h
@@ -40,18 +40,18 @@ struct LengthPercentageValidator {
         return std::nullopt;
     }
 
-    template<auto R> static bool isValid(CSS::LengthPercentageRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::LengthPercentageRaw<R, V> raw, CSSPropertyParserOptions)
     {
         // Values other than 0 and +/-∞ are not supported for <length-percentage> numeric ranges currently.
         return isValidNonCanonicalizableDimensionValue(raw);
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::LengthPercentage<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::LengthPercentage<R>>;
-    using DimensionToken = DimensionConsumer<CSS::LengthPercentage<R>, LengthPercentageValidator>;
-    using PercentageToken = PercentageConsumer<CSS::LengthPercentage<R>, LengthPercentageValidator>;
-    using NumberToken = NumberConsumerForUnitlessValues<CSS::LengthPercentage<R>, LengthPercentageValidator, CSS::LengthUnit::Px>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::LengthPercentage<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::LengthPercentage<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::LengthPercentage<R, V>, LengthPercentageValidator>;
+    using PercentageToken = PercentageConsumer<CSS::LengthPercentage<R, V>, LengthPercentageValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::LengthPercentage<R, V>, LengthPercentageValidator, CSS::LengthUnit::Px>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h
@@ -35,15 +35,15 @@ struct NumberValidator {
         return CSS::UnitTraits<CSS::NumberUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::NumberRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::NumberRaw<R, V> raw, CSSPropertyParserOptions)
     {
         return isValidCanonicalValue(raw);
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Number<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Number<R>>;
-    using NumberToken = NumberConsumer<CSS::Number<R>, NumberValidator>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Number<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Number<R, V>>;
+    using NumberToken = NumberConsumer<CSS::Number<R, V>, NumberValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentageDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentageDefinitions.h
@@ -35,15 +35,15 @@ struct PercentageValidator {
         return CSS::UnitTraits<CSS::PercentageUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::PercentageRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::PercentageRaw<R, V> raw, CSSPropertyParserOptions)
     {
         return isValidCanonicalValue(raw);
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Percentage<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Percentage<R>>;
-    using PercentageToken = PercentageConsumer<CSS::Percentage<R>, PercentageValidator>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Percentage<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Percentage<R, V>>;
+    using PercentageToken = PercentageConsumer<CSS::Percentage<R, V>, PercentageValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
@@ -36,7 +36,7 @@ struct ResolutionValidator {
         return CSS::UnitTraits<CSS::ResolutionUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::ResolutionRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::ResolutionRaw<R, V> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
             auto canonicalValue = CSS::canonicalize(raw);
@@ -45,9 +45,9 @@ struct ResolutionValidator {
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Resolution<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Resolution<R>>;
-    using DimensionToken = DimensionConsumer<CSS::Resolution<R>, ResolutionValidator>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Resolution<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Resolution<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::Resolution<R, V>, ResolutionValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
@@ -36,7 +36,7 @@ struct TimeValidator {
         return CSS::UnitTraits<CSS::TimeUnit>::validate(unitType);
     }
 
-    template<auto R> static bool isValid(CSS::TimeRaw<R> raw, CSSPropertyParserOptions)
+    template<auto R, typename V> static bool isValid(CSS::TimeRaw<R, V> raw, CSSPropertyParserOptions)
     {
         return isValidDimensionValue(raw, [&] {
             auto canonicalValue = CSS::canonicalize(raw);
@@ -45,9 +45,9 @@ struct TimeValidator {
     }
 };
 
-template<auto R> struct ConsumerDefinition<CSS::Time<R>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Time<R>>;
-    using DimensionToken = DimensionConsumer<CSS::Time<R>, TimeValidator>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Time<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Time<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::Time<R, V>, TimeValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
@@ -178,53 +178,53 @@ template<Range R = All, typename V = int> struct IntegerRaw : PrimitiveNumericRa
 
 // MARK: Number Primitive Raw
 
-template<Range R = All> struct NumberRaw : PrimitiveNumericRaw<R, NumberUnit, double> {
-    using Base = PrimitiveNumericRaw<R, NumberUnit, double>;
+template<Range R = All, typename V = double> struct NumberRaw : PrimitiveNumericRaw<R, NumberUnit, V> {
+    using Base = PrimitiveNumericRaw<R, NumberUnit, V>;
     using Base::Base;
 };
 
 // MARK: Percentage Primitive Raw
 
-template<Range R = All> struct PercentageRaw : PrimitiveNumericRaw<R, PercentageUnit, double> {
-    using Base = PrimitiveNumericRaw<R, PercentageUnit, double>;
+template<Range R = All, typename V = double> struct PercentageRaw : PrimitiveNumericRaw<R, PercentageUnit, V> {
+    using Base = PrimitiveNumericRaw<R, PercentageUnit, V>;
     using Base::Base;
 };
 
 // MARK: Dimension Primitives Raw
 
-template<Range R = All> struct AngleRaw : PrimitiveNumericRaw<R, AngleUnit, double> {
-    using Base = PrimitiveNumericRaw<R, AngleUnit, double>;
+template<Range R = All, typename V = double> struct AngleRaw : PrimitiveNumericRaw<R, AngleUnit, V> {
+    using Base = PrimitiveNumericRaw<R, AngleUnit, V>;
     using Base::Base;
 };
-template<Range R = All> struct LengthRaw : PrimitiveNumericRaw<R, LengthUnit, float> {
-    using Base = PrimitiveNumericRaw<R, LengthUnit, float>;
+template<Range R = All, typename V = float> struct LengthRaw : PrimitiveNumericRaw<R, LengthUnit, V> {
+    using Base = PrimitiveNumericRaw<R, LengthUnit, V>;
     using Base::Base;
 };
-template<Range R = All> struct TimeRaw : PrimitiveNumericRaw<R, TimeUnit, double> {
-    using Base = PrimitiveNumericRaw<R, TimeUnit, double>;
+template<Range R = All, typename V = double> struct TimeRaw : PrimitiveNumericRaw<R, TimeUnit, V> {
+    using Base = PrimitiveNumericRaw<R, TimeUnit, V>;
     using Base::Base;
 };
-template<Range R = All> struct FrequencyRaw : PrimitiveNumericRaw<R, FrequencyUnit, double> {
-    using Base = PrimitiveNumericRaw<R, FrequencyUnit, double>;
+template<Range R = All, typename V = double> struct FrequencyRaw : PrimitiveNumericRaw<R, FrequencyUnit, V> {
+    using Base = PrimitiveNumericRaw<R, FrequencyUnit, V>;
     using Base::Base;
 };
-template<Range R = Nonnegative> struct ResolutionRaw : PrimitiveNumericRaw<R, ResolutionUnit, double> {
-    using Base = PrimitiveNumericRaw<R, ResolutionUnit, double>;
+template<Range R = Nonnegative, typename V = double> struct ResolutionRaw : PrimitiveNumericRaw<R, ResolutionUnit, V> {
+    using Base = PrimitiveNumericRaw<R, ResolutionUnit, V>;
     using Base::Base;
 };
-template<Range R = All> struct FlexRaw : PrimitiveNumericRaw<R, FlexUnit, double> {
-    using Base = PrimitiveNumericRaw<R, FlexUnit, double>;
+template<Range R = All, typename V = double> struct FlexRaw : PrimitiveNumericRaw<R, FlexUnit, V> {
+    using Base = PrimitiveNumericRaw<R, FlexUnit, V>;
     using Base::Base;
 };
 
 // MARK: Dimension + Percentage Primitives Raw
 
-template<Range R = All> struct AnglePercentageRaw : PrimitiveNumericRaw<R, AnglePercentageUnit, double> {
-    using Base = PrimitiveNumericRaw<R, AnglePercentageUnit, double>;
+template<Range R = All, typename V = double> struct AnglePercentageRaw : PrimitiveNumericRaw<R, AnglePercentageUnit, V> {
+    using Base = PrimitiveNumericRaw<R, AnglePercentageUnit, V>;
     using Base::Base;
 };
-template<Range R = All> struct LengthPercentageRaw : PrimitiveNumericRaw<R, LengthPercentageUnit, double> {
-    using Base = PrimitiveNumericRaw<R, LengthPercentageUnit, double>;
+template<Range R = All, typename V = float> struct LengthPercentageRaw : PrimitiveNumericRaw<R, LengthPercentageUnit, V> {
+    using Base = PrimitiveNumericRaw<R, LengthPercentageUnit, V>;
     using Base::Base;
 };
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h
@@ -36,7 +36,7 @@ namespace CSS {
 
 double canonicalizeAngle(double value, AngleUnit);
 
-template<auto R> double canonicalize(AngleRaw<R> raw)
+template<auto R, typename V> double canonicalize(AngleRaw<R, V> raw)
 {
     return canonicalizeAngle(raw.value, raw.unit);
 }
@@ -45,7 +45,7 @@ template<auto R> double canonicalize(AngleRaw<R> raw)
 
 double canonicalizeTime(double, TimeUnit);
 
-template<auto R> double canonicalize(TimeRaw<R> raw)
+template<auto R, typename V> double canonicalize(TimeRaw<R, V> raw)
 {
     return canonicalizeTime(raw.value, raw.unit);
 }
@@ -54,7 +54,7 @@ template<auto R> double canonicalize(TimeRaw<R> raw)
 
 double canonicalizeFrequency(double, FrequencyUnit);
 
-template<auto R> double canonicalize(FrequencyRaw<R> raw)
+template<auto R, typename V> double canonicalize(FrequencyRaw<R, V> raw)
 {
     return canonicalizeFrequency(raw.value, raw.unit);
 }
@@ -63,7 +63,7 @@ template<auto R> double canonicalize(FrequencyRaw<R> raw)
 
 double canonicalizeResolution(double, ResolutionUnit);
 
-template<auto R> double canonicalize(ResolutionRaw<R> raw)
+template<auto R, typename V> double canonicalize(ResolutionRaw<R, V> raw)
 {
     return canonicalizeResolution(raw.value, raw.unit);
 }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
@@ -53,16 +53,16 @@ template<NumericRaw RawType> struct Serialize<RawType> {
     }
 };
 
-template<auto nR, auto pR> struct Serialize<NumberOrPercentageResolvedToNumber<nR, pR>> {
-    void operator()(StringBuilder& builder, const NumberOrPercentageResolvedToNumber<nR, pR>& value)
+template<auto nR, auto pR, typename V> struct Serialize<NumberOrPercentageResolvedToNumber<nR, pR, V>> {
+    void operator()(StringBuilder& builder, const NumberOrPercentageResolvedToNumber<nR, pR, V>& value)
     {
         WTF::switchOn(value,
-            [&](const Number<nR>& number) {
+            [&](const typename NumberOrPercentageResolvedToNumber<nR, pR, V>::Number& number) {
                 serializationForCSS(builder, number);
             },
-            [&](const Percentage<pR>& percentage) {
+            [&](const typename NumberOrPercentageResolvedToNumber<nR, pR, V>::Percentage& percentage) {
                 if (auto raw = percentage.raw())
-                    serializationForCSS(builder, NumberRaw<nR> { raw->value / 100.0 });
+                    serializationForCSS(builder, NumberRaw<nR, V> { raw->value / 100.0 });
                 else
                     serializationForCSS(builder, percentage);
             }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
@@ -304,91 +304,94 @@ template<Range R = All, typename V = int> struct Integer : PrimitiveNumeric<Inte
 
 // MARK: Number Primitive
 
-template<Range R = All> struct Number : PrimitiveNumeric<NumberRaw<R>> {
-    using Base = PrimitiveNumeric<NumberRaw<R>>;
+template<Range R = All, typename V = double> struct Number : PrimitiveNumeric<NumberRaw<R, V>> {
+    using Base = PrimitiveNumeric<NumberRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Number>;
 };
 
 // MARK: Percentage Primitive
 
-template<Range R = All> struct Percentage : PrimitiveNumeric<PercentageRaw<R>> {
-    using Base = PrimitiveNumeric<PercentageRaw<R>>;
+template<Range R = All, typename V = double> struct Percentage : PrimitiveNumeric<PercentageRaw<R, V>> {
+    using Base = PrimitiveNumeric<PercentageRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Percentage>;
 };
 
 // MARK: Dimension Primitives
 
-template<Range R = All> struct Angle : PrimitiveNumeric<AngleRaw<R>> {
-    using Base = PrimitiveNumeric<AngleRaw<R>>;
+template<Range R = All, typename V = double> struct Angle : PrimitiveNumeric<AngleRaw<R, V>> {
+    using Base = PrimitiveNumeric<AngleRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Angle>;
 };
-template<Range R = All> struct Length : PrimitiveNumeric<LengthRaw<R>> {
-    using Base = PrimitiveNumeric<LengthRaw<R>>;
+template<Range R = All, typename V = float> struct Length : PrimitiveNumeric<LengthRaw<R, V>> {
+    using Base = PrimitiveNumeric<LengthRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Length>;
 };
-template<Range R = All> struct Time : PrimitiveNumeric<TimeRaw<R>> {
-    using Base = PrimitiveNumeric<TimeRaw<R>>;
+template<Range R = All, typename V = double> struct Time : PrimitiveNumeric<TimeRaw<R, V>> {
+    using Base = PrimitiveNumeric<TimeRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Time>;
 };
-template<Range R = All> struct Frequency : PrimitiveNumeric<FrequencyRaw<R>> {
-    using Base = PrimitiveNumeric<FrequencyRaw<R>>;
+template<Range R = All, typename V = double> struct Frequency : PrimitiveNumeric<FrequencyRaw<R, V>> {
+    using Base = PrimitiveNumeric<FrequencyRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Frequency>;
 };
-template<Range R = Nonnegative> struct Resolution : PrimitiveNumeric<ResolutionRaw<R>> {
-    using Base = PrimitiveNumeric<ResolutionRaw<R>>;
+template<Range R = Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<ResolutionRaw<R, V>> {
+    using Base = PrimitiveNumeric<ResolutionRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Resolution>;
 };
-template<Range R = All> struct Flex : PrimitiveNumeric<FlexRaw<R>> {
-    using Base = PrimitiveNumeric<FlexRaw<R>>;
+template<Range R = All, typename V = double> struct Flex : PrimitiveNumeric<FlexRaw<R, V>> {
+    using Base = PrimitiveNumeric<FlexRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveNumericMarkableTraits<Flex>;
 };
 
 // MARK: Dimension + Percentage Primitives
 
-template<Range R = All> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R>> {
-    using Base = PrimitiveNumeric<AnglePercentageRaw<R>>;
+template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R, V>> {
+    using Base = PrimitiveNumeric<AnglePercentageRaw<R, V>>;
     using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<AnglePercentage<R>>;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<AnglePercentage<R, V>>;
 };
-template<Range R = All> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R>> {
-    using Base = PrimitiveNumeric<LengthPercentageRaw<R>>;
+template<Range R = All, typename V = float> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
+    using Base = PrimitiveNumeric<LengthPercentageRaw<R, V>>;
     using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<LengthPercentage<R>>;
+    using MarkableTraits = PrimitiveNumericMarkableTraits<LengthPercentage<R, V>>;
 };
 
 // MARK: Additional Common Groupings
 
 // NOTE: This is spelled with an explicit "Or" to distinguish it from types like AnglePercentage/LengthPercentage that have behavior distinctions beyond just being a union of the two types (specifically, calc() has specific behaviors for those types).
-template<Range nR = All, Range pR = nR> struct NumberOrPercentage {
-    NumberOrPercentage(std::variant<Number<nR>, Percentage<pR>> value)
+template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPercentage {
+    using Number = CSS::Number<nR, V>;
+    using Percentage = CSS::Percentage<pR, V>;
+
+    NumberOrPercentage(std::variant<Number, Percentage>&& value)
     {
         WTF::switchOn(WTFMove(value), [this](auto&& alternative) { this->value = WTFMove(alternative); });
     }
 
-    NumberOrPercentage(NumberRaw<nR> value)
-        : value { Number<nR> { WTFMove(value) } }
+    NumberOrPercentage(typename Number::Raw value)
+        : value { Number { WTFMove(value) } }
     {
     }
 
-    NumberOrPercentage(Number<nR> value)
+    NumberOrPercentage(Number value)
         : value { WTFMove(value) }
     {
     }
 
-    NumberOrPercentage(PercentageRaw<pR> value)
-        : value { Percentage<pR> { WTFMove(value) } }
+    NumberOrPercentage(typename Percentage::Raw value)
+        : value { Percentage { WTFMove(value) } }
     {
     }
 
-    NumberOrPercentage(Percentage<pR> value)
+    NumberOrPercentage(Percentage value)
         : value { WTFMove(value) }
     {
     }
@@ -398,16 +401,16 @@ template<Range nR = All, Range pR = nR> struct NumberOrPercentage {
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-        using ResultType = decltype(visitor(std::declval<Number<nR>>()));
+        using ResultType = decltype(visitor(std::declval<Number>()));
 
         return WTF::switchOn(value,
             [](EmptyToken) -> ResultType {
                 RELEASE_ASSERT_NOT_REACHED();
             },
-            [&](const Number<nR>& number) -> ResultType {
+            [&](const Number& number) -> ResultType {
                 return visitor(number);
             },
-            [&](const Percentage<pR>& percentage) -> ResultType {
+            [&](const Percentage& percentage) -> ResultType {
                 return visitor(percentage);
             }
         );
@@ -427,31 +430,34 @@ private:
 
     bool isEmpty() const { return std::holds_alternative<EmptyToken>(value); }
 
-    std::variant<EmptyToken, Number<nR>, Percentage<pR>> value;
+    std::variant<EmptyToken, Number, Percentage> value;
 };
 
-template<Range nR = All, Range pR = nR> struct NumberOrPercentageResolvedToNumber {
-    NumberOrPercentageResolvedToNumber(std::variant<Number<nR>, Percentage<pR>> value)
+template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPercentageResolvedToNumber {
+    using Number = CSS::Number<nR, V>;
+    using Percentage = CSS::Percentage<pR, V>;
+
+    NumberOrPercentageResolvedToNumber(std::variant<Number, Percentage>&& value)
     {
         WTF::switchOn(WTFMove(value), [this](auto&& alternative) { this->value = WTFMove(alternative); });
     }
 
-    NumberOrPercentageResolvedToNumber(NumberRaw<nR> value)
-        : value { Number<nR> { WTFMove(value) } }
+    NumberOrPercentageResolvedToNumber(typename Number::Raw value)
+        : value { Number { WTFMove(value) } }
     {
     }
 
-    NumberOrPercentageResolvedToNumber(Number<nR> value)
+    NumberOrPercentageResolvedToNumber(Number value)
         : value { WTFMove(value) }
     {
     }
 
-    NumberOrPercentageResolvedToNumber(PercentageRaw<pR> value)
-        : value { Percentage<pR> { WTFMove(value) } }
+    NumberOrPercentageResolvedToNumber(typename Percentage::Raw value)
+        : value { Percentage { WTFMove(value) } }
     {
     }
 
-    NumberOrPercentageResolvedToNumber(Percentage<pR> value)
+    NumberOrPercentageResolvedToNumber(Percentage value)
         : value { WTFMove(value) }
     {
     }
@@ -461,16 +467,16 @@ template<Range nR = All, Range pR = nR> struct NumberOrPercentageResolvedToNumbe
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-        using ResultType = decltype(visitor(std::declval<Number<nR>>()));
+        using ResultType = decltype(visitor(std::declval<Number>()));
 
         return WTF::switchOn(value,
             [](EmptyToken) -> ResultType {
                 RELEASE_ASSERT_NOT_REACHED();
             },
-            [&](const Number<nR>& number) -> ResultType {
+            [&](const Number& number) -> ResultType {
                 return visitor(number);
             },
-            [&](const Percentage<pR>& percentage) -> ResultType {
+            [&](const Percentage& percentage) -> ResultType {
                 return visitor(percentage);
             }
         );
@@ -490,24 +496,24 @@ private:
 
     bool isEmpty() const { return std::holds_alternative<EmptyToken>(value); }
 
-    std::variant<EmptyToken, Number<nR>, Percentage<pR>> value;
+    std::variant<EmptyToken, Number, Percentage> value;
 };
 
 } // namespace CSS
 } // namespace WebCore
 
-template<auto R, typename T> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Integer<R, T>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Number<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Percentage<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Angle<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Length<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Time<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Frequency<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Resolution<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Flex<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::AnglePercentage<R>> = true;
-template<auto R> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::LengthPercentage<R>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Integer<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Number<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Percentage<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Angle<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Length<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Time<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Frequency<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Resolution<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Flex<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::AnglePercentage<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::LengthPercentage<R, V>> = true;
 
 template<typename Raw> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::PrimitiveNumeric<Raw>> = true;
-template<auto nR, auto pR> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::NumberOrPercentage<nR, pR>> = true;
-template<auto nR, auto pR> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::NumberOrPercentageResolvedToNumber<nR, pR>> = true;
+template<auto nR, auto pR, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::NumberOrPercentage<nR, pR, V>> = true;
+template<auto nR, auto pR, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::NumberOrPercentageResolvedToNumber<nR, pR, V>> = true;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2335,8 +2335,8 @@ static Ref<StyleGradientImage> autoFillStrongPasswordMaskImage()
                 .colorInterpolationMethod = Style::GradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Unpremultiplied),
                 .gradientLine = { Style::Angle<> { 90 } },
                 .stops = {
-                    { Style::Color { Color::black },            Style::LengthPercentage<> { Style::Percentage<> { 50 } } },
-                    { Style::Color { Color::transparentBlack }, Style::LengthPercentage<> { Style::Percentage<> { 100 } } }
+                    { Style::Color { Color::black },            Style::LengthPercentage<>::Percentage { 50 } },
+                    { Style::Color { Color::transparentBlack }, Style::LengthPercentage<>::Percentage { 100 } }
                 }
             }
         }

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -127,12 +127,12 @@ static std::optional<float> resolveColorStopPosition(const GradientLinearColorSt
         return std::nullopt;
 
     return WTF::switchOn(*position,
-        [&](const Length<>& length) -> std::optional<float> {
+        [&](const typename LengthPercentage<>::Dimension& length) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
             return length.value / gradientLength;
         },
-        [&](const Percentage<>& percentage) -> std::optional<float> {
+        [&](const typename LengthPercentage<>::Percentage& percentage) -> std::optional<float> {
             return percentage.value / 100.0;
         },
         [&](const typename LengthPercentage<>::Calc& calc) -> std::optional<float> {
@@ -149,10 +149,10 @@ static std::optional<float> resolveColorStopPosition(const GradientAngularColorS
         return std::nullopt;
 
     return WTF::switchOn(*position,
-        [](const Angle<>& angle) -> std::optional<float> {
+        [](const typename AnglePercentage<>::Dimension& angle) -> std::optional<float> {
             return angle.value / 360.0;
         },
-        [](const Percentage<>& percentage) -> std::optional<float> {
+        [](const typename AnglePercentage<>::Percentage& percentage) -> std::optional<float> {
             return percentage.value / 100.0;
         },
         [&](const typename AnglePercentage<>::Calc& calc) -> std::optional<float> {

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -38,13 +38,13 @@ auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComp
 {
     return WTF::switchOn(value.offset,
         [&](CSS::Keyword::Left) {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 0 } } };
+            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 0 } } };
         },
         [&](CSS::Keyword::Right)  {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 100 } } };
+            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 100 } } };
         },
         [&](CSS::Keyword::Center)  {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { Percentage<> { 50 } } };
+            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
             return TwoComponentPositionHorizontal { .offset = toStyle(value, state) };
@@ -56,13 +56,13 @@ auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoCompon
 {
     return WTF::switchOn(value.offset,
         [&](CSS::Keyword::Top) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 0 } } };
+            return TwoComponentPositionVertical { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 0 } } };
         },
         [&](CSS::Keyword::Bottom) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 100 } } };
+            return TwoComponentPositionVertical { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 100 } } };
         },
         [&](CSS::Keyword::Center) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { Percentage<> { 50 } } };
+            return TwoComponentPositionVertical { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 50 } } };
         },
         [&](const CSS::LengthPercentage<>& value) {
             return TwoComponentPositionVertical { .offset = toStyle(value, state) };

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -60,17 +60,17 @@ template<Numeric StyleType> struct Blending<StyleType> {
 
 // MARK: Interpolation of mixed numeric types
 // https://drafts.csswg.org/css-values/#combine-mixed
-template<auto R> struct Blending<LengthPercentage<R>> {
-    constexpr auto canBlend(const LengthPercentage<R>&, const LengthPercentage<R>&) -> bool
+template<auto R, typename V> struct Blending<LengthPercentage<R, V>> {
+    constexpr auto canBlend(const LengthPercentage<R, V>&, const LengthPercentage<R, V>&) -> bool
     {
         return true;
     }
 
-    auto blend(const LengthPercentage<R>& from, const LengthPercentage<R>& to, const BlendingContext& context) -> LengthPercentage<R>
+    auto blend(const LengthPercentage<R, V>& from, const LengthPercentage<R, V>& to, const BlendingContext& context) -> LengthPercentage<R, V>
     {
-        using Length = typename LengthPercentage<R>::Dimension;
-        using Percentage = typename LengthPercentage<R>::Percentage;
-        using Calc = typename LengthPercentage<R>::Calc;
+        using Length = typename LengthPercentage<R, V>::Dimension;
+        using Percentage = typename LengthPercentage<R, V>::Percentage;
+        using Calc = typename LengthPercentage<R, V>::Calc;
 
         // Interpolation of dimension-percentage value combinations (e.g. <length-percentage>, <frequency-percentage>,
         // <angle-percentage>, <time-percentage> or equivalent notations) is defined as:
@@ -117,13 +117,13 @@ template<auto R> struct Blending<LengthPercentage<R>> {
     }
 };
 
-// `NumberOrPercentageResolvedToNumber<nR,pR>` forwards to `Number<nR>`.
-template<auto nR, auto pR> struct Blending<NumberOrPercentageResolvedToNumber<nR, pR>> {
-    auto canBlend(const NumberOrPercentageResolvedToNumber<nR, pR>& a, const NumberOrPercentageResolvedToNumber<nR, pR>& b) -> bool
+// `NumberOrPercentageResolvedToNumber<nR, pR, V>` forwards to `Number<nR, V>`.
+template<auto nR, auto pR, typename V> struct Blending<NumberOrPercentageResolvedToNumber<nR, pR, V>> {
+    auto canBlend(const NumberOrPercentageResolvedToNumber<nR, pR, V>& a, const NumberOrPercentageResolvedToNumber<nR, pR, V>& b) -> bool
     {
         return Style::canBlend(a.value, b.value);
     }
-    auto blend(const NumberOrPercentageResolvedToNumber<nR, pR>& a, const NumberOrPercentageResolvedToNumber<nR, pR>& b, const BlendingContext& context) -> NumberOrPercentageResolvedToNumber<nR, pR>
+    auto blend(const NumberOrPercentageResolvedToNumber<nR, pR, V>& a, const NumberOrPercentageResolvedToNumber<nR, pR, V>& b, const BlendingContext& context) -> NumberOrPercentageResolvedToNumber<nR, pR, V>
     {
         return Style::blend(a.value, b.value, context);
     }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
@@ -42,12 +42,12 @@ inline Calculation::Child copyCalculation(Calc auto const& value)
     return value.protectedCalculation()->copyRoot();
 }
 
-template<auto R> Calculation::Child copyCalculation(const Number<R>& value)
+template<auto R, typename V> Calculation::Child copyCalculation(const Number<R, V>& value)
 {
     return Calculation::number(value.value);
 }
 
-template<auto R> Calculation::Child copyCalculation(const Percentage<R>& value)
+template<auto R, typename V> Calculation::Child copyCalculation(const Percentage<R, V>& value)
 {
     return Calculation::percentage(value.value);
 }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -44,7 +44,7 @@ template<typename T> struct ConversionDataSpecializer {
     }
 };
 
-template<auto R> struct ConversionDataSpecializer<CSS::LengthRaw<R>> {
+template<auto R, typename V> struct ConversionDataSpecializer<CSS::LengthRaw<R, V>> {
     CSSToLengthConversionData operator()(const BuilderState& state)
     {
         return state.useSVGZoomRulesForLength()
@@ -63,17 +63,17 @@ template<typename T> CSSToLengthConversionData conversionData(const BuilderState
 // MARK: Raw -> CSS
 
 template<typename> struct RawToCSSMapping;
-template<auto R, typename T> struct RawToCSSMapping<CSS::IntegerRaw<R, T>> { using type = CSS::Integer<R, T>; };
-template<auto R> struct RawToCSSMapping<CSS::NumberRaw<R>>                 { using type = CSS::Number<R>; };
-template<auto R> struct RawToCSSMapping<CSS::PercentageRaw<R>>             { using type = CSS::Percentage<R>; };
-template<auto R> struct RawToCSSMapping<CSS::AngleRaw<R>>                  { using type = CSS::Angle<R>; };
-template<auto R> struct RawToCSSMapping<CSS::LengthRaw<R>>                 { using type = CSS::Length<R>; };
-template<auto R> struct RawToCSSMapping<CSS::TimeRaw<R>>                   { using type = CSS::Time<R>; };
-template<auto R> struct RawToCSSMapping<CSS::FrequencyRaw<R>>              { using type = CSS::Frequency<R>; };
-template<auto R> struct RawToCSSMapping<CSS::ResolutionRaw<R>>             { using type = CSS::Resolution<R>; };
-template<auto R> struct RawToCSSMapping<CSS::FlexRaw<R>>                   { using type = CSS::Flex<R>; };
-template<auto R> struct RawToCSSMapping<CSS::AnglePercentageRaw<R>>        { using type = CSS::AnglePercentage<R>; };
-template<auto R> struct RawToCSSMapping<CSS::LengthPercentageRaw<R>>       { using type = CSS::LengthPercentage<R>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::IntegerRaw<R, V>>          { using type = CSS::Integer<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::NumberRaw<R, V>>           { using type = CSS::Number<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::PercentageRaw<R, V>>       { using type = CSS::Percentage<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::AngleRaw<R, V>>            { using type = CSS::Angle<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::LengthRaw<R, V>>           { using type = CSS::Length<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::TimeRaw<R, V>>             { using type = CSS::Time<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::FrequencyRaw<R, V>>        { using type = CSS::Frequency<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::ResolutionRaw<R, V>>       { using type = CSS::Resolution<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::FlexRaw<R, V>>             { using type = CSS::Flex<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::AnglePercentageRaw<R, V>>  { using type = CSS::AnglePercentage<R, V>; };
+template<auto R, typename V> struct RawToCSSMapping<CSS::LengthPercentageRaw<R, V>> { using type = CSS::LengthPercentage<R, V>; };
 
 // MARK: CSS -> Raw
 
@@ -101,131 +101,129 @@ template<auto R, typename V, typename... Rest> constexpr Integer<R, V> canonical
     return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
 }
 
-template<auto R, typename... Rest> constexpr Number<R> canonicalize(const CSS::NumberRaw<R>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> constexpr Number<R, V> canonicalize(const CSS::NumberRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
 {
     return { raw.value };
 }
 
-template<auto R, typename... Rest> constexpr Number<R> canonicalize(const CSS::NumberRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> constexpr Number<R, V> canonicalize(const CSS::NumberRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
 {
     return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
 }
 
-template<auto R, typename... Rest> constexpr Percentage<R> canonicalize(const CSS::PercentageRaw<R>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> constexpr Percentage<R, V> canonicalize(const CSS::PercentageRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
 {
-    return { raw.value };
+    return { static_cast<V>(raw.value) };
 }
 
-template<auto R, typename... Rest> constexpr Percentage<R> canonicalize(const CSS::PercentageRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename... Rest> Angle<R> canonicalize(const CSS::AngleRaw<R>& raw, NoConversionDataRequiredToken, Rest&&...)
-{
-    return { CSS::canonicalize(raw) };
-}
-
-template<auto R, typename... Rest> Angle<R> canonicalize(const CSS::AngleRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> constexpr Percentage<R, V> canonicalize(const CSS::PercentageRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
 {
     return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
 }
 
-template<auto R, typename... Rest> Length<R> canonicalize(const CSS::LengthRaw<R>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
+template<auto R, typename V, typename... Rest> Angle<R, V> canonicalize(const CSS::AngleRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
+{
+    return { static_cast<V>(CSS::canonicalize(raw)) };
+}
+
+template<auto R, typename V, typename... Rest> Angle<R, V> canonicalize(const CSS::AngleRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+{
+    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+}
+
+template<auto R, typename V, typename... Rest> Length<R, V> canonicalize(const CSS::LengthRaw<R, V>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
 {
     ASSERT(!requiresConversionData(raw));
 
     return { canonicalizeAndClampLength(raw.value, raw.unit, token, std::forward<Rest>(rest)...) };
 }
 
-template<auto R, typename... Rest> Length<R> canonicalize(const CSS::LengthRaw<R>& raw, const CSSToLengthConversionData& conversionData, Rest&&...)
+template<auto R, typename V, typename... Rest> Length<R, V> canonicalize(const CSS::LengthRaw<R, V>& raw, const CSSToLengthConversionData& conversionData, Rest&&...)
 {
     ASSERT(CSS::collectComputedStyleDependencies(raw).canResolveDependenciesWithConversionData(conversionData));
 
     return { canonicalizeAndClampLength(raw.value, raw.unit, conversionData) };
 }
 
-template<auto R, typename... Rest> Time<R> canonicalize(const CSS::TimeRaw<R>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> Time<R, V> canonicalize(const CSS::TimeRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
 {
-    return { CSS::canonicalize(raw) };
+    return { static_cast<V>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename... Rest> Time<R> canonicalize(const CSS::TimeRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename... Rest> Frequency<R> canonicalize(const CSS::FrequencyRaw<R>& raw, NoConversionDataRequiredToken, Rest&&...)
-{
-    return { CSS::canonicalize(raw) };
-}
-
-template<auto R, typename... Rest> Frequency<R> canonicalize(const CSS::FrequencyRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> Time<R, V> canonicalize(const CSS::TimeRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
 {
     return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
 }
 
-template<auto R, typename... Rest> Resolution<R> canonicalize(const CSS::ResolutionRaw<R>& raw, NoConversionDataRequiredToken, Rest&&...)
+template<auto R, typename V, typename... Rest> Frequency<R, V> canonicalize(const CSS::FrequencyRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
 {
-    return { CSS::canonicalize(raw) };
+    return { static_cast<V>(CSS::canonicalize(raw)) };
 }
 
-template<auto R, typename... Rest> Resolution<R> canonicalize(const CSS::ResolutionRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
-{
-    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
-}
-
-template<auto R, typename... Rest> constexpr Flex<R> canonicalize(const CSS::FlexRaw<R>& raw, NoConversionDataRequiredToken, Rest&&...)
-{
-    return { raw.value };
-}
-
-template<auto R, typename... Rest> constexpr Flex<R> canonicalize(const CSS::FlexRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> Frequency<R, V> canonicalize(const CSS::FrequencyRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
 {
     return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
 }
 
-template<auto R, typename... Rest> AnglePercentage<R> canonicalize(const CSS::AnglePercentageRaw<R>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
+template<auto R, typename V, typename... Rest> Resolution<R, V> canonicalize(const CSS::ResolutionRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
+{
+    return { static_cast<V>(CSS::canonicalize(raw)) };
+}
+
+template<auto R, typename V, typename... Rest> Resolution<R, V> canonicalize(const CSS::ResolutionRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+{
+    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+}
+
+template<auto R, typename V, typename... Rest> constexpr Flex<R, V> canonicalize(const CSS::FlexRaw<R, V>& raw, NoConversionDataRequiredToken, Rest&&...)
+{
+    return { static_cast<V>(raw.value) };
+}
+
+template<auto R, typename V, typename... Rest> constexpr Flex<R, V> canonicalize(const CSS::FlexRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+{
+    return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
+}
+
+template<auto R, typename V, typename... Rest> AnglePercentage<R, V> canonicalize(const CSS::AnglePercentageRaw<R, V>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
 {
     return CSS::switchOnUnitType(raw.unit,
-        [&](CSS::PercentageUnit) -> AnglePercentage<R> {
-            return { canonicalize(CSS::PercentageRaw<R> { raw.value }, token, std::forward<Rest>(rest)...) };
+        [&](CSS::PercentageUnit) -> AnglePercentage<R, V> {
+            return { canonicalize(CSS::PercentageRaw<R, V> { raw.value }, token, std::forward<Rest>(rest)...) };
         },
-        [&](CSS::AngleUnit angleUnit) -> AnglePercentage<R> {
-            return { canonicalize(CSS::AngleRaw<R> { angleUnit, raw.value }, token, std::forward<Rest>(rest)...) };
+        [&](CSS::AngleUnit angleUnit) -> AnglePercentage<R, V> {
+            return { canonicalize(CSS::AngleRaw<R, V> { angleUnit, raw.value }, token, std::forward<Rest>(rest)...) };
         }
     );
 }
 
-template<auto R, typename... Rest> AnglePercentage<R> canonicalize(const CSS::AnglePercentageRaw<R>& raw, const CSSToLengthConversionData&, Rest&&... rest)
+template<auto R, typename V, typename... Rest> AnglePercentage<R, V> canonicalize(const CSS::AnglePercentageRaw<R, V>& raw, const CSSToLengthConversionData&, Rest&&... rest)
 {
     return canonicalize(raw, NoConversionDataRequiredToken { }, std::forward<Rest>(rest)...);
 }
 
-template<auto R, typename... Rest> LengthPercentage<R> canonicalize(const CSS::LengthPercentageRaw<R>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
+template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicalize(const CSS::LengthPercentageRaw<R, V>& raw, NoConversionDataRequiredToken token, Rest&&... rest)
 {
     return CSS::switchOnUnitType(raw.unit,
-        [&](CSS::PercentageUnit) -> LengthPercentage<R> {
-            return canonicalize(CSS::PercentageRaw<R> { raw.value }, token, std::forward<Rest>(rest)...);
+        [&](CSS::PercentageUnit) -> LengthPercentage<R, V> {
+            return canonicalize(CSS::PercentageRaw<R, V> { raw.value }, token, std::forward<Rest>(rest)...);
         },
-        [&](CSS::LengthUnit lengthUnit) -> LengthPercentage<R> {
-            // NOTE: This uses the non-clamping version length canonicalization to match the behavior of CSSPrimitiveValue::convertToLength().
-            return Length<R> { narrowPrecisionToFloat(canonicalizeLength(raw.value, lengthUnit, token)) };
+        [&](CSS::LengthUnit lengthUnit) -> LengthPercentage<R, V> {
+            return Length<R, V> { canonicalizeAndClampLength(raw.value, lengthUnit, token) };
         }
     );
 }
 
-template<auto R, typename... Rest> LengthPercentage<R> canonicalize(const CSS::LengthPercentageRaw<R>& raw, const CSSToLengthConversionData& conversionData, Rest&&... rest)
+template<auto R, typename V, typename... Rest> LengthPercentage<R, V> canonicalize(const CSS::LengthPercentageRaw<R, V>& raw, const CSSToLengthConversionData& conversionData, Rest&&... rest)
 {
-    ASSERT(CSS::collectComputedStyleDependencies(raw).canResolveDependenciesWithConversionData(conversionData));
+    // ASSERT(CSS::collectComputedStyleDependencies(raw).canResolveDependenciesWithConversionData(conversionData));
 
     return CSS::switchOnUnitType(raw.unit,
-        [&](CSS::PercentageUnit) -> LengthPercentage<R> {
-            return canonicalize(CSS::PercentageRaw<R> { raw.value }, conversionData, std::forward<Rest>(rest)...);
+        [&](CSS::PercentageUnit) -> LengthPercentage<R, V> {
+            return canonicalize(CSS::PercentageRaw<R, V> { raw.value }, conversionData, std::forward<Rest>(rest)...);
         },
-        [&](CSS::LengthUnit lengthUnit) -> LengthPercentage<R> {
-            // NOTE: This uses the non-clamping version length canonicalization to match the behavior of CSSPrimitiveValue::convertToLength().
-            return Length<R> { narrowPrecisionToFloat(canonicalizeLength(raw.value, lengthUnit, conversionData)) };
+        [&](CSS::LengthUnit lengthUnit) -> LengthPercentage<R, V> {
+            return Length<R, V> { canonicalizeAndClampLength(raw.value, lengthUnit, conversionData) };
         }
     );
 }
@@ -238,43 +236,57 @@ Ref<CSSCalcValue> makeCalc(Ref<CalculationValue>, const RenderStyle&);
 float adjustForZoom(float, const RenderStyle&);
 
 // Length requires a specialized implementation due to zoom adjustment.
-template<auto R> struct ToCSS<Length<R>> {
-    auto operator()(const Length<R>& value, const RenderStyle& style) -> CSS::Length<R>
+template<auto R, typename V> struct ToCSS<Length<R, V>> {
+    auto operator()(const Length<R, V>& value, const RenderStyle& style) -> CSS::Length<R, V>
     {
-        return CSS::LengthRaw<R> { value.unit, adjustForZoom(value.value, style) };
+        return CSS::LengthRaw<R, V> { value.unit, adjustForZoom(value.value, style) };
+    }
+};
+
+template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::AnglePercentage<R, V>>> {
+    auto operator()(const UnevaluatedCalculation<CSS::AnglePercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::AnglePercentage<R, V>::Calc
+    {
+        return typename CSS::AnglePercentage<R, V>::Calc { makeCalc(value.protectedCalculation(), style) };
+    }
+};
+
+template<auto R, typename V> struct ToCSS<UnevaluatedCalculation<CSS::LengthPercentage<R, V>>> {
+    auto operator()(const UnevaluatedCalculation<CSS::LengthPercentage<R, V>>& value, const RenderStyle& style) -> typename CSS::LengthPercentage<R, V>::Calc
+    {
+        return typename CSS::LengthPercentage<R, V>::Calc { makeCalc(value.protectedCalculation(), style) };
     }
 };
 
 // AnglePercentage / LengthPercentage require specialized implementations due to additional `calc` field.
-template<auto R> struct ToCSS<AnglePercentage<R>> {
-    auto operator()(const AnglePercentage<R>& value, const RenderStyle& style) -> CSS::AnglePercentage<R>
+template<auto R, typename V> struct ToCSS<AnglePercentage<R, V>> {
+    auto operator()(const AnglePercentage<R, V>& value, const RenderStyle& style) -> CSS::AnglePercentage<R, V>
     {
         return WTF::switchOn(value,
-            [&](const Angle<R>& angle) -> CSS::AnglePercentage<R> {
-                return typename CSS::AnglePercentage<R>::Raw { angle.unit, angle.value };
+            [&](const Angle<R, V>& angle) -> CSS::AnglePercentage<R, V> {
+                return typename CSS::AnglePercentage<R, V>::Raw { angle.unit, angle.value };
             },
-            [&](const Percentage<R>& percentage) -> CSS::AnglePercentage<R> {
-                return typename CSS::AnglePercentage<R>::Raw { percentage.unit, percentage.value };
+            [&](const Percentage<R, V>& percentage) -> CSS::AnglePercentage<R, V> {
+                return typename CSS::AnglePercentage<R, V>::Raw { percentage.unit, percentage.value };
             },
-            [&](const typename AnglePercentage<R>::Calc& calculation) -> CSS::AnglePercentage<R> {
-                return typename CSS::AnglePercentage<R>::Calc { makeCalc(calculation.protectedCalculation(), style) };
+            [&](const typename AnglePercentage<R, V>::Calc& calculation) -> CSS::AnglePercentage<R, V> {
+                return toCSS(calculation, style);
             }
         );
     }
 };
 
-template<auto R> struct ToCSS<LengthPercentage<R>> {
-    auto operator()(const LengthPercentage<R>& value, const RenderStyle& style) -> CSS::LengthPercentage<R>
+template<auto R, typename V> struct ToCSS<LengthPercentage<R, V>> {
+    auto operator()(const LengthPercentage<R, V>& value, const RenderStyle& style) -> CSS::LengthPercentage<R, V>
     {
         return WTF::switchOn(value,
-            [&](const Length<R>& length) -> CSS::LengthPercentage<R> {
-                return typename CSS::LengthPercentage<R>::Raw { length.unit, adjustForZoom(length.value, style) };
+            [&](const typename LengthPercentage<R, V>::Dimension& length) -> CSS::LengthPercentage<R, V> {
+                return typename CSS::LengthPercentage<R, V>::Raw { length.unit, adjustForZoom(length.value, style) };
             },
-            [&](const Percentage<R>& percentage) -> CSS::LengthPercentage<R> {
-                return typename CSS::LengthPercentage<R>::Raw { percentage.unit, percentage.value };
+            [&](const typename LengthPercentage<R, V>::Percentage& percentage) -> CSS::LengthPercentage<R, V> {
+                return typename CSS::LengthPercentage<R, V>::Raw { percentage.unit, percentage.value };
             },
-            [&](const typename LengthPercentage<R>::Calc& calculation) -> CSS::LengthPercentage<R> {
-                return typename CSS::LengthPercentage<R>::Calc { makeCalc(calculation.protectedCalculation(), style) };
+            [&](const typename LengthPercentage<R, V>::Calc& calculation) -> CSS::LengthPercentage<R, V> {
+                return toCSS(calculation, style);
             }
         );
     }
@@ -289,8 +301,8 @@ template<Numeric StyleType> struct ToCSS<StyleType> {
 };
 
 // NumberOrPercentageResolvedToNumber requires specialization due to asymmetric representations.
-template<auto nR, auto pR> struct ToCSS<NumberOrPercentageResolvedToNumber<nR, pR>> {
-    auto operator()(const NumberOrPercentageResolvedToNumber<nR, pR>& value, const RenderStyle& style) -> CSS::NumberOrPercentageResolvedToNumber<nR, pR>
+template<auto nR, auto pR, typename V> struct ToCSS<NumberOrPercentageResolvedToNumber<nR, pR, V>> {
+    auto operator()(const NumberOrPercentageResolvedToNumber<nR, pR, V>& value, const RenderStyle& style) -> CSS::NumberOrPercentageResolvedToNumber<nR, pR, V>
     {
         return { toCSS(value.value, style) };
     }
@@ -310,9 +322,9 @@ template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::IntegerRaw
     }
 };
 
-template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthRaw<R>>> {
-    using From = CSS::UnevaluatedCalc<CSS::LengthRaw<R>>;
-    using To = Length<R>;
+template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthRaw<R, V>>> {
+    using From = CSS::UnevaluatedCalc<CSS::LengthRaw<R, V>>;
+    using To = Length<R, V>;
 
     template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
     {
@@ -320,9 +332,9 @@ template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthRaw<R>>> {
     }
 };
 
-template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R>>> {
-    using From = CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R>>;
-    using To = AnglePercentage<R>;
+template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R, V>>> {
+    using From = CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R, V>>;
+    using To = AnglePercentage<R, V>;
 
     template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
     {
@@ -331,16 +343,16 @@ template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R>>
         ASSERT(calc->category() == From::category);
 
         if (!calc->tree().type.percentHint)
-            return { Style::Angle<R> { calc->doubleValue(std::forward<Rest>(rest)...) } };
+            return { Style::Angle<R, V> { clampTo<V>(calc->doubleValue(std::forward<Rest>(rest)...)) } };
         if (std::holds_alternative<CSSCalc::Percentage>(calc->tree().root))
-            return { Style::Percentage<R> { calc->doubleValue(std::forward<Rest>(rest)...) } };
+            return { Style::Percentage<R, V> { clampTo<V>(calc->doubleValue(std::forward<Rest>(rest)...)) } };
         return { calc->createCalculationValue(std::forward<Rest>(rest)...) };
     }
 };
 
-template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R>>> {
-    using From = CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R>>;
-    using To = LengthPercentage<R>;
+template<auto R, typename V> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R, V>>> {
+    using From = CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R, V>>;
+    using To = LengthPercentage<R, V>;
 
     template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
     {
@@ -349,9 +361,9 @@ template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R>
         ASSERT(calc->category() == From::category);
 
         if (!calc->tree().type.percentHint)
-            return { Style::Length<R> { clampLengthToAllowedLimits(calc->doubleValue(std::forward<Rest>(rest)...)) } };
+            return { Style::Length<R, V> { clampLengthToAllowedLimits(calc->doubleValue(std::forward<Rest>(rest)...)) } };
         if (std::holds_alternative<CSSCalc::Percentage>(calc->tree().root))
-            return { Style::Percentage<R> { calc->doubleValue(std::forward<Rest>(rest)...) } };
+            return { Style::Percentage<R, V> { clampTo<V>(calc->doubleValue(std::forward<Rest>(rest)...)) } };
         return { calc->createCalculationValue(std::forward<Rest>(rest)...) };
     }
 };
@@ -395,14 +407,17 @@ template<CSS::Numeric NumericType> struct ToStyle<NumericType> {
 };
 
 // NumberOrPercentageResolvedToNumber, as the name implies, resolves its percentage to a number.
-template<auto nR, auto pR> struct ToStyle<CSS::NumberOrPercentageResolvedToNumber<nR, pR>> {
-    template<typename... Rest> auto operator()(const CSS::NumberOrPercentageResolvedToNumber<nR, pR>& value, Rest&&... rest) -> NumberOrPercentageResolvedToNumber<nR, pR>
+template<auto nR, auto pR, typename V> struct ToStyle<CSS::NumberOrPercentageResolvedToNumber<nR, pR, V>> {
+    using From = CSS::NumberOrPercentageResolvedToNumber<nR, pR, V>;
+    using To = NumberOrPercentageResolvedToNumber<nR, pR, V>;
+
+    template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
     {
         return WTF::switchOn(value,
-            [&](CSS::Number<nR> number) -> NumberOrPercentageResolvedToNumber<nR, pR> {
+            [&](const typename From::Number& number) -> To {
                 return { toStyle(number, std::forward<Rest>(rest)...) };
             },
-            [&](CSS::Percentage<pR> percentage) -> NumberOrPercentageResolvedToNumber<nR, pR> {
+            [&](const typename From::Percentage& percentage) -> To {
                 return { toStyle(percentage, std::forward<Rest>(rest)...).value / 100.0 };
             }
         );

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
@@ -46,12 +46,12 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, DimensionPercentageNumeric auto
     return WTF::switchOn(value, [&](const auto& value) -> WTF::TextStream& { return ts << value; });
 }
 
-template<auto nR, auto pR> WTF::TextStream& operator<<(WTF::TextStream& ts, const NumberOrPercentage<nR, pR>& value)
+template<auto nR, auto pR, typename V> WTF::TextStream& operator<<(WTF::TextStream& ts, const NumberOrPercentage<nR, pR, V>& value)
 {
     return WTF::switchOn(value, [&](const auto& value) -> WTF::TextStream& { return ts << value; });
 }
 
-template<auto nR, auto pR> WTF::TextStream& operator<<(WTF::TextStream& ts, const NumberOrPercentageResolvedToNumber<nR, pR>& value)
+template<auto nR, auto pR, typename V> WTF::TextStream& operator<<(WTF::TextStream& ts, const NumberOrPercentageResolvedToNumber<nR, pR, V>& value)
 {
     return ts << value.value;
 }

--- a/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
@@ -49,7 +49,7 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
                 return toStyle(value, state);
             },
             [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
-                return { Percentage<> { 0 } };
+                return { typename LengthPercentage<>::Percentage { 0 } };
             }
         );
     };
@@ -60,7 +60,7 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
                 return reflect(toStyle(value, state));
             },
             [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
-                return { Percentage<> { 0 } };
+                return { typename LengthPercentage<>::Percentage { 0 } };
             }
         );
     };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3060,9 +3060,21 @@ header: <WebCore/StylePrimitiveNumericTypes.h>
     double value;
 };
 
-[CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::Nonnegative> {
+using WebCore::Style::PercentageNonnegativeFloat = WebCore::Style::Percentage<WebCore::CSS::Nonnegative, float>;
+[CustomHeader, Nested] struct WebCore::Style::PercentageNonnegativeFloat {
     float value;
 };
+
+using WebCore::Style::PercentageAllFloat = WebCore::Style::Percentage<WebCore::CSS::All, float>;
+[CustomHeader, Nested] struct WebCore::Style::PercentageAllFloat {
+    float value;
+};
+
+using WebCore::Style::LengthNonnegative = WebCore::Style::Length<WebCore::CSS::Nonnegative>;
+[CustomHeader, Nested] struct WebCore::Style::LengthNonnegative {
+    float value;
+};
+using WebCore::Style::LengthAll = WebCore::Style::Length<WebCore::CSS::All>;
 [CustomHeader, Nested] struct WebCore::Style::Length<WebCore::CSS::All> {
     float value;
 };
@@ -3075,10 +3087,10 @@ header: <WebCore/StylePrimitiveNumericTypes.h>
 };
 
 [CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::All> {
-    std::variant<WebCore::Style::Length<WebCore::CSS::All>, WebCore::Style::Percentage<WebCore::CSS::All>> ipcData()
+    std::variant<WebCore::Style::LengthAll, WebCore::Style::PercentageAllFloat> ipcData()
 };
 [CustomHeader, Nested] struct WebCore::Style::LengthPercentage<WebCore::CSS::Nonnegative> {
-    std::variant<WebCore::Style::Length<WebCore::CSS::Nonnegative>, WebCore::Style::Percentage<WebCore::CSS::Nonnegative>> ipcData();
+    std::variant<WebCore::Style::LengthNonnegative, WebCore::Style::PercentageNonnegativeFloat> ipcData();
 };
 
 using WebCore::Style::LengthPercentageNonnegative = WebCore::Style::LengthPercentage<WebCore::CSS::Nonnegative>;

--- a/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
@@ -36,11 +36,11 @@ static WebCore::Style::GradientLinearColorStopList cacheableStops()
     return {
         {
             WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::red } },
-            WebCore::Style::Percentage<> { 50 }
+            WebCore::Style::LengthPercentage<>::Percentage { 50.0 }
         },
         {
             WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::blue } },
-            WebCore::Style::Percentage<> { 100 }
+            WebCore::Style::LengthPercentage<>::Percentage { 100.0 }
         }
     };
 }
@@ -50,11 +50,11 @@ static WebCore::Style::GradientLinearColorStopList someUncacheableStops()
     return {
         {
             WebCore::Style::Color { WebCore::Style::CurrentColor { } },
-            WebCore::Style::Percentage<> { 50 }
+            WebCore::Style::LengthPercentage<>::Percentage { 50 }
         },
         {
             WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::blue } },
-            WebCore::Style::Percentage<> { 100 }
+            WebCore::Style::LengthPercentage<>::Percentage { 100 }
         }
     };
 }
@@ -64,11 +64,11 @@ static WebCore::Style::GradientLinearColorStopList allUncacheableStops()
     return {
         {
             WebCore::Style::Color { WebCore::Style::CurrentColor { } },
-            WebCore::Style::Percentage<> { 50 }
+            WebCore::Style::LengthPercentage<>::Percentage { 50 }
         },
         {
             WebCore::Style::Color { WebCore::Style::CurrentColor { } },
-            WebCore::Style::Percentage<> { 100 }
+            WebCore::Style::LengthPercentage<>::Percentage { 100 }
         }
     };
 }


### PR DESCRIPTION
#### 826f74712a031178b2ebcb73ba1fa38de6192e97
<pre>
Allow specifying a ResolvedValueType for any CSS numeric primitive
<a href="https://bugs.webkit.org/show_bug.cgi?id=286625">https://bugs.webkit.org/show_bug.cgi?id=286625</a>

Reviewed by Antti Koivisto.

Allow specifying a ResolvedValueType for any CSS numeric primitive. This makes it
explicit that `LengthPercentage` resolves to float, rather than double, and allow
us to change that to something like LayoutUnit on a per-instance basis in the future.

This will also allow us to simplify CompactVariant by remove the alternative
representation functionality in a follow up.

Most of the change is piping the `V` template parameter around.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentageDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+FlexDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentageDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentageDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Canonicalization.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/shapes/StyleRectFunction.cpp:

Canonical link: <a href="https://commits.webkit.org/289482@main">https://commits.webkit.org/289482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc8521b0e6088bac2fbaf94bea2b2d1b1b97dd0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87078 "26 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33226 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36934 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93824 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14240 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76114 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75314 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7157 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19552 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14004 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->