### PR TITLE
[JSC] YARR: Update UCS canonicalization tables

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrCanonicalize.h
+++ b/Source/JavaScriptCore/yarr/YarrCanonicalize.h
@@ -52,7 +52,7 @@ struct CanonicalizationRange {
     UCS2CanonicalizationType type;
 };
 
-extern const size_t UCS2_CANONICALIZATION_RANGES;
+extern const size_t ucs2CanonicalizationRanges;
 extern const char32_t* const ucs2CharacterSetInfo[];
 extern const CanonicalizationRange ucs2RangeInfo[];
 extern const uint16_t canonicalTableLChar[256];
@@ -73,7 +73,7 @@ inline const char32_t* canonicalCharacterSetInfo(unsigned index, CanonicalMode c
 inline const CanonicalizationRange* canonicalRangeInfoFor(char32_t ch, CanonicalMode canonicalMode = CanonicalMode::UCS2)
 {
     const CanonicalizationRange* info = canonicalMode == CanonicalMode::UCS2 ? ucs2RangeInfo : unicodeRangeInfo;
-    size_t entries = canonicalMode == CanonicalMode::UCS2 ? UCS2_CANONICALIZATION_RANGES : UNICODE_CANONICALIZATION_RANGES;
+    size_t entries = canonicalMode == CanonicalMode::UCS2 ? ucs2CanonicalizationRanges : UNICODE_CANONICALIZATION_RANGES;
 
     while (true) {
         size_t candidate = entries >> 1;

--- a/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.cpp
+++ b/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,8 +55,8 @@ constexpr char32_t ucs2CharacterSet20[] = { 0x0462, 0x0463, 0x1c87, 0 };
 constexpr char32_t ucs2CharacterSet21[] = { 0x1e60, 0x1e61, 0x1e9b, 0 };
 constexpr char32_t ucs2CharacterSet22[] = { 0x1c88, 0xa64a, 0xa64b, 0 };
 
-static constexpr size_t UCS2_CANONICALIZATION_SETS = 23;
-const char32_t* const ucs2CharacterSetInfo[UCS2_CANONICALIZATION_SETS] = {
+static constexpr size_t ucs2CanonicalizationSets = 23;
+const char32_t* const ucs2CharacterSetInfo[ucs2CanonicalizationSets] = {
     ucs2CharacterSet0,
     ucs2CharacterSet1,
     ucs2CharacterSet2,
@@ -81,8 +82,8 @@ const char32_t* const ucs2CharacterSetInfo[UCS2_CANONICALIZATION_SETS] = {
     ucs2CharacterSet22,
 };
 
-const size_t UCS2_CANONICALIZATION_RANGES = 448;
-const CanonicalizationRange ucs2RangeInfo[UCS2_CANONICALIZATION_RANGES] = {
+const size_t ucs2CanonicalizationRanges = 460;
+const CanonicalizationRange ucs2RangeInfo[ucs2CanonicalizationRanges] = {
     { 0x0000, 0x0040, 0x0000, CanonicalizeUnique },
     { 0x0041, 0x005a, 0x0020, CanonicalizeRangeLo },
     { 0x005b, 0x0060, 0x0000, CanonicalizeUnique },
@@ -212,7 +213,8 @@ const CanonicalizationRange ucs2RangeInfo[UCS2_CANONICALIZATION_RANGES] = {
     { 0x027d, 0x027d, 0x29e7, CanonicalizeRangeLo },
     { 0x027e, 0x027f, 0x0000, CanonicalizeUnique },
     { 0x0280, 0x0280, 0x00da, CanonicalizeRangeHi },
-    { 0x0281, 0x0282, 0x0000, CanonicalizeUnique },
+    { 0x0281, 0x0281, 0x0000, CanonicalizeUnique },
+    { 0x0282, 0x0282, 0xa543, CanonicalizeRangeLo },
     { 0x0283, 0x0283, 0x00da, CanonicalizeRangeHi },
     { 0x0284, 0x0286, 0x0000, CanonicalizeUnique },
     { 0x0287, 0x0287, 0xa52a, CanonicalizeRangeLo },
@@ -375,7 +377,9 @@ const CanonicalizationRange ucs2RangeInfo[UCS2_CANONICALIZATION_RANGES] = {
     { 0x1d79, 0x1d79, 0x8a04, CanonicalizeRangeLo },
     { 0x1d7a, 0x1d7c, 0x0000, CanonicalizeUnique },
     { 0x1d7d, 0x1d7d, 0x0ee6, CanonicalizeRangeLo },
-    { 0x1d7e, 0x1dff, 0x0000, CanonicalizeUnique },
+    { 0x1d7e, 0x1d8d, 0x0000, CanonicalizeUnique },
+    { 0x1d8e, 0x1d8e, 0x8a38, CanonicalizeRangeLo },
+    { 0x1d8f, 0x1dff, 0x0000, CanonicalizeUnique },
     { 0x1e00, 0x1e5f, 0x0000, CanonicalizeAlternatingAligned },
     { 0x1e60, 0x1e61, 0x0015, CanonicalizeSet },
     { 0x1e62, 0x1e95, 0x0000, CanonicalizeAlternatingAligned },
@@ -458,10 +462,8 @@ const CanonicalizationRange ucs2RangeInfo[UCS2_CANONICALIZATION_RANGES] = {
     { 0x24b6, 0x24cf, 0x001a, CanonicalizeRangeLo },
     { 0x24d0, 0x24e9, 0x001a, CanonicalizeRangeHi },
     { 0x24ea, 0x2bff, 0x0000, CanonicalizeUnique },
-    { 0x2c00, 0x2c2e, 0x0030, CanonicalizeRangeLo },
-    { 0x2c2f, 0x2c2f, 0x0000, CanonicalizeUnique },
-    { 0x2c30, 0x2c5e, 0x0030, CanonicalizeRangeHi },
-    { 0x2c5f, 0x2c5f, 0x0000, CanonicalizeUnique },
+    { 0x2c00, 0x2c2f, 0x0030, CanonicalizeRangeLo },
+    { 0x2c30, 0x2c5f, 0x0030, CanonicalizeRangeHi },
     { 0x2c60, 0x2c61, 0x0000, CanonicalizeAlternatingAligned },
     { 0x2c62, 0x2c62, 0x29f7, CanonicalizeRangeHi },
     { 0x2c63, 0x2c63, 0x0ee6, CanonicalizeRangeHi },
@@ -509,7 +511,8 @@ const CanonicalizationRange ucs2RangeInfo[UCS2_CANONICALIZATION_RANGES] = {
     { 0xa78d, 0xa78d, 0xa528, CanonicalizeRangeHi },
     { 0xa78e, 0xa78f, 0x0000, CanonicalizeUnique },
     { 0xa790, 0xa793, 0x0000, CanonicalizeAlternatingAligned },
-    { 0xa794, 0xa795, 0x0000, CanonicalizeUnique },
+    { 0xa794, 0xa794, 0x0030, CanonicalizeRangeLo },
+    { 0xa795, 0xa795, 0x0000, CanonicalizeUnique },
     { 0xa796, 0xa7a9, 0x0000, CanonicalizeAlternatingAligned },
     { 0xa7aa, 0xa7aa, 0xa544, CanonicalizeRangeHi },
     { 0xa7ab, 0xa7ab, 0xa54f, CanonicalizeRangeHi },
@@ -521,8 +524,18 @@ const CanonicalizationRange ucs2RangeInfo[UCS2_CANONICALIZATION_RANGES] = {
     { 0xa7b1, 0xa7b1, 0xa52a, CanonicalizeRangeHi },
     { 0xa7b2, 0xa7b2, 0xa515, CanonicalizeRangeHi },
     { 0xa7b3, 0xa7b3, 0x03a0, CanonicalizeRangeLo },
-    { 0xa7b4, 0xa7b9, 0x0000, CanonicalizeAlternatingAligned },
-    { 0xa7ba, 0xab52, 0x0000, CanonicalizeUnique },
+    { 0xa7b4, 0xa7c3, 0x0000, CanonicalizeAlternatingAligned },
+    { 0xa7c4, 0xa7c4, 0x0030, CanonicalizeRangeHi },
+    { 0xa7c5, 0xa7c5, 0xa543, CanonicalizeRangeHi },
+    { 0xa7c6, 0xa7c6, 0x8a38, CanonicalizeRangeHi },
+    { 0xa7c7, 0xa7ca, 0x0000, CanonicalizeAlternatingUnaligned },
+    { 0xa7cb, 0xa7cf, 0x0000, CanonicalizeUnique },
+    { 0xa7d0, 0xa7d1, 0x0000, CanonicalizeAlternatingAligned },
+    { 0xa7d2, 0xa7d5, 0x0000, CanonicalizeUnique },
+    { 0xa7d6, 0xa7d9, 0x0000, CanonicalizeAlternatingAligned },
+    { 0xa7da, 0xa7f4, 0x0000, CanonicalizeUnique },
+    { 0xa7f5, 0xa7f6, 0x0000, CanonicalizeAlternatingUnaligned },
+    { 0xa7f7, 0xab52, 0x0000, CanonicalizeUnique },
     { 0xab53, 0xab53, 0x03a0, CanonicalizeRangeHi },
     { 0xab54, 0xab6f, 0x0000, CanonicalizeUnique },
     { 0xab70, 0xabbf, 0x97d0, CanonicalizeRangeHi },

--- a/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.js
+++ b/Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.js
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +29,7 @@ function printHeader()
     var copyright = (
                      "/*"                                                                            + "\n" +
                      " * Copyright (C) 2012-2018 Apple Inc. All rights reserved."                    + "\n" +
+                     " * Copyright (C) 2025 Tetsuharu Ohzeki <tetsuharu.ohzeki@gmail.com>."          + "\n" +
                      " *"                                                                            + "\n" +
                      " * Redistribution and use in source and binary forms, with or without"         + "\n" +
                      " * modification, are permitted provided that the following conditions"         + "\n" +
@@ -109,7 +111,6 @@ function createUCS2CanonicalGroups()
 function createTables(prefix, maxValue, canonicalGroups)
 {
     var prefixLower = prefix.toLowerCase();
-    var prefixUpper = prefix.toUpperCase();
     var typeInfo = [];
     var characterSetInfo = [];
     // Pass 2: populate typeInfo & characterSetInfo. For every character calculate
@@ -160,22 +161,25 @@ function createTables(prefix, maxValue, canonicalGroups)
         rangeInfo.push({begin:begin, end:end, type:type});
     }
 
+    const characterSetVarName = `${prefixLower}CharacterSet`;
     for (i in characterSetInfo) {
         var characters = ""
         var set = characterSetInfo[i];
         for (var j in set)
             characters += hex(set[j]) + ", ";
-        print("constexpr char32_t " + prefixLower + "CharacterSet" + i + "[] = { " + characters + "0 };");
+        print(`constexpr char32_t ${characterSetVarName + i}[] = { ${characters}0 };`);
     }
     print();
-    print("static constexpr size_t " + prefixUpper + "_CANONICALIZATION_SETS = " + characterSetInfo.length + ";");
-    print("const char32_t* const " + prefixLower + "CharacterSetInfo[" + prefixUpper + "_CANONICALIZATION_SETS] = {");
+    const canonicalizationSetsVarName = `${prefixLower}CanonicalizationSets`;
+    print(`static constexpr size_t ${canonicalizationSetsVarName} = ${characterSetInfo.length};`);
+    print(`const char32_t* const ${prefixLower}CharacterSetInfo[${canonicalizationSetsVarName}] = {`);
     for (i in characterSetInfo)
-    print("    " + prefixLower + "CharacterSet" + i + ",");
+        print(`    ${characterSetVarName + i},`);
     print("};");
     print();
-    print("const size_t " + prefixUpper + "_CANONICALIZATION_RANGES = " + rangeInfo.length + ";");
-    print("const CanonicalizationRange " + prefixLower + "RangeInfo[" + prefixUpper + "_CANONICALIZATION_RANGES] = {");
+    const canonicalizationRangesVarName = `${prefixLower}CanonicalizationRanges`;
+    print(`const size_t ${canonicalizationRangesVarName} = ${rangeInfo.length};`);
+    print(`const CanonicalizationRange ${prefixLower}RangeInfo[${canonicalizationRangesVarName}] = {`);
     for (i in rangeInfo) {
         var info = rangeInfo[i];
         var typeAndValue = info.type.split(':');
@@ -205,7 +209,7 @@ function createTables(prefix, maxValue, canonicalGroups)
 
 printHeader();
 
-createTables("UCS2", MAX_UCS2, createUCS2CanonicalGroups());
+createTables("ucs2", MAX_UCS2, createUCS2CanonicalGroups());
 
 printFooter();
 


### PR DESCRIPTION
#### 99be77af7cd26a3cccfd2d037e0f0d2478d43513
<pre>
[JSC] YARR: Update UCS canonicalization tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=286687">https://bugs.webkit.org/show_bug.cgi?id=286687</a>

Reviewed by Michael Saboff.

test262 has coverage for this change.

* Source/JavaScriptCore/yarr/YarrCanonicalize.h:
(JSC::Yarr::canonicalRangeInfoFor):
* Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.cpp: I made this change by:
    `/System/Library/Frameworks/JavaScriptCore.framework/Versions/Current/Helpers/jsc ./YarrCanonicalizeUCS2.js &gt; ./YarrCanonicalizeUCS2.cpp`
  on macOS 15.3（24D60).
* Source/JavaScriptCore/yarr/YarrCanonicalizeUCS2.js: Rename some generated variable names to match our style checker.
(printHeader):
(printFooter):
(set characters.hex.set string_appeared_here):
(set characters):
(characters.string_appeared_here.set characterSetInfo):

Canonical link: <a href="https://commits.webkit.org/290334@main">https://commits.webkit.org/290334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/057d89597e6a9ec0e7eaf9efa8a0f21e140a4f5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40287 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68956 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26612 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81242 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35641 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39393 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82318 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96340 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88295 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20151 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9862 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22028 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110788 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16456 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26581 "Found 5 new JSC stress test failures: wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-collect-continuously, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19907 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->