### PR TITLE
Update WTF::copyElements() to take in spans

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -52,7 +52,7 @@ ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(std::span<const Char
         auto result = AtomStringImpl::add(characters);
         slot.m_impl = result;
         slot.m_length = characters.size();
-        WTF::copyElements(slot.m_buffer, characters.data(), characters.size());
+        WTF::copyElements(std::span<UChar> { slot.m_buffer }, characters);
         return result.releaseNonNull();
     }
 

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1212,7 +1212,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             auto result = std::to_chars(temporary.data(), temporary.data() + maxInt32StringLength, number);
             ASSERT(result.ec != std::errc::value_too_large);
             unsigned lengthToCopy = result.ptr - temporary.data();
-            WTF::copyElements(std::bit_cast<uint16_t*>(buffer() + m_length), std::bit_cast<const uint8_t*>(temporary.data()), lengthToCopy);
+            WTF::copyElements(spanReinterpretCast<uint16_t>(bufferSpan().subspan(m_length)), spanReinterpretCast<const uint8_t>(std::span { temporary }).first(lengthToCopy));
             m_length += lengthToCopy;
         }
         return;
@@ -1235,7 +1235,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             std::array<char, WTF::dragonbox::max_string_length<WTF::dragonbox::ieee754_binary64>()> temporary;
             const char* cursor = WTF::dragonbox::detail::to_chars_n<WTF::dragonbox::Mode::ToShortest>(number, temporary.data());
             size_t length = cursor - temporary.data();
-            WTF::copyElements(std::bit_cast<uint16_t*>(buffer() + m_length), std::bit_cast<const uint8_t*>(temporary.data()), length);
+            WTF::copyElements(spanReinterpretCast<uint16_t>(bufferSpan().subspan(m_length)), spanReinterpretCast<const uint8_t>(std::span { temporary }).first(length));
             m_length += length;
         }
         return;

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1167,6 +1167,13 @@ match_constness_t<SourceType, DestinationType>& consumeAndReinterpretCastTo(std:
     return spanReinterpretCast<match_constness_t<SourceType, DestinationType>>(consumeSpan(data, sizeof(DestinationType)))[0];
 }
 
+template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
+bool spansOverlap(std::span<T, TExtent> a, std::span<U, UExtent> b)
+{
+    return static_cast<const void*>(a.data()) < static_cast<const void*>(std::to_address(b.end()))
+        && static_cast<const void*>(b.data()) < static_cast<const void*>(std::to_address(a.end()));
+}
+
 /* WTF_FOR_EACH */
 
 // https://www.scs.stanford.edu/~dm/blog/va-opt.html
@@ -1489,6 +1496,7 @@ using WTF::skip;
 using WTF::spanConstCast;
 using WTF::spanHasPrefix;
 using WTF::spanHasSuffix;
+using WTF::spansOverlap;
 using WTF::spanReinterpretCast;
 using WTF::toTwosComplement;
 using WTF::tryBinarySearch;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -411,31 +411,25 @@ public:
     template<typename CharacterType>
     ALWAYS_INLINE static void copyCharacters(std::span<CharacterType> destination, std::span<const CharacterType> source)
     {
-        // FIXME: Move this assertion to copyElements().
-        ASSERT(destination.size() >= source.size());
-        return copyElements(destination.data(), source.data(), source.size());
+        return copyElements(destination, source);
     }
 
     ALWAYS_INLINE static void copyCharacters(std::span<UChar> destination, std::span<const LChar> source)
     {
         static_assert(sizeof(UChar) == sizeof(uint16_t));
         static_assert(sizeof(LChar) == sizeof(uint8_t));
-        // FIXME: Move this assertion to copyElements().
-        ASSERT(destination.size() >= source.size());
-        return copyElements(std::bit_cast<uint16_t*>(destination.data()), source.data(), source.size());
+        return copyElements(spanReinterpretCast<uint16_t>(destination), source);
     }
 
     ALWAYS_INLINE static void copyCharacters(std::span<LChar> destination, std::span<const UChar> source)
     {
         static_assert(sizeof(UChar) == sizeof(uint16_t));
         static_assert(sizeof(LChar) == sizeof(uint8_t));
-        // FIXME: Move this assertion to copyElements().
-        ASSERT(destination.size() >= source.size());
 #if ASSERT_ENABLED
         for (auto character : source)
             ASSERT(isLatin1(character));
 #endif
-        return copyElements(std::bit_cast<uint8_t*>(destination.data()), std::bit_cast<const uint16_t*>(source.data()), source.size());
+        return copyElements(destination, spanReinterpretCast<const uint16_t>(source));
     }
 
     // Some string features, like reference counting and the atomicity flag, are not

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -117,7 +117,7 @@ TEST(WTF_StringCommon, CopyElements64To8)
     for (unsigned i = 0; i < 4096; ++i)
         source.append(i);
 
-    WTF::copyElements(destination.data(), source.data(), 4096);
+    WTF::copyElements(destination.mutableSpan(), source.span());
     for (unsigned i = 0; i < 4096; ++i)
         EXPECT_EQ(destination[i], static_cast<uint8_t>(i));
 }
@@ -138,7 +138,7 @@ TEST(WTF_StringCommon, CopyElements64To16)
     for (unsigned i = 0; i < 4096; ++i)
         source.append(i);
 
-    WTF::copyElements(destination.data(), source.data(), 4096 + 4 + 4096);
+    WTF::copyElements(destination.mutableSpan(), source.span());
     for (unsigned i = 0; i < 4096; ++i)
         EXPECT_EQ(destination[i], static_cast<uint16_t>(i));
     EXPECT_EQ(destination[4096 + 0], 0xffffU);
@@ -165,7 +165,7 @@ TEST(WTF_StringCommon, CopyElements64To32)
     for (unsigned i = 0; i < 4096; ++i)
         source.append(i);
 
-    WTF::copyElements(destination.data(), source.data(), 4096 + 4 + 4096);
+    WTF::copyElements(destination.mutableSpan(), source.span());
     for (unsigned i = 0; i < 4096; ++i)
         EXPECT_EQ(destination[i], static_cast<uint32_t>(i));
     EXPECT_EQ(destination[4096 + 0], 0xffffffffU);
@@ -192,7 +192,7 @@ TEST(WTF_StringCommon, CopyElements32To16)
     for (unsigned i = 0; i < 4096; ++i)
         source.append(i);
 
-    WTF::copyElements(destination.data(), source.data(), 4096 + 4 + 4096);
+    WTF::copyElements(destination.mutableSpan(), source.span());
     for (unsigned i = 0; i < 4096; ++i)
         EXPECT_EQ(destination[i], static_cast<uint16_t>(i));
     EXPECT_EQ(destination[4096 + 0], 0xffffU);


### PR DESCRIPTION
#### fa6476f64a4d70ad7fa219da9ab47a13f2178adf
<pre>
Update WTF::copyElements() to take in spans
<a href="https://bugs.webkit.org/show_bug.cgi?id=286715">https://bugs.webkit.org/show_bug.cgi?id=286715</a>

Reviewed by Ryosuke Niwa.

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::copyFromInt32ShapeArray):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::copyFromDoubleShapeArray):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::sort):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncToReversed):
(JSC::genericTypedArrayViewProtoFuncSortImpl):
(JSC::genericTypedArrayViewProtoFuncToSorted):
(JSC::genericTypedArrayViewProtoFuncWith):
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::make):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):
* Source/JavaScriptCore/runtime/StableSort.h:
(JSC::arrayMerge):
(JSC::arrayStableSort):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::copyElements):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::copyCharacters):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, CopyElements64To8)):
(TestWebKitAPI::TEST(WTF_StringCommon, CopyElements64To16)):
(TestWebKitAPI::TEST(WTF_StringCommon, CopyElements64To32)):
(TestWebKitAPI::TEST(WTF_StringCommon, CopyElements32To16)):

Canonical link: <a href="https://commits.webkit.org/289733@main">https://commits.webkit.org/289733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/501731ea08fb48bc053bf5455e59eccf48fa0895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87795 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38545 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67793 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25536 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33844 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37652 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80593 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94547 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86570 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14963 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11003 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75872 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18678 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7965 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13695 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20282 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109064 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14723 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26228 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->