### PR TITLE
Unreviewed build fix after 289347@main

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.cpp
@@ -40,4 +40,9 @@ WebTransportBidirectionalStreamConstructionParameters& WebTransportBidirectional
 
 WebTransportBidirectionalStreamConstructionParameters::~WebTransportBidirectionalStreamConstructionParameters() = default;
 
+WebTransportBidirectionalStreamConstructionParameters WebTransportBidirectionalStreamConstructionParameters::isolatedCopy() &&
+{
+    return { identifier, Ref { sink } };
+}
+
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.h
@@ -41,7 +41,7 @@ struct WebTransportBidirectionalStreamConstructionParameters {
     WEBCORE_EXPORT WebTransportBidirectionalStreamConstructionParameters(WebTransportBidirectionalStreamConstructionParameters&&);
     WEBCORE_EXPORT WebTransportBidirectionalStreamConstructionParameters& operator=(WebTransportBidirectionalStreamConstructionParameters&&);
     WEBCORE_EXPORT ~WebTransportBidirectionalStreamConstructionParameters();
-    WebTransportBidirectionalStreamConstructionParameters isolatedCopy() && { return { identifier, Ref { sink } }; }
+    WEBCORE_EXPORT WebTransportBidirectionalStreamConstructionParameters isolatedCopy() &&;
 
     WebTransportStreamIdentifier identifier;
     Ref<WritableStreamSink> sink;


### PR DESCRIPTION
#### 767f2908b78d877f0f48e735931552093a2e0b88
<pre>
Unreviewed build fix after 289347@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=286683">https://bugs.webkit.org/show_bug.cgi?id=286683</a>
<a href="https://rdar.apple.com/143823660">rdar://143823660</a>

* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.cpp:
(WebCore::WebTransportBidirectionalStreamConstructionParameters::isolatedCopy):
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamConstructionParameters.h:
(WebCore::WebTransportBidirectionalStreamConstructionParameters::isolatedCopy): Deleted.

Canonical link: <a href="https://commits.webkit.org/289500@main">https://commits.webkit.org/289500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fc83d0f5f91c6cb0305b6956c9e11ddb928e913

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87189 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14768 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5343 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/47708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5116 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75599 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/34172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14351 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14555 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/74773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75390 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/19735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7280 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13574 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19663 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14115 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->