### PR TITLE
OOB crash under WebKit::dataProviderGetBytesAtPositionCallback during off-main-thread incremental PDF loading

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -91,7 +91,7 @@ private:
 
     void appendAccumulatedDataToDataBuffer(ByteRangeRequest&);
 
-    std::span<const uint8_t> dataSpanForRange(uint64_t position, size_t count, CheckValidRanges) const;
+    void dataSpanForRange(uint64_t position, size_t count, CheckValidRanges, CompletionHandler<void(std::span<const uint8_t>)>&&) const;
     uint64_t availableDataSize() const;
 
     void getResourceBytesAtPosition(size_t count, off_t position, DataRequestCompletionHandler&&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -140,11 +140,10 @@ void ByteRangeRequest::completeUnconditionally(PDFIncrementalLoader& loader)
 
     auto availableRequestBytes = std::min<uint64_t>(m_count, availableBytes - m_position);
 
-    auto data = loader.dataSpanForRange(m_position, availableRequestBytes, CheckValidRanges::No);
-    if (!data.data())
-        return;
-
-    completeWithBytes(data, loader);
+    loader.dataSpanForRange(m_position, availableRequestBytes, CheckValidRanges::No, [this, &loader](std::span<const uint8_t> data) {
+        if (data.data())
+            completeWithBytes(data, loader);
+    });
 }
 
 #pragma mark -
@@ -355,13 +354,13 @@ uint64_t PDFIncrementalLoader::availableDataSize() const
     return plugin->streamedBytes();
 }
 
-std::span<const uint8_t> PDFIncrementalLoader::dataSpanForRange(uint64_t position, size_t count, CheckValidRanges checkValidRanges) const
+void PDFIncrementalLoader::dataSpanForRange(uint64_t position, size_t count, CheckValidRanges checkValidRanges, CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler) const
 {
     RefPtr plugin = m_plugin.get();
     if (!plugin)
-        return { };
+        return completionHandler({ });
 
-    return plugin->dataSpanForRange(position, count, checkValidRanges);
+    plugin->dataSpanForRange(position, count, checkValidRanges, WTFMove(completionHandler));
 }
 
 void PDFIncrementalLoader::incrementalPDFStreamDidFinishLoading()
@@ -537,12 +536,15 @@ bool PDFIncrementalLoader::requestCompleteIfPossible(ByteRangeRequest& request)
     if (!plugin)
         return false;
 
-    auto data = plugin->dataSpanForRange(request.position(), request.count(), CheckValidRanges::Yes);
-    if (!data.data())
-        return false;
+    bool requestCompleted = false;
+    plugin->dataSpanForRange(request.position(), request.count(), CheckValidRanges::Yes, [protectedLoader = Ref { *this }, &request, &requestCompleted](std::span<const uint8_t> data) {
+        if (!data.data())
+            return;
+        request.completeWithBytes(data, protectedLoader.get());
+        requestCompleted = true;
+    });
 
-    request.completeWithBytes(data, *this);
-    return true;
+    return requestCompleted;
 }
 
 void PDFIncrementalLoader::requestDidCompleteWithBytes(ByteRangeRequest& request, size_t byteCount)
@@ -622,20 +624,25 @@ size_t PDFIncrementalLoader::dataProviderGetBytesAtPosition(std::span<uint8_t> b
         return 0;
     }
 
-    if (auto data = plugin->dataSpanForRange(position, buffer.size(), CheckValidRanges::Yes); data.data()) {
+    std::optional<size_t> bytesProvided;
+    plugin->dataSpanForRange(position, buffer.size(), CheckValidRanges::Yes, [&buffer, &bytesProvided](std::span<const uint8_t> data) {
+        if (!data.data() || !buffer.data())
+            return;
         memcpySpan(buffer, data);
+        bytesProvided = data.size();
+    });
+
+    if (bytesProvided) {
 #if !LOG_DISABLED
         decrementThreadsWaitingOnCallback();
-        incrementalLoaderLog(makeString("Satisfied range request for "_s, data.size(), " bytes at position "_s, position, " synchronously"_s));
+        incrementalLoaderLog(makeString("Satisfied range request for "_s, *bytesProvided, " bytes at position "_s, position, " synchronously"_s));
 #endif
-        return data.size();
+        return *bytesProvided;
     }
 
     RefPtr dataSemaphore = createDataSemaphore();
     if (!dataSemaphore)
         return 0;
-
-    size_t bytesProvided = 0;
 
     RunLoop::protectedMain()->dispatch([protectedLoader = Ref { *this }, dataSemaphore, position, buffer, &bytesProvided] {
         if (dataSemaphore->wasSignaled())
@@ -654,10 +661,10 @@ size_t PDFIncrementalLoader::dataProviderGetBytesAtPosition(std::span<uint8_t> b
 
 #if !LOG_DISABLED
     decrementThreadsWaitingOnCallback();
-    incrementalLoaderLog(makeString("PDF data provider received "_s, bytesProvided, " bytes of requested "_s, buffer.size()));
+    incrementalLoaderLog(makeString("PDF data provider received "_s, bytesProvided.value_or(0), " bytes of requested "_s, buffer.size()));
 #endif
 
-    return bytesProvided;
+    return bytesProvided.value_or(0);
 }
 
 auto PDFIncrementalLoader::createDataSemaphore() -> RefPtr<SemaphoreWrapper>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -353,9 +353,14 @@ private:
     // Returns the number of bytes copied.
     size_t copyDataAtPosition(std::span<uint8_t> buffer, uint64_t sourcePosition) const;
     // FIXME: It would be nice to avoid having both the "copy into a buffer" and "return a pointer" ways of getting data.
-    std::span<const uint8_t> dataSpanForRange(uint64_t sourcePosition, size_t count, CheckValidRanges) const;
+    void dataSpanForRange(uint64_t sourcePosition, size_t count, CheckValidRanges, CompletionHandler<void(std::span<const uint8_t>)>&&) const;
     // Returns true only if we can satisfy all of the requests.
     bool getByteRanges(CFMutableArrayRef, std::span<const CFRange>) const;
+
+#if !LOG_DISABLED
+    uint64_t streamedBytesForDebugLogging() const;
+    void incrementalLoaderLogWithBytes(const String&, uint64_t streamedBytes);
+#endif
 
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -275,6 +275,26 @@ uint64_t PDFPluginBase::streamedBytes() const
     return m_streamedBytes;
 }
 
+#if !LOG_DISABLED
+
+// Thread safety analysis gets really confused by conditional locking, so
+// it is difficult to prove that any previous stack frame did in fact secure
+// the data lock without having to pass around Locker instances across dataSpanForRange()
+// and its callers. Instead, this method opts out of thread safety analysis
+// and ensures the lock is held when reading m_streamedBytes, else we assert.
+uint64_t PDFPluginBase::streamedBytesForDebugLogging() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+{
+    if (m_streamedDataLock.tryLock()) {
+        Locker locker { AdoptLock, m_streamedDataLock };
+        return m_streamedBytes;
+    }
+
+    m_streamedDataLock.assertIsOwner();
+    return m_streamedBytes;
+}
+
+#endif
+
 bool PDFPluginBase::haveStreamedDataForRange(uint64_t offset, size_t count) const
 {
     if (!m_data)
@@ -301,7 +321,7 @@ size_t PDFPluginBase::copyDataAtPosition(std::span<uint8_t> buffer, uint64_t sou
     return buffer.size();
 }
 
-std::span<const uint8_t> PDFPluginBase::dataSpanForRange(uint64_t sourcePosition, size_t count, CheckValidRanges checkValidRanges) const
+void PDFPluginBase::dataSpanForRange(uint64_t sourcePosition, size_t count, CheckValidRanges checkValidRanges, CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler) const
 {
     Locker locker { m_streamedDataLock };
 
@@ -323,9 +343,9 @@ std::span<const uint8_t> PDFPluginBase::dataSpanForRange(uint64_t sourcePosition
     };
 
     if (!haveValidData(checkValidRanges))
-        return { };
+        return completionHandler({ });
 
-    return span(m_data.get()).subspan(sourcePosition, count);
+    completionHandler(span(m_data.get()).subspan(sourcePosition, count));
 }
 
 bool PDFPluginBase::getByteRanges(CFMutableArrayRef dataBuffersArray, std::span<const CFRange> ranges) const
@@ -1335,20 +1355,19 @@ static void verboseLog(PDFIncrementalLoader* incrementalLoader, uint64_t streame
 void PDFPluginBase::incrementalLoaderLog(const String& message)
 {
 #if HAVE(INCREMENTAL_PDF_APIS)
-    if (!isMainRunLoop()) {
-        callOnMainRunLoop([this, protectedThis = Ref { *this }, message = message.isolatedCopy()] {
-            incrementalLoaderLog(message);
-        });
-        return;
-    }
-
-    auto streamedBytes = this->streamedBytes();
-    LOG_WITH_STREAM(IncrementalPDF, stream << message);
-    verboseLog(m_incrementalLoader.get(), streamedBytes, m_documentFinishedLoading);
-    LOG_WITH_STREAM(IncrementalPDFVerbose, stream << message);
+    ensureOnMainRunLoop([this, protectedThis = Ref { *this }, message = message.isolatedCopy(), byteCount = streamedBytesForDebugLogging()] {
+        incrementalLoaderLogWithBytes(message, byteCount);
+    });
 #else
     UNUSED_PARAM(message);
 #endif
+}
+
+void PDFPluginBase::incrementalLoaderLogWithBytes(const String& message, uint64_t streamedBytes)
+{
+    LOG_WITH_STREAM(IncrementalPDF, stream << message);
+    verboseLog(m_incrementalLoader.get(), streamedBytes, m_documentFinishedLoading);
+    LOG_WITH_STREAM(IncrementalPDFVerbose, stream << message);
 }
 
 #endif // !LOG_DISABLED


### PR DESCRIPTION
#### 1c283c67a9c09fd482520eb7daffac5a0916da61
<pre>
OOB crash under WebKit::dataProviderGetBytesAtPositionCallback during off-main-thread incremental PDF loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=284408">https://bugs.webkit.org/show_bug.cgi?id=284408</a>
<a href="https://rdar.apple.com/131110151">rdar://131110151</a>

Reviewed by Simon Fraser.

We occasionally crash trying to memcpy a buffer for incremental loading
data provision. Here&apos;s a representative trace:

```
Thread 4 Crashed::   Dispatch queue: LinearizedPagePreload
0 _platform_memmove + 96
1 void WTF::memcpySpan&lt;unsigned char, 18446744073709551615ul, unsigned char const, 18446744073709551615ul&gt;(std::__1::span&lt;unsigned char, 18446744073709551615ul&gt;, std::__1::span&lt;unsigned char const, 18446744073709551615ul&gt;) + 16
2 WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition(std::__1::span&lt;unsigned char, 18446744073709551615ul&gt;, long long) + 52
3 WebKit::dataProviderGetBytesAtPositionCallback(void*, void*, long long, unsigned long) + 308
4 provider_get_bytes_at_position + 84
5 CGDataProviderDirectGetBytesAtPositionInternal + 308
```

While we don&apos;t have a reproducible case yet, some analysis of the
incremental loading code suggests there is a small flaw in the threading
model for PDFPluginBase::dataSpanForRange() callers. That method secures
a lock to produce the data span, but if a load stream fails after a
caller gets the data span and before accessing said span, callers may
end up referencing null data.

This patch is a speculative fix for this issue. We teach
dataSpanForRange to accept a completion handler, which callers will
adopt as a substitute for the work they would have done with the data
span they expect to receive. The completion handler can then be called
while the data lock is still held.

This fix exposed an issue with the threading model for debug logging,
since our logging unconditionally jumps to the main thread and requests
to hold the data lock, thus deadlocking the web process. We address this
by securing a copy of m_streamedBytes before jumping across thread
boundaries -- see PDFPluginBase::streamedBytesForDebugLogging(). This
method skirts around thread safety analysis but ensures that the data
lock _is secured_ by the calling thread,  else asserting.

* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::completeUnconditionally):
(WebKit::PDFIncrementalLoader::dataSpanForRange const):
(WebKit::PDFIncrementalLoader::requestCompleteIfPossible):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::dataSpanForRange const):
(WebKit::PDFPluginBase::incrementalLoaderLog):
(WebKit::PDFPluginBase::incrementalLoaderLogWithBytes):

Originally-landed-as: 283286.578@safari-7620-branch (de6e83ab1f4d). <a href="https://rdar.apple.com/143592990">rdar://143592990</a>
Canonical link: <a href="https://commits.webkit.org/289647@main">https://commits.webkit.org/289647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a6882185ab97b82308193f67b2229e511b86dd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87602 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38346 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15286 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25397 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48012 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5511 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94353 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14770 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75721 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18526 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14786 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14530 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16312 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->