### PR TITLE
Crash under WTF::Detail::CallableWrapper<WebCore::AudioSessionMac::handleDefaultDeviceChange>

### DIFF
--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -32,8 +32,9 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Observer.h>
-#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
@@ -101,7 +102,7 @@ public:
     virtual void sampleRateDidChange(const AudioSession&) { }
 };
 
-class WEBCORE_EXPORT AudioSession : public ThreadSafeRefCounted<AudioSession> {
+class WEBCORE_EXPORT AudioSession : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AudioSession> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(AudioSession, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(AudioSession);
 public:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -46,8 +46,7 @@ class RemoteAudioSession final
     : public WebCore::AudioSession
     , public WebCore::AudioSessionInterruptionObserver
     , public GPUProcessConnection::Client
-    , IPC::MessageReceiver
-    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession> {
+    , IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioSession);
 public:
     static Ref<RemoteAudioSession> create();


### PR DESCRIPTION
#### 4932734fe3705e5099ffd9522c9bacf7f353e1c3
<pre>
Crash under WTF::Detail::CallableWrapper&lt;WebCore::AudioSessionMac::handleDefaultDeviceChange&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=286663">https://bugs.webkit.org/show_bug.cgi?id=286663</a>
<a href="https://rdar.apple.com/143505451">rdar://143505451</a>

Reviewed by Jer Noble.

AudioSessionMac was calling `callOnMainThread()` in several places and capturing a raw pointer
to the session. That pointer may no longer be valid once the lambda runs asynchronously.

To address the issue, use AudioObjectAddPropertyListenerBlock() instead of AudioObjectAddPropertyListener()
so we can pass a block capturing a ThreadSafeWeakPtr to the session and so that we can request it be
dispatched to the main queue.

* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::removePropertyListenersForDefaultDevice const):
(WebCore::AudioSessionMac::handleDefaultDeviceChange):
(WebCore::AudioSessionMac::addDefaultDeviceObserverIfNeeded const):
(WebCore::AudioSessionMac::addSampleRateObserverIfNeeded const):
(WebCore::AudioSessionMac::addBufferSizeObserverIfNeeded const):
(WebCore::AudioSessionMac::addMuteChangeObserverIfNeeded const):
(WebCore::AudioSessionMac::removeMuteChangeObserverIfNeeded const):
(WebCore::AudioSessionMac::handleSampleRateChange): Deleted.
(WebCore::AudioSessionMac::handleBufferSizeChange): Deleted.
(WebCore::handleMutePropertyChange): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:

Canonical link: <a href="https://commits.webkit.org/289502@main">https://commits.webkit.org/289502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df8b01b5bd728e36720a67b1e7c8e2b388353b28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47669 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93890 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76152 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75353 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7223 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13575 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14325 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19618 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14070 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->