### PR TITLE
[JSC] WasmGC Array is broken for GC

### DIFF
--- a/JSTests/wasm/stress/array-element-creation.js
+++ b/JSTests/wasm/stress/array-element-creation.js
@@ -1,0 +1,17 @@
+//@ runDefault("--useConcurrentJIT=0")
+
+function main() {
+    const wasm_module_code = readFile('./resources/array-element-creation.wasm', 'binary');
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm_module_code), {});
+
+    const set = new Set();
+    const array = instance.exports.createArray();
+    for (let i = 0; i < 500000; i++) {
+        set.add(instance.exports.arrayGet(array, i));
+    }
+
+    if (set.size !== 500000)
+        throw new Error(set.size);
+}
+
+main();

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1830,59 +1830,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayNewEmpty, EncodedJSValue, (J
         return JSValue::encode(jsNull());
 
     // Create a default-initialized array with the right element type and length
-    JSWebAssemblyArray* array = nullptr;
-    if (fieldType.type.is<PackedType>()) {
-        switch (fieldType.type.as<PackedType>()) {
-        case Wasm::PackedType::I8: {
-            FixedVector<uint8_t> v(size);
-            v.fill(0); // Prevent GC from tracing uninitialized array slots
-            array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(v), arrayRTT);
-            break;
-        }
-        case Wasm::PackedType::I16: {
-            FixedVector<uint16_t> v(size);
-            v.fill(0);
-            array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(v), arrayRTT);
-            break;
-        }
-        }
-        return JSValue::encode(array);
-    }
-
-    ASSERT(fieldType.type.is<Type>());
-    switch (fieldType.type.as<Type>().kind) {
-    case Wasm::TypeKind::I32:
-    case Wasm::TypeKind::F32: {
-        FixedVector<uint32_t> v(size);
-        v.fill(0);
-        array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(v), arrayRTT);
-        break;
-    }
-    case Wasm::TypeKind::I64:
-    case Wasm::TypeKind::F64: {
-        FixedVector<uint64_t> v(size);
-        v.fill(0);
-        array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(v), arrayRTT);
-        break;
-    }
-    case Wasm::TypeKind::Ref:
-    case Wasm::TypeKind::RefNull: {
-        FixedVector<uint64_t> v(size);
-        v.fill(JSValue::encode(jsNull()));
-        array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(v), arrayRTT);
-        break;
-    }
-    case Wasm::TypeKind::V128: {
-        FixedVector<v128_t> v(size);
-        v.fill(vectorAllZeros());
-        array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(v), arrayRTT);
-        break;
-    }
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
-    return JSValue::encode(array ? array : jsNull());
+    return JSValue::encode(JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, arrayRTT));
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayGet, EncodedJSValue, (JSWebAssemblyInstance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index))

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -58,12 +58,9 @@ JSWebAssemblyArray* fillArray(JSWebAssemblyInstance* instance, Wasm::FieldType f
     JSGlobalObject* globalObject = instance->globalObject();
     VM& vm = instance->vm();
 
-    FixedVector<T> values(size);
-    if (!size)
-        return JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values), rtt);
-
-    values.fill(value);
-    return JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values), rtt);
+    auto* array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, rtt);
+    array->fill(0, static_cast<T>(value), size);
+    return array;
 }
 
 inline JSValue arrayNew(JSWebAssemblyInstance* instance, uint32_t typeIndex, uint32_t size, EncodedJSValue encValue)
@@ -103,9 +100,7 @@ inline JSValue arrayNew(JSWebAssemblyInstance* instance, uint32_t typeIndex, uin
         RELEASE_ASSERT_NOT_REACHED();
     }
     ASSERT(array);
-    if (array)
-        return array;
-    return jsNull();
+    return array;
 }
 
 inline JSValue arrayNew(JSWebAssemblyInstance* instance, uint32_t typeIndex, uint32_t size, v128_t value)
@@ -125,12 +120,9 @@ inline JSValue arrayNew(JSWebAssemblyInstance* instance, uint32_t typeIndex, uin
     if (UNLIKELY(productOverflows<uint32_t>(elementSize, size) || elementSize * size > maxArraySizeInBytes))
         return jsNull();
 
-    FixedVector<v128_t> values(size);
-    values.fill(value);
-    auto* array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values), rtt);
-    if (array)
-        return array;
-    return jsNull();
+    auto* array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, rtt);
+    array->fill(0, value, size);
+    return array;
 }
 
 template <typename T>
@@ -139,16 +131,19 @@ JSWebAssemblyArray* copyElementsInReverse(JSWebAssemblyInstance* instance, Wasm:
     JSGlobalObject* globalObject = instance->globalObject();
     VM& vm = instance->vm();
 
-    FixedVector<T> values(size);
+    auto* array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, rtt);
     if (!size)
-        return JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values), rtt);
+        return array;
 
+    auto* values = std::bit_cast<T*>(array->data());
     ASSERT(arguments);
     for (int srcIndex = size - 1; srcIndex >= 0; srcIndex--) {
         unsigned dstIndex = size - srcIndex - 1;
         values[dstIndex] = static_cast<T>(arguments[srcIndex]);
     }
-    return JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, size, WTFMove(values), rtt);
+    if (array->elementsAreRefTypes())
+        vm.writeBarrier(array);
+    return array;
 }
 
 // Expects arguments in reverse order
@@ -183,25 +178,11 @@ inline JSValue arrayNewFixed(JSWebAssemblyInstance* instance, uint32_t typeIndex
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }
-    if (array)
-        return array;
-    return jsNull();
+    return array;
 }
 
 template<typename T>
-EncodedJSValue createArrayValue(JSWebAssemblyInstance* instance, FieldType fieldType, size_t arraySize, FixedVector<T>&& tempValues, RefPtr<const Wasm::RTT> rtt)
-{
-    JSGlobalObject* globalObject = instance->globalObject();
-    VM& vm = globalObject->vm();
-
-    JSWebAssemblyArray* array = JSWebAssemblyArray::tryCreate(vm, globalObject->webAssemblyArrayStructure(), fieldType, arraySize, WTFMove(tempValues), rtt);
-
-    return JSValue::encode(array ? JSValue(array) : jsNull());
-}
-
-template<typename T>
-EncodedJSValue createArrayFromDataSegment(JSWebAssemblyInstance* instance, FieldType elementType, size_t arraySize,
-    unsigned dataSegmentIndex, unsigned offset, FixedVector<T>&& tempValues, RefPtr<const Wasm::RTT> rtt)
+EncodedJSValue createArrayFromDataSegment(JSWebAssemblyInstance* instance, FieldType elementType, size_t arraySize, unsigned dataSegmentIndex, unsigned offset, RefPtr<const Wasm::RTT> rtt)
 {
     // Determine the array length in bytes from the element type and desired array size
     size_t elementSize = elementType.type.elementSize();
@@ -216,24 +197,17 @@ EncodedJSValue createArrayFromDataSegment(JSWebAssemblyInstance* instance, Field
     if (UNLIKELY(sumOverflows<uint32_t>(offset, arrayLengthInBytes)))
         return JSValue::encode(jsNull());
 
+    JSGlobalObject* globalObject = instance->globalObject();
+    VM& vm = globalObject->vm();
+    auto* array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), elementType, arraySize, rtt);
+
     // Copy the data from the segment into the temp `values` vector
-    if (!instance->copyDataSegment(dataSegmentIndex, offset, arrayLengthInBytes, reinterpret_cast<uint8_t*>(tempValues.mutableSpan().data()))) {
+    if (!instance->copyDataSegment(array, dataSegmentIndex, offset, arrayLengthInBytes, reinterpret_cast<uint8_t*>(array->data()))) {
         // If copyDataSegment() returns false, the segment access is out of bounds.
         // In that case, the caller is responsible for throwing an exception.
         return JSValue::encode(jsNull());
     }
-
-    // Finally, return a JS value representing an array of the values from `tempValues`
-    return createArrayValue(instance, elementType, arraySize, WTFMove(tempValues), rtt);
-}
-
-inline EncodedJSValue createArrayFromElementSegment(JSWebAssemblyInstance* instance, size_t arraySize, unsigned elemSegmentIndex, unsigned offset, FixedVector<uint64_t>&& tempValues, RefPtr<const Wasm::RTT> rtt)
-{
-    // Copy the data from the segment into the temp `values` vector
-    instance->copyElementSegment(instance->module().moduleInformation().elements[elemSegmentIndex], offset, arraySize, tempValues.mutableSpan().data());
-
-    // Finally, return a JS value representing an array of the values from `tempValues`
-    return createArrayValue(instance, FieldType { StorageType { Types::I64 }, Mutability::Mutable }, arraySize, WTFMove(tempValues), rtt);
+    return JSValue::encode(array);
 }
 
 inline EncodedJSValue arrayNewData(JSWebAssemblyInstance* instance, uint32_t typeIndex, uint32_t dataSegmentIndex, uint32_t arraySize, uint32_t offset)
@@ -252,12 +226,10 @@ inline EncodedJSValue arrayNewData(JSWebAssemblyInstance* instance, uint32_t typ
     if (fieldType.type.is<PackedType>()) {
         switch (fieldType.type.as<PackedType>()) {
         case PackedType::I8: {
-            FixedVector<uint8_t> values(arraySize);
-            return createArrayFromDataSegment(instance, fieldType, arraySize, dataSegmentIndex, offset, WTFMove(values), arrayRTT);
+            return createArrayFromDataSegment<uint8_t>(instance, fieldType, arraySize, dataSegmentIndex, offset, arrayRTT);
         }
         case PackedType::I16: {
-            FixedVector<uint16_t> values(arraySize);
-            return createArrayFromDataSegment(instance, fieldType, arraySize, dataSegmentIndex, offset, WTFMove(values), arrayRTT);
+            return createArrayFromDataSegment<uint16_t>(instance, fieldType, arraySize, dataSegmentIndex, offset, arrayRTT);
         }
         default:
             break;
@@ -266,17 +238,14 @@ inline EncodedJSValue arrayNewData(JSWebAssemblyInstance* instance, uint32_t typ
         switch (fieldType.type.as<Type>().kind) {
         case Wasm::TypeKind::I32:
         case Wasm::TypeKind::F32: {
-            FixedVector<uint32_t> values(arraySize);
-            return createArrayFromDataSegment(instance, fieldType, arraySize, dataSegmentIndex, offset, WTFMove(values), arrayRTT);
+            return createArrayFromDataSegment<uint32_t>(instance, fieldType, arraySize, dataSegmentIndex, offset, arrayRTT);
         }
         case Wasm::TypeKind::I64:
         case Wasm::TypeKind::F64: {
-            FixedVector<uint64_t> values(arraySize);
-            return createArrayFromDataSegment(instance, fieldType, arraySize, dataSegmentIndex, offset, WTFMove(values), arrayRTT);
+            return createArrayFromDataSegment<uint64_t>(instance, fieldType, arraySize, dataSegmentIndex, offset, arrayRTT);
         }
         case Wasm::TypeKind::V128: {
-            FixedVector<v128_t> values(arraySize);
-            return createArrayFromDataSegment(instance, fieldType, arraySize, dataSegmentIndex, offset, WTFMove(values), arrayRTT);
+            return createArrayFromDataSegment<v128_t>(instance, fieldType, arraySize, dataSegmentIndex, offset, arrayRTT);
         }
         default:
             break;
@@ -308,14 +277,19 @@ inline EncodedJSValue arrayNewElem(JSWebAssemblyInstance* instance, uint32_t typ
     if (UNLIKELY(calculatedArrayEnd.hasOverflowed() || calculatedArrayEnd > segmentLength))
         return JSValue::encode(jsNull());
 
+    StorageType storageType(element->elementType);
     if (segmentLength) {
-        size_t elementTypeSize = typeSizeInBytes(StorageType(element->elementType));
+        size_t elementTypeSize = typeSizeInBytes(storageType);
         auto newArraySizeInBytes = CheckedSize { elementTypeSize } * arraySize;
         if (UNLIKELY(newArraySizeInBytes.hasOverflowed() || newArraySizeInBytes > maxArraySizeInBytes))
             return JSValue::encode(jsNull());
     }
-    FixedVector<uint64_t> values(arraySize);
-    return createArrayFromElementSegment(instance, arraySize, elemSegmentIndex, offset, WTFMove(values), arrayRTT);
+
+    JSGlobalObject* globalObject = instance->globalObject();
+    VM& vm = globalObject->vm();
+    auto* array = JSWebAssemblyArray::create(vm, globalObject->webAssemblyArrayStructure(), FieldType { storageType, Mutability::Mutable }, arraySize, arrayRTT);
+    instance->copyElementSegment(array, instance->module().moduleInformation().elements[elemSegmentIndex], offset, arraySize, std::bit_cast<uint64_t*>(array->data()));
+    return JSValue::encode(array);
 }
 
 inline EncodedJSValue arrayGet(JSWebAssemblyInstance* instance, uint32_t typeIndex, EncodedJSValue arrayValue, uint32_t index)
@@ -447,10 +421,7 @@ inline bool arrayInitElem(JSWebAssemblyInstance* instance, EncodedJSValue dst, u
     if (lastSrcElementIndexChecked > lengthOfElementSegment)
         return false;
 
-    if (size > 0) {
-        instance->copyElementSegment(*instance->elementAt(srcElementIndex), srcOffset, size, dstObject->reftypeData() + dstOffset);
-        instance->vm().writeBarrier(dstObject);
-    }
+    instance->copyElementSegment(dstObject, *instance->elementAt(srcElementIndex), srcOffset, size, dstObject->reftypeData() + dstOffset);
     return true;
 }
 
@@ -476,7 +447,7 @@ inline bool arrayInitData(JSWebAssemblyInstance* instance, EncodedJSValue dst, u
         return false;
 
     size_t elementSize = dstObject->elementType().type.elementSize();
-    return instance->copyDataSegment(srcDataIndex, srcOffset, size * elementSize, dstObject->data() + dstOffset * elementSize);
+    return instance->copyDataSegment(dstObject, srcDataIndex, srcOffset, size * elementSize, dstObject->data() + dstOffset * elementSize);
 }
 
 // structNew() expects the `arguments` array (when used) to be in reverse order

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -46,44 +46,43 @@ Structure* JSWebAssemblyArray::createStructure(VM& vm, JSGlobalObject* globalObj
     return Structure::create(vm, globalObject, prototype, TypeInfo(WebAssemblyGCObjectType, StructureFlags), info());
 }
 
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint8_t>&& payload, RefPtr<const Wasm::RTT> rtt)
+JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, RefPtr<const Wasm::RTT> rtt)
     : Base(vm, structure, rtt)
     , m_elementType(elementType)
     , m_size(size)
-    , m_payload8(WTFMove(payload))
 {
-}
+    if (m_elementType.type.is<Wasm::PackedType>()) {
+        switch (m_elementType.type.as<Wasm::PackedType>()) {
+        case Wasm::PackedType::I8:
+            new (&m_payload8) FixedVector<uint8_t>(m_size);
+            m_payload8.fill(0);
+            return;
+        case Wasm::PackedType::I16:
+            new (&m_payload16) FixedVector<uint16_t>(m_size);
+            m_payload16.fill(0);
+            return;
+        }
+        return;
+    }
 
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint16_t>&& payload, RefPtr<const Wasm::RTT> rtt)
-    : Base(vm, structure, rtt)
-    , m_elementType(elementType)
-    , m_size(size)
-    , m_payload16(WTFMove(payload))
-{
-}
-
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint32_t>&& payload, RefPtr<const Wasm::RTT> rtt)
-    : Base(vm, structure, rtt)
-    , m_elementType(elementType)
-    , m_size(size)
-    , m_payload32(WTFMove(payload))
-{
-}
-
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<uint64_t>&& payload, RefPtr<const Wasm::RTT> rtt)
-    : Base(vm, structure, rtt)
-    , m_elementType(elementType)
-    , m_size(size)
-    , m_payload64(WTFMove(payload))
-{
-}
-
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<v128_t>&& payload, RefPtr<const Wasm::RTT> rtt)
-    : Base(vm, structure, rtt)
-    , m_elementType(elementType)
-    , m_size(size)
-    , m_payload128(WTFMove(payload))
-{
+    switch (m_elementType.type.as<Wasm::Type>().kind) {
+    case Wasm::TypeKind::I32:
+    case Wasm::TypeKind::F32:
+        new (&m_payload32) FixedVector<uint32_t>(m_size);
+        m_payload32.fill(0);
+        return;
+    case Wasm::TypeKind::V128:
+        new (&m_payload128) FixedVector<v128_t>(m_size);
+        m_payload128.fill(v128_t { });
+        return;
+    default:
+        new (&m_payload64) FixedVector<uint64_t>(m_size);
+        if (elementsAreRefTypes())
+            m_payload64.fill(JSValue::encode(jsNull()));
+        else
+            m_payload64.fill(0);
+        return;
+    }
 }
 
 JSWebAssemblyArray::~JSWebAssemblyArray()
@@ -117,7 +116,7 @@ JSWebAssemblyArray::~JSWebAssemblyArray()
 void JSWebAssemblyArray::fill(uint32_t offset, uint64_t value, uint32_t size)
 {
     // Handle ref types separately to ensure write barriers are in effect.
-    if (isRefType(m_elementType.type.unpacked()) && !isI31ref(m_elementType.type.unpacked())) {
+    if (elementsAreRefTypes()) {
         for (size_t i = 0; i < size; i++)
             set(offset + i, value);
         return;
@@ -157,27 +156,19 @@ void JSWebAssemblyArray::fill(uint32_t offset, v128_t value, uint32_t size)
 void JSWebAssemblyArray::copy(JSWebAssemblyArray& dst, uint32_t dstOffset, uint32_t srcOffset, uint32_t size)
 {
     // Handle ref types separately to ensure write barriers are in effect.
-    if (isRefType(m_elementType.type.unpacked()) && !isI31ref(m_elementType.type.unpacked())) {
-        // If the ranges overlap then copy to a tmp buffer first.
-        if (&dst == this && dstOffset <= srcOffset + size && srcOffset <= dstOffset + size) {
-            FixedVector<uint64_t> tmpCopy(size);
-            std::copy(m_payload64.begin() + srcOffset, m_payload64.begin() + srcOffset + size, tmpCopy.mutableSpan().data());
-            for (size_t i = 0; i < size; i++)
-                dst.set(dstOffset + i, tmpCopy[i]);
-        } else {
-            for (size_t i = 0; i < size; i++)
-                dst.set(dstOffset + i, m_payload64[srcOffset + i]);
-        }
+    if (elementsAreRefTypes()) {
+        gcSafeMemmove(dst.m_payload64.mutableSpan().subspan(dstOffset).data(), m_payload64.span().subspan(srcOffset).data(), size * sizeof(JSValue));
+        vm().writeBarrier(this);
         return;
     }
 
     if (m_elementType.type.is<Wasm::PackedType>()) {
         switch (m_elementType.type.as<Wasm::PackedType>()) {
         case Wasm::PackedType::I8:
-            memmove(dst.m_payload8.mutableSpan().subspan(dstOffset).data(), m_payload8.span().subspan(srcOffset).data(), size);
+            memmove(dst.m_payload8.mutableSpan().subspan(dstOffset).data(), m_payload8.span().subspan(srcOffset).data(), size * sizeof(uint8_t));
             return;
         case Wasm::PackedType::I16:
-            std::copy(m_payload16.begin() + srcOffset, m_payload16.begin() + srcOffset + size, dst.m_payload16.begin() + dstOffset);
+            memmove(dst.m_payload16.mutableSpan().subspan(dstOffset).data(), m_payload16.span().subspan(srcOffset).data(), size * sizeof(uint16_t));
             return;
         }
     }
@@ -185,13 +176,13 @@ void JSWebAssemblyArray::copy(JSWebAssemblyArray& dst, uint32_t dstOffset, uint3
     switch (m_elementType.type.as<Wasm::Type>().kind) {
     case Wasm::TypeKind::I32:
     case Wasm::TypeKind::F32:
-        std::copy(m_payload32.begin() + srcOffset, m_payload32.begin() + srcOffset + size, dst.m_payload32.begin() + dstOffset);
+        memmove(dst.m_payload32.mutableSpan().subspan(dstOffset).data(), m_payload32.span().subspan(srcOffset).data(), size * sizeof(uint32_t));
         return;
     case Wasm::TypeKind::V128:
-        std::copy(m_payload128.begin() + srcOffset, m_payload128.begin() + srcOffset + size, dst.m_payload128.begin() + dstOffset);
+        memmove(dst.m_payload128.mutableSpan().subspan(dstOffset).data(), m_payload128.span().subspan(srcOffset).data(), size * sizeof(v128_t));
         return;
     default:
-        std::copy(m_payload64.begin() + srcOffset, m_payload64.begin() + srcOffset + size, dst.m_payload64.begin() + dstOffset);
+        memmove(dst.m_payload64.mutableSpan().subspan(dstOffset).data(), m_payload64.span().subspan(srcOffset).data(), size * sizeof(uint64_t));
         return;
     }
 }
@@ -209,10 +200,8 @@ void JSWebAssemblyArray::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
     Base::visitChildren(thisObject, visitor);
 
-    if (isRefType(thisObject->elementType().type)) {
-        for (unsigned i = 0; i < thisObject->size(); ++i)
-            visitor.append(std::bit_cast<WriteBarrier<Unknown>>(thisObject->get(i)));
-    }
+    if (thisObject->elementsAreRefTypes())
+        visitor.appendValues(std::bit_cast<WriteBarrier<Unknown>*>(thisObject->reftypeData()), thisObject->size());
 }
 
 DEFINE_VISIT_CHILDREN(JSWebAssemblyArray);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "WasmFormat.h"
 #include "WasmOps.h"
 #include "WasmTypeDefinition.h"
 #include "WebAssemblyGCObjectBase.h"
@@ -55,15 +56,11 @@ public:
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    template <typename ElementType>
-    static JSWebAssemblyArray* tryCreate(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, FixedVector<ElementType>&& payload, RefPtr<const Wasm::RTT> rtt)
+    static JSWebAssemblyArray* create(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, RefPtr<const Wasm::RTT> rtt)
     {
-        void* buffer = tryAllocateCell<JSWebAssemblyArray>(vm);
-        if (UNLIKELY(!buffer))
-            return nullptr;
-        JSWebAssemblyArray* array = new (NotNull, buffer) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(payload), rtt);
-        array->finishCreation(vm);
-        return array;
+        auto* object = new (NotNull, allocateCell<JSWebAssemblyArray>(vm)) JSWebAssemblyArray(vm, structure, elementType, size, rtt);
+        object->finishCreation(vm);
+        return object;
     }
 
     DECLARE_VISIT_CHILDREN;
@@ -96,9 +93,15 @@ public:
         return nullptr;
     };
 
+
+    bool elementsAreRefTypes() const
+    {
+        return Wasm::isRefType(m_elementType.type.unpacked());
+    }
+
     uint64_t* reftypeData()
     {
-        RELEASE_ASSERT(m_elementType.type.unpacked().isRef() || m_elementType.type.unpacked().isRefNull());
+        RELEASE_ASSERT(elementsAreRefTypes());
         return m_payload64.mutableSpan().data();
     }
 
@@ -213,11 +216,7 @@ public:
     }
 
 protected:
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint8_t>&&, RefPtr<const Wasm::RTT>);
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint16_t>&&, RefPtr<const Wasm::RTT>);
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint32_t>&&, RefPtr<const Wasm::RTT>);
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<uint64_t>&&, RefPtr<const Wasm::RTT>);
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, FixedVector<v128_t>&&, RefPtr<const Wasm::RTT>);
+    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, RefPtr<const Wasm::RTT>);
     ~JSWebAssemblyArray();
 
     DECLARE_DEFAULT_FINISH_CREATION;
@@ -228,6 +227,7 @@ protected:
     // A union is used here to ensure the underlying storage is aligned correctly.
     // The payload member used entirely depends on m_elementType, so no tag is required.
     union {
+        void* zeroInit { nullptr };
         FixedVector<uint8_t>  m_payload8;
         FixedVector<uint16_t> m_payload16;
         FixedVector<uint32_t> m_payload32;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -31,6 +31,7 @@
 #include "AbstractModuleRecord.h"
 #include "JSCInlines.h"
 #include "JSModuleNamespaceObject.h"
+#include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyCompileError.h"
 #include "JSWebAssemblyHelpers.h"
 #include "JSWebAssemblyLinkError.h"
@@ -539,7 +540,7 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
     }
 }
 
-bool JSWebAssemblyInstance::copyDataSegment(uint32_t segmentIndex, uint32_t offset, uint32_t lengthInBytes, uint8_t* values)
+bool JSWebAssemblyInstance::copyDataSegment(JSWebAssemblyArray* array, uint32_t segmentIndex, uint32_t offset, uint32_t lengthInBytes, uint8_t* values)
 {
     // Fail if the data segment index is out of bounds
     RELEASE_ASSERT(segmentIndex < module().moduleInformation().dataSegmentsCount());
@@ -559,17 +560,27 @@ bool JSWebAssemblyInstance::copyDataSegment(uint32_t segmentIndex, uint32_t offs
     const uint8_t* segmentData = &segment->byte(offset);
 
     // Copy the data from the segment into the out param vector
-    memcpy(values, segmentData, lengthInBytes);
+    if (array->elementsAreRefTypes()) {
+        gcSafeMemcpy(std::bit_cast<uint64_t*>(values), std::bit_cast<const uint64_t*>(segmentData), lengthInBytes);
+        m_vm->writeBarrier(array);
+    } else
+        memcpy(values, segmentData, lengthInBytes);
 
     return true;
 }
 
-void JSWebAssemblyInstance::copyElementSegment(const Element& segment, uint32_t srcOffset, uint32_t length, uint64_t* values)
+void JSWebAssemblyInstance::copyElementSegment(JSWebAssemblyArray* array, const Element& segment, uint32_t srcOffset, uint32_t length, uint64_t* values)
 {
     // Caller should have already checked that the (offset + length) calculation doesn't overflow int32,
     // and that the (offset + length) doesn't overflow the element segment
     ASSERT(!sumOverflows<uint32_t>(srcOffset, length));
     ASSERT((srcOffset + length) <= segment.length());
+
+    auto set = [&](size_t index, uint64_t value) {
+        values[index] = value;
+        if (array->elementsAreRefTypes())
+            m_vm->writeBarrier(array);
+    };
 
     for (uint32_t i = 0; i < length; i++) {
         uint32_t srcIndex = srcOffset + i;
@@ -578,7 +589,7 @@ void JSWebAssemblyInstance::copyElementSegment(const Element& segment, uint32_t 
 
         // Represent the null function as the null JS value
         if (initType == Element::InitializationType::FromRefNull) {
-            values[i] = static_cast<uint64_t>(JSValue::encode(jsNull()));
+            set(i, static_cast<uint64_t>(JSValue::encode(jsNull())));
             continue;
         }
 
@@ -590,12 +601,12 @@ void JSWebAssemblyInstance::copyElementSegment(const Element& segment, uint32_t 
             // and create them here dynamically instead.
             JSValue value = getFunctionWrapper(functionIndex);
             ASSERT(value.isCallable());
-            values[i] = static_cast<uint64_t>(JSValue::encode(value));
+            set(i, static_cast<uint64_t>(JSValue::encode(value)));
             continue;
         }
 
         if (initType == Element::InitializationType::FromGlobal) {
-            values[i] = loadI64Global(initialBitsOrIndex);
+            set(i, loadI64Global(initialBitsOrIndex));
             continue;
         }
 
@@ -605,7 +616,7 @@ void JSWebAssemblyInstance::copyElementSegment(const Element& segment, uint32_t 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=264454
         // Currently this should never fail, as the parse phase already validated it.
         RELEASE_ASSERT(success);
-        values[i] = result;
+        set(i, result);
     }
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -134,8 +134,8 @@ public:
     const Wasm::Element* elementAt(unsigned) const;
 
     void initElementSegment(uint32_t tableIndex, const Wasm::Element& segment, uint32_t dstOffset, uint32_t srcOffset, uint32_t length);
-    bool copyDataSegment(uint32_t segmentIndex, uint32_t offset, uint32_t lengthInBytes, uint8_t* values);
-    void copyElementSegment(const Wasm::Element& segment, uint32_t srcOffset, uint32_t length, uint64_t* values);
+    bool copyDataSegment(JSWebAssemblyArray*, uint32_t segmentIndex, uint32_t offset, uint32_t lengthInBytes, uint8_t* values);
+    void copyElementSegment(JSWebAssemblyArray*, const Wasm::Element& segment, uint32_t srcOffset, uint32_t length, uint64_t* values);
 
     bool isImportFunction(uint32_t functionIndex) const
     {


### PR DESCRIPTION
#### 70ce977b3a9f54ffd4e29817fea13b9729d82545
<pre>
[JSC] WasmGC Array is broken for GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=285580">https://bugs.webkit.org/show_bug.cgi?id=285580</a>
<a href="https://rdar.apple.com/141144921">rdar://141144921</a>

Reviewed by Keith Miller.

WasmGC Array is broken for GC in multiple ways. We carefully reviewed WasmGC
Array implementation. We found many issues, and this patch fixes them.

1. Doing GC while putting GC values in FixedVector. That&apos;s totally
   wrong. We fixed it by first creating WasmGC Array and modifying the
   contents later.
2. arrayNewElem is always creating I64 array, which is broken. We should
   create a specified typed array.
3. WasmGC Array copy implementation is using std::copy even for
   overlapping region. That&apos;s totally wrong, and it should use memmove.
   For GC-ref-types, we should use gcSafeMemmove.

* JSTests/wasm/stress/array-element-creation.js: Added.
* JSTests/wasm/stress/resources/array-element-creation.wasm: Added.
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::fillArray):
(JSC::Wasm::arrayNew):
(JSC::Wasm::copyElementsInReverse):
(JSC::Wasm::arrayNewFixed):
(JSC::Wasm::createArrayFromDataSegment):
(JSC::Wasm::arrayNewData):
(JSC::Wasm::arrayNewElem):
(JSC::Wasm::arrayInitElem):
(JSC::Wasm::arrayInitData):
(JSC::Wasm::createArrayValue): Deleted.
(JSC::Wasm::createArrayFromElementSegment): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::fill):
(JSC::JSWebAssemblyArray::copy):
(JSC::JSWebAssemblyArray::visitChildrenImpl):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::copyDataSegment):
(JSC::JSWebAssemblyInstance::copyElementSegment):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Originally-landed-as: ac2bd207812a. <a href="https://rdar.apple.com/143529972">rdar://143529972</a>
Canonical link: <a href="https://commits.webkit.org/289530@main">https://commits.webkit.org/289530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0725932e4081c598afd876600209bcdcc7d12dd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87260 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37116 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/80049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94007 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86034 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14422 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14627 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75446 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/19786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18227 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13592 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14441 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108528 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26117 "Found 8 new JSC stress test failures: wasm.yaml/wasm/gc/array_new_data.js.default-wasm, wasm.yaml/wasm/gc/array_new_data.js.wasm-bbq, wasm.yaml/wasm/gc/array_new_data.js.wasm-collect-continuously, wasm.yaml/wasm/gc/array_new_data.js.wasm-eager, wasm.yaml/wasm/gc/array_new_data.js.wasm-eager-jettison, wasm.yaml/wasm/gc/array_new_data.js.wasm-no-cjit, wasm.yaml/wasm/gc/array_new_data.js.wasm-slow-memory, wasm.yaml/wasm/stress/array-element-creation.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17629 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/15967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->