### PR TITLE
Use smart pointers more in UIScriptController related code

### DIFF
--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -2283,13 +2283,11 @@ static unsigned nextUIScriptCallbackID()
 
 void TestRunner::runUIScript(JSContextRef context, JSStringRef script, JSValueRef callback)
 {
-    m_pendingUIScriptInvocationData = nullptr;
-
     unsigned callbackID = nextUIScriptCallbackID();
     cacheTestRunnerCallback(callbackID, callback);
 
     if (!m_UIScriptContext)
-        m_UIScriptContext = makeUniqueWithoutFastMallocCheck<WTR::UIScriptContext>(*this, WTR::UIScriptController::create);
+        m_UIScriptContext = WTR::UIScriptContext::create(*this, WTR::UIScriptController::create);
 
     String scriptString({ reinterpret_cast<const UChar*>(JSStringGetCharactersPtr(script)), JSStringGetLength(script) });
     m_UIScriptContext->runUIScript(scriptString, callbackID);

--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -496,8 +496,7 @@ private:
         String scriptString;
     };
 
-    std::unique_ptr<WTR::UIScriptContext> m_UIScriptContext;
-    UIScriptInvocationData* m_pendingUIScriptInvocationData { nullptr };
+    RefPtr<WTR::UIScriptContext> m_UIScriptContext;
 
     std::vector<std::string> m_openPanelFiles;
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp
@@ -48,7 +48,6 @@ UIScriptContext::UIScriptContext(UIScriptContextDelegate& delegate, UIScriptCont
 UIScriptContext::~UIScriptContext()
 {
     m_controller->waitForOutstandingCallbacks();
-    m_controller->contextDestroyed();
 }
 
 void UIScriptContext::runUIScript(const String& script, unsigned scriptCallbackID)

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -28,6 +28,7 @@
 #include "JSWrappable.h"
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 
 OBJC_CLASS NSUndoManager;
 OBJC_CLASS NSView;
@@ -71,7 +72,6 @@ public:
 
     void notImplemented() const { RELEASE_ASSERT_NOT_REACHED(); }
 
-    void contextDestroyed();
     virtual void waitForOutstandingCallbacks() { /* notImplemented(); */ }
 
     void makeWindowObject(JSContextRef);
@@ -434,7 +434,7 @@ public:
 protected:
     explicit UIScriptController(UIScriptContext&);
     
-    UIScriptContext* context() { return m_context; }
+    UIScriptContext* context();
 
     virtual void clearAllCallbacks() { /* notImplemented(); */ }
 
@@ -453,7 +453,7 @@ protected:
 
     JSObjectRef objectFromRect(const WebCore::FloatRect&) const;
 
-    UIScriptContext* m_context;
+    WeakPtr<UIScriptContext> m_context;
 
 #if PLATFORM(COCOA)
     bool m_capsLockOn { false };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -76,13 +76,13 @@ TextExtractionOptions* toTextExtractionOptions(JSContextRef context, JSValueRef 
 }
 
 UIScriptController::UIScriptController(UIScriptContext& context)
-    : m_context(&context)
+    : m_context(context)
 {
 }
 
-void UIScriptController::contextDestroyed()
+UIScriptContext* UIScriptController::context()
 {
-    m_context = nullptr;
+    return m_context.get();
 }
 
 void UIScriptController::makeWindowObject(JSContextRef context)

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -35,11 +35,12 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WTR {
 
-class TestInvocation final : public RefCounted<TestInvocation>, public UIScriptContextDelegate {
+class TestInvocation final : public RefCounted<TestInvocation>, public UIScriptContextDelegate, public CanMakeWeakPtr<TestInvocation> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(TestInvocation);
 public:
@@ -119,7 +120,7 @@ private:
     struct UIScriptInvocationData {
         unsigned callbackID;
         WebKit::WKRetainPtr<WKStringRef> scriptString;
-        TestInvocation* testInvocation;
+        WeakPtr<TestInvocation> testInvocation;
     };
     static void runUISideScriptAfterUpdateCallback(WKErrorRef, void* context);
     static void runUISideScriptImmediately(WKErrorRef, void* context);
@@ -167,8 +168,7 @@ private:
     WKRetainPtr<WKImageRef> m_pixelResult;
     WKRetainPtr<WKArrayRef> m_repaintRects;
     
-    std::unique_ptr<UIScriptContext> m_UIScriptContext;
-    UIScriptInvocationData* m_pendingUIScriptInvocationData { nullptr };
+    RefPtr<UIScriptContext> m_UIScriptContext;
 };
 
 } // namespace WTR


### PR DESCRIPTION
#### a51462a095c75b6841c9c54f3cf646ae6c633df0
<pre>
Use smart pointers more in UIScriptController related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=286646">https://bugs.webkit.org/show_bug.cgi?id=286646</a>
<a href="https://rdar.apple.com/143784212">rdar://143784212</a>

Reviewed by Tim Horton.

This started as a fix for a crash in WebKitTestRunner when the callback of
EventStreamPlayer.playStream:window:completionHandler: is called after the
UIScriptContext is destroyed, and the unsafely implicitly captured raw pointer
to the UIScriptContext is dereferenced.  I expanded a bit to remove or replace
unsafe pointer use with smart pointers.

* Tools/DumpRenderTree/TestRunner.cpp:
(TestRunner::runUIScript):
* Tools/DumpRenderTree/TestRunner.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptContext.cpp:
(UIScriptContext::~UIScriptContext):
* Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h:
(WTR::UIScriptContext::create):
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::context): Deleted.
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::UIScriptController::UIScriptController):
(WTR::UIScriptController::context):
(WTR::UIScriptController::contextDestroyed): Deleted.
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::runUISideScriptImmediately):
(WTR::TestInvocation::runUISideScript):
(WTR::TestInvocation::~TestInvocation): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::playBackEvents):
(WTR::UIScriptControllerMac::beginBackSwipe):
(WTR::UIScriptControllerMac::completeBackSwipe):
(WTR::UIScriptControllerMac::playBackEventStream):

Canonical link: <a href="https://commits.webkit.org/289477@main">https://commits.webkit.org/289477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c338c6be87dfaa8f0bb31404e59f15ad9ed9914a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91958 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14677 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5041 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33211 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fill-columns-001.html (failure)") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/36955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93845 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14261 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74691 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18095 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13563 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14280 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17468 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->