### PR TITLE
`SubscribeToCookieChangeNotifications` and `UnsubscribeFromCookieChangeNotifications` IPC messages do not verify cookie access

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -981,10 +981,11 @@ void NetworkConnectionToWebProcess::domCookiesForHost(const URL& url, Completion
 
 void NetworkConnectionToWebProcess::subscribeToCookieChangeNotifications(const URL& url, const URL& firstParty, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto allowCookieAccess = protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, firstParty);
-    MESSAGE_CHECK_COMPLETION(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate, completionHandler(false));
-    if (allowCookieAccess != NetworkProcess::AllowCookieAccess::Allow)
-        return completionHandler({ });
+    MESSAGE_CHECK(HashSet<String>::isValidValue(host));
+    MESSAGE_CHECK(protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, URL { host }) != NetworkProcess::AllowCookieAccess::Terminate);
+
+    ASSERT(!m_hostsWithCookieListeners.contains(host));
+    m_hostsWithCookieListeners.add(host);
 
     bool startedListening = false;
     if (CheckedPtr networkStorageSession = storageSession())
@@ -997,6 +998,9 @@ void NetworkConnectionToWebProcess::subscribeToCookieChangeNotifications(const U
 
 void NetworkConnectionToWebProcess::unsubscribeFromCookieChangeNotifications(const String& host)
 {
+    MESSAGE_CHECK(HashSet<String>::isValidValue(host));
+    MESSAGE_CHECK(protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, URL { host }) != NetworkProcess::AllowCookieAccess::Terminate);
+
     bool removed = m_hostsWithCookieListeners.remove(host);
     ASSERT_UNUSED(removed, removed);
 


### PR DESCRIPTION
#### fefd6d49648deacc3f994d6aa938f152ac0e202d
<pre>
`SubscribeToCookieChangeNotifications` and `UnsubscribeFromCookieChangeNotifications` IPC messages do not verify cookie access
<a href="https://rdar.apple.com/140448767">rdar://140448767</a>

Reviewed by Chris Dumez.

Add MESSAGE_CHECK to subscribeToCookieChangeNotifications and unsubscribeFromCookieChangeNotifications as they may come from WebProcess.
These are similar checks to NetworkConnectionToWebProcess::domCookiesForHost and are necessary for subscribeToCookieChangeNotifications,
as it would otherwise allow a WebProcess to learn about new cookies.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::subscribeToCookieChangeNotifications):
(WebKit::NetworkConnectionToWebProcess::unsubscribeFromCookieChangeNotifications):

Originally-landed-as: 283286.534@safari-7620-branch (39b5b5e24156). rdar://143594069
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fefd6d49648deacc3f994d6aa938f152ac0e202d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87228 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6738 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41588 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92089 "Hash fefd6d49 for PR 39655 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/37968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7014 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14807 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/92089 "Hash fefd6d49 for PR 39655 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/37968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90230 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/7014 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/41588 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/92089 "Hash fefd6d49 for PR 39655 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/7014 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/41588 "Hash fefd6d49 for PR 39655 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37084 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/7014 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/41588 "Hash fefd6d49 for PR 39655 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93974 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14390 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/14807 "Hash fefd6d49 for PR 39655 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14594 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/41588 "Hash fefd6d49 for PR 39655 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75423 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/41588 "Hash fefd6d49 for PR 39655 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14409 "Hash fefd6d49 for PR 39655 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17597 "Hash fefd6d49 for PR 39655 does not build (failure)") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->