### PR TITLE
[JSC] Add `constinit` specifier for generated C++ sources for YARR

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.cpp
+++ b/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.cpp
@@ -55,8 +55,8 @@ constexpr char32_t ucs2CharacterSet20[] = { 0x0462, 0x0463, 0x1c87, 0 };
 constexpr char32_t ucs2CharacterSet21[] = { 0x1e60, 0x1e61, 0x1e9b, 0 };
 constexpr char32_t ucs2CharacterSet22[] = { 0x1c88, 0xa64a, 0xa64b, 0 };
 
-static constexpr size_t ucs2CanonicalizationSets = 23;
-const char32_t* const ucs2CharacterSetInfo[ucs2CanonicalizationSets] = {
+static constinit const size_t ucs2CanonicalizationSets = 23;
+constinit const char32_t* const ucs2CharacterSetInfo[ucs2CanonicalizationSets] = {
     ucs2CharacterSet0,
     ucs2CharacterSet1,
     ucs2CharacterSet2,
@@ -82,8 +82,8 @@ const char32_t* const ucs2CharacterSetInfo[ucs2CanonicalizationSets] = {
     ucs2CharacterSet22,
 };
 
-const size_t ucs2CanonicalizationRanges = 460;
-const CanonicalizationRange ucs2RangeInfo[ucs2CanonicalizationRanges] = {
+constinit const size_t ucs2CanonicalizationRanges = 460;
+constinit const CanonicalizationRange ucs2RangeInfo[ucs2CanonicalizationRanges] = {
     { 0x0000, 0x0040, 0x0000, CanonicalizeUnique },
     { 0x0041, 0x005a, 0x0020, CanonicalizeRangeLo },
     { 0x005b, 0x0060, 0x0000, CanonicalizeUnique },
@@ -546,7 +546,7 @@ const CanonicalizationRange ucs2RangeInfo[ucs2CanonicalizationRanges] = {
     { 0xff5b, 0xffff, 0x0000, CanonicalizeUnique },
 };
 
-const uint16_t canonicalTableLChar[256] = {
+constinit const uint16_t canonicalTableLChar[256] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
     0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,

--- a/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.js
+++ b/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.js
@@ -171,15 +171,15 @@ function createTables(prefix, maxValue, canonicalGroups)
     }
     print();
     const canonicalizationSetsVarName = `${prefixLower}CanonicalizationSets`;
-    print(`static constexpr size_t ${canonicalizationSetsVarName} = ${characterSetInfo.length};`);
-    print(`const char32_t* const ${prefixLower}CharacterSetInfo[${canonicalizationSetsVarName}] = {`);
+    print(`static constinit const size_t ${canonicalizationSetsVarName} = ${characterSetInfo.length};`);
+    print(`constinit const char32_t* const ${prefixLower}CharacterSetInfo[${canonicalizationSetsVarName}] = {`);
     for (i in characterSetInfo)
         print(`    ${characterSetVarName + i},`);
     print("};");
     print();
     const canonicalizationRangesVarName = `${prefixLower}CanonicalizationRanges`;
-    print(`const size_t ${canonicalizationRangesVarName} = ${rangeInfo.length};`);
-    print(`const CanonicalizationRange ${prefixLower}RangeInfo[${canonicalizationRangesVarName}] = {`);
+    print(`constinit const size_t ${canonicalizationRangesVarName} = ${rangeInfo.length};`);
+    print(`constinit const CanonicalizationRange ${prefixLower}RangeInfo[${canonicalizationRangesVarName}] = {`);
     for (i in rangeInfo) {
         var info = rangeInfo[i];
         var typeAndValue = info.type.split(':');
@@ -188,7 +188,7 @@ function createTables(prefix, maxValue, canonicalGroups)
     print("};");
     print();
     // Create canonical table for LChar domain
-    let line = "const uint16_t canonicalTableLChar[256] = {";
+    let line = "constinit const uint16_t canonicalTableLChar[256] = {";
     for (let i = 0; i < 256; i++) {
         if (!(i % 16)) {
             print(line);

--- a/Source/JavaScriptCore/yarr/create_regex_tables
+++ b/Source/JavaScriptCore/yarr/create_regex_tables
@@ -63,7 +63,7 @@ for name, classes in types.items():
     ranges.sort();
     
     if emitTables and classes["UseTable"] and (not "Inverse" in classes):
-        array = ("static const char _%sData[65536] = {\n" % name);
+        array = ("static constinit const char _%sData[65536] = {\n" % name);
         i = 0
         for (min,max) in ranges:
             while i < min:

--- a/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
+++ b/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
@@ -605,7 +605,7 @@ class PropertyData:
             propertyData.dump(file, propertyData != cls.allPropertyData[-1])
 
         file.write("using CreateCharacterClass = std::unique_ptr<CharacterClass> (*)();\n")
-        file.write("static CreateCharacterClass createCharacterClassFunctions[{}] = {{\n   ".format(len(cls.allPropertyData)))
+        file.write("static constinit CreateCharacterClass createCharacterClassFunctions[{}] = {{\n   ".format(len(cls.allPropertyData)))
         functionsOnThisLine = 0
         for propertyData in cls.allPropertyData:
             file.write(" {},".format(propertyData.getCreateFuncName()))
@@ -650,7 +650,7 @@ class PropertyData:
                 hashTable[hash] = (len(valueTable), None)
                 valueTable.append((key, keyValue[1]))
 
-            hashTableString += "static const struct HashIndex {}TableIndex[{}] = {{\n".format(tablePrefix, len(hashTable))
+            hashTableString += "static constinit const struct HashIndex {}TableIndex[{}] = {{\n".format(tablePrefix, len(hashTable))
 
             for tableIndex in hashTable:
                 value = -1
@@ -664,12 +664,12 @@ class PropertyData:
 
             hashTableString += "};\n\n"
 
-            hashTableString += "static const struct HashValue {}TableValue[{}] = {{\n".format(tablePrefix, len(valueTable))
+            hashTableString += "static constinit const struct HashValue {}TableValue[{}] = {{\n".format(tablePrefix, len(valueTable))
             for value in valueTable:
                 hashTableString += "    {{ \"{}\", {} }},\n".format(value[0], value[1])
             hashTableString += "};\n\n"
 
-            hashTableString += "static const struct HashTable {}HashTable = \n".format(tablePrefix)
+            hashTableString += "static constinit const struct HashTable {}HashTable = \n".format(tablePrefix)
             hashTableString += "    {{ {}, {}, {}TableValue, {}TableIndex }};\n\n".format(len(valueTable), hashMask, tablePrefix, tablePrefix)
             return hashTableString
 

--- a/Source/JavaScriptCore/yarr/hasher.py
+++ b/Source/JavaScriptCore/yarr/hasher.py
@@ -242,7 +242,7 @@ def createHashTable(keys, hashTableName):
             if depth > maxDepth:
                 maxDepth = depth
 
-        string = "static const struct CompactHashIndex {}[{}] = {{\n".format(hashTableName, compactSize)
+        string = "static constinit const struct CompactHashIndex {}[{}] = {{\n".format(hashTableName, compactSize)
         for i in range(compactSize):
             T = -1
             if i in table:


### PR DESCRIPTION
#### 586a345ddf5b3ce3314c68ab10701a41873ea9ac
<pre>
[JSC] Add `constinit` specifier for generated C++ sources for YARR
<a href="https://bugs.webkit.org/show_bug.cgi?id=286686">https://bugs.webkit.org/show_bug.cgi?id=286686</a>

Reviewed by Yusuke Suzuki and Keith Miller.

This ensures that they&apos;re static initialization explicitly and just for readability.
This does a same thing in bug 286413.

* Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.cpp: I made this change by:
  `/System/Library/Frameworks/JavaScriptCore.framework/Versions/Current/Helpers/jsc ./YarrCanonicalizeUCS2.js &gt; ./YarrCanonicalizeUCS2.cpp`
  on macOS 15.3（24D60).
* Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.js:
(characters.string_appeared_here.set characterSetInfo):
* Source/JavaScriptCore/yarr/create_regex_tables:
* Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py:
(PropertyData.dumpAll):
(PropertyData.createAndDumpHashTable.createAndDumpHashTableHelper):
* Source/JavaScriptCore/yarr/hasher.py:
(createHashTable.createHashTableHelper):

Canonical link: <a href="https://commits.webkit.org/290480@main">https://commits.webkit.org/290480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/240990abfec713a804f346ec0bb85595fe6ab8c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69390 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26990 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49751 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36132 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40034 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82970 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96953 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88905 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77591 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22043 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20641 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10545 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17325 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22651 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111396 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17066 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26671 "Found 3 new JSC stress test failures: wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->