### PR TITLE
Hang in +[NSString stringEncodingForData:encodingOptions:convertedString:usedLossyConversion:].

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -40,8 +40,18 @@
 #import "WebExtensionUtilities.h"
 #import <CoreFoundation/CFBundle.h>
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/MIMETypeRegistry.h>
+#import <WebCore/TextResourceDecoder.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/FileSystem.h>
+#import <wtf/HashSet.h>
+#import <wtf/Language.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/MakeString.h>
+#import <wtf/text/WTFString.h>
 
 #if PLATFORM(MAC)
 #import <pal/spi/mac/NSImageSPI.h>
@@ -219,11 +229,42 @@ RefPtr<API::Data> WebExtension::resourceDataForPath(const String& originalPath, 
 
     auto *cocoaPath = static_cast<NSString *>(path);
 
-    if ([cocoaPath hasPrefix:@"data:"]) {
-        if (auto base64Range = [cocoaPath rangeOfString:@";base64,"]; base64Range.location != NSNotFound) {
-            auto *base64String = [cocoaPath substringFromIndex:NSMaxRange(base64Range)];
-            auto *data = [[NSData alloc] initWithBase64EncodedString:base64String options:0];
-            return API::Data::createWithoutCopying(data);
+    bool isServiceWorker = backgroundContentIsServiceWorker();
+    if (!isServiceWorker && [path isEqualToString:generatedBackgroundPageFilename])
+        return generatedBackgroundContent();
+
+    if (isServiceWorker && [path isEqualToString:generatedBackgroundServiceWorkerFilename])
+        return generatedBackgroundContent();
+
+    NSData *data = resourceDataForPath(path, outError, CacheResult::No, suppressErrors);
+    if (!data)
+        return nil;
+
+    RefPtr decoder = WebCore::TextResourceDecoder::create(resourceMIMETypeForPath(path), { }, true);
+    auto string = decoder->decode(span(data));
+    if (!string)
+        return nil;
+
+    if (cacheResult == CacheResult::Yes) {
+        if (!m_resources)
+            m_resources = [NSMutableDictionary dictionary];
+        [m_resources setObject:string forKey:path];
+    }
+
+    return string;
+}
+
+NSData *WebExtension::resourceDataForPath(NSString *path, NSError **outError, CacheResult cacheResult, SuppressNotFoundErrors suppressErrors)
+{
+    ASSERT(path);
+
+    if (outError)
+        *outError = nil;
+
+    if ([path hasPrefix:@"data:"]) {
+        if (auto base64Range = [path rangeOfString:@";base64,"]; base64Range.location != NSNotFound) {
+            auto *base64String = [path substringFromIndex:NSMaxRange(base64Range)];
+            return [[NSData alloc] initWithBase64EncodedString:base64String options:0];
         }
 
         if (auto commaRange = [cocoaPath rangeOfString:@","]; commaRange.location != NSNotFound) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -92,6 +92,8 @@ std::optional<SourcePair> sourcePairForResource(const String& path, WebExtension
     RefPtr<API::Error> error;
     Ref extension = extensionContext.extension();
     auto scriptString = extension->resourceStringForPath(path, error, WebExtension::CacheResult::Yes);
+    NSError *error;
+    String scriptString = extensionContext.extension().resourceStringForPath(path, &error, WebExtension::CacheResult::Yes);
     if (!scriptString || error) {
         extensionContext.recordError(wrapper(error));
         return std::nullopt;


### PR DESCRIPTION
#### 5b6e0dc21eca226b029ec5a8975baed5ee6ea625
<pre>
Hang in +[NSString stringEncodingForData:encodingOptions:convertedString:usedLossyConversion:].
<a href="https://webkit.org/b/285533">https://webkit.org/b/285533</a>
<a href="https://rdar.apple.com/142452073">rdar://142452073</a>

Reviewed by Brian Weinstein.

Use WebCore::TextResourceDecoder instead of +[NSString stringEncodingForData:].
Also cache the result so detection only happens once, and avoids disk access when
an extension is executing the same script over and over in many tabs.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceStringForPath): Use TextResourceDecoder.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::sourcePairForResource): Cache the result.

Originally-landed-as: 144dde143d3a. rdar://143591794
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b6e0dc21eca226b029ec5a8975baed5ee6ea625

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87248 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6758 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41608 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37988 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7034 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14830 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67434 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25164 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90250 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/7034 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/41608 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47748 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/7034 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/41608 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37104 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/7034 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/41608 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93994 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14410 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/14830 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76233 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14614 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/41608 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75438 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/41608 "Hash 5b6e0dc2 for PR 39715 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7340 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14429 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19722 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->