### PR TITLE
Further reduce unsafe printf usage

### DIFF
--- a/Source/JavaScriptCore/API/tests/FunctionToStringTests.cpp
+++ b/Source/JavaScriptCore/API/tests/FunctionToStringTests.cpp
@@ -30,6 +30,7 @@
 #include "InitializeThreading.h"
 #include "JavaScript.h"
 #include <stdio.h>
+#include <wtf/text/ASCIILiteral.h>
 
 int testFunctionToString()
 {
@@ -106,9 +107,7 @@ int testFunctionToString()
         failed = true;
 
     JSGlobalContextRelease(context);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("%s: function toString tests.\n", failed ? "FAIL" : "PASS");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("%s: function toString tests.\n", failed ? "FAIL"_s : "PASS"_s);
 
     return failed;
 }

--- a/Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp
+++ b/Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp
@@ -33,6 +33,7 @@
 #include "JSObjectRefPrivate.h"
 #include "JavaScript.h"
 #include "ProxyObject.h"
+#include <wtf/text/ASCIILiteral.h>
 
 using namespace JSC;
 
@@ -42,10 +43,8 @@ int testJSObjectGetProxyTarget()
     
     printf("JSObjectGetProxyTargetTest:\n");
     
-    auto test = [&] (const char* description, bool currentResult) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        printf("    %s: %s\n", description, currentResult ? "PASS" : "FAIL");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto test = [&] (ASCIILiteral description, bool currentResult) {
+        SAFE_PRINTF("    %s: %s\n", description, currentResult ? "PASS"_s : "FAIL"_s);
         overallResult &= currentResult;
     };
     
@@ -100,9 +99,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     JSGlobalContextRelease(context);
     JSContextGroupRelease(group);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("JSObjectGetProxyTargetTest: %s\n", overallResult ? "PASS" : "FAIL");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("JSObjectGetProxyTargetTest: %s\n", overallResult ? "PASS"_s : "FAIL"_s);
     return !overallResult;
 }
 

--- a/Source/JavaScriptCore/runtime/ExceptionFuzz.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionFuzz.cpp
@@ -37,7 +37,7 @@ static unsigned s_numberOfExceptionFuzzChecks;
 unsigned numberOfExceptionFuzzChecks() { return s_numberOfExceptionFuzzChecks; }
 
 // Call this only if you know that exception fuzzing is enabled.
-void doExceptionFuzzing(JSGlobalObject* globalObject, ThrowScope& scope, const char* where, const void* returnPC)
+void doExceptionFuzzing(JSGlobalObject* globalObject, ThrowScope& scope, ASCIILiteral where, const void* returnPC)
 {
     VM& vm = scope.vm();
     ASSERT(Options::useExceptionFuzz());
@@ -48,9 +48,7 @@ void doExceptionFuzzing(JSGlobalObject* globalObject, ThrowScope& scope, const c
     
     unsigned fireTarget = Options::fireExceptionFuzzAt();
     if (fireTarget == s_numberOfExceptionFuzzChecks) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        printf("JSC EXCEPTION FUZZ: Throwing fuzz exception with call frame %p, seen in %s and return address %p.\n", globalObject, where, returnPC);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        SAFE_PRINTF("JSC EXCEPTION FUZZ: Throwing fuzz exception with call frame %p, seen in %s and return address %p.\n", globalObject, where, returnPC);
         fflush(stdout);
 
         // The ThrowScope also checks for unchecked simulated exceptions before throwing a

--- a/Source/JavaScriptCore/runtime/ExceptionFuzz.h
+++ b/Source/JavaScriptCore/runtime/ExceptionFuzz.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Options.h"
+#include <wtf/text/ASCIILiteral.h>
 
 namespace JSC {
 
@@ -34,10 +35,10 @@ class JSGlobalObject;
 class ThrowScope;
 
 // Call this only if you know that exception fuzzing is enabled.
-void doExceptionFuzzing(JSGlobalObject*, ThrowScope&, const char* where, const void* returnPC);
+void doExceptionFuzzing(JSGlobalObject*, ThrowScope&, ASCIILiteral where, const void* returnPC);
 
 // This is what you should call if you don't know if fuzzing is enabled.
-ALWAYS_INLINE void doExceptionFuzzingIfEnabled(JSGlobalObject* globalObject, ThrowScope& scope, const char* where, const void* returnPC)
+ALWAYS_INLINE void doExceptionFuzzingIfEnabled(JSGlobalObject* globalObject, ThrowScope& scope, ASCIILiteral where, const void* returnPC)
 {
     if (LIKELY(!Options::useExceptionFuzz()))
         return;

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1087,7 +1087,7 @@ void secureMemsetSpan(std::span<T, Extent> destination, uint8_t byte)
 #define WTF_EXPAND3(...) WTF_EXPAND2(WTF_EXPAND2(WTF_EXPAND2(WTF_EXPAND2(__VA_ARGS__))))
 #define WTF_EXPAND2(...) WTF_EXPAND1(WTF_EXPAND1(WTF_EXPAND1(WTF_EXPAND1(__VA_ARGS__))))
 #define WTF_EXPAND1(...) __VA_ARGS__
-#define WTF_FOR_EACH_HELPER(macro, a1, ...) macro(a1) __VA_OPT__(WTF_FOR_EACH_AGAIN PARENS (macro, __VA_ARGS__))
+#define WTF_FOR_EACH_HELPER(macro, a1, ...) macro(a1) __VA_OPT__(, WTF_FOR_EACH_AGAIN WTF_PARENS (macro, __VA_ARGS__))
 #define WTF_FOR_EACH_AGAIN() WTF_FOR_EACH_HELPER
 #define WTF_FOR_EACH(macro, ...) __VA_OPT__(WTF_EXPAND(WTF_FOR_EACH_HELPER(macro, __VA_ARGS__)))
 
@@ -1101,7 +1101,7 @@ template <class T> inline typename std::enable_if<std::is_pointer<T>::value, T>:
     return arg;
 }
 
-// This version of printf rejects char* but accepts known null terminated
+// These versions of printf reject char* but accept known null terminated
 // string types, like ASCIILiteral and CString. A type can specialize
 // 'safePrintfType' to advertise conversion to null terminated string.
 
@@ -1111,6 +1111,8 @@ template <class T> inline typename std::enable_if<std::is_pointer<T>::value, T>:
 #define SAFE_PRINTF_TYPE(...) WTF_FOR_EACH(WTF::safePrintfType, __VA_ARGS__)
 
 #define SAFE_PRINTF(format, ...) printf(format, SAFE_PRINTF_TYPE(__VA_ARGS__))
+#define SAFE_FPRINTF(file, format, ...) fprintf(file, format, SAFE_PRINTF_TYPE(__VA_ARGS__))
+#define SAFE_SPRINTF(destinationSpan, format, ...) snprintf(destinationSpan.data(), destinationSpan.size_bytes(), format, SAFE_PRINTF_TYPE(__VA_ARGS__))
 
 template<typename T> concept ByteType = sizeof(T) == 1 && ((std::is_integral_v<T> && !std::same_as<T, bool>) || std::same_as<T, std::byte>) && !std::is_const_v<T>;
 

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -63,6 +63,15 @@ public:
         : ASCIILiteral()
     { }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    template<size_t length>
+    consteval ASCIILiteral(const char (&literal)[length])
+        : m_charactersWithNullTerminator(unsafeMakeSpan(literal, length))
+    {
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(literal[length - 1] == '\0');
+    }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     unsigned hash() const;
     constexpr bool isNull() const { return m_charactersWithNullTerminator.empty(); }
 

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -115,9 +115,7 @@ TextStream& TextStream::operator<<(const char* string)
 TextStream& TextStream::operator<<(const void* p)
 {
     char buffer[printBufferSize];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    snprintf(buffer, sizeof(buffer) - 1, "%p", p);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_SPRINTF(std::span { buffer }, "%p", p);
     return *this << buffer;
 }
 

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -50,16 +50,12 @@ std::span<char> TextCodec::getUnencodableReplacement(char32_t codePoint, Unencod
 
     switch (handling) {
     case UnencodableHandling::Entities: {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        int count = snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "&#%u;", static_cast<unsigned>(codePoint));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        int count = SAFE_SPRINTF(std::span { replacement }, "&#%u;", static_cast<unsigned>(codePoint));
         ASSERT(count >= 0);
         return std::span { replacement }.first(std::max<int>(0, count));
     }
     case UnencodableHandling::URLEncodedEntities: {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        int count = snprintf(replacement.data(), sizeof(UnencodableReplacementArray), "%%26%%23%u%%3B", static_cast<unsigned>(codePoint));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        int count = SAFE_SPRINTF(std::span { replacement }, "%%26%%23%u%%3B", static_cast<unsigned>(codePoint));
         ASSERT(count >= 0);
         return std::span { replacement }.first(std::max<int>(0, count));
     } }

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -166,7 +166,7 @@ void GCController::dumpHeapForVM(VM& vm)
 
     FileSystem::writeToFile(fileHandle, utf8String.span());
     FileSystem::closeFile(fileHandle);
-    WTFLogAlways("Dumped GC heap to %s%s", tempFilePath.utf8().data(), isMainThread() ? ""_s : " for Worker");
+    WTFLogAlways("Dumped GC heap to %s%s", tempFilePath.utf8().data(), isMainThread() ? "" : " for Worker");
 }
 
 void GCController::dumpHeap()

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -432,9 +432,7 @@ static_assert(sizeof(StyleProperties) == sizeof(SameSizeAsStyleProperties), "sty
 #ifndef NDEBUG
 void StyleProperties::showStyle()
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    fprintf(stderr, "%s\n", asText().ascii().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_FPRINTF(stderr, "%s\n", asText().ascii());
 }
 #endif
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -314,12 +314,11 @@ void Node::dumpStatistics()
         }
     }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Number of Nodes: %d\n\n", liveNodeSet().computeSize());
     printf("Number of Nodes with RareData: %zu\n", nodesWithRareData);
     printf("  Mixed use: %zu\n", mixedRareDataUseCount);
     for (auto it : rareDataSingleUseTypeCounts)
-        printf("  %s: %zu\n", stringForRareDataUseType(static_cast<NodeRareData::UseType>(it.key)).characters(), it.value);
+        SAFE_PRINTF("  %s: %zu\n", stringForRareDataUseType(static_cast<NodeRareData::UseType>(it.key)), it.value);
     printf("\n");
 
 
@@ -337,7 +336,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
     printf("Element tag name distibution:\n");
     for (auto& stringSizePair : perTagCount)
-        printf("  Number of <%s> tags: %zu\n", stringSizePair.key.utf8().data(), stringSizePair.value);
+        SAFE_PRINTF("  Number of <%s> tags: %zu\n", stringSizePair.key.utf8(), stringSizePair.value);
 
     printf("Attributes:\n");
     printf("  Number of Attributes (non-Node and Node): %zu [%zu]\n", attributes, sizeof(Attribute));
@@ -345,7 +344,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("  Number of Elements with attribute storage: %zu [%zu]\n", elementsWithAttributeStorage, sizeof(ElementData));
     printf("  Number of Elements with RareData: %zu\n", elementsWithRareData);
     printf("  Number of Elements with NamedNodeMap: %zu [%zu]\n", elementsWithNamedNodeMap, sizeof(NamedNodeMap));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // DUMP_NODE_STATISTICS
 }
@@ -2003,7 +2001,6 @@ static void appendAttributeDesc(const Node* node, StringBuilder& stringBuilder, 
     stringBuilder.append(attr);
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void Node::showNode(ASCIILiteral prefix) const
 {
     if (prefix.isNull())
@@ -2011,15 +2008,14 @@ void Node::showNode(ASCIILiteral prefix) const
     if (isTextNode()) {
         String value = makeStringByReplacingAll(nodeValue(), '\\', "\\\\"_s);
         value = makeStringByReplacingAll(value, '\n', "\\n"_s);
-        fprintf(stderr, "%s%s\t%p \"%s\"\n", prefix.characters(), nodeName().utf8().data(), this, value.utf8().data());
+        SAFE_FPRINTF(stderr, "%s%s\t%p \"%s\"\n", prefix, nodeName().utf8(), this, value.utf8());
     } else {
         StringBuilder attrs;
         appendAttributeDesc(this, attrs, classAttr, " CLASS="_s);
         appendAttributeDesc(this, attrs, styleAttr, " STYLE="_s);
-        fprintf(stderr, "%s%s\t%p (renderer %p) %s%s%s\n", prefix.characters(), nodeName().utf8().data(), this, renderer(), attrs.toString().utf8().data(), needsStyleRecalc() ? " (needs style recalc)" : "", childNeedsStyleRecalc() ? " (child needs style recalc)" : "");
+        SAFE_FPRINTF(stderr, "%s%s\t%p (renderer %p) %s%s%s\n", prefix, nodeName().utf8(), this, renderer(), attrs.toString().utf8(), needsStyleRecalc() ? " (needs style recalc)"_s : ""_s, childNeedsStyleRecalc() ? " (child needs style recalc)"_s : ""_s);
     }
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void Node::showTreeForThis() const
 {

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -456,14 +456,11 @@ int HistoryItem::showTree() const
 
 int HistoryItem::showTreeWithIndent(unsigned indentLevel) const
 {
-    Vector<char> prefix;
+    StringBuilder prefix;
     for (unsigned i = 0; i < indentLevel; ++i)
-        prefix.append("  "_span);
-    prefix.append('\0');
+        prefix.append("  "_s);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    fprintf(stderr, "%s+-%s (%p)\n", prefix.data(), m_urlString.utf8().data(), this);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_FPRINTF(stderr, "%s+-%s (%p)\n", prefix.toString().utf8(), m_urlString.utf8(), this);
     
     int totalSubItems = 0;
     for (unsigned i = 0; i < m_children.size(); ++i)

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1354,9 +1354,7 @@ void dumpInnerHTML(WebCore::HTMLElement*);
 
 void dumpInnerHTML(WebCore::HTMLElement* element)
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("%s\n", element->innerHTML().ascii().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("%s\n", element->innerHTML().ascii());
 }
 
 #endif

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -574,9 +574,7 @@ void printLayoutTreeForLiveDocuments()
             continue;
         if (document->frame() && document->frame()->isMainFrame())
             fprintf(stderr, "----------------------main frame--------------------------\n");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        fprintf(stderr, "%s\n", document->url().string().utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        SAFE_FPRINTF(stderr, "%s\n", document->url().string().utf8());
         // FIXME: Need to find a way to output geometry without layout context.
         auto& renderView = *document->renderView();
         auto layoutTree = TreeBuilder::buildLayoutTree(renderView);

--- a/Source/WebCore/loader/appcache/ApplicationCache.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCache.cpp
@@ -171,9 +171,7 @@ void ApplicationCache::clearStorageID()
 void ApplicationCache::dump()
 {
     for (const auto& urlAndResource : m_resources) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        printf("%s ", urlAndResource.key.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        SAFE_PRINTF("%s ", urlAndResource.key.utf8());
         ApplicationCacheResource::dumpType(urlAndResource.value->type());
     }
 }

--- a/Source/WebCore/rendering/CounterNode.cpp
+++ b/Source/WebCore/rendering/CounterNode.cpp
@@ -347,15 +347,13 @@ static void showTreeAndMark(const CounterNode* node)
         root = root->parent();
 
     for (const CounterNode* current = root; current; current = current->nextInPreOrder()) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        fprintf(stderr, "%c", (current == node) ? '*' : ' ');
+        SAFE_FPRINTF(stderr, "%c", (current == node) ? '*' : ' ');
         for (const CounterNode* parent = current; parent && parent != root; parent = parent->parent())
             fprintf(stderr, "    ");
-        fprintf(stderr, "%p %s: %d %d P:%p PS:%p NS:%p R:%p\n",
-            current, current->actsAsReset() ? "reset____" : "increment", current->value(),
+        SAFE_FPRINTF(stderr, "%p %s: %d %d P:%p PS:%p NS:%p R:%p\n",
+            current, current->actsAsReset() ? "reset____"_s : "increment"_s, current->value(),
             current->countInParent(), current->parent(), current->previousSibling(),
             current->nextSibling(), &current->owner());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     fflush(stderr);
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6407,9 +6407,7 @@ void showLayerTree(const WebCore::RenderLayer* layer)
         WebCore::RenderAsTextFlag::DontUpdateLayout,
         WebCore::RenderAsTextFlag::ShowLayoutState,
     });
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    fprintf(stderr, "\n%s\n", output.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_FPRINTF(stderr, "\n%s\n", output.utf8());
 }
 
 void showLayerTree(const WebCore::RenderObject* renderer)

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -110,9 +110,7 @@ void WebMemorySampler::stop()
     m_sampleTimer.stop();
     FileSystem::closeFile(m_sampleLogFile);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("Stopped memory sampler for process %s %d\n", processName().utf8().data(), getCurrentProcessID());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("Stopped memory sampler for process %s %d\n", processName().utf8(), getCurrentProcessID());
     // Flush stdout buffer so python script can be guaranteed to read up to this point.
     fflush(stdout);
     m_isRunning = false;
@@ -165,9 +163,7 @@ void WebMemorySampler::stopTimerFired()
 {
     if (!m_isRunning)
         return;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("%g seconds elapsed. Stopping memory sampler...\n", m_runningTime);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     stop();
 }
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -82,9 +82,7 @@ void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 
     xpc_connection_set_event_handler(m_connection.get(), [](xpc_object_t event) {
         if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_CONNECTION_INTERRUPTED) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            fprintf(stderr, "Unexpected XPC connection issue: %s\n", event.debugDescription.UTF8String);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            SAFE_FPRINTF(stderr, "Unexpected XPC connection issue: %s\n", String(event.debugDescription).utf8());
             return;
         }
 
@@ -93,10 +91,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (waitForServiceToExist == WaitForServiceToExist::Yes) {
         auto result = maybeConnectToService(m_serviceName);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (result == MACH_PORT_NULL)
-            printf("Waiting for service '%s' to be available\n", m_serviceName.characters());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            SAFE_PRINTF("Waiting for service '%s' to be available\n", m_serviceName);
 
         while (result == MACH_PORT_NULL) {
             usleep(1000);
@@ -104,9 +100,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("Connecting to service '%s'\n", m_serviceName.characters());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("Connecting to service '%s'\n", m_serviceName);
     xpc_connection_activate(m_connection.get());
 
     sendAuditToken();
@@ -114,27 +108,21 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void Connection::sendPushMessage(PushMessageForTesting&& message, CompletionHandler<void(String)>&& completionHandler)
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Injecting push message\n");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::InjectPushMessageForTesting(WTFMove(message)), WTFMove(completionHandler));
 }
 
 void Connection::getPushPermissionState(const String& scope, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     printf("Getting push permission state\n");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPushPermissionState(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
 }
 
 void Connection::requestPushPermission(const String& scope, CompletionHandler<void(bool)>&& completionHandler)
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    printf("Request push permission state for %s\n", scope.utf8().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    SAFE_PRINTF("Request push permission state for %s\n", scope.utf8());
 
     sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RequestPushPermission(WebCore::SecurityOriginData::fromURL(URL { scope })), WTFMove(completionHandler));
 }

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -203,9 +203,7 @@ public:
     void run(WebPushTool::Connection& connection) override
     {
         connection.getPushPermissionState(m_scope, [this](WebCore::PushPermissionState state) mutable {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             printf("Got push permission status: %u\n", static_cast<unsigned>(state));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             done();
         });
     }
@@ -224,9 +222,7 @@ public:
     void run(WebPushTool::Connection& connection) override
     {
         connection.requestPushPermission(m_scope, [this](bool granted) mutable {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             printf("Requested push permission with result: %d\n", granted);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             done();
         });
     }


### PR DESCRIPTION
#### 3d5443f7963ad280d0419e45092902c3155dcd9c
<pre>
Further reduce unsafe printf usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=286627">https://bugs.webkit.org/show_bug.cgi?id=286627</a>
&lt;<a href="https://rdar.apple.com/problem/143766922">rdar://problem/143766922</a>&gt;

Reviewed by Chris Dumez.

Added SAFE_FPRINTF and SAFE_SPRINTF.

Fixed up some mistakes in the way I imported the FOR_EACH macro, which trigger
when you have more than one argument.

Deployed SAFE_PRINTF, SAFE_FPRINTF, and SAFE_SPRINTF in all the simple cases.

Added a consteval ASCIILiteral constructor from string literal. This enables you
to use a string literal directly without adding _s in any context where conversion
to ASCIILiteral is unambiguous (e.g., an ASCIILIteral function argument).

(It is extremely difficult, but technically possible, to invoke the ASCIILiteral
constructor using a manually declared constant array of characters that is not
null terminated. So it includes a RELEASE_ASSERT that you didn&apos;t do that.)

* Source/JavaScriptCore/API/tests/FunctionToStringTests.cpp:
(testFunctionToString):
* Source/JavaScriptCore/API/tests/JSObjectGetProxyTargetTest.cpp:
(testJSObjectGetProxyTarget):
* Source/JavaScriptCore/API/tests/MultithreadedMultiVMExecutionTest.cpp:
(startMultithreadedMultiVMExecutionTest):
(finalizeMultithreadedMultiVMExecutionTest):
* Source/JavaScriptCore/runtime/ExceptionFuzz.cpp:
(JSC::doExceptionFuzzing):
* Source/JavaScriptCore/runtime/ExceptionFuzz.h:
(JSC::doExceptionFuzzingIfEnabled):
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WTF/wtf/text/TextStream.cpp:
(WTF::TextStream::operator&lt;&lt;):
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
* Source/WebCore/bindings/js/GCController.cpp:
(WebCore::GCController::dumpHeapForVM):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::showStyle):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::dumpStatistics):
(WebCore::Node::showNode const):
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::showTreeWithIndent const):
* Source/WebCore/html/HTMLElement.cpp:
(dumpInnerHTML):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::printLayoutTreeForLiveDocuments):
* Source/WebCore/loader/appcache/ApplicationCache.cpp:
(WebCore::ApplicationCache::dump):
* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::showTreeAndMark):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::showLayerTree):
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::stop):
(WebKit::WebMemorySampler::stopTimerFired):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::connectToService):
(WebPushTool::Connection::sendPushMessage):
(WebPushTool::Connection::getPushPermissionState):
(WebPushTool::Connection::requestPushPermission):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):

Canonical link: <a href="https://commits.webkit.org/289537@main">https://commits.webkit.org/289537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47198f0b79c9b0ca9129b4610882ac3f535dd2b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87284 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92145 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14867 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33381 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37141 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/80074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94033 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86058 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14446 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75466 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19798 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18256 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13596 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14465 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108552 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14210 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26122 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17653 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->