### PR TITLE
AX: With ENABLE(AX_THREAD_TEXT_APIS), we can crash when using cached selection text marker ranges constructed from VisiblePositionRange / VisibleSelection

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -347,6 +347,9 @@ public:
     AXTextMarkerRange(const VisiblePositionRange&);
     AXTextMarkerRange(const VisibleSelection&);
     AXTextMarkerRange(const std::optional<SimpleRange>&);
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    AXTextMarkerRange(const InlineBoxAndOffset& start, const InlineBoxAndOffset& end);
+#endif
     AXTextMarkerRange(const AXTextMarker&, const AXTextMarker&);
     AXTextMarkerRange(AXTextMarker&&, AXTextMarker&&);
 #if PLATFORM(MAC)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -34,6 +34,7 @@
 #include "AccessibilityTableCell.h"
 #include "AccessibilityTableRow.h"
 #include "FrameSelection.h"
+#include "InlineRunAndOffset.h"
 #include "LocalFrameView.h"
 #include "Page.h"
 #include <wtf/MonotonicTime.h>
@@ -169,7 +170,14 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     auto* axFocus = axObjectCache.focusedObjectForPage(document->page());
     if (axFocus)
         tree->setFocusedNodeID(axFocus->objectID());
+
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    auto selection = document->selection().selection();
+    tree->setSelectedTextMarkerRange({ selection.visibleStart().inlineBoxAndOffset(), selection.visibleEnd().inlineBoxAndOffset() });
+#else
     tree->setSelectedTextMarkerRange(document->selection().selection());
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
     tree->updateLoadingProgress(axObjectCache.loadingProgress());
 
     const auto relations = axObjectCache.relations();

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -32,6 +32,7 @@
 #import "AccessibilityObject.h"
 #import "AccessibilityTable.h"
 #import "DeprecatedGlobalSettings.h"
+#import "InlineRunAndOffset.h"
 #import "LocalFrameView.h"
 #import "RenderObject.h"
 #import "WebAccessibilityObjectWrapperMac.h"
@@ -1009,7 +1010,11 @@ void AXObjectCache::onSelectedTextChanged(const VisiblePositionRange& selection)
                 if (auto* endObject = get(endPosition.anchorNode()))
                     createIsolatedObjectIfNeeded(*endObject);
 
+#if ENABLE(AX_THREAD_TEXT_APIS)
+                tree->setSelectedTextMarkerRange({ selection.start.inlineBoxAndOffset(), selection.end.inlineBoxAndOffset() });
+#else
                 tree->setSelectedTextMarkerRange({ selection });
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
             }
         }
     }


### PR DESCRIPTION
#### da5763cd2e622ebadfd9391ff1ccd345ba1cea48
<pre>
AX: With ENABLE(AX_THREAD_TEXT_APIS), we can crash when using cached selection text marker ranges constructed from VisiblePositionRange / VisibleSelection
<a href="https://bugs.webkit.org/show_bug.cgi?id=286710">https://bugs.webkit.org/show_bug.cgi?id=286710</a>
<a href="https://rdar.apple.com/143849705">rdar://143849705</a>

Reviewed by NOBODY (OOPS!).

Prior to this commit, we would call `AXIsolatedTree::setSelectedTextMarkerRange` with an AXTextMarkerRange constructed
from a VisiblePositionRange. This is a problem, since offsets in VisiblePositionRange are pre-whitespace collapse,
while the text runs we cache off the main-thread are post-whitespace collapse, meaning the offsets would reguarly point
to the wrong character, or completely out-of-bounds of the text runs, causing crashes.

With this commit, for ENABLE(AX_THREAD_TEXT_APIS), we instead construct the selection AXTextMarkerRange using
VisiblePosition::inlineBoxAndOffset(), which does all the necessary work to turn the VisiblePosition into an offset
that points into some inline box, which is the basis for the text runs we cache off the main-thread.

This fixes mac/dynamic-selection.html in ENABLE(AX_THREAD_TEXT_APIS), and unblocks the ability to fix more tests which
now fail for other reasons that are not selection related.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::create):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::onSelectedTextChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f7b28a388d661fc23229f88768eeb1300755bbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25189 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5198 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33391 "Found 3 new test failures: http/tests/security/file-system-access-via-dataTransfer.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html imported/w3c/web-platform-tests/xhr/request-content-length.any.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37159 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14464 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10527 "Found 1 new test failure: fast/css/view-transitions-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76275 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75480 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19813 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7396 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19776 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->