### PR TITLE
REGRESSION(289305@main): [Sequoia Debug] accessibility/mac/scrolling-in-pdf-crash.html is timing out(failure in EWS)

### DIFF
--- a/LayoutTests/accessibility/mac/scrolling-in-pdf-crash.html
+++ b/LayoutTests/accessibility/mac/scrolling-in-pdf-crash.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <script src="../../resources/accessibility-helper.js"></script>
 </head>
 <body>
@@ -16,8 +17,9 @@ if (window.accessibilityController) {
 
     var pageOne, pageTwo;
     var pdfAxObject, pdfLayerController;
-    requestAnimationFrame(async function() {
+    internals.registerPDFTest(async () => {
         await new Promise((resolve) => setTimeout(resolve, 0)); // Wait for the embed plugin to load after style update.
+        await UIHelper.waitForPDFFadeIn();
 
         await waitFor(() => {
             const embedElement = accessibilityController.accessibleElementById("pdfEmbed");
@@ -56,7 +58,7 @@ if (window.accessibilityController) {
 
         debug(output);
         finishJSTest();
-    });
+    }, plugin);
 }
 </script>
 </body>


### PR DESCRIPTION
#### 9acb41a3e29c6ad934003ed15bd0e6706b96f6fd
<pre>
REGRESSION(289305@main): [Sequoia Debug] accessibility/mac/scrolling-in-pdf-crash.html is timing out(failure in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286647">https://bugs.webkit.org/show_bug.cgi?id=286647</a>
<a href="https://rdar.apple.com/143784797">rdar://143784797</a>

Reviewed by Wenson Hsieh.

In 289305@main, we applied some test fixes under accessibility/mac, but
it seems like we forgot to give this failing test the same treatment.
This patch addresses that mistake.

* LayoutTests/accessibility/mac/scrolling-in-pdf-crash.html:

Canonical link: <a href="https://commits.webkit.org/289489@main">https://commits.webkit.org/289489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d78449795934f0053c33238c0045221d1c69f0fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37860 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67329 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25077 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47648 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93867 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76132 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75333 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7200 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13570 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14302 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->