### PR TITLE
Simplify fullscreen scroll position saving and restoring IPC

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1274,24 +1274,6 @@ void WKPageRequestExitFullScreen(WKPageRef pageRef)
 #endif
 }
 
-void WKPageSaveScrollPositionForFullScreen(WKPageRef pageRef)
-{
-    CRASH_IF_SUSPENDED;
-#if ENABLE(FULLSCREEN_API)
-    if (RefPtr manager = toImpl(pageRef)->fullScreenManager())
-        manager->saveScrollPosition();
-#endif
-}
-
-void WKPageRestoreScrollPositionAfterFullScreen(WKPageRef pageRef)
-{
-    CRASH_IF_SUSPENDED;
-#if ENABLE(FULLSCREEN_API)
-    if (RefPtr manager = toImpl(pageRef)->fullScreenManager())
-        manager->restoreScrollPosition();
-#endif
-}
-
 void WKPageSetPageFormClient(WKPageRef pageRef, const WKPageFormClientBase* wkClient)
 {
     CRASH_IF_SUSPENDED;

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -233,8 +233,6 @@ WK_EXPORT void WKPageSetFullScreenClientForTesting(WKPageRef page, const WKPageF
 WK_EXPORT void WKPageDidEnterFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageWillExitFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageDidExitFullScreen(WKPageRef pageRef);
-WK_EXPORT void WKPageSaveScrollPositionForFullScreen(WKPageRef pageRef);
-WK_EXPORT void WKPageRestoreScrollPositionAfterFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageRequestExitFullScreen(WKPageRef pageRef);
 
 // A client can implement either a navigation client or loader and policy clients, but never both.

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -190,16 +190,6 @@ void WebFullScreenManagerProxy::requestExitFullScreen()
     sendToWebProcess(Messages::WebFullScreenManager::RequestExitFullScreen());
 }
 
-void WebFullScreenManagerProxy::saveScrollPosition()
-{
-    sendToWebProcess(Messages::WebFullScreenManager::SaveScrollPosition());
-}
-
-void WebFullScreenManagerProxy::restoreScrollPosition()
-{
-    sendToWebProcess(Messages::WebFullScreenManager::RestoreScrollPosition());
-}
-
 void WebFullScreenManagerProxy::setFullscreenInsets(const WebCore::FloatBoxExtent& insets)
 {
     sendToWebProcess(Messages::WebFullScreenManager::SetFullscreenInsets(insets));

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -119,8 +119,6 @@ public:
     void setAnimatingFullScreen(bool);
     void requestRestoreFullScreen(CompletionHandler<void(bool)>&&);
     void requestExitFullScreen();
-    void saveScrollPosition();
-    void restoreScrollPosition();
     void setFullscreenInsets(const WebCore::FloatBoxExtent&);
     void setFullscreenAutoHideDuration(Seconds);
     void closeWithCallback(CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1039,8 +1039,6 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     [_fullscreenViewController.get().view addGestureRecognizer:_interactivePanDismissGestureRecognizer.get()];
 #endif // ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
 
-    manager->saveScrollPosition();
-
     page->setSuppressVisibilityUpdates(true);
     page->startDeferringResizeEvents();
     page->startDeferringScrollEvents();
@@ -1420,7 +1418,6 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     [self _reinsertWebViewUnderPlaceholder];
 
     if (auto* manager = self._manager) {
-        manager->restoreScrollPosition();
         manager->setAnimatingFullScreen(false);
         manager->didExitFullScreen();
     }
@@ -1646,7 +1643,6 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         manager->requestExitFullScreen();
         manager->setAnimatingFullScreen(true);
         manager->willExitFullScreen();
-        manager->restoreScrollPosition();
         manager->setAnimatingFullScreen(false);
         manager->didExitFullScreen();
     }

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -250,7 +250,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _page->startDeferringResizeEvents();
     _page->startDeferringScrollEvents();
-    [self _manager]->saveScrollPosition();
     _savedObscuredContentInsets = _page->obscuredContentInsets();
     _page->setObscuredContentInsets({ });
     [[self window] setFrame:screenFrame display:NO];
@@ -368,7 +367,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [[_webView window] makeKeyAndOrderFront:self];
 
         _page->scalePageRelativeToScrollPosition(_savedScale, { });
-        [self _manager]->restoreScrollPosition();
         _page->setObscuredContentInsets(_savedObscuredContentInsets);
         [self _manager]->setAnimatingFullScreen(false);
         [self _manager]->didExitFullScreen();
@@ -544,7 +542,6 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [self _manager]->setAnimatingFullScreen(false);
     [self _manager]->didExitFullScreen();
     _page->scalePageRelativeToScrollPosition(_savedScale, { });
-    [self _manager]->restoreScrollPosition();
     _page->setObscuredContentInsets(_savedObscuredContentInsets);
     _page->flushDeferredResizeEvents();
     _page->flushDeferredScrollEvents();

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -77,9 +77,6 @@ public:
     void willExitFullScreen();
     void didExitFullScreen();
 
-    void saveScrollPosition();
-    void restoreScrollPosition();
-
     WebCore::Element* element();
 
     void videoControlsManagerDidChange();

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -32,8 +32,6 @@ messages -> WebFullScreenManager {
     WillExitFullScreen()
     DidExitFullScreen()
     SetAnimatingFullScreen(bool animating)
-    SaveScrollPosition()
-    RestoreScrollPosition()
     SetFullscreenInsets(WebCore::FloatBoxExtent insets)
     SetFullscreenAutoHideDuration(Seconds duration)
 }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -460,8 +460,6 @@ bool TestController::willEnterFullScreen(WKPageRef page)
 {
     if (m_dumpFullScreenCallbacks)
         protectedCurrentInvocation()->outputText("supportsFullScreen() == true\nenterFullScreenForElement()\n"_s);
-
-    WKPageSaveScrollPositionForFullScreen(page);
     return true;
 }
 
@@ -530,7 +528,6 @@ void TestController::beganExitFullScreen(WKPageRef page, WKRect initialFrame, WK
 void TestController::finishFullscreenExit(WKPageRef page)
 {
     WKPageDidExitFullScreen(page);
-    WKPageRestoreScrollPositionAfterFullScreen(page);
 }
 
 void TestController::requestExitFullscreenFromUIProcess(WKPageRef page)


### PR DESCRIPTION
#### de46b3e4adc512b6c9fb15350f2d48078c6ad9d7
<pre>
Simplify fullscreen scroll position saving and restoring IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=286701">https://bugs.webkit.org/show_bug.cgi?id=286701</a>
<a href="https://rdar.apple.com/143842152">rdar://143842152</a>

Reviewed by Jer Noble.

Saving scroll position only happens when we begin entering fullscreen.
Restoring scroll position only happens when we end exiting fullscreen.
This is covered by the test fullscreen/fullscreen-restore-scroll-position.html

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSaveScrollPositionForFullScreen): Deleted.
(WKPageRestoreScrollPositionAfterFullScreen): Deleted.
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::saveScrollPosition): Deleted.
(WebKit::WebFullScreenManagerProxy::restoreScrollPosition): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
(-[WKFullScreenWindowController _completedExitFullScreen]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:completionHandler:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::didExitFullScreen):
(WebKit::WebFullScreenManager::saveScrollPosition): Deleted.
(WebKit::WebFullScreenManager::restoreScrollPosition): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::willEnterFullScreen):
(WTR::TestController::finishFullscreenExit):

Canonical link: <a href="https://commits.webkit.org/290276@main">https://commits.webkit.org/290276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b71ae57119d3586341b87074e6f59e5e484669a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68899 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26563 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6914 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35549 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96248 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16614 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12220 "Found 2 new test failures: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77770 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77079 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21507 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9764 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16627 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21938 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->