### PR TITLE
Pure virtual function called! in WebCore::ScriptExecutionContext::postCrossThreadTask<WebCore::IDBDatabase &,void (WebCore::IDBDatabase::*&)(const WebCore::IDBError &),const WebCore::IDBError &>

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -68,7 +68,7 @@ IDBDatabase::IDBDatabase(ScriptExecutionContext& context, IDBClient::IDBConnecti
     , m_eventNames(eventNames())
 {
     LOG(IndexedDB, "IDBDatabase::IDBDatabase - Creating database %s with version %" PRIu64 " connection %" PRIu64 " (%p)", m_info.name().utf8().data(), m_info.version(), m_databaseConnectionIdentifier.toUInt64(), this);
-    m_connectionProxy->registerDatabaseConnection(*this);
+    m_connectionProxy->registerDatabaseConnection(*this, context.identifier());
 }
 
 IDBDatabase::~IDBDatabase()

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -32,6 +32,7 @@
 #include "IDBDatabaseInfo.h"
 #include "IDBKeyPath.h"
 #include "IDBTransactionMode.h"
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 
@@ -44,7 +45,7 @@ class IDBTransactionInfo;
 
 struct EventNames;
 
-class IDBDatabase final : public ThreadSafeRefCounted<IDBDatabase>, public EventTarget, public IDBActiveDOMObject {
+class IDBDatabase final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<IDBDatabase>, public EventTarget, public IDBActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(IDBDatabase);
 public:
     static Ref<IDBDatabase> create(ScriptExecutionContext&, IDBClient::IDBConnectionProxy&, const IDBResultData&);
@@ -77,12 +78,12 @@ public:
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::IDBDatabase; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
-    void refEventTarget() final { ThreadSafeRefCounted<IDBDatabase>::ref(); }
-    void derefEventTarget() final { ThreadSafeRefCounted<IDBDatabase>::deref(); }
+    void refEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void derefEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     // ActiveDOMObject.
-    void ref() const final { ThreadSafeRefCounted::ref(); }
-    void deref() const final { ThreadSafeRefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
+    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     IDBDatabaseInfo& info() { return m_info; }
     IDBDatabaseConnectionIdentifier databaseConnectionIdentifier() const { return m_databaseConnectionIdentifier; }
@@ -135,8 +136,7 @@ private:
     HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_abortingTransactions;
     
     const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
-
-    bool m_isContextSuspended { false };
+    std::atomic<bool> m_isContextSuspended { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -281,24 +281,36 @@ void IDBConnectionProxy::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifi
     callConnectionOnMainThread(&IDBConnectionToServer::abortOpenAndUpgradeNeeded, databaseConnectionIdentifier, transactionIdentifier);
 }
 
-void IDBConnectionProxy::fireVersionChangeEvent(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion)
+std::pair<RefPtr<IDBDatabase>, std::optional<ScriptExecutionContextIdentifier>> IDBConnectionProxy::databaseFromConnectionIdentifier(IDBDatabaseConnectionIdentifier connectionIdentifier)
 {
-    RefPtr<IDBDatabase> database;
-    {
-        Locker locker { m_databaseConnectionMapLock };
-        database = m_databaseConnectionMap.get(databaseConnectionIdentifier);
+    Locker locker { m_databaseConnectionMapLock };
+    auto it = m_databaseConnectionMap.find(connectionIdentifier);
+    if (it == m_databaseConnectionMap.end())
+        return { };
+
+    RefPtr database = it->value.database.get();
+    if (!database) {
+        m_databaseConnectionMap.remove(it);
+        return { };
     }
 
+    return { database, it->value.contextIdentifier };
+}
+
+void IDBConnectionProxy::fireVersionChangeEvent(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion)
+{
+    auto [database, contextIdentifier] = databaseFromConnectionIdentifier(databaseConnectionIdentifier);
     if (!database)
         return;
 
+    ASSERT(contextIdentifier);
     if (database->isContextSuspended()) {
         didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer::Yes);
-        database->performCallbackOnOriginThread(*database, &IDBDatabase::connectionToServerLost, IDBError { ExceptionCode::UnknownError, "Connection on cached page closed to unblock other connections"_s });
+        ScriptExecutionContext::ensureOnContextThreadForCrossThreadTask(*contextIdentifier, createCrossThreadTask(*database,  &IDBDatabase::connectionToServerLost, IDBError { ExceptionCode::UnknownError, "Connection on cached page closed to unblock other connections"_s }));
         return;
     }
 
-    database->performCallbackOnOriginThread(*database, &IDBDatabase::fireVersionChangeEvent, requestIdentifier, requestedVersion);
+    ScriptExecutionContext::ensureOnContextThreadForCrossThreadTask(*contextIdentifier, createCrossThreadTask(*database,  &IDBDatabase::fireVersionChangeEvent, requestIdentifier, requestedVersion));
 }
 
 void IDBConnectionProxy::didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer connectionClosed)
@@ -427,16 +439,11 @@ void IDBConnectionProxy::databaseConnectionClosed(IDBDatabase& database)
 
 void IDBConnectionProxy::didCloseFromServer(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const IDBError& error)
 {
-    RefPtr<IDBDatabase> database;
-    {
-        Locker locker { m_databaseConnectionMapLock };
-        database = m_databaseConnectionMap.get(databaseConnectionIdentifier);
-    }
-
+    auto [database, contextIdentifier] = databaseFromConnectionIdentifier(databaseConnectionIdentifier);
     if (!database)
         return;
 
-    database->performCallbackOnOriginThread(*database, &IDBDatabase::didCloseFromServer, error);
+    ScriptExecutionContext::ensureOnContextThreadForCrossThreadTask(*contextIdentifier, createCrossThreadTask(*database,  &IDBDatabase::didCloseFromServer, error));
 }
 
 void IDBConnectionProxy::connectionToServerLost(const IDBError& error)
@@ -448,16 +455,11 @@ void IDBConnectionProxy::connectionToServerLost(const IDBError& error)
     }
 
     for (auto connectionIdentifier : databaseConnectionIdentifiers) {
-        RefPtr<IDBDatabase> database;
-        {
-            Locker locker { m_databaseConnectionMapLock };
-            database = m_databaseConnectionMap.get(connectionIdentifier);
-        }
-
+        auto [database, contextIdentifier] = databaseFromConnectionIdentifier(connectionIdentifier);
         if (!database)
             continue;
 
-        database->performCallbackOnOriginThread(*database, &IDBDatabase::connectionToServerLost, error);
+        ScriptExecutionContext::ensureOnContextThreadForCrossThreadTask(*contextIdentifier, createCrossThreadTask(*database,  &IDBDatabase::connectionToServerLost, error));
     }
 
     Vector<IDBResourceIdentifier> openDBRequestIdentifiers;
@@ -544,19 +546,18 @@ void IDBConnectionProxy::didGetAllDatabaseNamesAndVersions(const IDBResourceIden
     request->performCallbackOnOriginThread(*request, &IDBDatabaseNameAndVersionRequest::complete, WTFMove(databases));
 }
 
-void IDBConnectionProxy::registerDatabaseConnection(IDBDatabase& database)
+void IDBConnectionProxy::registerDatabaseConnection(IDBDatabase& database, ScriptExecutionContextIdentifier identifier)
 {
     Locker locker { m_databaseConnectionMapLock };
 
     ASSERT(!m_databaseConnectionMap.contains(database.databaseConnectionIdentifier()));
-    m_databaseConnectionMap.set(database.databaseConnectionIdentifier(), &database);
+    m_databaseConnectionMap.set(database.databaseConnectionIdentifier(), WeakIDBDatabase { &database, identifier });
 }
 
 void IDBConnectionProxy::unregisterDatabaseConnection(IDBDatabase& database)
 {
     Locker locker { m_databaseConnectionMapLock };
 
-    ASSERT(!m_databaseConnectionMap.contains(database.databaseConnectionIdentifier()) || m_databaseConnectionMap.get(database.databaseConnectionIdentifier()) == &database);
     m_databaseConnectionMap.remove(database.databaseConnectionIdentifier());
 }
 
@@ -662,9 +663,17 @@ void IDBConnectionProxy::abortActivitiesForCurrentThread()
 void IDBConnectionProxy::setContextSuspended(ScriptExecutionContext& currentContext, bool isContextSuspended)
 {
     {
+        auto currentContextIdentifier = currentContext.identifier();
         Locker locker { m_databaseConnectionMapLock };
-        setMatchingItemsContextSuspended(currentContext, m_databaseConnectionMap, isContextSuspended);
+        for (auto weakDatabase : m_databaseConnectionMap.values()) {
+            if (RefPtr database = weakDatabase.database.get()) {
+                auto contextIdentifier = weakDatabase.contextIdentifier;
+                if (contextIdentifier && contextIdentifier == currentContextIdentifier)
+                    database->setIsContextSuspended(isContextSuspended);
+            }
+        }
     }
+
     {
         Locker locker { m_openDBRequestMapLock };
         setMatchingItemsContextSuspended(currentContext, m_openDBRequestMap, isContextSuspended);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -121,7 +121,7 @@ public:
     void getAllDatabaseNamesAndVersions(ScriptExecutionContext&, Function<void(std::optional<Vector<IDBDatabaseNameAndVersion>>&&)>&&);
     void didGetAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, std::optional<Vector<IDBDatabaseNameAndVersion>>&&);
 
-    void registerDatabaseConnection(IDBDatabase&);
+    void registerDatabaseConnection(IDBDatabase&, ScriptExecutionContextIdentifier);
     void unregisterDatabaseConnection(IDBDatabase&);
 
     void forgetActiveOperations(const Vector<RefPtr<TransactionOperation>>&);
@@ -136,6 +136,7 @@ private:
     bool hasRecordOfTransaction(const IDBTransaction&) const WTF_REQUIRES_LOCK(m_transactionMapLock);
 
     void saveOperation(TransactionOperation&);
+    std::pair<RefPtr<IDBDatabase>, std::optional<ScriptExecutionContextIdentifier>> databaseFromConnectionIdentifier(IDBDatabaseConnectionIdentifier);
 
     template<typename... Parameters, typename... Arguments>
     void callConnectionOnMainThread(void (IDBConnectionToServer::*method)(Parameters...), Arguments&&... arguments)
@@ -168,7 +169,11 @@ private:
     Lock m_databaseInfoMapLock;
     Lock m_mainThreadTaskLock;
 
-    HashMap<IDBDatabaseConnectionIdentifier, IDBDatabase*> m_databaseConnectionMap WTF_GUARDED_BY_LOCK(m_databaseConnectionMapLock);
+    struct WeakIDBDatabase {
+        ThreadSafeWeakPtr<IDBDatabase> database;
+        std::optional<ScriptExecutionContextIdentifier> contextIdentifier;
+    };
+    HashMap<IDBDatabaseConnectionIdentifier, WeakIDBDatabase> m_databaseConnectionMap WTF_GUARDED_BY_LOCK(m_databaseConnectionMapLock);
     HashMap<IDBResourceIdentifier, RefPtr<IDBOpenDBRequest>> m_openDBRequestMap WTF_GUARDED_BY_LOCK(m_openDBRequestMapLock);
     HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_pendingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);
     HashMap<IDBResourceIdentifier, RefPtr<IDBTransaction>> m_committingTransactions WTF_GUARDED_BY_LOCK(m_transactionMapLock);

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -785,6 +785,27 @@ bool ScriptExecutionContext::ensureOnContextThread(ScriptExecutionContextIdentif
     return true;
 }
 
+bool ScriptExecutionContext::ensureOnContextThreadForCrossThreadTask(ScriptExecutionContextIdentifier identifier, CrossThreadTask&& crossThreadTask)
+{
+    {
+        Locker locker { allScriptExecutionContextsMapLock };
+        auto context = allScriptExecutionContextsMap().get(identifier);
+
+        if (!context)
+            return false;
+
+        if (!context->isContextThread()) {
+            context->postTask([crossThreadTask = WTFMove(crossThreadTask)](ScriptExecutionContext&) mutable {
+                crossThreadTask.performTask();
+            });
+            return true;
+        }
+    }
+
+    crossThreadTask.performTask();
+    return true;
+}
+
 void ScriptExecutionContext::postTaskToResponsibleDocument(Function<void(Document&)>&& callback)
 {
     if (auto* document = dynamicDowncast<Document>(*this)) {

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -329,6 +329,7 @@ public:
     WEBCORE_EXPORT static bool postTaskForModeToWorkerOrWorklet(ScriptExecutionContextIdentifier, Task&&, const String&);
     WEBCORE_EXPORT static bool ensureOnContextThread(ScriptExecutionContextIdentifier, Task&&);
     WEBCORE_EXPORT static bool isContextThread(ScriptExecutionContextIdentifier);
+    WEBCORE_EXPORT static bool ensureOnContextThreadForCrossThreadTask(ScriptExecutionContextIdentifier, CrossThreadTask&&);
 
     ScriptExecutionContextIdentifier identifier() const { return m_identifier; }
 


### PR DESCRIPTION
#### c39fe29e14e462ab59dd2e81bb9bae409dde1905
<pre>
Pure virtual function called! in WebCore::ScriptExecutionContext::postCrossThreadTask&lt;WebCore::IDBDatabase &amp;,void (WebCore::IDBDatabase::*&amp;)(const WebCore::IDBError &amp;),const WebCore::IDBError &amp;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=283040">https://bugs.webkit.org/show_bug.cgi?id=283040</a>
<a href="https://rdar.apple.com/139782420">rdar://139782420</a>

Reviewed by Chris Dumez.

Crash log indicates IDBDatabase (IDBActiveDOMObject) can post task to ScriptExecutionContext from the main thread when
context is being destroyed on a background thread. This is problematic because ScriptExecutionContext is not
thread-safe and IDBDatabase is not supposed to access it directly from a non-context thread. This patch fixes the issue
by posting task via ScriptExecutionContext::ensureOnContextThread function instead, as the function acquires lock as
needed. Also this patch replaces raw pointer in m_databaseConnectionMap with ThreadSafeWeakPtr, and make
IDBDatabase::m_isContextSuspended std::atomic for better thread safety.

* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::IDBDatabase):
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::databaseFromConnectionIdentifier):
(WebCore::IDBClient::IDBConnectionProxy::fireVersionChangeEvent):
(WebCore::IDBClient::IDBConnectionProxy::didCloseFromServer):
(WebCore::IDBClient::IDBConnectionProxy::connectionToServerLost):
(WebCore::IDBClient::IDBConnectionProxy::registerDatabaseConnection):
(WebCore::IDBClient::IDBConnectionProxy::unregisterDatabaseConnection):
(WebCore::IDBClient::IDBConnectionProxy::setContextSuspended):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::ensureOnContextThreadForCrossThreadTask):
* Source/WebCore/dom/ScriptExecutionContext.h:

Originally-landed-as: 283286.491@safari-7620-branch (ae369124fc38). <a href="https://rdar.apple.com/143595292">rdar://143595292</a>
Canonical link: <a href="https://commits.webkit.org/289646@main">https://commits.webkit.org/289646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f9eab094a23b5cb28feaeb8989c7991b74c6f36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15284 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25396 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33666 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37457 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94351 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14768 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75121 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14784 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->