### PR TITLE
[CSS] Early return from matching when doing invalidation

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -60,12 +60,13 @@ public:
     void matchUserRules();
 
     bool matchesAnyAuthorRules();
+    bool matchesAnyRules(const RuleSet&);
 
     void setMode(SelectorChecker::Mode mode) { m_mode = mode; }
+
     void setPseudoElementRequest(const std::optional<PseudoElementRequest>& request) { m_pseudoElementRequest = request; }
     void setMedium(const MQ::MediaQueryEvaluator& medium) { m_isPrintStyle = medium.isPrintMedia(); }
 
-    bool hasAnyMatchingRules(const RuleSet&);
 
     const MatchResult& matchResult() const;
     std::unique_ptr<MatchResult> releaseMatchResult();
@@ -98,6 +99,7 @@ private:
     void collectMatchingRules(CascadeLevel);
     void collectMatchingRules(const MatchRequest&);
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
+    bool isFirstMatchModeAndHasMatchedAnyRules() const;
     bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, const ContainerNode* scopingRoot = nullptr);
     bool containerQueriesMatch(const RuleData&, const MatchRequest&);
     struct ScopingRootWithDistance {
@@ -127,6 +129,8 @@ private:
 
     bool m_shouldIncludeEmptyRules { false };
     bool m_isPrintStyle { false };
+    // FIXME: This should be a SelectorChecker::Mode.
+    bool m_firstMatchMode { false };
     std::optional<PseudoElementRequest> m_pseudoElementRequest { };
     SelectorChecker::Mode m_mode { SelectorChecker::Mode::ResolvingStyle };
 

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -316,7 +316,7 @@ bool SharingResolver::styleSharingCandidateMatchesRuleSet(const StyledElement& e
         return false;
 
     ElementRuleCollector collector(element, m_ruleSets, &m_selectorMatchingState);
-    return collector.hasAnyMatchingRules(*ruleSet);
+    return collector.matchesAnyRules(*ruleSet);
 }
 
 bool SharingResolver::sharingCandidateHasIdenticalStyleAffectingAttributes(const Context& context, const StyledElement& sharingCandidate) const


### PR DESCRIPTION
#### ce251e4c49e1a920d5079015b2cd287bacc29590
<pre>
[CSS] Early return from matching when doing invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=286721">https://bugs.webkit.org/show_bug.cgi?id=286721</a>
<a href="https://rdar.apple.com/138419832">rdar://138419832</a>

Reviewed by Antti Koivisto.

For invalidation, we generally don&apos;t want to collect rules
but just to know if any rule matches. We can optimize for
this use case by early returning on first match.

 * Source/WebCore/style/ElementRuleCollector.cpp:
 (WebCore::Style::ElementRuleCollector::isFirstMatchModeAndHasMatchedAnyRules const):
 (WebCore::Style::ElementRuleCollector::collectMatchingRules):
 (WebCore::Style::ElementRuleCollector::transferMatchedRules):
 (WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
 (WebCore::Style::ElementRuleCollector::matchAllRules):
 (WebCore::Style::ElementRuleCollector::hasAnyMatchingRules): Deleted.

 Renamed to matchesAnyRules().

 * Source/WebCore/style/ElementRuleCollector.h:
 * Source/WebCore/style/StyleSharingResolver.cpp:
 (WebCore::Style::SharingResolver::styleSharingCandidateMatchesRuleSet const):

Canonical link: <a href="https://commits.webkit.org/289611@main">https://commits.webkit.org/289611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc45b114464fbe8d8da7bcafc3f1846e3926d01f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15224 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5682 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/79223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33617 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37397 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14707 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75674 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20053 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18477 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7661 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20026 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->