### PR TITLE
Release assertion failure in BuilderConverter::convertLength via BuilderConverter::convertLengthOrAuto

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/css-builder-converter-border-image-slice-crash-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/css-builder-converter-border-image-slice-crash-expected.txt
@@ -1,0 +1,5 @@
+This test passes if WebKit does not crash.
+
+
+PASS CSS typed OM should perform type checks
+

--- a/LayoutTests/fast/css/css-typed-om/css-builder-converter-border-image-slice-crash.html
+++ b/LayoutTests/fast/css/css-typed-om/css-builder-converter-border-image-slice-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CSS typed OM should perform type checks</title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+</head>
+  <body>
+    <p>This test passes if WebKit does not crash.</p>
+    <script>
+      test(t => {
+        const borderImageSlice = document.body.computedStyleMap().get('border-image-slice');
+        assert_throws_js(TypeError, () => {
+          document.body.attributeStyleMap.set('width', borderImageSlice);
+        }, "attributeStyleMap.set() throws an error");
+      });
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -135,6 +135,12 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
             return Exception { ExceptionCode::TypeError, "Invalid values"_s };
     }
 
+    // FIXME: If https://bugs.webkit.org/show_bug.cgi?id=285867 is implemented this is not needed.
+    if (value->isBorderImageSliceValue()) {
+        if (propertyID != CSSPropertyBorderImageSlice && propertyID != CSSPropertyMaskBorderSlice)
+            return Exception { ExceptionCode::TypeError, "Invalid values"_s };
+    }
+
     if (!setProperty(propertyID, value.releaseNonNull()))
         return Exception { ExceptionCode::TypeError, "Invalid values"_s };
 


### PR DESCRIPTION
#### 9c7af0436718a1cdc41a5f82facd0604d896ddfe
<pre>
Release assertion failure in BuilderConverter::convertLength via BuilderConverter::convertLengthOrAuto
<a href="https://bugs.webkit.org/show_bug.cgi?id=285423">https://bugs.webkit.org/show_bug.cgi?id=285423</a>

Reviewed by NOBODY (OOPS!).

Check if we are setting a CSSValue of type BorderImageSliceClass and if so throw a TypeError.

* LayoutTests/fast/css/css-typed-om/css-builder-converter-border-image-slice-crash-expected.txt: Added.
* LayoutTests/fast/css/css-typed-om/css-builder-converter-border-image-slice-crash.html: Added.
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c7af0436718a1cdc41a5f82facd0604d896ddfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67263 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25026 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47585 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33148 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93771 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76068 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75267 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19606 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7104 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19499 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->