### PR TITLE
Support CSS unit literals in Style numeric types

### DIFF
--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.h
@@ -45,12 +45,73 @@ struct ValueLiteral {
 
     static constexpr UnitType unit = unitValue;
     double value;
+
+    constexpr explicit ValueLiteral(double initialValue)
+        : value { initialValue }
+    {
+    }
+
+    // Synthesize all comparison and equality operators.
+
+    auto operator<=>(const ValueLiteral&) const = default;
+
+    // Support binary arithmetic between `ValueLiteral` and machine numeric types.
+
+    constexpr ValueLiteral& operator+=(const ValueLiteral& rhs)
+    {
+        value += rhs.value;
+        return *this;
+    }
+
+    constexpr ValueLiteral& operator+=(std::convertible_to<double> auto const& rhs)
+    {
+        value += static_cast<double>(rhs);
+        return *this;
+    }
+
+    constexpr ValueLiteral& operator-=(const ValueLiteral& rhs)
+    {
+        value -= rhs.value;
+        return *this;
+    }
+
+    constexpr ValueLiteral& operator-=(std::convertible_to<double> auto const& rhs)
+    {
+        value -= static_cast<double>(rhs);
+        return *this;
+    }
+
+    friend constexpr ValueLiteral operator+(const ValueLiteral& lhs, const ValueLiteral& rhs)
+    {
+        return ValueLiteral { lhs.value + rhs.value };
+    }
+    friend constexpr ValueLiteral operator+(const ValueLiteral& lhs, std::convertible_to<double> auto const& rhs)
+    {
+        return ValueLiteral { lhs.value + static_cast<double>(rhs) };
+    }
+    friend constexpr ValueLiteral operator+(std::convertible_to<double> auto const& lhs, const ValueLiteral& rhs)
+    {
+        return ValueLiteral { static_cast<double>(lhs) + rhs.value };
+    }
+
+    friend constexpr ValueLiteral operator-(const ValueLiteral& lhs, const ValueLiteral& rhs)
+    {
+        return ValueLiteral { lhs.value - rhs.value };
+    }
+    friend constexpr ValueLiteral operator-(const ValueLiteral& lhs, std::convertible_to<double> auto const& rhs)
+    {
+        return ValueLiteral { lhs.value - static_cast<double>(rhs) };
+    }
+    friend constexpr ValueLiteral operator-(std::convertible_to<double> auto const& lhs, const ValueLiteral& rhs)
+    {
+        return ValueLiteral { static_cast<double>(lhs) - rhs.value };
+    }
 };
 
 #define CSS_DEFINE_UNIT_LITERAL(type, name) \
     inline namespace Literals { \
-        consteval ValueLiteral<type> operator""_css_##name(long double value) { return { static_cast<double>(value) }; } \
-        consteval ValueLiteral<type> operator""_css_##name(unsigned long long value) { return { static_cast<double>(value) }; } \
+        consteval ValueLiteral<type> operator""_css_##name(long double value) { return ValueLiteral<type> { static_cast<double>(value) }; } \
+        consteval ValueLiteral<type> operator""_css_##name(unsigned long long value) { return ValueLiteral<type> { static_cast<double>(value) }; } \
     }
 
 // MARK: - Unit Cast

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -94,6 +94,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(HTMLInputElement);
 
+using namespace CSS::Literals;
 using namespace HTMLNames;
 
 class ListAttributeTargetObserver final : public IdTargetObserver {
@@ -2330,10 +2331,10 @@ static Ref<StyleGradientImage> autoFillStrongPasswordMaskImage()
         FunctionNotation<CSSValueLinearGradient, Style::LinearGradient> {
             .parameters = {
                 .colorInterpolationMethod = Style::GradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Unpremultiplied),
-                .gradientLine = { Style::Angle<> { 90 } },
+                .gradientLine = 90_css_deg,
                 .stops = {
-                    { Style::Color { Color::black },            Style::LengthPercentage<>::Percentage { 50 } },
-                    { Style::Color { Color::transparentBlack }, Style::LengthPercentage<>::Percentage { 100 } }
+                    { Style::Color { Color::black },            50_css_percentage },
+                    { Style::Color { Color::transparentBlack }, 100_css_percentage },
                 }
             }
         }

--- a/Source/WebCore/style/values/backgrounds/StyleBoxShadow.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleBoxShadow.cpp
@@ -53,8 +53,8 @@ auto ToStyle<CSS::BoxShadow>::operator()(const CSS::BoxShadow& value, const Buil
     return {
         .color = value.color ? toStyle(*value.color, state) : Color::currentColor(),
         .location = toStyle(value.location, state),
-        .blur = value.blur ? toStyle(*value.blur, state) : Length<CSS::Nonnegative> { 0 },
-        .spread = value.spread ? toStyle(*value.spread, state) : Length<> { 0 },
+        .blur = value.blur ? toStyle(*value.blur, state) : 0_css_px,
+        .spread = value.spread ? toStyle(*value.spread, state) : 0_css_px,
         .inset = toStyle(value.inset, state),
         .isWebkitBoxShadow = value.isWebkitBoxShadow,
     };

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -34,20 +34,22 @@
 namespace WebCore {
 namespace Style {
 
+using namespace CSS::Literals;
+
 auto ToStyle<CSS::TwoComponentPositionHorizontal>::operator()(const CSS::TwoComponentPositionHorizontal& value, const BuilderState& state) -> TwoComponentPositionHorizontal
 {
     return WTF::switchOn(value.offset,
         [&](CSS::Keyword::Left) {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 0 } } };
+            return TwoComponentPositionHorizontal { 0_css_percentage };
         },
-        [&](CSS::Keyword::Right)  {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 100 } } };
+        [&](CSS::Keyword::Right) {
+            return TwoComponentPositionHorizontal { 100_css_percentage };
         },
-        [&](CSS::Keyword::Center)  {
-            return TwoComponentPositionHorizontal { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 50 } } };
+        [&](CSS::Keyword::Center) {
+            return TwoComponentPositionHorizontal { 50_css_percentage };
         },
         [&](const CSS::LengthPercentage<>& value) {
-            return TwoComponentPositionHorizontal { .offset = toStyle(value, state) };
+            return TwoComponentPositionHorizontal { toStyle(value, state) };
         }
     );
 }
@@ -56,16 +58,16 @@ auto ToStyle<CSS::TwoComponentPositionVertical>::operator()(const CSS::TwoCompon
 {
     return WTF::switchOn(value.offset,
         [&](CSS::Keyword::Top) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 0 } } };
+            return TwoComponentPositionVertical { 0_css_percentage };
         },
         [&](CSS::Keyword::Bottom) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 100 } } };
+            return TwoComponentPositionVertical { 100_css_percentage };
         },
         [&](CSS::Keyword::Center) {
-            return TwoComponentPositionVertical { .offset = LengthPercentage<> { typename LengthPercentage<>::Percentage { 50 } } };
+            return TwoComponentPositionVertical { 50_css_percentage };
         },
         [&](const CSS::LengthPercentage<>& value) {
-            return TwoComponentPositionVertical { .offset = toStyle(value, state) };
+            return TwoComponentPositionVertical { toStyle(value, state) };
         }
     );
 }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -99,6 +99,16 @@ template<CSS::DimensionPercentageNumeric CSSType> struct PrimitiveNumeric<CSSTyp
     {
     }
 
+    PrimitiveNumeric(WebCore::CSS::ValueLiteral<Dimension::UnitTraits::canonical> literal)
+        : m_value { Dimension { literal } }
+    {
+    }
+
+    PrimitiveNumeric(WebCore::CSS::ValueLiteral<Percentage::UnitTraits::canonical> literal)
+        : m_value { Percentage { literal } }
+    {
+    }
+
     // NOTE: CalculatedValue is intentionally not part of IPCData.
     using IPCData = std::variant<Dimension, Percentage>;
     PrimitiveNumeric(IPCData&& data)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
@@ -35,6 +35,8 @@
 namespace WebCore {
 namespace Style {
 
+using namespace CSS::Literals;
+
 // MARK: - Percentage
 
 template<auto R, typename V> struct Evaluation<Percentage<R, V>> {
@@ -136,15 +138,15 @@ template<auto R, typename V> auto reflect(const LengthPercentage<R, V>& value) -
     return WTF::switchOn(value,
         [&](const Dimension& value) -> Result {
             // If `value` is 0, we can avoid the `calc` altogether.
-            if (value.value == 0)
-                return Percentage { 100 };
+            if (value == 0_css_px)
+                return 100_css_percentage;
 
             // Turn this into a calc expression: `calc(100% - value)`.
             return Calc { Calculation::subtract(Calculation::percentage(100), copyCalculation(value)) };
         },
         [&](const Percentage& value) -> Result {
             // If `value` is a percentage, we can avoid the `calc` altogether.
-            return Percentage { 100 - value.value };
+            return 100_css_percentage - value.value;
         },
         [&](const Calc& value) -> Result {
             // Turn this into a calc expression: `calc(100% - value)`.
@@ -167,7 +169,6 @@ template<auto aR, auto bR, typename V> auto reflectSum(const LengthPercentage<aR
     constexpr auto resultR = mergeRanges(aR, bR);
 
     using Result = LengthPercentage<resultR, V>;
-    using PercentageResult = typename Result::Percentage;
     using CalcResult = typename Result::Calc;
     using PercentageA = typename LengthPercentage<aR, V>::Percentage;
     using PercentageB = typename LengthPercentage<bR, V>::Percentage;
@@ -177,14 +178,14 @@ template<auto aR, auto bR, typename V> auto reflectSum(const LengthPercentage<aR
 
     // If both `a` and `b` are 0, turn this into a calc expression: `calc(100% - (0 + 0))` aka `100%`.
     if (aIsZero && bIsZero)
-        return PercentageResult { 100 };
+        return 100_css_percentage;
 
     // If just `a` is 0, we can just consider the case of `calc(100% - b)`.
     if (aIsZero) {
         return WTF::switchOn(b,
             [&](const PercentageB& b) -> Result {
                 // And if `b` is a percent, we can avoid the `calc` altogether.
-                return PercentageResult { 100 - b.value };
+                return 100_css_percentage - b.value;
             },
             [&](const auto& b) -> Result {
                 // Otherwise, turn this into a calc expression: `calc(100% - b)`.
@@ -198,7 +199,7 @@ template<auto aR, auto bR, typename V> auto reflectSum(const LengthPercentage<aR
         return WTF::switchOn(a,
             [&](const PercentageA& a) -> Result {
                 // And if `a` is a percent, we can avoid the `calc` altogether.
-                return PercentageResult { 100 - a.value };
+                return 100_css_percentage - a.value;
             },
             [&](const auto& a) -> Result {
                 // Otherwise, turn this into a calc expression: `calc(100% - a)`.
@@ -209,7 +210,7 @@ template<auto aR, auto bR, typename V> auto reflectSum(const LengthPercentage<aR
 
     // If both and `a` and `b` are percentages, we can avoid the `calc` altogether.
     if (WTF::holdsAlternative<PercentageA>(a) && WTF::holdsAlternative<PercentageB>(b))
-        return PercentageResult { 100 - (get<PercentageA>(a).value + get<PercentageB>(b).value) };
+        return 100_css_percentage - (get<PercentageA>(a).value + get<PercentageB>(b).value);
 
     // Otherwise, turn this into a calc expression: `calc(100% - (a + b))`.
     return CalcResult { Calculation::subtract(Calculation::percentage(100), Calculation::add(copyCalculation(a), copyCalculation(b))) };

--- a/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleRectFunction.cpp
@@ -31,6 +31,8 @@
 namespace WebCore {
 namespace Style {
 
+using namespace CSS::Literals;
+
 // MARK: - Conversion
 
 auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& state) -> Inset
@@ -49,7 +51,7 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
                 return toStyle(value, state);
             },
             [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
-                return { typename LengthPercentage<>::Percentage { 0 } };
+                return 0_css_percentage;
             }
         );
     };
@@ -60,7 +62,7 @@ auto ToStyle<CSS::Rect>::operator()(const CSS::Rect& value, const BuilderState& 
                 return reflect(toStyle(value, state));
             },
             [&](const CSS::Keyword::Auto&) -> LengthPercentage<> {
-                return { typename LengthPercentage<>::Percentage { 0 } };
+                return 0_css_percentage;
             }
         );
     };

--- a/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp
@@ -31,16 +31,18 @@
 
 namespace TestWebKitAPI {
 
+using namespace WebCore::CSS::Literals;
+
 static WebCore::Style::GradientLinearColorStopList cacheableStops()
 {
     return {
         {
             WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::red } },
-            WebCore::Style::LengthPercentage<>::Percentage { 50.0 }
+            50_css_percentage
         },
         {
             WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::blue } },
-            WebCore::Style::LengthPercentage<>::Percentage { 100.0 }
+            100_css_percentage
         }
     };
 }
@@ -50,11 +52,11 @@ static WebCore::Style::GradientLinearColorStopList someUncacheableStops()
     return {
         {
             WebCore::Style::Color { WebCore::Style::CurrentColor { } },
-            WebCore::Style::LengthPercentage<>::Percentage { 50 }
+            50_css_percentage
         },
         {
             WebCore::Style::Color { WebCore::Style::ResolvedColor { WebCore::Color::blue } },
-            WebCore::Style::LengthPercentage<>::Percentage { 100 }
+            100_css_percentage
         }
     };
 }
@@ -64,11 +66,11 @@ static WebCore::Style::GradientLinearColorStopList allUncacheableStops()
     return {
         {
             WebCore::Style::Color { WebCore::Style::CurrentColor { } },
-            WebCore::Style::LengthPercentage<>::Percentage { 50 }
+            50_css_percentage
         },
         {
             WebCore::Style::Color { WebCore::Style::CurrentColor { } },
-            WebCore::Style::LengthPercentage<>::Percentage { 100 }
+            100_css_percentage
         }
     };
 }


### PR DESCRIPTION
#### 2b36e733418e14d34a0f89670800352547a2f3da
<pre>
Support CSS unit literals in Style numeric types
<a href="https://bugs.webkit.org/show_bug.cgi?id=286696">https://bugs.webkit.org/show_bug.cgi?id=286696</a>

Reviewed by Darin Adler and Antti Koivisto.

Makes it possible to initialize Style primitive numeric types
using CSS unit literals like 100_css_px. Additionally adds support
for basic arithmetic to simplify a few call sites.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.h:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/style/values/backgrounds/StyleBoxShadow.cpp:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/shapes/StyleRectFunction.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/StyleGradient.cpp:

Canonical link: <a href="https://commits.webkit.org/289759@main">https://commits.webkit.org/289759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8c42ffe4dca2130ec3b681a765f68acd588be7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87849 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42237 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92726 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15538 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/92726 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25578 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79490 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/92726 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94611 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15017 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11054 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76677 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18678 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8021 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15034 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14777 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->