### PR TITLE
[ANGLE] Add envvar to allow gating ASSERTs at runtime

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/debug.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/debug.cpp
@@ -36,6 +36,13 @@
 #include "common/entry_points_enum_autogen.h"
 #include "common/system_utils.h"
 
+#if defined(ANGLE_ENABLE_ASSERTS)
+bool AreAssertionsEnabled() {
+    static bool enabled = [] { return angle::GetEnvironmentVar("ANGLE_DISABLE_ASSERTS") != "1"; }();
+    return enabled;
+}
+#endif  // defined(ANGLE_ENABLE_ASSERTS)
+
 namespace gl
 {
 

--- a/Source/ThirdParty/ANGLE/src/common/log_utils.h
+++ b/Source/ThirdParty/ANGLE/src/common/log_utils.h
@@ -262,10 +262,13 @@ std::ostream &FmtHex(std::ostream &os, T value)
 
 // A macro asserting a condition and outputting failures to the debug log
 #if defined(ANGLE_ENABLE_ASSERTS)
-#    define ASSERT(expression)                                                                \
-        (expression ? static_cast<void>(0)                                                    \
-                    : (FATAL() << "\t! Assert failed in " << __FUNCTION__ << " (" << __FILE__ \
-                               << ":" << __LINE__ << "): " << #expression))
+bool AreAssertionsEnabled();
+#    define ASSERT(expression)                                                               \
+        (expression ? static_cast<void>(0)                                                   \
+            : (!AreAssertionsEnabled()                                                       \
+                ? static_cast<void>(0)                                                       \
+                : (FATAL() << "\t! Assert failed in " << __FUNCTION__ << " (" << __FILE__    \
+                    << ":" << __LINE__ << "): " << #expression)))
 #else
 #    define ASSERT(condition) ANGLE_EAT_STREAM_PARAMETERS << !(condition)
 #endif  // defined(ANGLE_ENABLE_ASSERTS)


### PR DESCRIPTION
#### 591d8cca0024ecb5403b2baba14abe1f160ad6b0
<pre>
[ANGLE] Add envvar to allow gating ASSERTs at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=286591">https://bugs.webkit.org/show_bug.cgi?id=286591</a>
<a href="https://rdar.apple.com/143716846">rdar://143716846</a>

Reviewed by Kimmo Kinnunen.

Add a `AreAssertionsEnabled()` function to `log_utils.h` to check a
runtime envvar once, and cache said value.This function is defined in
`common/debug.cpp`. This will allow us to modulate the ASSERTs crashing
the process regardless of how the ANGLE build was done.

The env var gating this is `ANGLE_DISABLE_ASSERTS`, so setting it to 1
will turn off asserts.

Additionally, the function is gated behind the `ANGLE_ENABLE_ASSERTS`
guard, so this will have no impact on production builds.

* Source/ThirdParty/ANGLE/src/common/debug.cpp:
(AreAssertionsEnabled):
* Source/ThirdParty/ANGLE/src/common/log_utils.h:

Canonical link: <a href="https://commits.webkit.org/289548@main">https://commits.webkit.org/289548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48c11d748a65d8ea1ff3cd3f9ba3a9ecd8788fac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37999 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67436 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25171 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47755 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37115 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94006 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14421 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10498 "Found 1 new test failure: fast/css/view-transitions-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75444 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18569 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18226 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7353 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14440 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->