### PR TITLE
Improve performance of using ProcessSyncClient

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -827,6 +827,9 @@ void Page::setMainFrameURLAndOrigin(const URL& url, RefPtr<SecurityOrigin>&& ori
         return;
     }
 
+    if (!settings().siteIsolationEnabled())
+        return;
+
     // If this page is hosting the local main frame, make sure the url and origin
     // match what we expect, then broadcast them out to other processes.
     RELEASE_ASSERT(url == m_topDocumentSyncData->documentURL);
@@ -842,7 +845,8 @@ void Page::setMainFrameURLAndOrigin(const URL& url, RefPtr<SecurityOrigin>&& ori
 void Page::setAudioSessionType(DOMAudioSessionType audioSessionType)
 {
     m_topDocumentSyncData->audioSessionType = audioSessionType;
-    processSyncClient().broadcastAudioSessionTypeToOtherProcesses(audioSessionType);
+    if (settings().siteIsolationEnabled())
+        processSyncClient().broadcastAudioSessionTypeToOtherProcesses(audioSessionType);
 }
 
 DOMAudioSessionType Page::audioSessionType() const
@@ -857,7 +861,8 @@ void Page::setUserDidInteractWithPage(bool didInteract)
         return;
 
     m_topDocumentSyncData->userDidInteractWithPage = didInteract;
-    processSyncClient().broadcastUserDidInteractWithPageToOtherProcesses(didInteract);
+    if (settings().siteIsolationEnabled())
+        processSyncClient().broadcastUserDidInteractWithPageToOtherProcesses(didInteract);
 }
 
 bool Page::userDidInteractWithPage() const
@@ -871,7 +876,8 @@ void Page::setAutofocusProcessed()
         return;
 
     m_topDocumentSyncData->isAutofocusProcessed = true;
-    processSyncClient().broadcastIsAutofocusProcessedToOtherProcesses(true);
+    if (settings().siteIsolationEnabled())
+        processSyncClient().broadcastIsAutofocusProcessedToOtherProcesses(true);
 }
 
 bool Page::autofocusProcessed() const
@@ -890,7 +896,8 @@ void Page::setTopDocumentHasFullscreenElement(bool hasFullscreenElement)
         return;
 
     m_topDocumentSyncData->hasFullscreenElement = hasFullscreenElement;
-    processSyncClient().broadcastHasFullscreenElementToOtherProcesses(hasFullscreenElement);
+    if (settings().siteIsolationEnabled())
+        processSyncClient().broadcastHasFullscreenElementToOtherProcesses(hasFullscreenElement);
 }
 
 bool Page::topDocumentHasFullscreenElement()
@@ -909,7 +916,8 @@ void Page::setHasInjectedUserScript()
         return;
 
     m_topDocumentSyncData->hasInjectedUserScript = true;
-    processSyncClient().broadcastHasInjectedUserScriptToOtherProcesses(true);
+    if (settings().siteIsolationEnabled())
+        processSyncClient().broadcastHasInjectedUserScriptToOtherProcesses(true);
 }
 
 void Page::updateProcessSyncData(const ProcessSyncData& data)
@@ -4267,7 +4275,8 @@ void Page::didChangeMainDocument(Document* newDocument)
 {
     m_topDocumentSyncData = newDocument ? newDocument->syncData() : DocumentSyncData::create();
 
-    processSyncClient().broadcastTopDocumentSyncDataToOtherProcesses(m_topDocumentSyncData.get());
+    if (settings().siteIsolationEnabled())
+        processSyncClient().broadcastTopDocumentSyncDataToOtherProcesses(m_topDocumentSyncData.get());
 
 #if ENABLE(WEB_RTC)
     m_rtcController->reset(m_shouldEnableICECandidateFilteringByDefault);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp
@@ -55,17 +55,13 @@ bool WebProcessSyncClient::siteIsolationEnabled()
 
 void WebProcessSyncClient::broadcastProcessSyncDataToOtherProcesses(const WebCore::ProcessSyncData& data)
 {
-    if (!siteIsolationEnabled())
-        return;
-
+    ASSERT(siteIsolationEnabled());
     protectedPage()->send(Messages::WebPageProxy::BroadcastProcessSyncData(data));
 }
 
 void WebProcessSyncClient::broadcastTopDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncData& data)
 {
-    if (!siteIsolationEnabled())
-        return;
-
+    ASSERT(siteIsolationEnabled());
     protectedPage()->send(Messages::WebPageProxy::BroadcastTopDocumentSyncData(data));
 }
 


### PR DESCRIPTION
#### 71e15ecdd6bf1f97d0d0799d0d25a40a7e323b10
<pre>
Improve performance of using ProcessSyncClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=286626">https://bugs.webkit.org/show_bug.cgi?id=286626</a>
<a href="https://rdar.apple.com/142782753">rdar://142782753</a>

Reviewed by Alex Christensen.

Relying on the ProcessSyncClient to do its own &quot;is site isolation enabled?&quot; check was more
complicated and expensive than doing the check up front.

Additionally - by having Page do the check up front on its own - we avoid a whole bunch of
virtual dispatches when site isolation is disabled.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::setMainFrameURLAndOrigin):
(WebCore::Page::setAudioSessionType):
(WebCore::Page::setUserDidInteractWithPage):
(WebCore::Page::setAutofocusProcessed):
(WebCore::Page::setTopDocumentHasFullscreenElement):
(WebCore::Page::setHasInjectedUserScript):
(WebCore::Page::didChangeMainDocument):
* Source/WebKit/WebProcess/WebCoreSupport/WebProcessSyncClient.cpp:
(WebKit::WebProcessSyncClient::broadcastProcessSyncDataToOtherProcesses):
(WebKit::WebProcessSyncClient::broadcastTopDocumentSyncDataToOtherProcesses):

Canonical link: <a href="https://commits.webkit.org/289459@main">https://commits.webkit.org/289459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a4c8bd9fef754a6b9018a6263273d49653a4707

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37766 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14605 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25025 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36883 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10326 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75269 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19611 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18038 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14208 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19501 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->