### PR TITLE
ASAN_TRAP in WebCore::FilterEffect::takeImageInputs called from WebCore::SVGFilter::apply

### DIFF
--- a/LayoutTests/svg/filters/feMerge-zero-inputs-expected.txt
+++ b/LayoutTests/svg/filters/feMerge-zero-inputs-expected.txt
@@ -1,0 +1,3 @@
+Passes if it does not crash.
+
+

--- a/LayoutTests/svg/filters/feMerge-zero-inputs.html
+++ b/LayoutTests/svg/filters/feMerge-zero-inputs.html
@@ -1,0 +1,26 @@
+<style>
+    p {
+      filter: url(#x12);
+    }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    function main() {
+        window.resizeTo(0, 1);
+        x27.removeChild(x30);
+    }
+</script>
+<body onload="main()">
+    <p>Passes if it does not crash.</p>
+    <svg id="x11" height="14%">
+        <image href="x" href="#x32" x2="0px">
+            <filter id="x12" width="0px">
+                <feMerge id="x27" result="x27" x="825em" height="100%" y="0%">
+                    <feMergeNode id="x30" result="x30"/>
+                </feMerge>
+            </filter>
+        </image>
+    </svg>
+</body>

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -140,11 +140,11 @@ void SVGFilterPrimitiveStandardAttributes::markFilterEffectForRepaint()
 
 void SVGFilterPrimitiveStandardAttributes::markFilterEffectForRebuild()
 {
+    m_effect = nullptr;
+
     CheckedPtr renderer = this->renderer();
     if (!renderer)
         return;
-
-    m_effect = nullptr;
 
     if (auto* filterPrimitiveRenderer = dynamicDowncast<RenderSVGResourceFilterPrimitive>(renderer.get())) {
         filterPrimitiveRenderer->markFilterEffectForRebuild();


### PR DESCRIPTION
#### bd4af90cc0a25b949b09a93463e9d9028a7c20b3
<pre>
ASAN_TRAP in WebCore::FilterEffect::takeImageInputs called from WebCore::SVGFilter::apply
<a href="https://bugs.webkit.org/show_bug.cgi?id=286649">https://bugs.webkit.org/show_bug.cgi?id=286649</a>
<a href="https://rdar.apple.com/141026221">rdar://141026221</a>

Reviewed by Said Abou-Hallawa.

The bug was caused by inputs to the FEMerge being size 0.
The original size was one, but the test script deleted the
child &lt;feMergeNode&gt;. This breaks the SVGFilter.
The fix is:
SVGFilterPrimitiveStandardAttributes::markFilterEffectForRebuild()
should clear m_effect even if the renderer is null.
This will force us to try to create a new one when
applying the broken SVGFilter.

* LayoutTests/svg/filters/feMerge-zero-inputs-expected.txt: Added.
* LayoutTests/svg/filters/feMerge-zero-inputs.html: Added.
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::markFilterEffectForRebuild):

Canonical link: <a href="https://commits.webkit.org/289632@main">https://commits.webkit.org/289632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6a15de186b0972eede91f2336b2a7edef2b0e8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67540 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25275 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33518 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94185 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76360 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75575 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18617 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19957 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18381 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7541 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14621 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19916 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->