### PR TITLE
Release assertion failure in LegacyRenderSVGShape::strokeBoundingBox()

### DIFF
--- a/LayoutTests/svg/crash-svg-filter-empty-viewport-expected.txt
+++ b/LayoutTests/svg/crash-svg-filter-empty-viewport-expected.txt
@@ -1,0 +1,17 @@
+Verify there is no crash when setting x/y baseVal on a filter referencing an empty viewport
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS x.unitType is SVGLength.SVG_LENGTHTYPE_PERCENTAGE
+PASS x.value is -0
+PASS x.unitType is SVGLength.SVG_LENGTHTYPE_PERCENTAGE
+PASS x.value is 0
+PASS y.unitType is SVGLength.SVG_LENGTHTYPE_PERCENTAGE
+PASS y.value is -0
+PASS y.unitType is SVGLength.SVG_LENGTHTYPE_PERCENTAGE
+PASS y.value is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/crash-svg-filter-empty-viewport.svg
+++ b/LayoutTests/svg/crash-svg-filter-empty-viewport.svg
@@ -1,0 +1,28 @@
+<svg width="0" height="0" xmlns="http://www.w3.org/2000/svg" onload="test()">
+  <script href="../resources/js-test.js"/>
+  <filter id="filter"></filter>
+  <marker id="marker" orient="1" filter="url(#filter)"></marker>
+  <line marker-end="url(#marker)"></line>
+  <script>
+    description('Verify there is no crash when setting x/y baseVal on a filter referencing an empty viewport');
+
+    function test() {
+      let filter = document.getElementById("filter");
+      x = filter.x.baseVal;
+      shouldBe('x.unitType', "SVGLength.SVG_LENGTHTYPE_PERCENTAGE");
+      shouldBe('x.value', "-0");
+      x.value = 1;
+      shouldBe('x.unitType', "SVGLength.SVG_LENGTHTYPE_PERCENTAGE");
+      shouldBe('x.value', "0");
+      y = filter.y.baseVal;
+      shouldBe("y.unitType", "SVGLength.SVG_LENGTHTYPE_PERCENTAGE");
+      shouldBe("y.value", "-0");
+      y.value = 2;
+      shouldBe("y.unitType", "SVGLength.SVG_LENGTHTYPE_PERCENTAGE");
+      shouldBe("y.value", "0");
+
+      if (window.testRunner)
+        testRunner.dumpAsText();
+    }
+  </script>
+</svg>

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -198,7 +198,10 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToPercentage(float
     if (!viewportSize)
         return Exception { ExceptionCode::NotSupportedError };
 
-    return value / dimensionForLengthMode(lengthMode, *viewportSize) * 100;
+    if (auto divisor = dimensionForLengthMode(lengthMode, *viewportSize))
+        return value / divisor * 100;
+
+    return value;
 }
 
 ExceptionOr<float> SVGLengthContext::convertValueFromPercentageToUserUnits(float value, SVGLengthMode lengthMode) const


### PR DESCRIPTION
#### 6866936923f71c78e121c3f98c950ada4a991841
<pre>
Release assertion failure in LegacyRenderSVGShape::strokeBoundingBox()
<a href="https://bugs.webkit.org/show_bug.cgi?id=285429">https://bugs.webkit.org/show_bug.cgi?id=285429</a>

Reviewed by Said Abou-Hallawa.

The test case converts the SVG baseVal x/y values on the filter from a percentage to a
user unit. To do this convertValueFromUserUnitsToPercentage is used, but the divisor
in the calculation will be zero since the filter width/height is zero (due to empty outer svg viewport), so in the
end SVG baseVal x/y values will be set to NaN.

This causes a problem on when calculating the filter repaint rect in SVGRenderSupport::intersectRepaintRectWithResources
since the x and y values are NaN, causing m_accurateRepaintBoundingBox to be an empty Markable object and thus the
Release assertion failure upon dereference.

To fix this detect whenever the divisor is zero in convertValueFromUserUnitsToPercentage and return 0 if so.

* LayoutTests/svg/crash-svg-filter-empty-viewport-expected.txt: Added.
* LayoutTests/svg/crash-svg-filter-empty-viewport.svg: Added.
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueFromUserUnitsToPercentage const):

Canonical link: <a href="https://commits.webkit.org/289664@main">https://commits.webkit.org/289664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b0386a4f1498690a13458993d31ec9a5da4c4c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67616 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25366 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33616 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37399 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14709 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10793 "Found 1 new test failure: imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76451 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20051 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7663 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20028 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->