### PR TITLE
Enforce m_rootPath for remaining DOMFileSystem file access

### DIFF
--- a/LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html
+++ b/LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html
@@ -15,31 +15,44 @@ function runTest() {
     window.jsTestIsAsync = true;
 
     let path = location.pathname.split("/");
-    let targetFileName = internals.createTemporaryFile(`${path[path.length - 1]}`, "");
+    let filename = path[path.length - 1];
+    let targetFileName = internals.createTemporaryFile(`${filename}`, "");
+    let targetDirectory = targetFileName.substring(0, targetFileName.length - filename);
 
     let input = document.createElement("input");
     input.type = "file";
 
     let file = new File([], targetFileName, {"type":"text/plain"});
+    let directory = new File([], targetDirectory, {"type":"text/plain"});
 
     dataTransfer = new DataTransfer();
     dataTransfer.items.add(file)
+    dataTransfer.items.add(directory)
     input.files = dataTransfer.files;
+
+    let resultCount = 0;
 
     var functionOnSuccess = function (file)
     {
-        testFailed("Should not receive file");
-        finishJSTest()
+        testFailed("Received file");
+        if (resultCount == 2)
+            finishJSTest()
+        resultCount++;
     }
 
     var functionOnError = function (value)
     {
         testPassed("Should not receive file");
-        finishJSTest()
+        if (resultCount == 2)
+            finishJSTest()
+        resultCount++;
     }
 
     input.webkitEntries.forEach((entry) => {
         entry.file(functionOnSuccess, functionOnError)
+        entry.getParent(functionOnSuccess, functionOnError)
+        if (entry.isDirectory)
+            entry.createReader().readEntries(functionOnSuccess, functionOnError)
     });
 }
 

--- a/LayoutTests/platform/mac-wk1/http/tests/security/file-system-access-via-dataTransfer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/file-system-access-via-dataTransfer-expected.txt
@@ -6,6 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS Should not receive file
 PASS Should not receive file
 PASS Should not receive file
+PASS Should not receive file
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -246,6 +246,9 @@ void DOMFileSystem::listDirectory(ScriptExecutionContext& context, FileSystemDir
         return;
     }
 
+    if (m_rootPath.isEmpty())
+        return completionHandler(Exception { ExceptionCode::NotFoundError, "Path does not exist"_s });
+
     m_workQueue->dispatch([protectedThis = Ref { *this }, context = Ref { context }, completionHandler = WTFMove(completionHandler), fullPath = crossThreadCopy(WTFMove(fullPath)), directoryVirtualPath = crossThreadCopy(WTFMove(directoryVirtualPath))]() mutable {
         auto listedChildren = listDirectoryWithMetadata(fullPath);
         callOnMainThread([protectedThis = WTFMove(protectedThis), context = WTFMove(context), completionHandler = WTFMove(completionHandler), listedChildren = crossThreadCopy(WTFMove(listedChildren)), directoryVirtualPath = WTFMove(directoryVirtualPath).isolatedCopy()]() mutable {
@@ -261,6 +264,10 @@ void DOMFileSystem::getParent(ScriptExecutionContext& context, FileSystemEntry& 
     auto virtualPath = resolveRelativeVirtualPath(entry.virtualPath(), ".."_s);
     ASSERT(virtualPath[0] == '/');
     auto fullPath = evaluatePath(virtualPath);
+
+    if (m_rootPath.isEmpty())
+        return completionCallback(Exception { ExceptionCode::NotFoundError, "Path does not exist"_s });
+
     m_workQueue->dispatch([protectedThis = Ref { *this }, context = Ref { context }, fullPath = crossThreadCopy(WTFMove(fullPath)), virtualPath = crossThreadCopy(WTFMove(virtualPath)), completionCallback = WTFMove(completionCallback)]() mutable {
         auto validatedVirtualPath = validatePathIsExpectedType(fullPath, WTFMove(virtualPath), FileSystem::FileType::Directory);
         callOnMainThread([protectedThis = WTFMove(protectedThis), context = WTFMove(context), validatedVirtualPath = crossThreadCopy(WTFMove(validatedVirtualPath)), completionCallback = WTFMove(completionCallback)]() mutable {


### PR DESCRIPTION
#### b3d35bb8ab6482329d4d5e6c4737548156a49279
<pre>
Enforce m_rootPath for remaining DOMFileSystem file access
<a href="https://bugs.webkit.org/show_bug.cgi?id=283117">https://bugs.webkit.org/show_bug.cgi?id=283117</a>
<a href="https://rdar.apple.com/139533231">rdar://139533231</a>

Reviewed by Chris Dumez.

This is a follow-up to 276184@main where I added validation in
DOMFileSystem::get{Entry,File}. That missed the ability to leverage getParent
and listDirectory for testing if a directory exists. This patch closes that
hole.

* LayoutTests/http/tests/security/file-system-access-via-dataTransfer-expected.txt:
* LayoutTests/http/tests/security/file-system-access-via-dataTransfer.html:
* LayoutTests/platform/mac-wk1/http/tests/security/file-system-access-via-dataTransfer-expected.txt: Copied from LayoutTests/http/tests/security/file-system-access-via-dataTransfer-expected.txt.
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
(WebCore::DOMFileSystem::listDirectory):
(WebCore::DOMFileSystem::getParent):

Originally-landed-as: 283286.586@safari-7620-branch (bddd7907adf8). <a href="https://rdar.apple.com/143592706">rdar://143592706</a>
Canonical link: <a href="https://commits.webkit.org/289479@main">https://commits.webkit.org/289479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47fdbe93996bcf39453b2d518751f3b0fd6ac1c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67301 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93817 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76104 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75304 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18535 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18076 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7150 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19545 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13997 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17439 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->