### PR TITLE
AXRemoteFrame::generateRemoteToken() should return a Vector

### DIFF
--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -38,7 +38,7 @@ public:
 #if PLATFORM(COCOA)
     void initializePlatformElementWithRemoteToken(std::span<const uint8_t>, int);
     Vector<uint8_t> generateRemoteToken() const;
-    RetainPtr<id> remoteFramePlatformElement() const final { return m_remoteFramePlatformElement; }
+    RetainPtr<id> remoteFramePlatformElement() const { return m_remoteFramePlatformElement; }
     pid_t processIdentifier() const { return m_processIdentifier; }
     std::optional<FrameIdentifier> frameID() const { return m_frameID; }
     void setFrameID(FrameIdentifier frameID) { m_frameID = frameID; }

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -660,8 +660,7 @@ Vector<uint8_t> AXRemoteFrame::generateRemoteToken() const
 {
     if (auto* parent = parentObject()) {
         // We use the parent's wrapper so that the remote frame acts as a pass through for the remote token bridge.
-        NSData *data = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:parent->wrapper()];
-        return makeVector(data);
+        return makeVector([NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:parent->wrapper()]);
     }
 
     return { };


### PR DESCRIPTION
#### ef9a33db81844c3fa5b3701acc4cd47848d24983
<pre>
AXRemoteFrame::generateRemoteToken() should return a Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=281327">https://bugs.webkit.org/show_bug.cgi?id=281327</a>
<a href="https://rdar.apple.com/137766980">rdar://137766980</a>

Reviewed by Timothy Hatcher.

Copy the data out of the local NSData.

* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AXRemoteFrame::generateRemoteToken const):

Originally-landed-as: 283286.476@safari-7620-branch (0be2067be05a). <a href="https://rdar.apple.com/143595350">rdar://143595350</a>
Canonical link: <a href="https://commits.webkit.org/289515@main">https://commits.webkit.org/289515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d965176674bb7e39555b8e9d74e5c432a98bae8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37842 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67315 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25068 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5043 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33215 "Found 2 new test failures: http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fill-columns-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93849 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75320 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7182 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13582 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->