### PR TITLE
Add way to check whether iframe's owner element may follow dark appearance

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt
@@ -1,0 +1,27 @@
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+Test unloaded HTML supports dark mode correctly.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS setupDone is true
+In header, scheme is light and dark.
+PASS iframeElem.srcdoc is not ""
+PASS window.getComputedStyle(pElem).getPropertyValue('color') is 'rgb(0, 0, 0)'
+PASS window.getComputedStyle(pElem).getPropertyValue('color') is 'rgb(255, 255, 255)'
+In main, scheme is normal.
+PASS iframeElem.srcdoc is not ""
+PASS window.getComputedStyle(pElem).getPropertyValue('color') is 'rgb(0, 0, 0)'
+PASS window.getComputedStyle(pElem).getPropertyValue('color') is 'rgb(0, 0, 0)'
+In footer, scheme is dark only.
+PASS iframeElem.srcdoc is not ""
+PASS window.getComputedStyle(pElem).getPropertyValue('color') is 'rgb(255, 255, 255)'
+PASS window.getComputedStyle(pElem).getPropertyValue('color') is 'rgb(255, 255, 255)'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/http/tests/iframe-monitor/dark-mode.html
+++ b/LayoutTests/http/tests/iframe-monitor/dark-mode.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="./resources/monitor-setup.js"></script>
+</head>
+<body>
+<script>
+description("Test unloaded HTML supports dark mode correctly.");
+window.jsTestIsAsync = true;
+
+var setupDone = false;
+var iframeElem;
+var pElem;
+
+onload = async () => {
+    setupDone = await setup();
+    shouldBeTrue(`setupDone`);
+
+    if (setupDone) {
+        // Make sure iframe load is done after rule is set correctly.
+        const stage = document.querySelector('#stage');
+
+        stage.innerHTML = `
+            <style>
+                header { color-scheme: light dark; }
+                footer { color-scheme: dark; }
+            </style>
+            <header>
+                <iframe name="frame1" src="./resources/iframe--eligible--.html"></iframe>
+            </header>
+            <main>
+                <iframe name="frame2" src="./resources/iframe--eligible--.html"></iframe>
+            </main>
+            <footer>
+                <iframe name="frame3" src="./resources/iframe--eligible--.html"></iframe>
+            </footer>
+        `;
+
+        const black = `'rgb(0, 0, 0)'`;
+        const white = `'rgb(255, 255, 255)'`;
+
+        debug("In header, scheme is light and dark.")
+        await test('frame1', black, white);
+
+        debug("In main, scheme is normal.")
+        await test('frame2', black, black);
+
+        debug("In footer, scheme is dark only.")
+        await test('frame3', white, white);
+    }
+
+    finishJSTest();
+}
+
+async function test(frameName, lightModeExpected, darkModeExpected) {
+    iframeElem = await waitUntilUnload(frameName);
+
+    shouldNotBe(`iframeElem.srcdoc`, '""');
+
+    pElem = iframeElem.contentDocument.querySelector('p');
+
+    internals.settings.setUseDarkAppearance(false);
+    test_prop('pElem', 'color', lightModeExpected);
+
+    internals.settings.setUseDarkAppearance(true);
+    test_prop('pElem', 'color', darkModeExpected);
+}
+
+function test_prop(elemName, prop, expected) {
+    shouldBe(`window.getComputedStyle(${elemName}).getPropertyValue('${prop}')`, expected);
+}
+
+</script>
+<div id="stage"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
+++ b/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
@@ -42,4 +42,5 @@ async function waitUntilUnload(name) {
 
     // extra wait time
     await pause(100);
+    return iframe;
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9300,11 +9300,18 @@ float Document::deviceScaleFactor() const
     return deviceScaleFactor;
 }
 
+#if ENABLE(DARK_MODE_CSS)
+OptionSet<ColorScheme> Document::resolvedColorScheme(const RenderStyle* style) const
+{
+    bool isNormal = !style || style->colorScheme().isNormal();
+    return isNormal ? m_colorScheme : style->colorScheme().colorScheme();
+}
+#endif
+
 bool Document::useDarkAppearance(const RenderStyle* style) const
 {
 #if ENABLE(DARK_MODE_CSS)
-    bool isNormal = !style || style->colorScheme().isNormal();
-    auto colorScheme = isNormal ? m_colorScheme : style->colorScheme().colorScheme();
+    auto colorScheme = resolvedColorScheme(style);
 
     if (colorScheme.contains(ColorScheme::Dark) && !colorScheme.contains(ColorScheme::Light))
         return true;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -714,6 +714,9 @@ public:
 
     WEBCORE_EXPORT bool useElevatedUserInterfaceLevel() const;
     WEBCORE_EXPORT bool useDarkAppearance(const RenderStyle*) const;
+#if ENABLE(DARK_MODE_CSS)
+    OptionSet<ColorScheme> resolvedColorScheme(const RenderStyle*) const;
+#endif
 
     OptionSet<StyleColorOptions> styleColorOptions(const RenderStyle*) const;
     CompositeOperator compositeOperatorForBackgroundColor(const Color&, const RenderObject&) const;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1032,14 +1032,12 @@ enum class RubyOverhang : bool {
     None
 };
 
-#if ENABLE(DARK_MODE_CSS)
 enum class ColorScheme : uint8_t {
     Light = 1 << 0,
     Dark = 1 << 1
 };
 
 constexpr size_t ColorSchemeBits = 2;
-#endif
 
 constexpr size_t GridAutoFlowBits = 4;
 enum InternalGridAutoFlow : uint8_t {


### PR DESCRIPTION
#### f99fba6f4b88b7538876ecc2d490efc81eeebdb7
<pre>
Add way to check whether iframe&apos;s owner element may follow dark appearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=286713">https://bugs.webkit.org/show_bug.cgi?id=286713</a>
<a href="https://rdar.apple.com/143827621">rdar://143827621</a>

Reviewed by Aditya Keerthi.

Need to detect iframe element in main document may respond to dark appearance in CSS or document’s meta tag.

Add `Document::resolvedColorScheme(RenderStyle*) const` to get the element&apos;s color scheme to check which scheme
is ready to be used for the element.

* LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/dark-mode.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js:
(async waitUntilUnload):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolvedColorScheme const):
(WebCore::Document::useDarkAppearance const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::generateResourceMonitorErrorHTML):
(WebCore::LocalFrame::showResourceMonitoringError):
* Source/WebCore/rendering/style/RenderStyleConstants.h:

Canonical link: <a href="https://commits.webkit.org/289613@main">https://commits.webkit.org/289613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fa8895784ff949fe93aff1a1e4bf2e99b03143d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92297 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67544 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25279 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90437 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47885 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37290 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94182 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14600 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10713 "Found 2 new test failures: fonts/ligature.html imported/w3c/web-platform-tests/css/selectors/invalidation/fullscreen-pseudo-class-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76361 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14618 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19913 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->