### PR TITLE
Remove WTF::allOf from the codebase.

### DIFF
--- a/Source/WTF/wtf/Algorithms.h
+++ b/Source/WTF/wtf/Algorithms.h
@@ -42,14 +42,4 @@ bool anyOf(ContainerType&& container, NOESCAPE AnyOfFunction&& anyOfFunction)
     return false;
 }
 
-template<typename ContainerType, typename AllOfFunction>
-bool allOf(ContainerType&& container, NOESCAPE AllOfFunction&& allOfFunction)
-{
-    for (auto& value : container) {
-        if (!allOfFunction(value))
-            return false;
-    }
-    return true;
-}
-
 } // namespace WTF

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -154,7 +154,7 @@ WebMediaSessionLogger& WebMediaSessionManager::logger()
 
 bool WebMediaSessionManager::alwaysOnLoggingAllowed() const
 {
-    return allOf(m_clientState, [] (auto& state) {
+    return std::ranges::all_of(m_clientState, [] (auto& state) {
         return state->client.alwaysOnLoggingAllowed();
     });
 }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -824,6 +824,12 @@ void RTCPeerConnection::updateIceConnectionState(RTCIceConnectionState)
     });
 }
 
+static bool isIceTransportUsedByTransceiver(const RTCIceTransport& iceTransport, RTCRtpTransceiver& transceiver)
+{
+    auto* dtlsTransport = transceiver.sender().transport();
+    return dtlsTransport && &dtlsTransport->iceTransport() == &iceTransport;
+}
+
 // https://w3c.github.io/webrtc-pc/#rtcpeerconnectionstate-enum
 RTCPeerConnectionState RTCPeerConnection::computeConnectionState()
 {
@@ -834,7 +840,7 @@ RTCPeerConnectionState RTCPeerConnection::computeConnectionState()
     iceTransports.removeAllMatching([&](auto& iceTransport) {
         if (m_sctpTransport && &m_sctpTransport->transport().iceTransport() == iceTransport.ptr())
             return false;
-        return allOf(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
+        return std::ranges::all_of(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
             return !isIceTransportUsedByTransceiver(iceTransport.get(), *transceiver);
         });
     });
@@ -843,7 +849,7 @@ RTCPeerConnectionState RTCPeerConnection::computeConnectionState()
     dtlsTransports.removeAllMatching([&](auto& dtlsTransport) {
         if (m_sctpTransport && &m_sctpTransport->transport() == dtlsTransport.ptr())
             return false;
-        return allOf(m_transceiverSet.list(), [&dtlsTransport](auto& transceiver) {
+        return std::ranges::all_of(m_transceiverSet.list(), [&dtlsTransport](auto& transceiver) {
             return transceiver->sender().transport() != dtlsTransport.ptr();
         });
     });
@@ -854,13 +860,17 @@ RTCPeerConnectionState RTCPeerConnection::computeConnectionState()
     if (anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Disconnected; }))
         return RTCPeerConnectionState::Disconnected;
 
-    if (allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; }) && allOf(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::New || transport->state() == RTCDtlsTransportState::Closed; }))
+    if (std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; })
+        && std::ranges::all_of(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::New || transport->state() == RTCDtlsTransportState::Closed; }))
         return RTCPeerConnectionState::New;
 
     if (anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Checking; }) || anyOf(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::New || transport->state() == RTCDtlsTransportState::Connecting; }))
         return RTCPeerConnectionState::Connecting;
 
-    ASSERT(allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }) && allOf(dtlsTransports, [](auto& transport) { return transport->state() == RTCDtlsTransportState::Connected || transport->state() == RTCDtlsTransportState::Closed; }));
+    ASSERT(std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; })
+        && std::ranges::all_of(dtlsTransports, [](auto& transport) {
+            return transport->state() == RTCDtlsTransportState::Connected || transport->state() == RTCDtlsTransportState::Closed;
+        }));
     return RTCPeerConnectionState::Connected;
 }
 
@@ -877,12 +887,6 @@ void RTCPeerConnection::updateConnectionState()
     scheduleEvent(Event::create(eventNames().connectionstatechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-static bool isIceTransportUsedByTransceiver(const RTCIceTransport& iceTransport, RTCRtpTransceiver& transceiver)
-{
-    auto* dtlsTransport = transceiver.sender().transport();
-    return dtlsTransport && &dtlsTransport->iceTransport() == &iceTransport;
-}
-
 // https://w3c.github.io/webrtc-pc/#dom-rtciceconnectionstate
 RTCIceConnectionState RTCPeerConnection::computeIceConnectionStateFromIceTransports()
 {
@@ -894,7 +898,7 @@ RTCIceConnectionState RTCPeerConnection::computeIceConnectionStateFromIceTranspo
     iceTransports.removeAllMatching([&](auto& iceTransport) {
         if (m_sctpTransport && &m_sctpTransport->transport().iceTransport() == iceTransport.ptr())
             return false;
-        return allOf(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
+        return std::ranges::all_of(m_transceiverSet.list(), [&iceTransport](auto& transceiver) {
             return !isIceTransportUsedByTransceiver(iceTransport.get(), *transceiver);
         });
     });
@@ -903,13 +907,15 @@ RTCIceConnectionState RTCPeerConnection::computeIceConnectionStateFromIceTranspo
         return RTCIceConnectionState::Failed;
     if (anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Disconnected; }))
         return RTCIceConnectionState::Disconnected;
-    if (allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; }))
+    if (std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Closed; }))
         return RTCIceConnectionState::New;
     if (anyOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::New || transport->state() == RTCIceTransportState::Checking; }))
         return RTCIceConnectionState::Checking;
-    if (allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }))
+    if (std::ranges::all_of(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }))
         return RTCIceConnectionState::Completed;
-    ASSERT(allOf(iceTransports, [](auto& transport) { return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed; }));
+    ASSERT(std::ranges::all_of(iceTransports, [](auto& transport) {
+        return transport->state() == RTCIceTransportState::Connected || transport->state() == RTCIceTransportState::Completed || transport->state() == RTCIceTransportState::Closed;
+    }));
     return RTCIceConnectionState::Connected;
 }
 

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -151,7 +151,7 @@ static inline bool isMediaStreamCorrectlyStarted(const MediaStream& stream)
     if (stream.getTracks().isEmpty())
         return false;
 
-    return WTF::allOf(stream.getTracks(), [](auto& track) {
+    return std::ranges::all_of(stream.getTracks(), [](auto& track) {
         return !track->source().captureDidFail();
     });
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1625,7 +1625,7 @@ ExceptionOr<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::createTran
         scaleValues.reserveInitialCapacity(sendEncodings.size());
         if (sendEncodings.size() == 1 && sendEncodings[0].scaleResolutionDownBy)
             scaleValues.append(sendEncodings[0].scaleResolutionDownBy.value());
-        else if (allOf(sendEncodings, [](auto& encoding) { return encoding.scaleResolutionDownBy.value_or(1) == 1; })) {
+        else if (std::ranges::all_of(sendEncodings, [](auto& encoding) { return encoding.scaleResolutionDownBy.value_or(1) == 1; })) {
             for (unsigned i = sendEncodings.size() - 1; i >= 1; i--)
                 scaleValues.append(i * 2);
             scaleValues.append(1);

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -198,7 +198,7 @@ static ExceptionOr<Ref<CSSNumericValue>> invert(Ref<CSSNumericValue>&& value)
 template<typename T>
 static RefPtr<CSSNumericValue> operationOnValuesOfSameUnit(T&& operation, const Vector<Ref<CSSNumericValue>>& values)
 {
-    bool allValuesHaveSameUnit = values.size() && WTF::allOf(values, [&] (const Ref<CSSNumericValue>& value) {
+    bool allValuesHaveSameUnit = values.size() && std::ranges::all_of(values, [&] (const Ref<CSSNumericValue>& value) {
         auto* unitValue = dynamicDowncast<CSSUnitValue>(value.get());
         return unitValue ? unitValue->unitEnum() == downcast<CSSUnitValue>(values[0].get()).unitEnum() : false;
     });
@@ -252,7 +252,7 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::multiplyInternal(Vector<Ref<C
     // https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-mul
     auto values = prependItemsOfTypeOrThis<CSSMathProduct>(WTFMove(numericValues));
 
-    bool allUnitValues = WTF::allOf(values, [&] (const Ref<CSSNumericValue>& value) {
+    bool allUnitValues = std::ranges::all_of(values, [&] (const Ref<CSSNumericValue>& value) {
         return is<CSSUnitValue>(value.get());
     });
     if (allUnitValues) {
@@ -333,9 +333,11 @@ bool CSSNumericValue::equals(FixedVector<CSSNumberish>&& values)
 {
     // https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-equals
     auto numericValues = WTF::map(WTFMove(values), rectifyNumberish);
-    return WTF::allOf(numericValues, [&] (const Ref<CSSNumericValue>& value) {
-        return this->equals(value.get());
-    });
+    for (const auto& value : numericValues) {
+        if (!this->equals(value.get()))
+            return false;
+    }
+    return true;
 }
 
 ExceptionOr<Ref<CSSUnitValue>> CSSNumericValue::to(String&& unit)

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -140,7 +140,7 @@ ExceptionOr<Ref<CSSTransformComponent>> CSSTransformValue::setItem(size_t index,
 bool CSSTransformValue::is2D() const
 {
     // https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-is2d
-    return WTF::allOf(m_components, [] (auto& component) {
+    return std::ranges::all_of(m_components, [] (auto& component) {
         return component->is2D();
     });
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -568,7 +568,7 @@ void Document::configureSharedLogger()
     if (!logger)
         return;
 
-    bool alwaysOnLoggingAllowed = !allDocumentsMap().isEmpty() && WTF::allOf(allDocumentsMap().values(), [](auto& document) {
+    bool alwaysOnLoggingAllowed = !allDocumentsMap().isEmpty() && std::ranges::all_of(allDocumentsMap().values(), [](auto& document) {
         return document->isAlwaysOnLoggingAllowed();
     });
     logger->setEnabled(sharedLoggerOwner(), alwaysOnLoggingAllowed);

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -145,7 +145,7 @@ static std::pair<std::array<int, 4>, std::array<int, 4>> boundingNeighbors(int i
     const auto compareColorsAndSetBounds = [&areColorsRelated](const auto& bytes, auto& tightestBoundingColors, auto& tightestBoundingDiff, auto colorIndex, auto neighborIndex1, auto neighborIndex2) {
         if (areColorsRelated(neighborIndex1, colorIndex, neighborIndex2)) {
             if (setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex1, colorIndex, neighborIndex2)) {
-                if (WTF::allOf(tightestBoundingDiff, [](auto& item) { return !item; })) {
+                if (std::ranges::all_of(tightestBoundingDiff, [](auto& item) { return !item; })) {
                     tightestBoundingColors = {
                         { bytes[colorIndex], bytes[colorIndex + 1], bytes[colorIndex + 2], bytes[colorIndex + 3] },
                         { bytes[colorIndex], bytes[colorIndex + 1], bytes[colorIndex + 2], bytes[colorIndex + 3] }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -802,7 +802,7 @@ bool ContentSecurityPolicy::requireTrustedTypesForSinkGroup(const String& sinkGr
 // https://w3c.github.io/trusted-types/dist/spec/#should-block-sink-type-mismatch
 bool ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup(const String& stringContext, const String& sink, const String& sinkGroup, StringView source) const
 {
-    return allOf(m_policies, [&](auto& policy) {
+    return std::ranges::all_of(m_policies, [&](auto& policy) {
         bool isAllowed = true;
         if (policy->requiresTrustedTypesForScript() && sinkGroup == "script"_s) {
             if (!policy->isReportOnly())

--- a/Source/WebCore/platform/graphics/ContentTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/ContentTypeUtilities.cpp
@@ -39,7 +39,7 @@ bool contentTypeMeetsContainerAndCodecTypeRequirements(const ContentType& type, 
     if (!allowedMediaCodecTypes)
         return true;
 
-    return WTF::allOf(type.codecs(), [&] (auto& codec) {
+    return std::ranges::all_of(type.codecs(), [&] (auto& codec) {
         return WTF::anyOf(*allowedMediaCodecTypes, [&] (auto& allowedCodec) {
             return codec.startsWith(allowedCodec);
         });

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -385,7 +385,7 @@ bool CDMPrivateFairPlayStreaming::supportsConfigurationWithRestrictions(const CD
     if (restrictions.persistentStateDenied && configuration.persistentState == CDMRequirement::Required)
         return false;
 
-    if (WTF::allOf(configuration.sessionTypes, [restrictions](auto& sessionType) {
+    if (std::ranges::all_of(configuration.sessionTypes, [restrictions](auto& sessionType) {
         return restrictions.deniedSessionTypes.contains(sessionType);
     }))
         return false;

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -97,7 +97,7 @@ void GPUProcess::setScreenProperties(const WebCore::ScreenProperties& screenProp
         return;
     }
 
-    bool allScreensAreHDR = allOf(screenProperties.screenDataMap.values(), [] (auto& screenData) {
+    bool allScreensAreHDR = std::ranges::all_of(screenProperties.screenDataMap.values(), [] (auto& screenData) {
         return screenData.screenSupportsHighDynamicRange;
     });
     setShouldOverrideScreenSupportsHighDynamicRange(true, allScreensAreHDR);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -493,7 +493,7 @@ void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientO
 
     MESSAGE_CHECK(!contextOrigin.isNull());
 
-    bool isNewOrigin = WTF::allOf(m_clientOrigins.values(), [&contextOrigin](auto& origin) {
+    bool isNewOrigin = std::ranges::all_of(m_clientOrigins.values(), [&contextOrigin](auto& origin) {
         return contextOrigin != origin.clientOrigin;
     });
     RefPtr server = this->server();
@@ -539,7 +539,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
     if (!m_isThrottleable)
         updateThrottleState();
 
-    bool isDeletedOrigin = WTF::allOf(m_clientOrigins.values(), [&clientOrigin](auto& origin) {
+    bool isDeletedOrigin = std::ranges::all_of(m_clientOrigins.values(), [&clientOrigin](auto& origin) {
         return clientOrigin.clientOrigin != origin.clientOrigin;
     });
 
@@ -567,7 +567,7 @@ bool WebSWServerConnection::computeThrottleState(const RegistrableDomain& domain
     if (!server)
         return true;
 
-    return WTF::allOf(server->connections().values(), [&domain](auto& serverConnection) {
+    return std::ranges::all_of(server->connections().values(), [&domain](auto& serverConnection) {
         Ref connection = downcast<WebSWServerConnection>(serverConnection.get());
         return connection->isThrottleable() || !connection->hasMatchingClient(domain);
     });

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -128,7 +128,7 @@ static bool isEmptyOriginDirectory(const String& directory)
         , ".DS_Store"_s
 #endif
     };
-    return WTF::allOf(children, [&] (auto& child) {
+    return std::ranges::all_of(children, [&] (auto& child) {
         return invalidFileNames.contains(child);
     });
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2984,7 +2984,7 @@ void WebProcessProxy::updateRuntimeStatistics()
 
 bool WebProcessProxy::isAlwaysOnLoggingAllowed() const
 {
-    return WTF::allOf(pages(), [](auto& page) {
+    return std::ranges::all_of(pages(), [](auto& page) {
         return page->isAlwaysOnLoggingAllowed();
     });
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2201,7 +2201,7 @@ void WebProcess::clearCurrentModifierStateForTesting()
 
 bool WebProcess::areAllPagesThrottleable() const
 {
-    return WTF::allOf(m_pageMap.values(), [](auto& page) {
+    return std::ranges::all_of(m_pageMap.values(), [](auto& page) {
         return page->isThrottleable();
     });
 }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1415,7 +1415,7 @@ void WebProcess::updatePageScreenProperties()
         return;
     }
 
-    bool allPagesAreOnHDRScreens = allOf(m_pageMap.values(), [] (auto& page) {
+    bool allPagesAreOnHDRScreens = std::ranges::all_of(m_pageMap.values(), [] (auto& page) {
         return page && screenSupportsHighDynamicRange(page->localMainFrameView());
     });
     setShouldOverrideScreenSupportsHighDynamicRange(true, allPagesAreOnHDRScreens);

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -1697,7 +1697,9 @@ TEST(WTF_WeakPtr, WeakHashMapIterators)
             ASSERT(pairs.size(), 40U);
             for (unsigned i = 0; i < 50; ++i) {
                 if (!(i % 5))
-                    EXPECT_TRUE(WTF::allOf(pairs, [&](auto& item) { return item.first != objects[i].get(); }));
+                    EXPECT_TRUE(std::ranges::all_of(pairs, [&](auto& item) {
+                        return item.first != objects[i].get();
+                    }));
                 else if (!(i % 6))
                     EXPECT_TRUE(pairs.contains(std::pair { objects[i].get(), i * 51 }));
                 else
@@ -1715,7 +1717,9 @@ TEST(WTF_WeakPtr, WeakHashMapIterators)
             ASSERT(pairs.size(), 36U);
             for (unsigned i = 0; i < 50; ++i) {
                 if (!(i % 5) || !(i % 9))
-                    EXPECT_TRUE(WTF::allOf(pairs, [&](auto& item) { return item.first != objects[i].get(); }));
+                    EXPECT_TRUE(std::ranges::all_of(pairs, [&](auto& item) {
+                        return item.first != objects[i].get();
+                    }));
                 else if (!(i % 6))
                     EXPECT_TRUE(pairs.contains(std::pair { objects[i].get(), i * 51 }));
                 else


### PR DESCRIPTION
#### 3126ee91ff79ce76f1dce73e23b68fdb93484c13
<pre>
Remove WTF::allOf from the codebase.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286659">https://bugs.webkit.org/show_bug.cgi?id=286659</a>

Reviewed by NOBODY (OOPS!).

This API is not necessary with the newer version of STL.

* Source/WTF/wtf/Algorithms.h:
(WTF::allOf): Deleted.
* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::WebMediaSessionManager::alwaysOnLoggingAllowed const):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::isIceTransportUsedByTransceiver):
(WebCore::RTCPeerConnection::computeConnectionState):
(WebCore::RTCPeerConnection::computeIceConnectionStateFromIceTransports):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::isMediaStreamCorrectlyStarted):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::createTransceiverBackends):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::operationOnValuesOfSameUnit):
(WebCore::CSSNumericValue::multiplyInternal):
(WebCore::CSSNumericValue::equals):
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::is2D const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::configureSharedLogger):
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::boundingNeighbors):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowMissingTrustedTypesForSinkGroup const):
* Source/WebCore/platform/graphics/ContentTypeUtilities.cpp:
(WebCore::contentTypeMeetsContainerAndCodecTypeRequirements):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMPrivateFairPlayStreaming::supportsConfigurationWithRestrictions const):
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::setScreenProperties):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::isEmptyOriginDirectory):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::isAlwaysOnLoggingAllowed const):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::areAllPagesThrottleable const):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::updatePageScreenProperties):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST(WTF_WeakPtr, WeakHashMapIterators)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3126ee91ff79ce76f1dce73e23b68fdb93484c13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38481 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67736 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25484 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48107 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37589 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80530 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94483 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86507 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14900 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10937 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76589 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75824 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18617 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7874 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20219 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109001 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14660 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26209 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->