### PR TITLE
Make WTF HashMap::{Keys, Values} std::ranges compatible

### DIFF
--- a/Source/WTF/wtf/HashIterators.h
+++ b/Source/WTF/wtf/HashIterators.h
@@ -62,7 +62,7 @@ namespace WTF {
         const ValueType* operator->() const { return get(); }
 
         HashTableConstIteratorAdapter& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableConstIteratorAdapter& operator++(int) { auto result = *this; ++m_impl; return result; }
 
         Keys keys() { return Keys(*this); }
         Values values() { return Values(*this); }
@@ -92,7 +92,7 @@ namespace WTF {
         ValueType* operator->() const { return get(); }
 
         HashTableIteratorAdapter& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableIteratorAdapter& operator++(int) { auto result = *this; ++m_impl; return result; }
 
         operator HashTableConstIteratorAdapter<HashTableType, ValueType>() {
             typename HashTableType::const_iterator i = m_impl;
@@ -117,6 +117,7 @@ namespace WTF {
         typedef HashTableConstIteratorAdapter<HashTableType, KeyValuePair<KeyType, MappedType>> ConstIterator;
 
     public:
+        HashTableConstKeysIterator() { }
         HashTableConstKeysIterator(const ConstIterator& impl) : m_impl(impl) {}
         
         const KeyType* get() const { return &(m_impl.get()->key); }
@@ -124,7 +125,7 @@ namespace WTF {
         const KeyType* operator->() const { return get(); }
 
         HashTableConstKeysIterator& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableConstKeysIterator& operator++(int) { auto result = *this; ++m_impl; return result; }
 
         ConstIterator m_impl;
     };
@@ -141,6 +142,7 @@ namespace WTF {
         typedef HashTableConstIteratorAdapter<HashTableType, KeyValuePair<KeyType, MappedType>> ConstIterator;
 
     public:
+        HashTableConstValuesIterator() { }
         HashTableConstValuesIterator(const ConstIterator& impl) : m_impl(impl) {}
         
         const MappedType* get() const { return std::addressof(m_impl.get()->value); }
@@ -148,7 +150,7 @@ namespace WTF {
         const MappedType* operator->() const { return get(); }
 
         HashTableConstValuesIterator& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableConstValuesIterator& operator++(int) { auto result = *this; ++m_impl; return result; }
 
         ConstIterator m_impl;
     };
@@ -166,6 +168,7 @@ namespace WTF {
         typedef HashTableConstIteratorAdapter<HashTableType, KeyValuePair<KeyType, MappedType>> ConstIterator;
 
     public:
+        HashTableKeysIterator() { }
         HashTableKeysIterator(const Iterator& impl) : m_impl(impl) {}
         
         KeyType* get() const { return &(m_impl.get()->key); }
@@ -173,7 +176,7 @@ namespace WTF {
         KeyType* operator->() const { return get(); }
 
         HashTableKeysIterator& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableKeysIterator& operator++(int) { auto result = *this; ++m_impl; return result; }
 
         operator HashTableConstKeysIterator<HashTableType, KeyType, MappedType>() {
             ConstIterator i = m_impl;
@@ -196,6 +199,7 @@ namespace WTF {
         typedef HashTableConstIteratorAdapter<HashTableType, KeyValuePair<KeyType, MappedType>> ConstIterator;
 
     public:
+        HashTableValuesIterator() { }
         HashTableValuesIterator(const Iterator& impl) : m_impl(impl) {}
         
         MappedType* get() const { return std::addressof(m_impl.get()->value); }
@@ -203,7 +207,7 @@ namespace WTF {
         MappedType* operator->() const { return get(); }
 
         HashTableValuesIterator& operator++() { ++m_impl; return *this; }
-        // postfix ++ intentionally omitted
+        HashTableValuesIterator& operator++(int) { auto result = *this; ++m_impl; return result; }
 
         operator HashTableConstValuesIterator<HashTableType, KeyType, MappedType>() {
             ConstIterator i = m_impl;

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -1287,4 +1287,31 @@ TEST(WTF_HashMap, GetOptional)
 
 }
 
+TEST(WTF_HashMap, KeysValuesRangesAllAnyNoneOf)
+{
+    IntHashMap map;
+    map.add(1, 1);
+    map.add(2, 2);
+    map.add(3, 3);
+
+    EXPECT_TRUE(std::ranges::all_of(map.keys(), [] (int el) {
+        return el < 4;
+    }));
+    EXPECT_TRUE(std::ranges::none_of(map.keys(), [] (int el) {
+        return el > 4;
+    }));
+    EXPECT_TRUE(std::ranges::any_of(map.keys(), [] (int el) {
+        return el < 2;
+    }));
+    EXPECT_TRUE(std::ranges::all_of(map.values(), [] (int el) {
+        return el < 4;
+    }));
+    EXPECT_TRUE(std::ranges::none_of(map.values(), [] (int el) {
+        return el > 4;
+    }));
+    EXPECT_TRUE(std::ranges::any_of(map.values(), [] (int el) {
+        return el < 2;
+    }));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 075b01389171cd5e22e3ad906f34bf36ae048d4f
<pre>
Make WTF HashMap::{Keys, Values} std::ranges compatible
<a href="https://bugs.webkit.org/show_bug.cgi?id=286665">https://bugs.webkit.org/show_bug.cgi?id=286665</a>

Reviewed by Sam Weinig and Darin Adler.

Follow up of #39593.

* Source/WTF/wtf/HashIterators.h:
(WTF::HashTableConstKeysIterator::HashTableConstKeysIterator):
(WTF::HashTableConstKeysIterator::operator++):
(WTF::HashTableConstValuesIterator::HashTableConstValuesIterator):
(WTF::HashTableConstValuesIterator::operator++):
(WTF::HashTableKeysIterator::HashTableKeysIterator):
(WTF::HashTableKeysIterator::operator++):
(WTF::HashTableValuesIterator::HashTableValuesIterator):
(WTF::HashTableValuesIterator::operator++):
* Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp:
(TestWebKitAPI::TEST(WTF_HashMap, KeysValuesRangesAllAnyNoneOf)):

Canonical link: <a href="https://commits.webkit.org/289560@main">https://commits.webkit.org/289560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc459ccbbcd5a6929877d91ea2d460929eb60bfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25104 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5088 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33266 "Found 2 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37012 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79941 "Found 1449 new JSC stress test failures: cdjs-tests.yaml/main.js.ftl-eager-no-cjit, cdjs-tests.yaml/red_black_tree_test.js.ftl-eager-no-cjit, microbenchmarks/Int16Array-load-int-mul.js.ftl-eager-no-cjit, microbenchmarks/Int8Array-load-with-byteLength.js.ftl-eager-no-cjit, microbenchmarks/abc-simple-backward-loop.js.ftl-eager-no-cjit, microbenchmarks/abc-simple-forward-loop.js.ftl-eager-no-cjit, microbenchmarks/abs-boolean.js.ftl-eager-no-cjit, microbenchmarks/aliased-arguments-getbyval.js.ftl-eager-no-cjit, microbenchmarks/arguments-named-and-reflective.js.lockdown, microbenchmarks/arguments-strict-mode.js.ftl-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93902 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85930 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76167 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75369 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18573 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19708 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18145 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7235 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14337 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19630 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108423 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14082 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26092 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17525 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->