### PR TITLE
[WebGPU] Out of order encoding and submission leads to potential incorrect validation

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -48,11 +48,12 @@ struct WGPUBufferImpl {
 
 namespace WebGPU {
 
+class CommandBuffer;
 class CommandEncoder;
 class Device;
 
 // https://gpuweb.github.io/gpuweb/#gpubuffer
-class Buffer : public WGPUBufferImpl, public ThreadSafeRefCounted<Buffer> {
+class Buffer : public WGPUBufferImpl, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Buffer> {
     WTF_MAKE_TZONE_ALLOCATED(Buffer);
 public:
     enum class State : uint8_t;
@@ -92,6 +93,8 @@ public:
     id<MTLBuffer> buffer() const { return m_buffer; }
     id<MTLBuffer> indirectBuffer() const;
     id<MTLBuffer> indirectIndexedBuffer() const { return m_indirectIndexedBuffer; }
+    id<MTLBuffer> indirectIndexedBuffer(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t firstInstance, id<MTLIndirectCommandBuffer> = nil);
+    id<MTLBuffer> indirectIndexedBuffer(uint32_t firstIndex, uint32_t indexCount, uint32_t firstInstance, id<MTLIndirectCommandBuffer> = nil) const;
 
     uint64_t initialSize() const;
     uint64_t currentSize() const;
@@ -111,13 +114,17 @@ public:
     void indirectBufferRecomputed(uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
     void indirectIndexedBufferRecomputed(MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
-    bool canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, id<MTLIndirectCommandBuffer> = nil) const;
-    void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, id<MTLIndirectCommandBuffer> = nil);
+    bool canSkipDrawIndexedValidation(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t firstInstance, id<MTLIndirectCommandBuffer> = nil) const;
+    void drawIndexedValidated(uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, MTLIndexType, uint32_t firstInstance, id<MTLIndirectCommandBuffer> = nil);
+    void skippedDrawIndexedValidation(CommandEncoder&, uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, uint32_t instanceCount, MTLIndexType, uint32_t firstInstance, uint32_t baseVertex, uint32_t minInstanceCount, uint32_t primitiveOffset, id<MTLIndirectCommandBuffer> = nil);
+    void skippedDrawIndirectIndexedValidation(CommandEncoder&, Buffer*, MTLIndexType, uint32_t indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType);
+    void skippedDrawIndirectValidation(CommandEncoder&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
     bool didReadOOB(id<MTLIndirectCommandBuffer> = nil) const;
     void didReadOOB(uint32_t v, id<MTLIndirectCommandBuffer> = nil);
 
-    void indirectBufferInvalidated();
+    void indirectBufferInvalidated(CommandEncoder* = nullptr);
+    void indirectBufferInvalidated(CommandEncoder&);
 #if ENABLE(WEBGPU_SWIFT)
     void copyFrom(const std::span<const uint8_t>, const size_t offset) HAS_SWIFTCXX_THUNK;
 #endif
@@ -136,6 +143,11 @@ private:
     void setState(State);
     void incrementBufferMapCount();
     void decrementBufferMapCount();
+    id<MTLBuffer> makeIndexIndirectBuffer();
+    uint64_t mapGPUAddress(MTLResourceID, uint32_t firstInstance) const;
+    void takeSlowIndexValidationPath(CommandBuffer&, uint32_t firstIndex, uint32_t indexCount, uint32_t vertexCount, uint32_t instanceCount, MTLIndexType, uint32_t firstInstance, uint32_t baseVertex, uint32_t minInstanceCount, uint32_t primitiveOffset);
+    void takeSlowIndirectIndexValidationPath(CommandBuffer&, Buffer&, MTLIndexType, uint32_t indexBufferOffsetInBytes, uint32_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType);
+    void takeSlowIndirectValidationPath(CommandBuffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
 private PUBLIC_IN_WEBGPU_SWIFT:
     id<MTLBuffer> m_buffer { nil };
@@ -168,6 +180,9 @@ private:
 
     const Ref<Device> m_device;
     mutable WeakHashSet<CommandEncoder> m_commandEncoders;
+    mutable HashMap<uint64_t, uint32_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_gpuResourceMap;
+    WeakHashSet<CommandEncoder> m_skippedValidationCommandEncoders;
+    bool m_mustTakeSlowIndexValidationPath { false };
 #if CPU(X86_64)
     bool m_mappedAtCreation { false };
 #endif

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -44,9 +44,9 @@ class Device;
 class CommandBuffer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CommandBuffer>, public WGPUCommandBufferImpl {
     WTF_MAKE_TZONE_ALLOCATED(CommandBuffer);
 public:
-    static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, Device& device, id<MTLSharedEvent> sharedEvent, uint64_t sharedEventSignalValue, CommandEncoder& commandEncoder)
+    static Ref<CommandBuffer> create(id<MTLCommandBuffer> commandBuffer, Device& device, id<MTLSharedEvent> sharedEvent, uint64_t sharedEventSignalValue, Vector<Function<void(CommandBuffer&)>>&& onCommitHandlers, CommandEncoder& commandEncoder)
     {
-        return adoptRef(*new CommandBuffer(commandBuffer, device, sharedEvent, sharedEventSignalValue, commandEncoder));
+        return adoptRef(*new CommandBuffer(commandBuffer, device, sharedEvent, sharedEventSignalValue, WTFMove(onCommitHandlers), commandEncoder));
     }
     static Ref<CommandBuffer> createInvalid(Device& device)
     {
@@ -69,9 +69,12 @@ public:
 
     NSString* lastError() const;
     bool waitForCompletion();
+    void preCommitHandler();
+    void postCommitHandler();
+    void addPostCommitHandler(Function<void(id<MTLCommandBuffer>)>&&);
 
 private:
-    CommandBuffer(id<MTLCommandBuffer>, Device&, id<MTLSharedEvent>, uint64_t sharedEventSignalValue, CommandEncoder&);
+    CommandBuffer(id<MTLCommandBuffer>, Device&, id<MTLSharedEvent>, uint64_t sharedEventSignalValue, Vector<Function<void(CommandBuffer&)>>&&, CommandEncoder&);
     CommandBuffer(Device&);
     void retainTimestampsForOneUpdateLoop();
 
@@ -82,6 +85,8 @@ private:
     const Ref<Device> m_device;
     NSString* m_lastErrorString { nil };
     id<MTLSharedEvent> m_sharedEvent { nil };
+    Vector<Function<void(CommandBuffer&)>> m_preCommitHandlers;
+    Vector<Function<void(id<MTLCommandBuffer>)>> m_postCommitHandlers;
     const uint64_t m_sharedEventSignalValue { 0 };
     // FIXME: we should not need this semaphore - https://bugs.webkit.org/show_bug.cgi?id=272353
     BinarySemaphore m_commandBufferComplete;

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -31,6 +31,7 @@
 #import "WebGPU.h"
 #import "WebGPUExt.h"
 #import <wtf/FastMalloc.h>
+#import <wtf/Function.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/RetainReleaseSwift.h>
@@ -127,6 +128,7 @@ public:
     static void trackEncoder(CommandEncoder&, WeakHashSet<CommandEncoder>&);
     uint64_t uniqueId() const { return m_uniqueId; }
     NSMutableSet<id<MTLCounterSampleBuffer>> *timestampBuffers() const { return m_retainedTimestampBuffers; };
+    void addOnCommitHandler(Function<void(CommandBuffer&)>&&);
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&, uint64_t uniqueId);
@@ -173,6 +175,7 @@ private:
     NSMutableSet<id<MTLBuffer>> *m_retainedBuffers { nil };
     HashSet<RefPtr<const Sampler>> m_retainedSamplers;
     NSMutableSet<id<MTLCounterSampleBuffer>> *m_retainedTimestampBuffers { nil };
+    Vector<Function<void(CommandBuffer&)>> m_onCommitHandlers;
     id<MTLSharedEvent> m_sharedEvent { nil };
     uint64_t m_sharedEventSignalValue { 0 };
 private PUBLIC_IN_WEBGPU_SWIFT:

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -855,7 +855,7 @@ extension WebGPU.CommandEncoder {
         // FIXME: rdar://138042799 remove default argument.
         source.setCommandEncoder(self, false)
         destination.setCommandEncoder(self, false)
-        destination.indirectBufferInvalidated()
+        destination.indirectBufferInvalidated(self)
         guard size != 0, !source.isDestroyed() && !destination.isDestroyed() else {
             return
         }
@@ -887,7 +887,7 @@ extension WebGPU.CommandEncoder {
         let apiDestinationBuffer = WebGPU.fromAPI(destination.buffer)
         sourceTexture.setCommandEncoder(self)
         apiDestinationBuffer.setCommandEncoder(self, false)
-        apiDestinationBuffer.indirectBufferInvalidated()
+        apiDestinationBuffer.indirectBufferInvalidated(self)
         guard !sourceTexture.isDestroyed() && !apiDestinationBuffer.isDestroyed() else {
             return
         }
@@ -1470,7 +1470,7 @@ extension WebGPU.CommandEncoder {
         }
         // FIXME: rdar://138042799 need to pass in the default argument.
         buffer.setCommandEncoder(self, false)
-        buffer.indirectBufferInvalidated()
+        buffer.indirectBufferInvalidated(self)
         guard let offsetInt = Int(exactly: offset), let sizeInt = Int(exactly: size) else {
             return
         }
@@ -1497,7 +1497,7 @@ extension WebGPU.CommandEncoder {
         querySet.setCommandEncoder(self)
         // FIXME: rdar://138042799 need to pass in the default argument.
         destination.setCommandEncoder(self, false)
-        destination.indirectBufferInvalidated();
+        destination.indirectBufferInvalidated(self);
         guard !(querySet.isDestroyed() || destination.isDestroyed() || queryCount == 0) else {
             return
         }

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -102,6 +102,7 @@ private:
     const Ref<Device> m_device;
     MTLSize m_threadsPerThreadgroup;
     Vector<uint32_t> m_computeDynamicOffsets;
+    Vector<uint32_t> m_priorComputeDynamicOffsets;
     RefPtr<const ComputePipeline> m_pipeline;
     Ref<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -109,7 +109,7 @@ public:
     static std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer*, Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, bool& splitEncoder);
     static std::pair<id<MTLBuffer>, uint64_t> clampIndirectBufferToValidValues(Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, bool& splitEncoder);
     enum class IndexCall { Draw, IndirectDraw, Skip, CachedIndirectDraw };
-    static IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, RenderPassEncoder&, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
+    static std::pair<IndexCall, id<MTLBuffer>> clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, RenderPassEncoder&, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
     void splitRenderPass();
     static std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount(const RenderPipeline*, bool& needsValidationLayerWorkaround, uint64_t (^)(uint32_t));
 
@@ -133,7 +133,7 @@ private:
     bool issuedDrawCall() const;
     void incrementDrawCount(uint32_t = 1);
     bool occlusionQueryIsDestroyed() const;
-    IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, bool& needsValidationLayerWorkaround);
+    std::pair<IndexCall, id<MTLBuffer>> clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, bool& needsValidationLayerWorkaround);
     std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount(bool& needsValidationLayerWorkaround) const;
     std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool& splitEncoder);
     std::pair<id<MTLBuffer>, uint64_t> clampIndirectBufferToValidValues(Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool& splitEncoder);
@@ -157,7 +157,9 @@ private:
     bool m_depthReadOnly { false };
     bool m_stencilReadOnly { false };
     Vector<uint32_t> m_vertexDynamicOffsets;
+    Vector<uint32_t> m_priorVertexDynamicOffsets;
     Vector<uint32_t> m_fragmentDynamicOffsets;
+    Vector<uint32_t> m_priorFragmentDynamicOffsets;
     Ref<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
     using EntryUsage = OptionSet<BindGroupEntryUsage>;


### PR DESCRIPTION
#### cb889bc9fe7ef028ee24aa8c822832e4be6495d1
<pre>
[WebGPU] Out of order encoding and submission leads to potential incorrect validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=286669">https://bugs.webkit.org/show_bug.cgi?id=286669</a>
<a href="https://rdar.apple.com/143806368">rdar://143806368</a>

Reviewed by Dan Glastonbury.

Since we attempt to avoid repeated vertex buffer validation, out of order
encoding may allow for skipping validation incorrectly.

This out of order encoding which mutates the index buffer seems incredibly uncommon.
I have not trigged the issue on a single site I&apos;m aware of.

The performance is quite bad but it does not appear anyone is intentionally doing
anything of this nature, so this PR is for correctness.

* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::span):
(WebGPU::Buffer::makeIndexIndirectBuffer):
(WebGPU::Buffer::getBufferContents):
(WebGPU::Buffer::mapGPUAddress const):
(WebGPU::Buffer::canSkipDrawIndexedValidation const):
(WebGPU::Buffer::drawIndexedValidated):
(WebGPU::verifyIndexBufferData):
(WebGPU::Buffer::takeSlowIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectIndexValidationPath):
(WebGPU::verifyIndirectBufferData):
(WebGPU::Buffer::takeSlowIndirectValidationPath):
(WebGPU::Buffer::skippedDrawIndexedValidation):
(WebGPU::Buffer::skippedDrawIndirectIndexedValidation):
(WebGPU::Buffer::skippedDrawIndirectValidation):
(WebGPU::Buffer::didReadOOB):
(WebGPU::Buffer::indirectBufferInvalidated):
* Source/WebGPU/WebGPU/CommandBuffer.h:
(WebGPU::CommandBuffer::create):
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::CommandBuffer):
(WebGPU::CommandBuffer::makeInvalid):
(WebGPU::CommandBuffer::preCommitHandler):
(WebGPU::CommandBuffer::postCommitHandler):
(WebGPU::CommandBuffer::addPostCommitHandler):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::copyBufferToBuffer):
(WebGPU::CommandEncoder::copyTextureToBuffer):
(WebGPU::CommandEncoder::clearBuffer):
(WebGPU::CommandEncoder::finish):
(WebGPU::CommandEncoder::resolveQuerySet):
(WebGPU::CommandEncoder::addOnCommitHandler):
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.copyBufferToBuffer(_:sourceOffset:destination:destinationOffset:size:)):
(WebGPU.copyTextureToBuffer(_:destination:copySize:)):
(WebGPU.clearBuffer(_:offset:size:)):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::addResourceToActiveResources):
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/Queue.h:
(WebGPU::Queue::WTF_GUARDED_BY_LOCK):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::waitForAllCommitedWorkToComplete):
(WebGPU::Queue::commitMTLCommandBuffer):
(WebGPU::Queue::submit):
(WebGPU::Queue::synchronizeResourceAndWait):
(WebGPU::Queue::clearBuffer):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::drawIndexed):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::addResourceToActiveResources):
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::checkForIndirectDrawDeviceLost):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectBufferToValidValues):
(WebGPU::RenderPassEncoder::drawIndexed):
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/290044@main">https://commits.webkit.org/290044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e33ccaea4c624e1d442140634b502fd96b6bf62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93621 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16362 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91661 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38521 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95459 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15834 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16090 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/20888 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15850 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19040 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->