### PR TITLE
Promote isZero/isEmpty/evaluate to proper customization points

### DIFF
--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,12 +78,6 @@ template<typename... Ts> inline constexpr auto TreatAsTupleLike<std::tuple<Ts...
 
 // - Variant-like
 template<typename... Ts> inline constexpr auto TreatAsVariantLike<std::variant<Ts...>> = true;
-
-// MARK: Utility Concepts
-
-template<typename T> concept HasIsZero = requires(T t) {
-    { t.isZero() } -> std::convertible_to<bool>;
-};
 
 // MARK: - Standard Leaf Types
 
@@ -393,12 +387,6 @@ template<typename T> struct SpaceSeparatedPoint {
     const T& x() const { return get<0>(value); }
     const T& y() const { return get<1>(value); }
 
-    bool isZero() const
-        requires HasIsZero<T>
-    {
-        return x().isZero() && y().isZero();
-    }
-
     SpaceSeparatedPair<T> value;
 };
 
@@ -429,18 +417,6 @@ template<typename T> struct SpaceSeparatedSize {
 
     const T& width() const { return get<0>(value); }
     const T& height() const { return get<1>(value); }
-
-    bool isZero() const
-        requires HasIsZero<T>
-    {
-        return width().isZero() && height().isZero();
-    }
-
-    bool isEmpty() const
-        requires HasIsZero<T>
-    {
-        return width().isZero() || height().isZero();
-    }
 
     SpaceSeparatedPair<T> value;
 };

--- a/Source/WebCore/css/values/CSSValueConcepts.h
+++ b/Source/WebCore/css/values/CSSValueConcepts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,5 +68,15 @@ template<typename> inline constexpr auto TreatAsVariantLike = false;
 
 // The `VariantLike` concept can be used to filter to types that specialize `TreatAsVariantLike`.
 template<typename T> concept VariantLike = TreatAsVariantLike<T>;
+
+// The `HasIsZero` concept can be used to filter to types that have an `isZero` member function.
+template<typename T> concept HasIsZero = requires(T t) {
+    { t.isZero() } -> std::convertible_to<bool>;
+};
+
+// The `HasIsEmpty` concept can be used to filter to types that have an `isEmpty` member function.
+template<typename T> concept HasIsEmpty = requires(T t) {
+    { t.isEmpty() } -> std::convertible_to<bool>;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericConcepts.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericConcepts.h
@@ -77,8 +77,11 @@ template<typename T> concept NumericRaw = std::derived_from<T, PrimitiveNumericR
 // Forward declaration of PrimitiveNumeric to needed to create a hard constraint for the Numeric concept below.
 template<NumericRaw> struct PrimitiveNumeric;
 
-// Concept for use in generic contexts to filter on numeric CSS types.
+// Concept for use in generic contexts to filter on all numeric CSS types.
 template<typename T> concept Numeric = VariantLike<T> && std::derived_from<T, PrimitiveNumeric<typename T::Raw>>;
+
+// Concept for use in generic contexts to filter on non-composite numeric CSS types.
+template<typename T> concept NonCompositeNumeric = Numeric<T> && (!CompositeUnitEnum<typename T::UnitType>);
 
 // Concept for use in generic contexts to filter on dimension-percentage numeric CSS types.
 template<typename T> concept DimensionPercentageNumeric = Numeric<T> && CompositeUnitEnum<typename T::UnitType>;

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -2,6 +2,7 @@
  * (C) 1999 Lars Knoll (knoll@kde.org)
  * (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -86,7 +87,10 @@ inline bool ShadowApplier::isLastShadowIteration()
 
 inline bool ShadowApplier::shadowIsCompletelyCoveredByText(bool textIsOpaque)
 {
-    return textIsOpaque && m_shadow && m_shadow->location().isZero() && m_shadow->radius().isZero();
+    return textIsOpaque
+        && m_shadow
+        && Style::isZero(m_shadow->location())
+        && Style::isZero(m_shadow->radius());
 }
 
 ShadowApplier::~ShadowApplier()

--- a/Source/WebCore/style/values/backgrounds/StyleBorderRadius.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderRadius.cpp
@@ -59,7 +59,7 @@ auto ToStyle<CSS::BorderRadius>::operator()(const CSS::BorderRadius& value, cons
     };
 }
 
-FloatRoundedRect::Radii evaluate(const BorderRadius& value, FloatSize referenceBox)
+auto Evaluation<BorderRadius>::operator()(const BorderRadius& value, FloatSize referenceBox) -> FloatRoundedRect::Radii
 {
     return {
         evaluate(value.topLeft, referenceBox),

--- a/Source/WebCore/style/values/backgrounds/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderRadius.h
@@ -56,10 +56,14 @@ template<size_t I> const auto& get(const BorderRadius& value)
         return value.bottomLeft;
 }
 
+// MARK: - Conversion
+
 template<> struct ToCSS<BorderRadius> { auto operator()(const BorderRadius&, const RenderStyle&) -> CSS::BorderRadius; };
 template<> struct ToStyle<CSS::BorderRadius> { auto operator()(const CSS::BorderRadius&, const BuilderState&) -> BorderRadius; };
 
-FloatRoundedRect::Radii evaluate(const BorderRadius&, FloatSize referenceBox);
+// MARK: - Evaluation
+
+template<> struct Evaluation<BorderRadius> { auto operator()(const BorderRadius&, FloatSize) -> FloatRoundedRect::Radii; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -108,19 +108,9 @@ auto ToStyle<CSS::Position>::operator()(const CSS::Position& position, const Bui
 
 // MARK: - Evaluation
 
-FloatPoint evaluate(const Position& position, FloatSize referenceBox)
+auto Evaluation<Position>::operator()(const Position& position, FloatSize referenceBox) -> FloatPoint
 {
     return evaluate(position.value, referenceBox);
-}
-
-float evaluate(const TwoComponentPositionHorizontal& component, float referenceWidth)
-{
-    return evaluate(component.offset, referenceWidth);
-}
-
-float evaluate(const TwoComponentPositionVertical& component, float referenceHeight)
-{
-    return evaluate(component.offset, referenceHeight);
 }
 
 } // namespace CSS

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -93,9 +93,7 @@ template<> struct ToStyle<CSS::Position> { auto operator()(const CSS::Position&,
 
 // MARK: - Evaluation
 
-FloatPoint evaluate(const Position&, FloatSize referenceBox);
-float evaluate(const TwoComponentPositionHorizontal&, float referenceWidth);
-float evaluate(const TwoComponentPositionVertical&, float referenceHeight);
+template<> struct Evaluation<Position> { auto operator()(const Position&, FloatSize) -> FloatPoint; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericConcepts.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericConcepts.h
@@ -32,8 +32,11 @@ namespace Style {
 // Forward declaration of PrimitiveNumeric to needed to create a hard constraint for the Numeric concept below.
 template<CSS::Numeric> struct PrimitiveNumeric;
 
-// Concept for use in generic contexts to filter on numeric Style types.
+// Concept for use in generic contexts to filter on all numeric Style types.
 template<typename T> concept Numeric = std::derived_from<T, PrimitiveNumeric<typename T::CSS>>;
+
+// Concept for use in generic contexts to filter on non-composite numeric Style types.
+template<typename T> concept NonCompositeNumeric = Numeric<T> && CSS::NonCompositeNumeric<typename T::CSS>;
 
 // Concept for use in generic contexts to filter on dimension-percentage numeric Style types.
 template<typename T> concept DimensionPercentageNumeric = Numeric<T> && VariantLike<T> && CSS::DimensionPercentageNumeric<typename T::CSS>;

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -40,33 +40,6 @@
 namespace WebCore {
 namespace Style {
 
-// MARK: - Offset Point Evaluation
-
-static FloatPoint evaluate(const ByCoordinatePair& value, const FloatSize& boxSize)
-{
-    return evaluate(value.offset, boxSize);
-}
-
-static FloatPoint evaluate(const ToPosition& value, const FloatSize& boxSize)
-{
-    return evaluate(value.offset, boxSize);
-}
-
-static FloatPoint evaluate(const std::variant<ToPosition, ByCoordinatePair>& value, const FloatSize& boxSize)
-{
-    return WTF::switchOn(value, [&](const auto& value) -> FloatPoint { return evaluate(value, boxSize); });
-}
-
-static float evaluate(const std::variant<HLineCommand::To, HLineCommand::By>& value, float width)
-{
-    return WTF::switchOn(value, [&](const auto& value) -> float { return evaluate(value.offset, width); });
-}
-
-static float evaluate(const std::variant<VLineCommand::To, VLineCommand::By>& value, float height)
-{
-    return WTF::switchOn(value, [&](const auto& value) -> float { return evaluate(value.offset, height); });
-}
-
 // MARK: - Control Point Evaluation
 
 template<typename ControlPoint> static ControlPointAnchor evaluateControlPointAnchoring(const ControlPoint& value, ControlPointAnchor defaultValue)


### PR DESCRIPTION
#### 6f6b91eeb00de7d5019ce148307938c091bd5225
<pre>
Promote isZero/isEmpty/evaluate to proper customization points
<a href="https://bugs.webkit.org/show_bug.cgi?id=286692">https://bugs.webkit.org/show_bug.cgi?id=286692</a>

Reviewed by Darin Adler.

Turns a few overloaded / member functions into customization points
to allow use of them over generic tuples and variants.

* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/CSSValueConcepts.h:
* Source/WebCore/rendering/TextPainter.cpp:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:

Canonical link: <a href="https://commits.webkit.org/289635@main">https://commits.webkit.org/289635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fd19a7f3cdd23e10dcb309dcd7de6186d0fe7c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87587 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92452 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15271 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48007 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33656 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37444 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94338 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14755 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75716 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18515 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7706 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14771 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14515 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->