### PR TITLE
REGRESSION (288901@main): animation when finding non-theme word in Strands game shows artifacts.

### DIFF
--- a/LayoutTests/fast/repaint/repaint-on-transform-change-expected.txt
+++ b/LayoutTests/fast/repaint/repaint-on-transform-change-expected.txt
@@ -1,0 +1,5 @@
+(repaint rects
+  (rect 10 8 200 200)
+  (rect 209 8 200 200)
+)
+

--- a/LayoutTests/fast/repaint/repaint-on-transform-change.html
+++ b/LayoutTests/fast/repaint/repaint-on-transform-change.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="resources/text-based-repaint.js" type="text/javascript"></script>
+</head>
+<body>
+  <div style="transform: translateX(1px)">
+    <div id="target" style="position:fixed; transform: translateX(1px); width: 200px; height: 200px; background: green"></div>
+  </div>
+</body>
+<script>
+repaintTest = function() {
+  document.getElementById("target").style.transform = "translateX(200px)";
+};
+runRepaintTest();
+</script>
+</html>

--- a/LayoutTests/fast/repaint/translate-animation-repaint.html
+++ b/LayoutTests/fast/repaint/translate-animation-repaint.html
@@ -40,7 +40,9 @@ const repaintRectsFromString = (str) => {
     const lines = str.split("\n");
     lines.shift();
     lines.pop();
-    return lines.map(line => line.trim());
+    return lines.map(line => line.trim()).filter(function(item, pos, arr){
+      return pos === 0 || item !== arr[pos-1];
+    });
 }
 
 (async function main() {
@@ -51,6 +53,8 @@ const repaintRectsFromString = (str) => {
 
     const animation = target.animate({ translate: ["200px", "200px"] }, { duration: 1, fill: "forwards" });
     await animation.finished;
+
+    await UIHelper.renderingUpdate();
 
     if (window.internals) {
         const repaintRects = repaintRectsFromString(window.internals?.repaintRectsAsText());

--- a/LayoutTests/platform/mac-wk1/fast/repaint/translate-animation-repaint-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/repaint/translate-animation-repaint-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that an element with a 'translate' animation does not leave its unanimated paint state on screen.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(rect 0 0 100 100)
+(rect 0 0 800 600)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5947,13 +5947,13 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
         m_scrollableArea->updateAllScrollbarRelatedStyle();
 
     updateDescendantDependentFlags();
-    updateTransform();
     updateBlendMode();
     updateFiltersAfterStyleChange(diff, oldStyle);
     clearClipRects();
 
     compositor().layerStyleChanged(diff, *this, oldStyle);
 
+    updateTransform();
     updateFilterPaintingStrategy();
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2434,7 +2434,7 @@ bool RenderLayerCompositor::updateBacking(RenderLayer& layer, RequiresCompositin
     // If a fixed position layer gained/lost a backing or the reason not compositing it changed,
     // the scrolling coordinator needs to recalculate whether it can do fast scrolling.
     if (layer.renderer().isFixedPositioned()) {
-        if (layer.viewportConstrainedNotCompositedReason() != queryData.nonCompositedForPositionReason) {
+        if (layer.viewportConstrainedNotCompositedReason() != queryData.nonCompositedForPositionReason  && !queryData.reevaluateAfterLayout) {
             layer.setViewportConstrainedNotCompositedReason(queryData.nonCompositedForPositionReason);
             layerChanged = true;
         }


### PR DESCRIPTION
#### 5df28f0be2e177821c29aa11102b6f933696d849
<pre>
REGRESSION (288901@main): animation when finding non-theme word in Strands game shows artifacts.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286706">https://bugs.webkit.org/show_bug.cgi?id=286706</a>
&lt;<a href="https://rdar.apple.com/143759652">rdar://143759652</a>&gt;

Reviewed by Simon Fraser.

If RenderLayerCompositor::layerStyleChanged changes the compositing status, it
updates the repaint rects on the layer and issues a repaint for the &apos;old&apos;
position.  This needs to happen before the new transform is writen to the
RenderLayer, otherwise the repaint happens at the new position (in the old
layer). Move updateTransform down a bit to get the right ordering.

There&apos;s also a second issue where queryData.nonCompositedForPositionReason
doesn&apos;t get computed if the compositing checks returned early and set
reevaluateAfterLayout=true. This can cause toggling between values (from the
style change check, and the post-layout compositing layer update check), so only
check the values if they&apos;ve been computed.

Adds a new test that catches both of these issues by checking the repaint rects
emitted.

* LayoutTests/fast/repaint/repaint-on-transform-change-expected.txt: Added.
* LayoutTests/fast/repaint/repaint-on-transform-change.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBacking):

Canonical link: <a href="https://commits.webkit.org/289581@main">https://commits.webkit.org/289581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49e4042f60feb6966b5e887edb8719b33b02382c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38134 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15070 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25254 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47853 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37250 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94142 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14560 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75548 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18585 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18347 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14578 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->