### PR TITLE
UAF may occur in WorkerInspectorProxy::sendMessageFromWorkerToFrontend

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
@@ -38,12 +38,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorWorkerAgent);
 
 InspectorWorkerAgent::InspectorWorkerAgent(WebAgentContext& context)
     : InspectorAgentBase("Worker"_s, context)
-    , m_frontendDispatcher(makeUnique<Inspector::WorkerFrontendDispatcher>(context.frontendRouter))
+    , m_pageChannel(PageChannel::create(*this))
+    , m_frontendDispatcher(makeUniqueRef<Inspector::WorkerFrontendDispatcher>(context.frontendRouter))
     , m_backendDispatcher(Inspector::WorkerBackendDispatcher::create(context.backendDispatcher, this))
 {
 }
 
-InspectorWorkerAgent::~InspectorWorkerAgent() = default;
+InspectorWorkerAgent::~InspectorWorkerAgent()
+{
+    m_pageChannel->detachFromParentAgent();
+}
 
 void InspectorWorkerAgent::didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*)
 {
@@ -106,11 +110,6 @@ Inspector::Protocol::ErrorStringOr<void> InspectorWorkerAgent::sendMessageToWork
     return { };
 }
 
-void InspectorWorkerAgent::sendMessageFromWorkerToFrontend(WorkerInspectorProxy& proxy, String&& message)
-{
-    m_frontendDispatcher->dispatchMessageFromWorker(proxy.identifier(), WTFMove(message));
-}
-
 bool InspectorWorkerAgent::shouldWaitForDebuggerOnStart() const
 {
     return m_enabled;
@@ -147,7 +146,7 @@ void InspectorWorkerAgent::disconnectFromAllWorkerInspectorProxies()
 
 void InspectorWorkerAgent::connectToWorkerInspectorProxy(WorkerInspectorProxy& proxy)
 {
-    proxy.connectToWorkerInspectorController(*this);
+    proxy.connectToWorkerInspectorController(m_pageChannel);
 
     m_connectedProxies.set(proxy.identifier(), proxy);
 
@@ -161,6 +160,31 @@ void InspectorWorkerAgent::disconnectFromWorkerInspectorProxy(WorkerInspectorPro
     m_connectedProxies.remove(proxy.identifier());
 
     proxy.disconnectFromWorkerInspectorController();
+}
+
+Ref<InspectorWorkerAgent::PageChannel> InspectorWorkerAgent::PageChannel::create(InspectorWorkerAgent& parentAgent)
+{
+    return adoptRef(*new PageChannel(parentAgent));
+}
+
+InspectorWorkerAgent::PageChannel::PageChannel(InspectorWorkerAgent& parentAgent)
+    : m_parentAgent(&parentAgent)
+{
+}
+
+void InspectorWorkerAgent::PageChannel::detachFromParentAgent()
+{
+    Locker locker { m_parentAgentLock };
+
+    m_parentAgent = nullptr;
+}
+
+void InspectorWorkerAgent::PageChannel::sendMessageFromWorkerToFrontend(WorkerInspectorProxy& proxy, String&& message)
+{
+    Locker locker { m_parentAgentLock };
+
+    if (CheckedPtr parentAgent = m_parentAgent)
+        parentAgent->frontendDispatcher().dispatchMessageFromWorker(proxy.identifier(), WTFMove(message));
 }
 
 } // namespace Inspector

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
@@ -29,17 +29,27 @@
 #include "WorkerInspectorProxy.h"
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/Lock.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class InspectorWorkerAgent : public InspectorAgentBase, public Inspector::WorkerBackendDispatcherHandler, public WorkerInspectorProxy::PageChannel {
+class InspectorWorkerAgent : public InspectorAgentBase, public Inspector::WorkerBackendDispatcherHandler, public CanMakeThreadSafeCheckedPtr<InspectorWorkerAgent> {
     WTF_MAKE_NONCOPYABLE(InspectorWorkerAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorWorkerAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorWorkerAgent);
+
 public:
     ~InspectorWorkerAgent();
+
+    Inspector::WorkerFrontendDispatcher& frontendDispatcher() { return *m_frontendDispatcher; }
 
     // InspectorAgentBase
     void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*);
@@ -50,9 +60,6 @@ public:
     Inspector::Protocol::ErrorStringOr<void> disable();
     Inspector::Protocol::ErrorStringOr<void> initialized(const String& workerId);
     Inspector::Protocol::ErrorStringOr<void> sendMessageToWorker(const String& workerId, const String& message);
-
-    // WorkerInspectorProxy::PageChannel
-    void sendMessageFromWorkerToFrontend(WorkerInspectorProxy&, String&& message);
 
     // InspectorInstrumentation
     bool shouldWaitForDebuggerOnStart() const;
@@ -67,10 +74,32 @@ protected:
     void connectToWorkerInspectorProxy(WorkerInspectorProxy&);
 
 private:
+    class PageChannel final : public WorkerInspectorProxy::PageChannel, public ThreadSafeRefCounted<PageChannel> {
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(PageChannel);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageChannel);
+
+    public:
+        static Ref<PageChannel> create(InspectorWorkerAgent&);
+
+        void ref() const final { ThreadSafeRefCounted::ref(); }
+        void deref() const final { ThreadSafeRefCounted::deref(); }
+
+        void detachFromParentAgent();
+        void sendMessageFromWorkerToFrontend(WorkerInspectorProxy&, String&&);
+
+    private:
+        explicit PageChannel(InspectorWorkerAgent&);
+
+        Lock m_parentAgentLock;
+        CheckedPtr<InspectorWorkerAgent> m_parentAgent WTF_GUARDED_BY_LOCK(m_parentAgentLock);
+    };
+
     void disconnectFromAllWorkerInspectorProxies();
     void disconnectFromWorkerInspectorProxy(WorkerInspectorProxy&);
 
-    std::unique_ptr<Inspector::WorkerFrontendDispatcher> m_frontendDispatcher;
+    const Ref<PageChannel> m_pageChannel;
+
+    UniqueRef<Inspector::WorkerFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::WorkerBackendDispatcher> m_backendDispatcher;
 
     MemoryCompactRobinHoodHashMap<String, WeakPtr<WorkerInspectorProxy>> m_connectedProxies;

--- a/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp
@@ -34,6 +34,8 @@ namespace WebCore {
 
 using namespace Inspector;
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageWorkerAgent);
+
 PageWorkerAgent::PageWorkerAgent(PageAgentContext& context)
     : InspectorWorkerAgent(context)
     , m_page(context.inspectedPage)

--- a/Source/WebCore/inspector/agents/page/PageWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageWorkerAgent.h
@@ -26,14 +26,19 @@
 #pragma once
 
 #include "InspectorWorkerAgent.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class Page;
 
 class PageWorkerAgent final : public InspectorWorkerAgent {
+    WTF_MAKE_TZONE_ALLOCATED(PageWorkerAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageWorkerAgent);
 public:
-    PageWorkerAgent(PageAgentContext&);
+    explicit PageWorkerAgent(PageAgentContext&);
+
     ~PageWorkerAgent();
 
 private:

--- a/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp
@@ -33,6 +33,8 @@ namespace WebCore {
 
 using namespace Inspector;
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerWorkerAgent);
+
 WorkerWorkerAgent::WorkerWorkerAgent(WorkerAgentContext& context)
     : InspectorWorkerAgent(context)
     , m_globalScope(context.globalScope)

--- a/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.h
@@ -26,14 +26,20 @@
 #pragma once
 
 #include "InspectorWorkerAgent.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class WorkerOrWorkletGlobalScope;
 
 class WorkerWorkerAgent final : public InspectorWorkerAgent {
+    WTF_MAKE_TZONE_ALLOCATED(WorkerWorkerAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerWorkerAgent);
+
 public:
-    WorkerWorkerAgent(WorkerAgentContext&);
+    explicit WorkerWorkerAgent(WorkerAgentContext&);
+
     ~WorkerWorkerAgent();
 
 private:

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -222,10 +222,8 @@ void WorkerInspectorProxy::sendMessageToWorkerInspectorController(const String& 
 
 void WorkerInspectorProxy::sendMessageFromWorkerToFrontend(String&& message)
 {
-    if (!m_pageChannel)
-        return;
-
-    m_pageChannel->sendMessageFromWorkerToFrontend(*this, WTFMove(message));
+    if (RefPtr pageChannel = m_pageChannel.get())
+        pageChannel->sendMessageFromWorkerToFrontend(*this, WTFMove(message));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -28,6 +28,9 @@
 #include "PageIdentifier.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <variant>
+#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
@@ -57,9 +60,15 @@ public:
     ~WorkerInspectorProxy();
 
     // A Worker's inspector messages come in and go out through the Page's WorkerAgent.
-    class PageChannel {
+    class PageChannel : public CanMakeThreadSafeCheckedPtr<PageChannel> {
+        WTF_MAKE_TZONE_ALLOCATED_INLINE(PageChannel);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageChannel);
+
     public:
         virtual ~PageChannel() = default;
+
+        virtual void ref() const = 0;
+        virtual void deref() const = 0;
         virtual void sendMessageFromWorkerToFrontend(WorkerInspectorProxy&, String&&) = 0;
     };
 
@@ -96,7 +105,7 @@ private:
     String m_identifier;
     URL m_url;
     String m_name;
-    PageChannel* m_pageChannel { nullptr };
+    CheckedPtr<PageChannel> m_pageChannel;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0338ad61ac9cb2d535e701ef9dace731b182237c
<pre>
UAF may occur in WorkerInspectorProxy::sendMessageFromWorkerToFrontend
<a href="https://bugs.webkit.org/show_bug.cgi?id=284327">https://bugs.webkit.org/show_bug.cgi?id=284327</a>
<a href="https://rdar.apple.com/140133704">rdar://140133704</a>

Reviewed by Chris Dumez.

WorkerInspectorProxy::m_pageChannel is a raw pointer and is prone to
being UAF. However, making the PageChannel class ref-counted is not
straightforward as WorkerInspectorController uses an array of
`std::unique_ptr`s to record that PageChannel and other agent objects (<a href="https://github.com/WebKit/WebKit/blob/3fa7ffbf74469b65cf23a05c1780319954860f3c/Source/WebCore/inspector/WorkerInspectorController.cpp#L217">https://github.com/WebKit/WebKit/blob/3fa7ffbf74469b65cf23a05c1780319954860f3c/Source/WebCore/inspector/WorkerInspectorController.cpp#L217</a>,
where WorkerWorkerAgent subclasses InspectorWorkerAgent and PageChannel).

My solution is to make PageChannel ref-counted but also make the class
pointed to by a std::unique_ptr own a PageChannel rather than inheriting
from PageChannel. That way, we can maintain unique_ptrs to
InspectorWorkerAgent and still have RefPtrs to PageChannel.

* Source/WebCore/inspector/agents/InspectorWorkerAgent.h:
* Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp:
(WebCore::InspectorWorkerAgent::InspectorWorkerAgent):
(WebCore::InspectorWorkerAgent::~InspectorWorkerAgent):
(WebCore::InspectorWorkerAgent::connectToWorkerInspectorProxy):
(WebCore::InspectorWorkerAgent::PageChannel::create):
(WebCore::InspectorWorkerAgent::PageChannel::PageChannel):
(WebCore::InspectorWorkerAgent::PageChannel::detachFromParentAgent):
   - Make the PageChannel class ref-counted.

(WebCore::InspectorWorkerAgent::frontendDispatcher):
(WebCore::InspectorWorkerAgent::sendMessageFromWorkerToFrontend): Deleted.
(WebCore::InspectorWorkerAgent::PageChannel::sendMessageFromWorkerToFrontend):
   - Reroute the sendMessageFromWorkerToFrontend method since now
     InspectorWorkerAgent owns the page channel instead of being one.

* Source/WebCore/workers/WorkerInspectorProxy.h:
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
(WebCore::WorkerInspectorProxy::sendMessageFromWorkerToFrontend):
* Source/WebCore/inspector/agents/page/PageWorkerAgent.cpp:
* Source/WebCore/inspector/agents/page/PageWorkerAgent.h:
* Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerWorkerAgent.h:
   - Enable the InspectorWorkerAgent::PageChannel class to be
     ref-counted.

Originally-landed-as: 283286.596@safari-7620-branch (e57de05ab1d3). <a href="https://rdar.apple.com/143592608">rdar://143592608</a>
Canonical link: <a href="https://commits.webkit.org/289536@main">https://commits.webkit.org/289536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be6e92769644aebe7b3dc51809b63245fe6cdef6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37976 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14815 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25157 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33334 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37092 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93982 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14398 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10485 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76229 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75434 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7327 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13595 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14417 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19710 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14162 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->