### PR TITLE
WritingTools.ProofreadingAcceptReject API test is failing

### DIFF
--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
@@ -353,7 +353,9 @@ extension WKIntelligenceReplacementTextEffectCoordinator: PlatformIntelligenceTe
             if let onFlushCompletion = self.onFlushCompletion {
                 // At this point, the last chunk has been received, and the session has ended, so the flush completion
                 // handler can now be invoked now that the animation is fully complete. There is no need to additionally
-                // restore the selection here since the selection would have already been restored when the session ended.
+                // restore the selection here since the selection would have already been restored when the session ended,
+                // if reverted, or the selection should not be restored at all if the session has already ended
+                // and has been accepted.
 
                 await onFlushCompletion()
                 self.onFlushCompletion = nil

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -303,7 +303,7 @@ using PlatformTextPlaceholder = NSTextPlaceholder;
 - (void)waitForProofreadingSuggestionsToBeReplaced
 {
     // FIXME: Avoid using a hard-coded delay.
-    TestWebKitAPI::Util::runFor(1.0_s);
+    TestWebKitAPI::Util::runFor(3.0_s);
 }
 
 @end


### PR DESCRIPTION
#### 6f7da1ea96ee43f2d39032af5e4a558951b57cbc
<pre>
WritingTools.ProofreadingAcceptReject API test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=286606">https://bugs.webkit.org/show_bug.cgi?id=286606</a>
<a href="https://rdar.apple.com/143731399">rdar://143731399</a>

Reviewed by Abrar Rahman Protyasha.

Update the selection restoration logic when a Writing Tools session ends to adhere to the correct behavior,
as described in the inline comments.

Also update the hard-coded delay in the test file to ensure that the animation is actually fully complete.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView didEndWritingToolsSession:accepted:]):
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift:
(WKIntelligenceReplacementTextEffectCoordinator.replacementEffectDidComplete(_:)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(-[WritingToolsWKWebView waitForProofreadingSuggestionsToBeReplaced]):

Canonical link: <a href="https://commits.webkit.org/289525@main">https://commits.webkit.org/289525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b2314588737f05ee056e4eb8c2f1b277ebcd492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67344 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25085 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93884 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76151 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18127 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7217 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13590 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19612 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14064 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->