### PR TITLE
Node refcounting should prevent ref()'s that escape the destructor [ Part 2 ]

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -467,10 +467,16 @@ public:
 
     ALWAYS_INLINE void decrementReferencingNodeCount(unsigned count = 1)
     {
+        ASSERT_WITH_SECURITY_IMPLICATION(m_referencingNodeCount >= count);
+
         m_referencingNodeCount -= count;
         if (!m_referencingNodeCount && !refCount()) {
+            // FIXME: Remove this redundant check.
             if (deletionHasBegun())
                 return;
+
+            // Restore the the final overlooking ref that deref() maintains.
+            m_refCountAndParentBit = s_refCountIncrement;
             setStateFlag(StateFlag::HasStartedDeletion);
             delete this;
         }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -855,12 +855,13 @@ ALWAYS_INLINE void Node::deref() const
     ASSERT(isMainThread());
     ASSERT(!m_adoptionIsRequired);
 
-    ASSERT(refCount());
+    ASSERT_WITH_SECURITY_IMPLICATION(refCount());
     auto updatedRefCount = m_refCountAndParentBit - s_refCountIncrement;
     if (!updatedRefCount) {
+        // FIXME: Remove this redundant check.
         if (deletionHasBegun())
             return;
-        // Don't update m_refCountAndParentBit to avoid double destruction through use of Ref<T>/RefPtr<T>.
+
 #if ASSERT_ENABLED
         m_inRemovedLastRefFunction = true;
 #endif


### PR DESCRIPTION
#### a7a2be07da735d966b1903215333f03deee1a1f9
<pre>
Node refcounting should prevent ref()&apos;s that escape the destructor [ Part 2 ]
<a href="https://bugs.webkit.org/show_bug.cgi?id=286700">https://bugs.webkit.org/show_bug.cgi?id=286700</a>
<a href="https://rdar.apple.com/143698424">rdar://143698424</a>

Reviewed by Chris Dumez.

<a href="https://commits.webkit.org/287208@main">https://commits.webkit.org/287208@main</a> added checking for ref()&apos;s that escape
the Node destructor.

The model I implemented was a bit relaxed for an edge case in Document
destruction. It a accepted a final refcount of either 0 or 1 (but not more).

This patch makes it strict. Now Node destruction requires a final refcount of
exactly 1.

(Node::deref maintains a final overlooking refcount of 1 to prevent re-entering
our destructor, and also to check whether our destructor adds any more ref&apos;s
that escape.)

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::~Document): Since m_referencingNodeCount is akin to a refcount,
also assert that no m_referencingNodeCount escapes destruction.

We can use 0 here because our 1 refcount already prevents re-entering our
destructor.

(WebCore::Document::removedLastRef): No need to incrementReferencingNodeCount()
to protect &apos;this&apos; inside this function. Our 1 refcount already protects us.

When we resurrect a document after its last ref has been removed (because it
still has referencing nodes), instead of resetting its refcount to 0, drop
its overlooking 1 refcount. This allows new ref&apos;s that were added during
removedLastRef to escape, which is consistent with the decision to resurrect.

* Source/WebCore/dom/Document.h:
(WebCore::Document::decrementReferencingNodeCount): Because removedLastRef
dropped our overlooking 1 refcount, restore it here before destruction.

Also added an ASSERT for underflow.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::Node): Do not inc / dec the referencing node count on the
Document itself. The Document never intends to reference itself (that would be
a leak), and this only worked mechanically for weird reasons, and now it
triggers my new ASSERT, so stop doing that.

(WebCore::Node::~Node): Check for exactly 1. This is the point of this patch.

(WebCore::Node::removedLastRef): Changed an ASSERT to RELEASE_ASSERT because
it&apos;s related to other RELEASE_ASSERTs and on a slow path.

* Source/WebCore/dom/Node.h:
(WebCore::Node::deref const): Changed an ASSERT to ASSERT_WITH_SECURITY_IMPLICATION
to help fuzzing look for mistakes in this patch.

Canonical link: <a href="https://commits.webkit.org/289569@main">https://commits.webkit.org/289569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60524cd4ad6548571017e6dd472187659c0f9435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87298 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14883 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67459 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25190 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5195 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33387 "Found 2 new test failures: editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14460 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10523 "Found 1 new test failure: fast/css/view-transitions-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76268 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75474 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7392 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13611 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19772 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14224 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->