### PR TITLE
[WTF] Define WTF_MAKE_CONFIGURABLE_ALLOCATED for container types

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -230,6 +230,8 @@
 		BCEA08042CCFDB33000AC148 /* VariantList.h in Headers */ = {isa = PBXBuildFile; fileRef = BCEA08032CCFDB33000AC148 /* VariantList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C2BCFC401F61D13000C9222C /* Language.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC3E1F61D13000C9222C /* Language.cpp */; };
 		C2BCFC421F61D61600C9222C /* LanguageCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC411F61D61600C9222C /* LanguageCF.cpp */; };
+		BBEA08042CCFDB33000AC148 /* MallocCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = BBEA08032CCFDB33000AC148 /* MallocCommon.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BBFA08042CCFDB33000AC148 /* MallocCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BBFA08032CCFDB33000AC148 /* MallocCommon.cpp */; settings = {ATTRIBUTES = (Private, ); }; };
 		C2BCFC551F621F3F00C9222C /* LineEnding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC531F621F3F00C9222C /* LineEnding.cpp */; };
 		C805EF39E5F14481A96D39FC /* ASCIILiteral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6F050790D9C432A99085E75 /* ASCIILiteral.cpp */; };
 		CD5497AC15857D0300B5BC30 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5497AA15857D0300B5BC30 /* MediaTime.cpp */; };
@@ -1589,6 +1591,8 @@
 		BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariantOperations.h; sourceTree = "<group>"; };
 		BCE0DFAA2D18670B003F0349 /* VariantExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantExtras.h; sourceTree = "<group>"; };
 		BCEA08032CCFDB33000AC148 /* VariantList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantList.h; sourceTree = "<group>"; };
+		BBEA08032CCFDB33000AC148 /* MallocCommon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MallocCommon.h; sourceTree = "<group>"; };
+		BBFA08032CCFDB33000AC148 /* MallocCommon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MallocCommon.cpp; sourceTree = "<group>"; };
 		C2BCFC3E1F61D13000C9222C /* Language.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Language.cpp; sourceTree = "<group>"; };
 		C2BCFC3F1F61D13000C9222C /* Language.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Language.h; sourceTree = "<group>"; };
 		C2BCFC411F61D61600C9222C /* LanguageCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LanguageCF.cpp; sourceTree = "<group>"; };
@@ -2371,6 +2375,8 @@
 				DD4901E527B4748A00D7E50D /* MainThreadData.h */,
 				5187AC942C08570600549EFE /* MainThreadDispatcher.cpp */,
 				5187AC932C08570600549EFE /* MainThreadDispatcher.h */,
+				BBFA08032CCFDB33000AC148 /* MallocCommon.cpp */,
+				BBEA08032CCFDB33000AC148 /* MallocCommon.h */,
 				1A233C7C17DAA6E300A93ACF /* MallocPtr.h */,
 				465005D72CD2840A00950C5F /* MallocSpan.h */,
 				304CA4E41375437EBE931D03 /* Markable.h */,
@@ -3474,6 +3480,7 @@
 				DD4901EC27B4748A00D7E50D /* MainThreadData.h in Headers */,
 				5187AC962C08570600549EFE /* MainThreadDispatcher.h in Headers */,
 				BC5267672C2726D600E422DD /* MakeString.h in Headers */,
+				BBEA08042CCFDB33000AC148 /* MallocCommon.h in Headers */,
 				DD3DC8D427A4BF8E007E5B61 /* MallocPtr.h in Headers */,
 				465005D82CD2840A00950C5F /* MallocSpan.h in Headers */,
 				DD3DC89727A4BF8E007E5B61 /* Markable.h in Headers */,
@@ -4213,6 +4220,7 @@
 				A8A473E5151A825B004123FF /* MainThread.cpp in Sources */,
 				A8A473E4151A825B004123FF /* MainThreadCocoa.mm in Sources */,
 				5187AC952C08570600549EFE /* MainThreadDispatcher.cpp in Sources */,
+				BBFA08042CCFDB33000AC148 /* MallocCommon.cpp in Sources */,
 				CD5497AC15857D0300B5BC30 /* MediaTime.cpp in Sources */,
 				ADF2CE671E39F106006889DB /* MemoryFootprintCocoa.cpp in Sources */,
 				AD89B6B71E6415080090707F /* MemoryPressureHandler.cpp in Sources */,

--- a/Source/WTF/wtf/Bag.h
+++ b/Source/WTF/wtf/Bag.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/FastMalloc.h>
+#include <wtf/MallocCommon.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Packed.h>
 #include <wtf/RawPtrTraits.h>
@@ -49,7 +50,7 @@ public:
 template<typename T, typename PassedPtrTraits = RawPtrTraits<T>, typename Malloc = FastMalloc>
 class Bag final {
     WTF_MAKE_NONCOPYABLE(Bag);
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_CONFIGURABLE_ALLOCATED(Malloc);
     using Node = BagNode<T, PassedPtrTraits>;
     using PtrTraits = typename PassedPtrTraits::template RebindTraits<Node>;
 
@@ -106,7 +107,7 @@ public:
     }
     
     class iterator {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_CONFIGURABLE_ALLOCATED(Malloc);
     public:
         iterator()
             : m_node(0)

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -167,6 +167,7 @@ set(WTF_PUBLIC_HEADERS
     MainThread.h
     MainThreadData.h
     MainThreadDispatcher.h
+    MallocCommon.h
     MallocPtr.h
     MallocSpan.h
     Markable.h
@@ -543,6 +544,7 @@ set(WTF_SOURCES
     Logging.cpp
     MainThread.cpp
     MainThreadDispatcher.cpp
+    MallocCommon.cpp
     MediaTime.cpp
     MemoryPressureHandler.cpp
     MetaAllocator.cpp

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -316,7 +316,7 @@ class CanMakeCheckedPtr : public CanMakeCheckedPtrBase<SingleThreadIntegralWrapp
 public:
     ~CanMakeCheckedPtr()
     {
-        static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "Objects that use CanMakeCheckedPtr must use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+        static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "Objects that use CanMakeCheckedPtr must use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
         static_assert(std::is_same<typename T::WTFDidOverrideDeleteForCheckedPtr, int>::value, "Objects that use CanMakeCheckedPtr must use WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR");
     }
 };
@@ -325,7 +325,7 @@ template<typename T, DefaultedOperatorEqual defaultedOperatorEqual = DefaultedOp
 public:
     ~CanMakeThreadSafeCheckedPtr()
     {
-        static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "Objects that use CanMakeCheckedPtr must use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+        static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "Objects that use CanMakeCheckedPtr must use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
         static_assert(std::is_same<typename T::WTFDidOverrideDeleteForCheckedPtr, int>::value, "Objects that use CanMakeCheckedPtr must use WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR");
     }
 };

--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <iterator>
+#include <wtf/MallocCommon.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>
 #include <wtf/TrailingArray.h>
@@ -37,7 +38,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(EmbeddedFixedVector);
 
 template<typename T, typename Malloc = EmbeddedFixedVectorMalloc>
 class EmbeddedFixedVector final : public TrailingArray<EmbeddedFixedVector<T, Malloc>, T> {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(EmbeddedFixedVector);
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(EmbeddedFixedVector, Malloc);
     WTF_MAKE_NONCOPYABLE(EmbeddedFixedVector);
     WTF_MAKE_NONMOVABLE(EmbeddedFixedVector);
 public:

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -26,12 +26,15 @@
 #pragma once
 
 #include <wtf/EmbeddedFixedVector.h>
+#include <wtf/MallocCommon.h>
 
 namespace WTF {
 
 template<typename T, typename Malloc>
 class FixedVector {
+    WTF_MAKE_CONFIGURABLE_ALLOCATED(Malloc);
 public:
+
     using Storage = EmbeddedFixedVector<T, Malloc>;
     using Self = FixedVector<T, Malloc>;
     using value_type = typename Storage::value_type;

--- a/Source/WTF/wtf/MallocCommon.cpp
+++ b/Source/WTF/wtf/MallocCommon.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/MallocCommon.h>
+
+namespace WTF {
+
+#if ASSERT_ENABLED
+thread_local static unsigned forbidMallocUseScopeCount;
+thread_local static unsigned disableMallocRestrictionScopeCount;
+
+ForbidMallocUseForCurrentThreadScope::ForbidMallocUseForCurrentThreadScope()
+{
+    ++forbidMallocUseScopeCount;
+}
+
+ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope()
+{
+    ASSERT(forbidMallocUseScopeCount);
+    --forbidMallocUseScopeCount;
+}
+
+DisableMallocRestrictionsForCurrentThreadScope::DisableMallocRestrictionsForCurrentThreadScope()
+{
+    ++disableMallocRestrictionScopeCount;
+}
+
+DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope()
+{
+    ASSERT(disableMallocRestrictionScopeCount);
+    --disableMallocRestrictionScopeCount;
+}
+
+void assertMallocRestrictionForCurrentThreadScope()
+{
+    ASSERT(!forbidMallocUseScopeCount || disableMallocRestrictionScopeCount);
+}
+#endif // ASSERT_ENABLED
+
+}

--- a/Source/WTF/wtf/MallocCommon.h
+++ b/Source/WTF/wtf/MallocCommon.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Assertions.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+class TryMallocReturnValue {
+public:
+    TryMallocReturnValue(void*);
+    TryMallocReturnValue(TryMallocReturnValue&&);
+    ~TryMallocReturnValue();
+    template<typename T> bool getValue(T*&) WARN_UNUSED_RETURN;
+private:
+    void operator=(TryMallocReturnValue&&) = delete;
+    mutable void* m_data;
+};
+
+inline TryMallocReturnValue::TryMallocReturnValue(void* data)
+    : m_data(data)
+{
+}
+
+inline TryMallocReturnValue::TryMallocReturnValue(TryMallocReturnValue&& source)
+    : m_data(source.m_data)
+{
+    source.m_data = nullptr;
+}
+
+inline TryMallocReturnValue::~TryMallocReturnValue()
+{
+    ASSERT(!m_data);
+}
+
+template<typename T> inline bool TryMallocReturnValue::getValue(T*& data)
+{
+    data = static_cast<T*>(m_data);
+    m_data = nullptr;
+    return data;
+}
+
+class ForbidMallocUseForCurrentThreadScope {
+public:
+#if ASSERT_ENABLED
+    WTF_EXPORT_PRIVATE ForbidMallocUseForCurrentThreadScope();
+    WTF_EXPORT_PRIVATE ~ForbidMallocUseForCurrentThreadScope();
+#else
+    ForbidMallocUseForCurrentThreadScope() = default;
+    ~ForbidMallocUseForCurrentThreadScope() { }
+#endif
+
+    ForbidMallocUseForCurrentThreadScope(const ForbidMallocUseForCurrentThreadScope&) = delete;
+    ForbidMallocUseForCurrentThreadScope(ForbidMallocUseForCurrentThreadScope&&) = delete;
+    ForbidMallocUseForCurrentThreadScope& operator=(const ForbidMallocUseForCurrentThreadScope&) = delete;
+    ForbidMallocUseForCurrentThreadScope& operator=(ForbidMallocUseForCurrentThreadScope&&) = delete;
+};
+
+class DisableMallocRestrictionsForCurrentThreadScope {
+public:
+#if ASSERT_ENABLED
+    WTF_EXPORT_PRIVATE DisableMallocRestrictionsForCurrentThreadScope();
+    WTF_EXPORT_PRIVATE ~DisableMallocRestrictionsForCurrentThreadScope();
+#else
+    DisableMallocRestrictionsForCurrentThreadScope() = default;
+    ~DisableMallocRestrictionsForCurrentThreadScope() { }
+#endif
+
+    DisableMallocRestrictionsForCurrentThreadScope(const DisableMallocRestrictionsForCurrentThreadScope&) = delete;
+    DisableMallocRestrictionsForCurrentThreadScope(DisableMallocRestrictionsForCurrentThreadScope&&) = delete;
+    DisableMallocRestrictionsForCurrentThreadScope& operator=(const DisableMallocRestrictionsForCurrentThreadScope&) = delete;
+    DisableMallocRestrictionsForCurrentThreadScope& operator=(DisableMallocRestrictionsForCurrentThreadScope&&) = delete;
+};
+
+#if ASSERT_ENABLED
+WTF_EXPORT_PRIVATE void assertMallocRestrictionForCurrentThreadScope();
+#else
+inline void assertMallocRestrictionForCurrentThreadScope() { }
+#endif
+
+} // namespace WTF
+
+using WTF::TryMallocReturnValue;
+using WTF::DisableMallocRestrictionsForCurrentThreadScope;
+using WTF::ForbidMallocUseForCurrentThreadScope;
+
+// FIXME: de-duplicate with WTF_MAKE_FAST_ALLOCATED_IMPL
+#define WTF_MAKE_CONFIGURABLE_ALLOCATED_IMPL(alloc, family) \
+    void* operator new(size_t, void* p) { return p; } \
+    void* operator new[](size_t, void* p) { return p; } \
+    \
+    void* operator new(size_t size) \
+    { \
+        return alloc::malloc(size); \
+    } \
+    \
+    void operator delete(void* p) \
+    { \
+        alloc::free(p); \
+    } \
+    \
+    void* operator new[](size_t size) \
+    { \
+        return alloc::malloc(size); \
+    } \
+    \
+    void operator delete[](void* p) \
+    { \
+        return alloc::free(p); \
+    } \
+    void* operator new(size_t, NotNullTag, void* location) \
+    { \
+        ASSERT(location); \
+        return location; \
+    } \
+    static void freeAfterDestruction(void* p) \
+    { \
+        alloc::fastFree(p); \
+    } \
+    using WTFIs ## family ## Allocated  = int; \
+
+#if ENABLE(MALLOC_HEAP_BREAKDOWN)
+// FIXME: de-duplicate with WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL
+#define WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc, family) \
+    void* operator new(size_t, void* p) { return p; } \
+    void* operator new[](size_t, void* p) { return p; } \
+    \
+    void* operator new(size_t size) \
+    { \
+        return classname##Malloc::malloc(size); \
+    } \
+    \
+    void operator delete(void* p) \
+    { \
+        classname##Malloc::free(p); \
+    } \
+    \
+    void* operator new[](size_t size) \
+    { \
+        return classname##Malloc::malloc(size); \
+    } \
+    \
+    void operator delete[](void* p) \
+    { \
+        classname##Malloc::free(p); \
+    } \
+    void* operator new(size_t, NotNullTag, void* location) \
+    { \
+        ASSERT(location); \
+        return location; \
+    } \
+    static void freeAfterDestruction(void* p) \
+    { \
+        classname##Malloc::free(p); \
+    } \
+    using WTFIs ## family ## Allocated = int; \
+
+#define WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(classname, alloc) \
+public: \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc) \
+private: \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_STRUCT_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(classname, alloc) \
+private: \
+public: \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc) \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_CONFIGURABLE_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(classname) \
+    WTF_ALLOW_COMPACT_POINTERS; \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(classname)
+
+#define WTF_MAKE_STRUCT_CONFIGURABLE_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(classname) \
+    WTF_ALLOW_STRUCT_COMPACT_POINTERS; \
+    WTF_MAKE_STRUCT_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(classname)
+
+#else
+
+#define WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc) \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_IMPL(alloc, alloc)
+
+#define WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(classname, alloc) \
+public: \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc) \
+private: \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_STRUCT_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(classname) \
+public: \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname) \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_CONFIGURABLE_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc) \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_IMPL(alloc::CompactMalloc, alloc)
+
+#define WTF_MAKE_CONFIGURABLE_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(classname, alloc) \
+public: \
+    WTF_MAKE_CONFIGURABLE_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc) \
+private: \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_STRUCT_CONFIGURABLE_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(classname, alloc) \
+public: \
+    WTF_MAKE_CONFIGURABLE_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(classname, alloc) \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#endif // ENABLE(MALLOC_HEAP_BREAKDOWN)
+
+#define WTF_MAKE_CONFIGURABLE_ALLOCATED(alloc) \
+public: \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_IMPL(alloc, alloc) \
+private: \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_STRUCT_CONFIGURABLE_ALLOCATED(alloc) \
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_IMPL(alloc, alloc) \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#if OS(DARWIN)
+#define WTF_PRIVATE_INLINE __private_extern__ inline __attribute__((always_inline))
+#else
+#define WTF_PRIVATE_INLINE inline __attribute__((always_inline))
+#endif

--- a/Source/WTF/wtf/MallocSpan.h
+++ b/Source/WTF/wtf/MallocSpan.h
@@ -27,6 +27,7 @@
 
 #include <utility>
 #include <wtf/FastMalloc.h>
+#include <wtf/MallocCommon.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TypeTraits.h>

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <wtf/MallocCommon.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
 
@@ -40,7 +41,7 @@ namespace WTF {
     // An iterator for SegmentedVector. It supports only the pre ++ operator
     template <typename T, size_t SegmentSize = 8, typename Malloc = SegmentedVectorMalloc> class SegmentedVector;
     template <typename T, size_t SegmentSize = 8, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
-        WTF_MAKE_FAST_ALLOCATED;
+        WTF_MAKE_CONFIGURABLE_ALLOCATED(FastMalloc);
     private:
         friend class SegmentedVector<T, SegmentSize, Malloc>;
     public:
@@ -83,7 +84,7 @@ namespace WTF {
         {
         }
 
-        SegmentedVector<T, SegmentSize>& m_vector;
+        SegmentedVector<T, SegmentSize, Malloc>& m_vector;
         size_t m_index;
     };
 

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -932,7 +932,7 @@ namespace WTF {
 template<class T, class... Args>
 ALWAYS_INLINE decltype(auto) makeUnique(Args&&... args)
 {
-    static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
     static_assert(!HasRefPtrMemberFunctions<T>::value, "T should not be RefCounted");
     return std::make_unique<T>(std::forward<Args>(args)...);
 }
@@ -940,7 +940,7 @@ ALWAYS_INLINE decltype(auto) makeUnique(Args&&... args)
 template<class T, class... Args>
 ALWAYS_INLINE decltype(auto) makeUniqueWithoutRefCountedCheck(Args&&... args)
 {
-    static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
     return std::make_unique<T>(std::forward<Args>(args)...);
 }
 

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -43,14 +43,14 @@ UniqueRef<T> makeUniqueRefWithoutFastMallocCheck(Args&&... args)
 template<class T, class... Args>
 UniqueRef<T> makeUniqueRefWithoutRefCountedCheck(Args&&... args)
 {
-    static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
     return makeUniqueRefWithoutFastMallocCheck<T>(std::forward<Args>(args)...);
 }
 
 template<typename T, class... Args>
 UniqueRef<T> makeUniqueRef(Args&&... args)
 {
-    static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    static_assert(std::is_same<typename T::WTFIsFastMallocAllocated, int>::value, "T should use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
     static_assert(!HasRefPtrMemberFunctions<T>::value, "T should not be RefCounted");
     return makeUniqueRefWithoutFastMallocCheck<T>(std::forward<Args>(args)...);
 }

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -697,7 +697,7 @@ struct UnsafeVectorOverflow {
 // Template default values are in Forward.h.
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 class Vector : private VectorBuffer<T, inlineCapacity, Malloc> {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Vector);
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(Vector, FastMalloc);
 private:
     typedef VectorBuffer<T, inlineCapacity, Malloc> Base;
     typedef VectorTypeOperations<T> TypeOperations;

--- a/Source/bmalloc/bmalloc/IsoHeap.h
+++ b/Source/bmalloc/bmalloc/IsoHeap.h
@@ -194,7 +194,7 @@ public: \
     \
     exportMacro static void freeAfterDestruction(void*); \
     \
-    using WTFIsFastAllocated = int; \
+    using WTFIsFastMallocAllocated = int; \
 private: \
     using __makeBisoMallocedMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 
@@ -220,7 +220,7 @@ public: \
     \
     exportMacro static void freeAfterDestruction(void*); \
     \
-    using WTFIsFastAllocated = int; \
+    using WTFIsFastMallocAllocated = int; \
 private: \
     using __makeBisoMallocedMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 

--- a/Source/bmalloc/bmalloc/IsoHeapInlines.h
+++ b/Source/bmalloc/bmalloc/IsoHeapInlines.h
@@ -147,7 +147,7 @@ public: \
         bisoHeap().deallocate(p); \
     } \
     \
-    using WTFIsFastAllocated = int; \
+    using WTFIsFastMallocAllocated = int; \
 private: \
     using __makeBisoMallocedInlineMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -171,7 +171,7 @@ public: \
         ::bmalloc::api::tzoneFree(p); \
     } \
     \
-    using WTFIsFastAllocated = int;
+    using WTFIsFastMallocAllocated = int;
 
 #define MAKE_BTZONE_MALLOCED_COMMON_NON_TEMPLATE(_type, _compactMode, _exportMacro) \
 private: \

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -72,7 +72,7 @@ public: \
         ::bmalloc::api::tzoneFree(p); \
     } \
     \
-    using WTFIsFastAllocated = int;
+    using WTFIsFastMallocAllocated = int;
 
 #define MAKE_BTZONE_MALLOCED_INLINE(_type, _compactMode) \
 public: \


### PR DESCRIPTION
#### f77dccdb4728f0595aa5189fcf9a59e02494f81a
<pre>
[WTF] Define WTF_MAKE_CONFIGURABLE_ALLOCATED for container types
<a href="https://bugs.webkit.org/show_bug.cgi?id=286711">https://bugs.webkit.org/show_bug.cgi?id=286711</a>
<a href="https://rdar.apple.com/143849704">rdar://143849704</a>

Reviewed by Yusuke Suzuki.

This allows us to specify that these types are allocated using the same
allocator as provided for their backing store, which is a more
comfortable default than &quot;always use FastMalloc no matter what the
caller tells us they want&quot;.

If in the future someone does want to use separate allocators for the
two, we can add another template parameter to configure the two
separately as needed.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Bag.h:
* Source/WTF/wtf/CheckedRef.h:
(WTF::CanMakeCheckedPtr::~CanMakeCheckedPtr):
(WTF::CanMakeThreadSafeCheckedPtr::~CanMakeThreadSafeCheckedPtr):
* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FastMalloc.h:
(WTF::FastMalloc::fastFree):
(WTF::FastCompactMalloc::fastFree):
(WTF::ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope): Deleted.
(WTF::DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope): Deleted.
(WTF::TryMallocReturnValue::TryMallocReturnValue): Deleted.
(WTF::TryMallocReturnValue::~TryMallocReturnValue): Deleted.
(WTF::TryMallocReturnValue::getValue): Deleted.
* Source/WTF/wtf/FixedVector.h:
* Source/WTF/wtf/MallocCommon.cpp: Added.
(WTF::ForbidMallocUseForCurrentThreadScope::ForbidMallocUseForCurrentThreadScope):
(WTF::ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope):
(WTF::DisableMallocRestrictionsForCurrentThreadScope::DisableMallocRestrictionsForCurrentThreadScope):
(WTF::DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope):
* Source/WTF/wtf/MallocCommon.h: Added.
(WTF::TryMallocReturnValue::TryMallocReturnValue):
(WTF::TryMallocReturnValue::~TryMallocReturnValue):
(WTF::TryMallocReturnValue::getValue):
(WTF::ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope):
(WTF::DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope):
* Source/WTF/wtf/MallocSpan.h:
* Source/WTF/wtf/SegmentedVector.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::makeUnique):
(WTF::makeUniqueWithoutRefCountedCheck):
* Source/WTF/wtf/UniqueRef.h:
(WTF::makeUniqueRefWithoutRefCountedCheck):
(WTF::makeUniqueRef):
* Source/WTF/wtf/Vector.h:
* Source/WTF/wtf/text/WTFString.h:
* Source/bmalloc/bmalloc/IsoHeap.h:
* Source/bmalloc/bmalloc/IsoHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeap.h:
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:

Canonical link: <a href="https://commits.webkit.org/290626@main">https://commits.webkit.org/290626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0201b5cf4e5b73e48255f7f99e37c5be7d2d63d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90522 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41304 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69667 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27227 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40434 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83328 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97424 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89302 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13009 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78730 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77930 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22321 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20943 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17724 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23056 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111791 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17463 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->