### PR TITLE
RELEASE_ASSERT that ImageIO could install all the supported image decoders

### DIFF
--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -416,7 +416,7 @@ bool MIMETypeRegistry::isSupportedImageMIMEType(const String& mimeType)
     // Ensure supportedImageMIMETypeArray matches defaultSupportedImageTypes().
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        for (auto& imageType : defaultSupportedImageTypes()) {
+        for (auto& imageType : supportedImageTypes()) {
             auto mimeType = MIMETypeForImageType(imageType);
             ASSERT_IMPLIES(!mimeType.isEmpty(), supportedImageMIMETypeSet.contains(mimeType));
         }

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.h
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageTypes();
+const MemoryCompactLookupOnlyRobinHoodHashSet<String>& supportedImageTypes();
 MemoryCompactRobinHoodHashSet<String>& additionalSupportedImageTypes();
 WEBCORE_EXPORT void setAdditionalSupportedImageTypes(const Vector<String>&);
 WEBCORE_EXPORT void setAdditionalSupportedImageTypesForTesting(const String&);

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -146,8 +146,14 @@ bool isDeclaredUTI(const String& UTI)
 void setImageSourceAllowableTypes(const Vector<String>& supportedImageTypes)
 {
 #if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
-    auto allowableTypes = createNSArray(supportedImageTypes);
-    CGImageSourceSetAllowableTypes((__bridge CFArrayRef)allowableTypes.get());
+    // A WebPage might be reinitialized. So restrict ImageIO to the default and
+    // the additional supported image formats only once.
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [supportedImageTypes] {
+        auto allowableTypes = createNSArray(supportedImageTypes);
+        auto status = CGImageSourceSetAllowableTypes((__bridge CFArrayRef)allowableTypes.get());
+        RELEASE_ASSERT_WITH_MESSAGE(supportedImageTypes.isEmpty() || status == noErr, "CGImageSourceSetAllowableTypes() returned error: %d.", status);
+    });
 #else
     UNUSED_PARAM(supportedImageTypes);
 #endif


### PR DESCRIPTION
#### 97223465600a0995db98f1fd0026b5569fb12b9a
<pre>
RELEASE_ASSERT that ImageIO could install all the supported image decoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=280990">https://bugs.webkit.org/show_bug.cgi?id=280990</a>
<a href="https://rdar.apple.com/135375243">rdar://135375243</a>

Reviewed by Simon Fraser.

We needs to check the return value of CGImageSourceSetAllowableTypes().

If CGImageSourceSetAllowableTypes() could not install all the supported image
decoders for any reason, we should halt the process launch and fail its creation
safely.

Because the WebPage can be reinitialized (WTR for example), it is important to
call GImageSourceSetAllowableTypes() only once and only when a WebProcess is
initialized.

In LockdownMode, WebKit enforces a very limited set of image types. UTIRegistry
must use the lockdownSupportedImageTypes instead of defaultSupportedImageTypes.
No additionalSupportedImageTypes() is allowed in LockdownMode.

* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isSupportedImageMIMEType):
* Source/WebCore/platform/graphics/cg/UTIRegistry.h:
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::isLockdownModeEnabled):
(WebCore::filterSupportedImageTypes):
(WebCore::defaultSupportedImageTypes):
(WebCore::lockdownSupportedImageTypes):
(WebCore::supportedImageTypes):
(WebCore::isSupportedImageType):
(WebCore::allowableDefaultSupportedImageTypes):
(WebCore::allowableLockdownSupportedImageTypes):
(WebCore::allowableSupportedImageTypes):
(WebCore::allowableAdditionalSupportedImageTypes):
(WebCore::allowableImageTypes):
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::setImageSourceAllowableTypes):

Canonical link: <a href="https://commits.webkit.org/289593@main">https://commits.webkit.org/289593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/141c53fc2934bcb67db8104bdc575c9f30a248e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15124 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25280 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47884 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37301 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94193 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14611 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76367 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75584 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18385 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7549 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17816 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->