### PR TITLE
CoreIPCPlistArray::toID() incorrect lifetime management with createNSArray

### DIFF
--- a/JSTests/stress/resize-array-buffer-constantly.js
+++ b/JSTests/stress/resize-array-buffer-constantly.js
@@ -1,0 +1,16 @@
+const backing = new ArrayBuffer(0x80, {maxByteLength: 0x100});
+const arr = new Int32Array(backing);
+
+function main(x) {
+    arr[0] = x;
+}
+
+for (let i = 0; i < 10000; i++) {
+    if (i % 2 == 0) {
+        backing.resize(0x90);
+    } else {
+        backing.resize(0x80);
+    }
+    main(i + 1000000.0000001);
+}
+

--- a/LayoutTests/http/wpt/mediastream/getUserMedia-rvfc-remove-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/getUserMedia-rvfc-remove-expected.txt
@@ -1,0 +1,3 @@
+
+PASS rvfc triggering frame removal
+

--- a/LayoutTests/http/wpt/mediastream/getUserMedia-rvfc-remove.html
+++ b/LayoutTests/http/wpt/mediastream/getUserMedia-rvfc-remove.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.className = 'test-iframe';
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+}
+
+let resolve;
+function waitForRemove()
+{
+    return new Promise(r => resolve = r);
+}
+
+let frame;
+function removeFrame()
+{
+    frame.remove();
+    resolve();
+}
+
+promise_test(async (test) => {
+    for (let i = 0; i < 10; i++) {
+        frame = await with_iframe("resources/getUserMedia-rvfc-remove-iframe.html");
+        await waitForRemove();
+    }
+}, "rvfc triggering frame removal");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/http/wpt/mediastream/resources/getUserMedia-rvfc-remove-iframe.html
+++ b/LayoutTests/http/wpt/mediastream/resources/getUserMedia-rvfc-remove-iframe.html
@@ -1,0 +1,23 @@
+<html>
+<body onload="start()">
+<video id="video" autoplay playsinline></video>
+<script>
+async function start()
+{
+    const localStream = await navigator.mediaDevices.getUserMedia({video: { width: 640, height: 480 } });
+    video.srcObject = localStream;
+    await video.play();
+
+    video.requestVideoFrameCallback(() => { });
+    video.requestVideoFrameCallback(() => {
+        self.parent.window.removeFrame();
+    });
+    video.requestVideoFrameCallback(() => { });
+    video.requestVideoFrameCallback(() => { });
+    video.requestVideoFrameCallback(() => { });
+    video.requestVideoFrameCallback(() => { });
+    video.requestVideoFrameCallback(() => { });
+}
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -100,7 +100,7 @@ class AbstractMacroAssembler : public AbstractMacroAssemblerBase {
 public:
     typedef AbstractMacroAssembler<AssemblerType> AbstractMacroAssemblerType;
     typedef AssemblerType AssemblerType_T;
-    friend class SuppressRegisetrAllocationValidation;
+    friend class SuppressRegisterAllocationValidation;
 
     template<PtrTag tag> using CodeRef = MacroAssemblerCodeRef<tag>;
 
@@ -893,10 +893,10 @@ public:
     }
 
     // DFG register allocation validation is broken in various cases. We need suppression mechanism otherwise, it introduces a new bug rather to bypass the issue.
-    class SuppressRegisetrAllocationValidation {
+    class SuppressRegisterAllocationValidation {
     public:
 #if ENABLE(DFG_REGISTER_ALLOCATION_VALIDATION)
-        SuppressRegisetrAllocationValidation(AbstractMacroAssemblerType& assembler)
+        SuppressRegisterAllocationValidation(AbstractMacroAssemblerType& assembler)
             : m_suppressRegisterValidation(assembler.m_suppressRegisterValidation, true)
         {
         }
@@ -904,7 +904,7 @@ public:
     private:
         SetForScope<bool> m_suppressRegisterValidation;
 #else
-        SuppressRegisetrAllocationValidation(AbstractMacroAssemblerType&) { }
+        SuppressRegisterAllocationValidation(AbstractMacroAssemblerType&) { }
 #endif
     };
 
@@ -945,6 +945,15 @@ public:
 
         for (auto& offset : m_registerAllocationForOffsets)
             offset.checkOffsets(offset1, offset2);
+    }
+
+    void checkRegisterAllocationAgainstSlowPathCall(const JumpList &from)
+    {
+        if (m_suppressRegisterValidation)
+            return;
+
+        for (auto& jump : from.jumps())
+            checkRegisterAllocationAgainstBranchRange(jump.label().m_label.offset(), debugOffset());
     }
 #endif
 

--- a/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
@@ -263,6 +263,9 @@ inline std::unique_ptr<SlowPathGenerator> slowPathCall(
     SpillRegistersMode spillMode, ExceptionCheckRequirement requirement,
     ResultType result, Arguments... arguments)
 {
+#if ENABLE(DFG_REGISTER_ALLOCATION_VALIDATION)
+    jit->checkRegisterAllocationAgainstSlowPathCall(from);
+#endif
     return makeUnique<CallResultAndArgumentsSlowPathGenerator<JumpType, FunctionType, ResultType, Arguments...>>(
         from, jit, function, spillMode, requirement, result, arguments...);
 }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -4815,6 +4815,7 @@ void SpeculativeJIT::compileInstanceOfCustom(Node* node)
 {
     // We could do something smarter here but this case is currently super rare and unless
     // Symbol.hasInstance becomes popular will likely remain that way.
+    SuppressRegisterAllocationValidation suppressScope(*this);
 
     JSValueOperand value(this, node->child1());
     SpeculateCellOperand constructor(this, node->child2());
@@ -14708,6 +14709,7 @@ void SpeculativeJIT::compileNewObject(Node* node)
 template<typename JSClass, typename Operation>
 void SpeculativeJIT::compileNewInternalFieldObjectImpl(Node* node, Operation operation)
 {
+    SuppressRegisterAllocationValidation suppressScope(*this);
     GPRTemporary result(this);
     GPRTemporary scratch1(this);
     GPRTemporary scratch2(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -912,7 +912,7 @@ void SpeculativeJIT::emitCall(Node* node)
         if (isTail) {
             RELEASE_ASSERT(node->op() == DirectTailCall);
 
-            SuppressRegisetrAllocationValidation suppressScope(*this);
+            SuppressRegisterAllocationValidation suppressScope(*this);
             Label mainPath = label();
             emitStoreCallSiteIndex(callSite);
             auto slowCases = callLinkInfo->emitDirectTailCallFastPath(*this, scopedLambda<void()>([&] {
@@ -934,7 +934,7 @@ void SpeculativeJIT::emitCall(Node* node)
             return;
         }
 
-        SuppressRegisetrAllocationValidation suppressScope(*this);
+        SuppressRegisterAllocationValidation suppressScope(*this);
         Label mainPath = label();
         emitStoreCallSiteIndex(callSite);
         auto slowCases = callLinkInfo->emitDirectFastPath(*this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1067,7 +1067,7 @@ void SpeculativeJIT::emitCall(Node* node)
         if (isTail) {
             RELEASE_ASSERT(node->op() == DirectTailCall);
 
-            SuppressRegisetrAllocationValidation suppressScope(*this);
+            SuppressRegisterAllocationValidation suppressScope(*this);
             Label mainPath = label();
             emitStoreCallSiteIndex(callSite);
             auto slowCases = callLinkInfo->emitDirectTailCallFastPath(*this, scopedLambda<void()>([&] {
@@ -1085,7 +1085,7 @@ void SpeculativeJIT::emitCall(Node* node)
             return;
         }
 
-        SuppressRegisetrAllocationValidation suppressScope(*this);
+        SuppressRegisterAllocationValidation suppressScope(*this);
         Label mainPath = label();
         emitStoreCallSiteIndex(callSite);
         auto slowCases = callLinkInfo->emitDirectFastPath(*this);
@@ -3931,7 +3931,7 @@ void SpeculativeJIT::compile(Node* node)
         if (!ok)
             break;
 
-        SuppressRegisetrAllocationValidation suppressScope(*this);
+        SuppressRegisterAllocationValidation suppressScope(*this);
 
         StorageOperand storage(this, storageEdge);
         GPRTemporary oldValue(this);

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -692,7 +692,7 @@ void HTMLVideoElement::cancelVideoFrameCallback(unsigned identifier)
     // Search first the requests currently being serviced, and mark them as cancelled if found.
     auto index = m_servicedVideoFrameRequests.findIf([identifier](auto& request) { return request->identifier == identifier; });
     if (index != notFound) {
-        m_servicedVideoFrameRequests[index]->cancelled = true;
+        m_servicedVideoFrameRequests[index]->callback = nullptr;
         return;
     }
 
@@ -710,7 +710,10 @@ void HTMLVideoElement::cancelVideoFrameCallback(unsigned identifier)
 void HTMLVideoElement::stop()
 {
     m_videoFrameRequests.clear();
-    m_servicedVideoFrameRequests.clear();
+
+    for (auto& request : m_servicedVideoFrameRequests)
+        request->callback = nullptr;
+
     HTMLMediaElement::stop();
 }
 
@@ -745,10 +748,8 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
 
     m_videoFrameRequests.swap(m_servicedVideoFrameRequests);
     for (auto& request : m_servicedVideoFrameRequests) {
-        if (!request->cancelled) {
-            Ref { request->callback }->handleEvent(std::round(now.milliseconds()), *videoFrameMetadata);
-            request->cancelled = true;
-        }
+        if (RefPtr callback = std::exchange(request->callback, { }))
+            callback->handleEvent(std::round(now.milliseconds()), *videoFrameMetadata);
     }
     m_servicedVideoFrameRequests.clear();
 

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -198,8 +198,7 @@ private:
         }
 
         unsigned identifier { 0 };
-        Ref<VideoFrameRequestCallback> callback;
-        bool cancelled { false };
+        RefPtr<VideoFrameRequestCallback> callback;
     };
     Vector<UniqueRef<VideoFrameRequest>> m_videoFrameRequests;
     Vector<UniqueRef<VideoFrameRequest>> m_servicedVideoFrameRequests;

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -59,7 +59,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCVPXVideoDecoder);
 
 static WorkQueue& vpxDecoderQueueSingleton()
 {
-    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("VPx VideoDecoder Queue"_s));
+    static std::once_flag onceKey;
+    static LazyNeverDestroyed<Ref<WorkQueue>> queue;
+    std::call_once(onceKey, [] {
+        queue.construct(WorkQueue::create("VPx VideoDecoder Queue"_s));
+    });
     return queue.get();
 }
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -54,7 +54,11 @@ static constexpr double defaultFrameRate = 30.0;
 
 static WorkQueue& vpxEncoderQueue()
 {
-    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("VPX VideoEncoder Queue"_s));
+    static std::once_flag onceKey;
+    static LazyNeverDestroyed<Ref<WorkQueue>> queue;
+    std::call_once(onceKey, [] {
+        queue.construct(WorkQueue::create("VPx VideoEncoder Queue"_s));
+    });
     return queue.get();
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm
@@ -59,8 +59,8 @@ CoreIPCPlistArray::CoreIPCPlistArray(Vector<CoreIPCPlistObject>&& array)
 
 RetainPtr<id> CoreIPCPlistArray::toID() const
 {
-    return createNSArray(m_array, [] (auto& object) -> id {
-        return object.toID().get();
+    return createNSArray(m_array, [] (auto& object) {
+        return object.toID();
     });
 }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -27,6 +27,7 @@
 
 #import "ArgumentCodersCocoa.h"
 #import "CoreIPCError.h"
+#import "CoreIPCPlistDictionary.h"
 #import "Encoder.h"
 #import "MessageSenderInlines.h"
 #import "test.h"
@@ -930,6 +931,26 @@ static void runTestCF(const CFHolderForTesting& holderArg)
 {
     runTestCFWithExpectedResult(holderArg, holderArg);
 };
+
+TEST(IPCSerialization, Plist)
+{
+    NSDictionary *plist = @{
+        @"key1": @"A String",
+        @"key2": @1.0,
+        @"key3": @[
+            @{
+                @"date": NSDate.now,
+                @"number": @2.0,
+                @"string": @"A String"
+            },
+        ],
+        @"key4": [NSData dataWithBytes:"Data test" length:strlen("Data test")]
+    };
+
+    auto p = WebKit::CoreIPCPlistDictionary(plist);
+    auto d = p.toID();
+    EXPECT_TRUE([d.get() isEqual:plist]);
+}
 
 TEST(IPCSerialization, Basic)
 {


### PR DESCRIPTION
#### 3a3c6732ffd4ee62b5c24e10e683068549ac1f3a
<pre>
CoreIPCPlistArray::toID() incorrect lifetime management with createNSArray
<a href="https://rdar.apple.com/140507449">rdar://140507449</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283915">https://bugs.webkit.org/show_bug.cgi?id=283915</a>

Reviewed by Sihui Liu.

* Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm:
(WebKit::CoreIPCPlistArray::toID const):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, Plist)):

Originally-landed-as: 283286.551@safari-7620-branch (09169e87e443). <a href="https://rdar.apple.com/143593960">rdar://143593960</a>
Canonical link: <a href="https://commits.webkit.org/289509@main">https://commits.webkit.org/289509@main</a>
</pre>
----------------------------------------------------------------------
#### 2c62bfaac3cff4e09f5bc024323d1a11d5049b63
<pre>
Access to vpxDecoderQueueSingleton() is not-threadsafe
<a href="https://rdar.apple.com/140577403">rdar://140577403</a>

Reviewed by Jean-Yves Avenard.

Make use of std::call-once to initialize the queue only once.

* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::vpxDecoderQueue):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::vpxEncoderQueue):

Originally-landed-as: 283286.533@safari-7620-branch (e975090744cf). <a href="https://rdar.apple.com/143594246">rdar://143594246</a>
Canonical link: <a href="https://commits.webkit.org/289508@main">https://commits.webkit.org/289508@main</a>
</pre>
----------------------------------------------------------------------
#### 6ddc52d0cf22036b8e5637cab2692fe8dab183f1
<pre>
Improve DFG_REGISTER_ALLOCATION_VALIDATION robustness
<a href="https://bugs.webkit.org/show_bug.cgi?id=283142">https://bugs.webkit.org/show_bug.cgi?id=283142</a>
<a href="https://rdar.apple.com/139826086">rdar://139826086</a>

Reviewed by Yusuke Suzuki.

DFG_REGISTER_ALLOCATION_VALIDATION currently checks for branches, but does not
consider slow paths. This leads to an oversight during validation that could
allow bugs to slip in.

* JSTests/stress/resize-array-buffer-constantly.js: Added.
(main):
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::RegisterAllocationOffset::checkOffset):
(JSC::AbstractMacroAssembler::checkRegisterAllocationAgainstSlowPathCall):
* Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h:
(JSC::DFG::slowPathCall):

Originally-landed-as: 283286.519@safari-7620-branch (21e99e5afce3). <a href="https://rdar.apple.com/143594883">rdar://143594883</a>
Canonical link: <a href="https://commits.webkit.org/289507@main">https://commits.webkit.org/289507@main</a>
</pre>
----------------------------------------------------------------------
#### fe980dac0c6c09fcfccc8e118c84ac22920be6dd
<pre>
J475d/24C76: Potential UAF in HTMLVideoElement::serviceRequestVideoFrameCallbacks
<a href="https://rdar.apple.com/140271547">rdar://140271547</a>

Reviewed by Eric Carlson.

When servicing rvfc requests, we can navigate the document which will stop the HTMLVideoElement.
This will clear the m_servicedVideoFrameRequests, which will delete the requests.

To prevent this issue, we clear the call of VideoFrameRequest but do not clear m_servicedVideoFrameRequests.
We remove VideoFrameRequest::cancelled as we now store a RefPtr callback.

* LayoutTests/http/wpt/mediastream/getUserMedia-rvfc-remove-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/getUserMedia-rvfc-remove.html: Added.
* LayoutTests/http/wpt/mediastream/resources/getUserMedia-rvfc-remove-iframe.html: Added.
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::cancelVideoFrameCallback):
(WebCore::HTMLVideoElement::stop):
(WebCore::HTMLVideoElement::serviceRequestVideoFrameCallbacks):
* Source/WebCore/html/HTMLVideoElement.h:

Originally-landed-as: 283286.513@safari-7620-branch (5e06ca5a17cd). <a href="https://rdar.apple.com/143595105">rdar://143595105</a>
Canonical link: <a href="https://commits.webkit.org/289506@main">https://commits.webkit.org/289506@main</a>
</pre>
----------------------------------------------------------------------
#### df324ce6945b6e5bc43417ee382ff35300ebabbc
<pre>
Remote Activation of Persistent Webcam Access without User Consent
<a href="https://rdar.apple.com/138483518">rdar://138483518</a>

Reviewed by Eric Carlson.

A getUserMedia call may happen before the document is stopped.
The document may be stopped between a source is created and the source is attached to the document via MediaStreamTrack::create.
In that case, the source in the GPUProcess will be created but will never be removed.
If the source is a clone of an active source in GPUProcess, this will prevent the capture to stop when document is tear down.

To prevent this, if the context is stopped, we end the capture source in UserMediaRequest::allow.

* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow):

Originally-landed-as: 283286.445@safari-7620-branch (bd990e20e91e). <a href="https://rdar.apple.com/143595500">rdar://143595500</a>
Canonical link: <a href="https://commits.webkit.org/289505@main">https://commits.webkit.org/289505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b74729b69117c241fd610d94ec1b4eba116c7003

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67296 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25051 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33187 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36923 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79900 "Found 1278 new JSC stress test failures: cdjs-tests.yaml/main.js.ftl-eager-no-cjit, microbenchmarks/Int16Array-bubble-sort.js.ftl-eager-no-cjit, microbenchmarks/Int8Array-load-with-byteLength.js.ftl-eager-no-cjit, microbenchmarks/Int8Array-load.js.ftl-eager-no-cjit, microbenchmarks/abc-forward-loop-equal.js.ftl-eager-no-cjit, microbenchmarks/abc-simple-backward-loop.js.ftl-eager-no-cjit, microbenchmarks/arguments-named-and-reflective.js.ftl-eager-no-cjit, microbenchmarks/arguments-out-of-bounds.js.ftl-eager-no-cjit, microbenchmarks/arguments-strict-mode.js.ftl-eager-no-cjit, microbenchmarks/array-access-polymorphic-structure.js.ftl-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93813 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85840 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76100 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75300 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19640 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7146 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13578 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19541 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108333 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13993 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26070 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->