### PR TITLE
AX: VoiceOver hangs in Safari when a select element deletes itself as a result of an onchange event

### DIFF
--- a/LayoutTests/accessibility/self-deleting-select-element-expected.txt
+++ b/LayoutTests/accessibility/self-deleting-select-element-expected.txt
@@ -1,0 +1,10 @@
+This test ensures we don't hang forever when deleting a select element from the DOM.
+
+PASS: We didn't loop infinitely as a result of the select element deleting itself.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+First text
+Make a selection:
+Last text

--- a/LayoutTests/accessibility/self-deleting-select-element.html
+++ b/LayoutTests/accessibility/self-deleting-select-element.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+First text
+<main>
+    <div>
+        <div role="group" aria-label="foo">
+            <label for="select">Make a selection:</label>
+            <select name="select" id="select">
+              <option value="">--Please choose an option--</option>
+              <option value="cat">Cat</option>
+              <option value="dog">Dog</option>
+            </select>
+        </div>
+    </div>
+</main>
+Last text
+
+<script>
+document.getElementById("select").addEventListener("change", () => {
+    document.getElementById("select").remove();
+});
+
+var output = "This test ensures we don't hang forever when deleting a select element from the DOM.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    document.getElementById("select").value = "cat";
+    // The change event is not triggered when changing the value of a select programmatically via JS, so manually dispatch
+    // a change event here.
+    document.getElementById('select').dispatchEvent(new Event("change"));
+    setTimeout(async function() {
+        touchAccessibilityTree(accessibilityController.rootElement);
+        output += "PASS: We didn't loop infinitely as a result of the select element deleting itself.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
#### edd3aebf883a942b39a45c649da0218e74b9b4c2
<pre>
AX: VoiceOver hangs in Safari when a select element deletes itself as a result of an onchange event
<a href="https://bugs.webkit.org/show_bug.cgi?id=286690">https://bugs.webkit.org/show_bug.cgi?id=286690</a>
<a href="https://rdar.apple.com/143830006">rdar://143830006</a>

Reviewed by Chris Fleizach.

AccessibilityObject::documentFrameView() is called a result of isIgnored(). When we process tree updates as a result
of a select element removing itself from the DOM, we can get into an infinite loop, as there may be strong references
to the select accessibility object on the stack, but its renderer and node are gone. So when a descendant iterates up
to it in AccessibilityObject::documentFrameView(), we try to use it to get a documentFrameView() because it
isAccessibilityRenderObject(), even though it no longer has a renderer. Then the descendant continues trying to find
a documentFrameView(), hits the renderer-less and node-less ancestor select again, repeating forever.

Fix this by making AccessibilityObject::documentFrameView() ensure the AccessibilityRenderObject or AccessibilityNodeObject
it iterates to actually has a valid node or renderer.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::documentFrameView const):
* LayoutTests/accessibility/self-deleting-select-element-expected.txt: Added.
* LayoutTests/accessibility/self-deleting-select-element.html: Added.

Canonical link: <a href="https://commits.webkit.org/289526@main">https://commits.webkit.org/289526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4db89490ae70c9dc327e7bdaf7d9c4786d3aeb95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67403 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25138 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47723 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33313 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37064 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93954 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14370 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10491 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76205 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19751 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7299 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19682 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->