### PR TITLE
Web Inspector: Enable Memory profiling in Workers

### DIFF
--- a/LayoutTests/inspector/heap/getPreview.html
+++ b/LayoutTests/inspector/heap/getPreview.html
@@ -53,8 +53,8 @@ function test()
                 HeapAgent.snapshot((error, timestamp, snapshotStringData) => { // Newly created objects.
                     InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                     let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                    workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                        let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                    workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                        let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                         snapshot.instancesWithClassName("string", (strings) => {
                             let heapSnapshotNode = strings.reduce((result, x) => result.id < x.id ? x : result, strings[0]);
                             HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
@@ -78,8 +78,8 @@ function test()
                 HeapAgent.snapshot((error, timestamp, snapshotStringData) => { // Newly created objects.
                     InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                     let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                    workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                        let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                    workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                        let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                         snapshot.instancesWithClassName("Function", (functions) => {
                             let heapSnapshotNode = functions.reduce((result, x) => result.id < x.id ? x : result, functions[0]);
                             HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
@@ -103,8 +103,8 @@ function test()
                 HeapAgent.snapshot((error, timestamp, snapshotStringData) => { // Newly created objects.
                     InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                     let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                    workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                        let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                    workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                        let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                         snapshot.instancesWithClassName("Map", (maps) => {
                             let heapSnapshotNode = maps.reduce((result, x) => result.id < x.id ? x : result, maps[0]);
                             HeapAgent.getPreview(heapSnapshotNode.id, (error, string, functionDetails, objectPreviewPayload) => {
@@ -143,8 +143,8 @@ function test()
                 HeapAgent.snapshot((error, timestamp, snapshotStringData) => { // Newly created objects.
                     InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                     let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                    workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                        let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                    workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                        let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
 
                         InspectorTest.evaluateInPage("triggerDeleteMapObject()");
                         HeapAgent.gc();

--- a/LayoutTests/inspector/heap/getRemoteObject.html
+++ b/LayoutTests/inspector/heap/getRemoteObject.html
@@ -34,8 +34,8 @@ function test()
             HeapAgent.snapshot((error, timestamp, snapshotStringData) => {
                 InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                 let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                    let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                    let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                     snapshot.instancesWithClassName("Window", (windowHeapSnapshotNodes) => {
                         if (!windowHeapSnapshotNodes.length) {
                             reject("Should should include at least one 'Window' instance.");
@@ -85,8 +85,8 @@ function test()
                 HeapAgent.snapshot((error, timestamp, snapshotStringData) => { // Newly created objects.
                     InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                     let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                    workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                        let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                    workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                        let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                         snapshot.instancesWithClassName("Map", (maps) => {
                             InspectorTest.expectThat(maps.length, "Should should include at least one 'Map' instance.");
 

--- a/LayoutTests/inspector/heap/imported-snapshot.html
+++ b/LayoutTests/inspector/heap/imported-snapshot.html
@@ -16,11 +16,12 @@ function test()
 
                 const importedTitle = "Imported Snapshot";
                 let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                    let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                    let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                     snapshot.snapshotStringData = snapshotStringData;
                     workerProxy.createImportedSnapshot(snapshotStringData, importedTitle, ({objectId, snapshot: serializedSnapshot}) => {
-                        let importedSnapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                        const target = null;
+                        let importedSnapshot = WI.HeapSnapshotProxy.deserialize(target, objectId, serializedSnapshot);
                         importedSnapshot.snapshotStringData = snapshotStringData;
 
                         InspectorTest.expectFalse(snapshot.imported, "Normal snapshot is not imported.");

--- a/LayoutTests/inspector/heap/snapshot.html
+++ b/LayoutTests/inspector/heap/snapshot.html
@@ -14,8 +14,8 @@ function test()
             HeapAgent.snapshot((error, timestamp, snapshotStringData) => {
                 InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                 let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                    let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                    let snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                     InspectorTest.expectThat(snapshot.totalSize > 1024, "Snapshot size should be greater than 1kb.");
                     InspectorTest.expectThat(snapshot.totalObjectCount > 100, "Snapshot object count should be greater than 100.");
                     InspectorTest.expectThat(snapshot.categories.get("Window"), "Snapshot should include a class category for 'Window'.");

--- a/LayoutTests/inspector/unit-tests/heap-snapshot-collection-event.html
+++ b/LayoutTests/inspector/unit-tests/heap-snapshot-collection-event.html
@@ -26,8 +26,8 @@ function test()
             HeapAgent.snapshot((error, timestamp, snapshotStringData) => {
                 InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                 let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                    snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                    snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                     InspectorTest.expectThat(snapshot, "Should create HeapSnapshotProxy snapshot.");
                     resolve();
                 });
@@ -43,7 +43,7 @@ function test()
             let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
             HeapAgent.snapshot((error, timestamp, snapshotStringData) => {
                 InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
-                workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
                     // Ignore result. This should trigger the collection event.
                 });
             });

--- a/LayoutTests/inspector/unit-tests/heap-snapshot.html
+++ b/LayoutTests/inspector/unit-tests/heap-snapshot.html
@@ -139,8 +139,8 @@ function test()
                 InspectorTest.expectThat(!error, "Should not have an error creating a snapshot.");
                 testSnapshot = WI.TestHeapSnapshot.fromPayload(JSON.parse(snapshotStringData));
                 let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-                workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-                    snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                workerProxy.createSnapshot(WI.mainTarget.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+                    snapshot = WI.HeapSnapshotProxy.deserialize(WI.mainTarget, objectId, serializedSnapshot);
                     InspectorTest.assert(testSnapshot, "Created TestHeapSnapshot");
                     InspectorTest.assert(snapshot, "Created HeapSnapshotProxy");
                     InspectorTest.expectThat(snapshot.totalSize === testSnapshot.totalSize, "Snapshots totalSize should match.");

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -40,6 +40,8 @@ localizedStrings["%d Unsupported (plural)"] = "%d Unsupported";
 localizedStrings["%d Unsupported (singular)"] = "%d Unsupported";
 localizedStrings["%d Warning"] = "%d Warning";
 localizedStrings["%d Warnings"] = "%d Warnings";
+/* Label for JavaScript heap snapshot identifier and user provided name. */
+localizedStrings["%d \u2014 \u201C%s\u201D"] = "%d \u2014 \u201C%s\u201D";
 localizedStrings["%d \xd7 %d pixels"] = "%d \xd7 %d pixels";
 localizedStrings["%d \xd7 %d pixels (Natural: %d \xd7 %d pixels)"] = "%d \xd7 %d pixels (Natural: %d \xd7 %d pixels)";
 localizedStrings["%d domain"] = "%d domain";
@@ -922,7 +924,7 @@ localizedStrings["Import Recording"] = "Import Recording";
 localizedStrings["Import audit or result"] = "Import audit or result";
 localizedStrings["Imported"] = "Imported";
 localizedStrings["Imported - %s"] = "Imported - %s";
-localizedStrings["Imported \u2014 %s"] = "Imported \u2014 %s";
+localizedStrings["Imported Snapshot \u2014 %s"] = "Imported Snapshot \u2014 %s";
 localizedStrings["Include original request data"] = "Include original request data";
 localizedStrings["Include original response data"] = "Include original response data";
 localizedStrings["Incomplete"] = "Incomplete";
@@ -1251,6 +1253,7 @@ localizedStrings["Page Overlay Options @ Layout Panel Grid Section Header"] = "P
 localizedStrings["Page Overlays @ Layout Sidebar Section Header"] = "Grid Overlays";
 /* Heading for list of flex container nodes */
 localizedStrings["Page Overlays for Flex containers @ Layout Sidebar Section Header"] = "Flexbox Overlays";
+localizedStrings["Page Snapshot %s"] = "Page Snapshot %s";
 localizedStrings["Page navigated at %s"] = "Page navigated at %s";
 localizedStrings["Page reloaded at %s"] = "Page reloaded at %s";
 /* Paint (render) phase timeline records */
@@ -1603,8 +1606,6 @@ localizedStrings["Skip Network @ Local Override Popover Options"] = "Skip Networ
 localizedStrings["Slashed Zeros @ Font Details Sidebar Property Value"] = "Slashed Zeros";
 /* Property value for `font-variant-capitals: small-caps`. */
 localizedStrings["Small Capitals @ Font Details Sidebar Property Value"] = "Small Capitals";
-localizedStrings["Snapshot %d"] = "Snapshot %d";
-localizedStrings["Snapshot %d \u2014 %s"] = "Snapshot %d \u2014 %s";
 localizedStrings["Snapshot Comparison (%d and %d)"] = "Snapshot Comparison (%d and %d)";
 localizedStrings["Snapshot List"] = "Snapshot List";
 localizedStrings["Socket"] = "Socket";
@@ -1993,6 +1994,7 @@ localizedStrings["With Object Properties"] = "With Object Properties";
 localizedStrings["Worker"] = "Worker";
 localizedStrings["Worker Thread"] = "Worker Thread";
 localizedStrings["Worker Threads"] = "Worker Threads";
+localizedStrings["Worker \u201C%s\u201D Snapshot %s"] = "Worker \u201C%s\u201D Snapshot %s";
 localizedStrings["Worker: %s"] = "Worker: %s";
 /* Title for list of JavaScript web worker execution contexts */
 localizedStrings["Workers @ Execution Context Picker"] = "Workers";

--- a/Source/WebInspectorUI/UserInterface/Controllers/HeapManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/HeapManager.js
@@ -85,11 +85,10 @@ WI.HeapManager = class HeapManager extends WI.Object
         this._enabled = false;
     }
 
-    snapshot(callback)
+    snapshot(target, callback)
     {
         console.assert(this._enabled);
 
-        let target = WI.assumingMainTarget();
         target.HeapAgent.snapshot((error, timestamp, snapshotStringData) => {
             if (error)
                 console.error(error);
@@ -102,8 +101,7 @@ WI.HeapManager = class HeapManager extends WI.Object
         console.assert(this._enabled);
         console.assert(node instanceof WI.HeapSnapshotNodeProxy);
 
-        let target = WI.assumingMainTarget();
-        target.HeapAgent.getPreview(node.id, (error, string, functionDetails, preview) => {
+        node.target.HeapAgent.getPreview(node.id, (error, string, functionDetails, preview) => {
             if (error)
                 console.error(error);
             callback(error, string, functionDetails, preview);
@@ -115,8 +113,7 @@ WI.HeapManager = class HeapManager extends WI.Object
         console.assert(this._enabled);
         console.assert(node instanceof WI.HeapSnapshotNodeProxy);
 
-        let target = WI.assumingMainTarget();
-        target.HeapAgent.getRemoteObject(node.id, objectGroup, (error, result) => {
+        node.target.HeapAgent.getRemoteObject(node.id, objectGroup, (error, result) => {
             if (error)
                 console.error(error);
             callback(error, result);
@@ -128,10 +125,6 @@ WI.HeapManager = class HeapManager extends WI.Object
     garbageCollected(target, payload)
     {
         if (!this._enabled)
-            return;
-
-        // FIXME: <https://webkit.org/b/167323> Web Inspector: Enable Memory profiling in Workers
-        if (target !== WI.mainTarget)
             return;
 
         let collection = WI.GarbageCollection.fromPayload(payload);

--- a/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js
@@ -49,7 +49,8 @@ WI.HeapAllocationsTimelineRecord = class HeapAllocationsTimelineRecord extends W
         return await new Promise((resolve, reject) => {
             let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
             workerProxy.createImportedSnapshot(snapshotStringData, title, ({objectId, snapshot: serializedSnapshot}) => {
-                let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+                const target = null;
+                let snapshot = WI.HeapSnapshotProxy.deserialize(target, objectId, serializedSnapshot);
                 snapshot.snapshotStringData = snapshotStringData;
                 resolve(new WI.HeapAllocationsTimelineRecord(timestamp, snapshot));
             });

--- a/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
@@ -51,8 +51,8 @@ WI.ConsoleObserver = class ConsoleObserver extends InspectorBackend.Dispatcher
     heapSnapshot(timestamp, snapshotStringData, title)
     {
         let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-        workerProxy.createSnapshot(snapshotStringData, title || null, ({objectId, snapshot: serializedSnapshot}) => {
-            let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+        workerProxy.createSnapshot(this._target.identifier, snapshotStringData, title || null, ({objectId, snapshot: serializedSnapshot}) => {
+            let snapshot = WI.HeapSnapshotProxy.deserialize(this._target, objectId, serializedSnapshot);
             snapshot.snapshotStringData = snapshotStringData;
             WI.timelineManager.heapSnapshotAdded(timestamp, snapshot);
         });

--- a/Source/WebInspectorUI/UserInterface/Protocol/HeapObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/HeapObserver.js
@@ -35,8 +35,8 @@ WI.HeapObserver = class HeapObserver extends InspectorBackend.Dispatcher
     trackingStart(timestamp, snapshotStringData)
     {
         let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-        workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-            let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+        workerProxy.createSnapshot(this._target.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+            let snapshot = WI.HeapSnapshotProxy.deserialize(this._target, objectId, serializedSnapshot);
             snapshot.snapshotStringData = snapshotStringData;
             WI.timelineManager.heapTrackingStarted(timestamp, snapshot);
         });
@@ -45,8 +45,8 @@ WI.HeapObserver = class HeapObserver extends InspectorBackend.Dispatcher
     trackingComplete(timestamp, snapshotStringData)
     {
         let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
-        workerProxy.createSnapshot(snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
-            let snapshot = WI.HeapSnapshotProxy.deserialize(objectId, serializedSnapshot);
+        workerProxy.createSnapshot(this._target.identifier, snapshotStringData, ({objectId, snapshot: serializedSnapshot}) => {
+            let snapshot = WI.HeapSnapshotProxy.deserialize(this._target, objectId, serializedSnapshot);
             snapshot.snapshotStringData = snapshotStringData;
             WI.timelineManager.heapTrackingCompleted(timestamp, snapshot);
         });

--- a/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
+++ b/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
@@ -54,7 +54,7 @@ WI.HeapSnapshotWorkerProxy = class HeapSnapshotWorkerProxy extends WI.Object
         this.performAction("clearSnapshots", callback);
     }
 
-    createSnapshot(snapshotStringData, callback)
+    createSnapshot(targetId, snapshotStringData, callback)
     {
         this.performAction("createSnapshot", ...arguments);
     }
@@ -66,8 +66,8 @@ WI.HeapSnapshotWorkerProxy = class HeapSnapshotWorkerProxy extends WI.Object
 
     createImportedSnapshot(snapshotStringData, title, callback)
     {
-        const imported = true;
-        this.performAction("createSnapshot", snapshotStringData, title, imported, callback);
+        const targetId = null;
+        this.performAction("createSnapshot", targetId, snapshotStringData, title, callback);
     }
 
     // Public

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClusterContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClusterContentView.js
@@ -75,6 +75,7 @@ WI.HeapSnapshotClusterContentView = class HeapSnapshotClusterContentView extends
         case "Promise":
         case "Error":
         case "Window":
+        case "DedicatedWorkerGlobalScope":
         case "Map Iterator":
         case "Set Iterator":
         case "Math":

--- a/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js
@@ -254,7 +254,7 @@ WI.HeapSnapshotInstancesDataGridTree = class HeapSnapshotInstancesDataGridTree e
     }
 };
 
-WI.HeapSnapshotObjectGraphDataGridTree = class HeapSnapshotInstancesDataGridTree extends WI.HeapSnapshotDataGridTree
+WI.HeapSnapshotObjectGraphDataGridTree = class HeapSnapshotObjectGraphDataGridTree extends WI.HeapSnapshotDataGridTree
 {
     get alwaysShowRetainedSize()
     {
@@ -275,7 +275,8 @@ WI.HeapSnapshotObjectGraphDataGridTree = class HeapSnapshotInstancesDataGridTree
                 this.appendChild(new WI.HeapSnapshotInstanceDataGridNode(instance, this));
         });
 
-        this.heapSnapshot.instancesWithClassName("Window", (instances) => {
+        let rootClassName = this.heapSnapshot.target.type === WI.TargetType.Worker ? "DedicatedWorkerGlobalScope" : "Window";
+        this.heapSnapshot.instancesWithClassName(rootClassName, (instances) => {
             for (let instance of instances) {
                 // FIXME: Why is the window.Window Function classified as a Window?
                 // In any case, ignore objects not dominated by the root, as they

--- a/Source/WebInspectorUI/UserInterface/Views/TextNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TextNavigationItem.css
@@ -40,3 +40,9 @@
 .navigation-bar .item:last-child.text {
     padding-inline-end: 2px;
 }
+
+@media (prefers-color-scheme: dark) {
+    .navigation-bar .item.text {
+        color: var(--text-color-secondary);
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
@@ -295,12 +295,15 @@ WI.TimelineTabContentView = class TimelineTabContentView extends WI.ContentBrows
             if (timelineRecord.name)
                 return WI.UIString("Frame %d \u2014 %s").format(timelineRecord.frameNumber, timelineRecord.name);
             return WI.UIString("Frame %d").format(timelineRecord.frameNumber);
-        case WI.TimelineRecord.Type.HeapAllocations:
-            if (timelineRecord.heapSnapshot.imported)
-                return WI.UIString("Imported \u2014 %s").format(timelineRecord.heapSnapshot.title);
-            if (timelineRecord.heapSnapshot.title)
-                return WI.UIString("Snapshot %d \u2014 %s").format(timelineRecord.heapSnapshot.identifier, timelineRecord.heapSnapshot.title);
-            return WI.UIString("Snapshot %d").format(timelineRecord.heapSnapshot.identifier);
+        case WI.TimelineRecord.Type.HeapAllocations: {
+            let snapshot = timelineRecord.heapSnapshot;
+            if (snapshot.imported)
+                return WI.UIString("Imported Snapshot \u2014 %s").format(snapshot.title || snapshot.identifier);
+            let title = snapshot.title ? WI.UIString("%d \u2014 \u201C%s\u201D", "Label for JavaScript heap snapshot identifier and user provided name.").format(snapshot.identifier, snapshot.title) : snapshot.identifier;
+            if (snapshot.target.type === WI.TargetType.Worker)
+                return WI.UIString("Worker \u201C%s\u201D Snapshot %s").format(snapshot.target.displayName, title);
+            return WI.UIString("Page Snapshot %s").format(title);
+        }
         case WI.TimelineRecord.Type.Media:
             // Since the `displayName` can be specific to an `animation-name`/`transition-property`,
             // use the generic `subtitle` text instead of we are rendering from the overview.

--- a/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshotWorker.js
+++ b/Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshotWorker.js
@@ -47,13 +47,13 @@ HeapSnapshotWorker = class HeapSnapshotWorker
         this._snapshots = [];
     }
 
-    createSnapshot(snapshotString, title, imported)
+    createSnapshot(targetId, snapshotString, title, imported)
     {
         let objectId = this._nextObjectId++;
-        let snapshot = new HeapSnapshot(objectId, snapshotString, title, imported);
+        let snapshot = new HeapSnapshot(targetId, objectId, snapshotString, title);
         this._objects.set(objectId, snapshot);
 
-        if (!imported) {
+        if (!snapshot.imported) {
             this._snapshots.push(snapshot);
 
             if (this._snapshots.length > 1) {


### PR DESCRIPTION
#### 4464c381ec4f5eed56465fd656bf37b3835b9a4a
<pre>
Web Inspector: Enable Memory profiling in Workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=167323">https://bugs.webkit.org/show_bug.cgi?id=167323</a>

Reviewed by BJ Burg.

The Web Inspector frontend always assumes the main target when interacting with `Heap`, meaning that even though `Heap` is already enabled inside `Worker` (i.e. there&apos;s even a `WebHeapAgent`) it&apos;ll never communicate with any other `WI.Target`.

Note that there are still a few things missing from full support as `Timelines` currently only supports the main target (e.g. auto-capture in `Worker` on page load won&apos;t happen).

* Source/WebInspectorUI/UserInterface/Models/HeapAllocationsInstrument.js:
(WI.HeapAllocationsInstrument.prototype.startInstrumentation):
(WI.HeapAllocationsInstrument.prototype.stopInstrumentation):
(WI.HeapAllocationsInstrument.prototype._takeHeapSnapshot):
Start and stop `Heap` for each `WI.Target` instead of just the main target.

* Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js:
(WI.ConsoleObserver.prototype.heapSnapshot):
* Source/WebInspectorUI/UserInterface/Protocol/HeapObserver.js:
(WI.HeapObserver.prototype.trackingStart):
(WI.HeapObserver.prototype.trackingComplete):
* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotDiffProxy.js:
(WI.HeapSnapshotDiffProxy):
(WI.HeapSnapshotDiffProxy.deserialize):
(WI.HeapSnapshotDiffProxy.prototype.get target): Added.
(WI.HeapSnapshotDiffProxy.prototype.instancesWithClassName):
(WI.HeapSnapshotDiffProxy.prototype.nodeWithIdentifier):
* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotNodeProxy.js:
(WI.HeapSnapshotNodeProxy):
(WI.HeapSnapshotNodeProxy.deserialize):
(WI.HeapSnapshotNodeProxy.prototype.get target): Added.
(WI.HeapSnapshotNodeProxy.prototype.shortestGCRootPath):
(WI.HeapSnapshotNodeProxy.prototype.dominatedNodes):
(WI.HeapSnapshotNodeProxy.prototype.retainedNodes):
(WI.HeapSnapshotNodeProxy.prototype.retainers):
* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotProxy.js:
(WI.HeapSnapshotProxy):
(WI.HeapSnapshotProxy.deserialize):
(WI.HeapSnapshotProxy.prototype.get target): Added.
(WI.HeapSnapshotProxy.prototype.get imported):
(WI.HeapSnapshotProxy.prototype.instancesWithClassName):
(WI.HeapSnapshotProxy.prototype.nodeWithIdentifier):
Pass along the `WI.Target` when handling events or creating new proxies.

* Source/WebInspectorUI/UserInterface/Controllers/HeapManager.js:
(WI.HeapManager.prototype.snapshot):
(WI.HeapManager.prototype.getPreview):
(WI.HeapManager.prototype.getRemoteObject):
(WI.HeapManager.prototype.garbageCollected):
Use the relevant `WI.Target` instead of just the main target.

* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js:
(WI.HeapSnapshotWorkerProxy.prototype.createImportedSnapshot):
* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshot.js:
(HeapSnapshot):
(HeapSnapshot.prototype.updateDeadNodesAndGatherCollectionData):
(HeapSnapshot.prototype.serialize):
(HeapSnapshot.prototype._isNodeGlobalObject):
* Source/WebInspectorUI/UserInterface/Workers/HeapSnapshot/HeapSnapshotWorker.js:
(HeapSnapshotWorker.prototype.createSnapshot):
Pass along a `targetId` so that when new heap snapshots are captured we can determine which previous snapshots to update for what&apos;s still live.
Keep a separate identifier counter for each title instead of a single global one (e.g. &quot;Page 1&quot; and &quot;Worker 1&quot; instead of &quot;Page 1&quot; and &quot;Worker 2&quot;).
Drive-by: Fix an exception after 284791@main caused by `_roots` (and `_labels`) not always being set.

* Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js:
(WI.HeapAllocationsTimelineRecord.async fromJSON):
Imported heap snapshots won&apos;t have a target.

* Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js:
(WI.HeapAllocationsTimelineView):
(WI.HeapAllocationsTimelineView.prototype._importButtonNavigationItemClicked):
(WI.HeapAllocationsTimelineView.prototype._takeHeapSnapshotClicked):
(WI.HeapAllocationsTimelineView.prototype._dataGridNodeSelected):
Allow for heap snapshots to be sorted by name since there&apos;s now more than just &quot;Snapshot #&quot;.

* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotClusterContentView.js:
(WI.HeapSnapshotClusterContentView.iconStyleClassNameForClassName):
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotDataGridTree.js:
(WI.HeapSnapshotObjectGraphDataGridTree.prototype.populateTopLevel):
* Source/WebInspectorUI/UserInterface/Views/HeapSnapshotInstanceDataGridNode.js:
(WI.HeapSnapshotInstanceDataGridNode.logHeapSnapshotNode):
(WI.HeapSnapshotInstanceDataGridNode.prototype.createCellContent):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populateWindowPreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._populatePreview):
(WI.HeapSnapshotInstanceDataGridNode.prototype._mouseoverHandler):
(WI.HeapSnapshotInstanceDataGridNode.prototype._mouseoverHandler.appendPath):
(WI.HeapSnapshotInstanceDataGridNode.prototype._mouseoverHandler.appendPathRow):
Don&apos;t assume that the root is named &quot;Window&quot;, as `Worker` should be &quot;DedicatedWorkerGlobalScope&quot;.

* Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js:
(WI.TimelineTabContentView.displayNameForRecord):
Change how heap snapshots are named now that they&apos;re captured in the page and `Worker`.

* Source/WebInspectorUI/UserInterface/Views/TextNavigationItem.css:
(@media (prefers-color-scheme: dark) .navigation-bar .item.text): Added.
Drive-by: Fix heap snapshot diff text color not being visible in dark mode.

* LayoutTests/inspector/heap/getPreview.html:
* LayoutTests/inspector/heap/getRemoteObject.html:
* LayoutTests/inspector/heap/imported-snapshot.html:
* LayoutTests/inspector/heap/snapshot.html:
* LayoutTests/inspector/unit-tests/heap-snapshot.html:
* LayoutTests/inspector/unit-tests/heap-snapshot-collection-event.html:

Canonical link: <a href="https://commits.webkit.org/289847@main">https://commits.webkit.org/289847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ab7cbd6267748837457c74c50f7e5666046e333

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42600 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15889 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/93145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91194 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79766 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/38050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35059 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/94991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15362 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/94991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15618 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75622 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/94991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20537 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15380 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/18568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->