### PR TITLE
Test what breaks when clamping all conversions to Length

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -567,45 +567,50 @@ bool CSSPrimitiveValue::conversionToCanonicalUnitRequiresConversionData() const
 
 template<> int CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<int>(resolveAsLengthDouble(conversionData));
+    return roundForImpreciseConversion<int>(resolveAsLengthDoubleClamping(conversionData));
 }
 
 template<> unsigned CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<unsigned>(resolveAsLengthDouble(conversionData));
+    return roundForImpreciseConversion<unsigned>(resolveAsLengthDoubleClamping(conversionData));
 }
 
 template<> float CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return narrowPrecisionToFloat(resolveAsLengthDouble(conversionData));
+    return static_cast<float>(resolveAsLengthDoubleClamping(conversionData));
 }
 
 template<> double CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return resolveAsLengthDouble(conversionData);
+    return resolveAsLengthDoubleClamping(conversionData);
 }
 
 template<> Length CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return Length(clampTo<float>(resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength), LengthType::Fixed);
+    return Length(static_cast<float>(resolveAsLengthDoubleClamping(conversionData)), LengthType::Fixed);
 }
 
 template<> short CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<short>(resolveAsLengthDouble(conversionData));
+    return roundForImpreciseConversion<short>(resolveAsLengthDoubleClamping(conversionData));
 }
 
 template<> unsigned short CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<unsigned short>(resolveAsLengthDouble(conversionData));
+    return roundForImpreciseConversion<unsigned short>(resolveAsLengthDoubleClamping(conversionData));
 }
 
 template<> LayoutUnit CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return LayoutUnit(resolveAsLengthDouble(conversionData));
+    return LayoutUnit(resolveAsLengthDoubleClamping(conversionData));
 }
 
-double CSSPrimitiveValue::resolveAsLengthDouble(const CSSToLengthConversionData& conversionData) const
+double CSSPrimitiveValue::resolveAsLengthDoubleClamping(const CSSToLengthConversionData& conversionData) const
+{
+    return clampTo<double>(resolveAsLengthDoubleNoClamping(conversionData), static_cast<double>(minValueForCssLength), static_cast<double>(maxValueForCssLength));
+}
+
+double CSSPrimitiveValue::resolveAsLengthDoubleNoClamping(const CSSToLengthConversionData& conversionData) const
 {
     if (isCalculated()) {
         // The multiplier and factor is applied to each value in the calc expression individually

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -238,7 +238,8 @@ private:
     void setPrimitiveUnitType(CSSUnitType type) { m_primitiveUnitType = enumToUnderlyingType(type); }
 
     // MARK: Length converting
-    double resolveAsLengthDouble(const CSSToLengthConversionData&) const;
+    double resolveAsLengthDoubleClamping(const CSSToLengthConversionData&) const;
+    double resolveAsLengthDoubleNoClamping(const CSSToLengthConversionData&) const;
 
     // MARK: Arbitrarily converting
     double doubleValue(CSSUnitType targetUnit, const CSSToLengthConversionData&) const;


### PR DESCRIPTION
#### e5c101699909c04a95710f5456a882333788886d
<pre>
Test what breaks when clamping all conversions to Length
<a href="https://bugs.webkit.org/show_bug.cgi?id=286640">https://bugs.webkit.org/show_bug.cgi?id=286640</a>

Reviewed by NOBODY (OOPS!).

FOR BOTS ONLY.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::resolveAsLength const):
(WebCore::CSSPrimitiveValue::resolveAsLengthDoubleClamping const):
(WebCore::CSSPrimitiveValue::resolveAsLengthDoubleNoClamping const):
(WebCore::CSSPrimitiveValue::resolveAsLengthDouble const): Deleted.
* Source/WebCore/css/CSSPrimitiveValue.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5c101699909c04a95710f5456a882333788886d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14650 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67299 "Found 1 new test failure: transforms/hittest-translated-content-off-to-infinity-and-back.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25055 "Found 1 new test failure: transforms/hittest-translated-content-off-to-infinity-and-back.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5027 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33192 "Found 1 new test failure: transforms/hittest-translated-content-off-to-infinity-and-back.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75522 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34071 "Found 1 new test failure: transforms/hittest-translated-content-off-to-infinity-and-back.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93818 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14234 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10359 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-multicol/file-control-crash.html transforms/hittest-translated-content-off-to-infinity-and-back.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76107 "Found 1 new test failure: transforms/hittest-translated-content-off-to-infinity-and-back.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75307 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19643 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18078 "Found 1 new test failure: transforms/hittest-translated-content-off-to-infinity-and-back.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7151 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->