### PR TITLE
[scroll-animations] Have ViewTimeline hold a Styleable subject

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller-expected.txt
@@ -1,0 +1,3 @@
+
+PASS view() on pseudo-element attaches to parent scroll container
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-pseudo-on-scroller.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Animating pseduo-element on scroller</title>
+</head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="./support/testcommon.js"></script>
+<script src="testcommon.js"></script>
+<style type="text/css">
+.scroller {
+  overflow: scroll;
+  width: 100px;
+  height: 100px;
+  margin: 1em;
+  outline: 1px solid;
+}
+.pseudo::before {
+  content: "";
+  display: inline;
+  width: 100px;
+  height: 50px;
+  background: red;
+  animation: bg linear;
+  animation-timeline: view(inline);
+}
+
+.content {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+
+@keyframes bg {
+  from {
+    background: rgb(0, 255, 0);
+  }
+  to {
+    background: rgb(0, 0, 255);
+  }
+}
+</style>
+<body>
+  <div class="scroller pseudo">
+    <div class="content"></div>
+  </div>
+  <div id="log"></div>
+</body>
+<script type="text/javascript">
+  'use strict';
+
+  promise_test(async t => {
+    await waitForCSSScrollTimelineStyle();
+    const scroller = document.querySelector('.scroller');
+    assert_equals(getComputedStyle(scroller, ':before').backgroundColor,
+                  'rgb(0, 0, 255)');
+  }, `view() on pseudo-element attaches to parent scroll container`);
+</script>
+</html>

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -487,7 +487,7 @@ void AnimationTimelinesController::attachPendingOperations()
     }
 }
 
-void AnimationTimelinesController::registerNamedViewTimeline(const AtomString& name, const Element& subject, ScrollAxis axis, ViewTimelineInsets&& insets)
+void AnimationTimelinesController::registerNamedViewTimeline(const AtomString& name, Element& subject, ScrollAxis axis, ViewTimelineInsets&& insets)
 {
     LOG_WITH_STREAM(Animations, stream << "AnimationTimelinesController::registerNamedViewTimeline: " << name << " subject: " << subject);
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -81,7 +81,7 @@ public:
     bool animationsAreSuspended() const { return m_isSuspended; }
 
     void registerNamedScrollTimeline(const AtomString&, Element&, ScrollAxis);
-    void registerNamedViewTimeline(const AtomString&, const Element&, ScrollAxis, ViewTimelineInsets&&);
+    void registerNamedViewTimeline(const AtomString&, Element&, ScrollAxis, ViewTimelineInsets&&);
     void unregisterNamedTimeline(const AtomString&, const Element&);
     void setTimelineForName(const AtomString&, const Element&, WebAnimation&);
     void updateNamedTimelineMapForTimelineScope(const TimelineScope&, const Element&);

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -160,15 +160,12 @@ void CSSAnimation::syncStyleOriginatedTimeline()
             timelinesController->setTimelineForName(name, target, *this);
         }, [&] (const Animation::AnonymousScrollTimeline& anonymousScrollTimeline) {
             auto scrollTimeline = ScrollTimeline::create(anonymousScrollTimeline.scroller, anonymousScrollTimeline.axis);
-            if (auto owningElement = this->owningElement())
-                scrollTimeline->setSource(*owningElement);
-            else
-                scrollTimeline->setSource(nullptr);
+            scrollTimeline->setSource(*owningElement());
             setTimeline(WTFMove(scrollTimeline));
         }, [&] (const Animation::AnonymousViewTimeline& anonymousViewTimeline) {
             auto insets = anonymousViewTimeline.insets;
             auto viewTimeline = ViewTimeline::create(nullAtom(), anonymousViewTimeline.axis, WTFMove(insets));
-            viewTimeline->setSubject(target.ptr());
+            viewTimeline->setSubject(*owningElement());
             setTimeline(WTFMove(viewTimeline));
         }
     );

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -74,6 +74,8 @@ public:
 
     virtual std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const TimelineRange&) const;
 
+    void removeTimelineFromDocument(Element*);
+
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
 
@@ -100,8 +102,6 @@ private:
     bool isScrollTimeline() const final { return true; }
 
     void animationTimingDidChange(WebAnimation&) override;
-
-    void removeTimelineFromDocument(Element*);
 
     struct CurrentTimeData {
         float scrollOffset { 0 };

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -28,6 +28,7 @@
 #include "CSSNumericValue.h"
 #include "CSSPrimitiveValue.h"
 #include "ScrollTimeline.h"
+#include "Styleable.h"
 #include "ViewTimelineOptions.h"
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
@@ -47,8 +48,9 @@ public:
     static ExceptionOr<Ref<ViewTimeline>> create(Document&, ViewTimelineOptions&& = { });
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
 
-    const Element* subject() const { return m_subject.get(); }
-    void setSubject(const Element*);
+    const Element* subject() const;
+    void setSubject(Element*);
+    void setSubject(const Styleable&);
 
     const ViewTimelineInsets& insets() const { return m_insets; }
     void setInsets(ViewTimelineInsets&& insets) { m_insets = WTFMove(insets); }
@@ -90,7 +92,7 @@ private:
 
     ExceptionOr<SpecifiedViewTimelineInsets> validateSpecifiedInsets(const ViewTimelineInsetValue, const Document&);
 
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;
+    WeakStyleable m_subject;
     std::optional<SpecifiedViewTimelineInsets> m_specifiedInsets;
     ViewTimelineInsets m_insets;
     CurrentTimeData m_cachedCurrentTimeData { };


### PR DESCRIPTION
#### f06878c33bc9f63117a77f6c67a5b5f4566f94f3
<pre>
[scroll-animations] Have ViewTimeline hold a Styleable subject
<a href="https://bugs.webkit.org/show_bug.cgi?id=286723">https://bugs.webkit.org/show_bug.cgi?id=286723</a>
<a href="https://rdar.apple.com/143860366">rdar://143860366</a>

Reviewed by Antoine Quint.

To handle ViewTimelines with associated pseudo elements, have ViewTimeline hold a
styleable subject.

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::subject const):
(WebCore::ViewTimeline::setSubject):
(WebCore::ViewTimeline::controller const):
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::ViewTimeline::documentWillUpdateAnimationsAndSendEvents):
(WebCore::ViewTimeline::sourceScrollerRenderer const):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/289801@main">https://commits.webkit.org/289801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/803b451d08939674f852ff77a4d5fd155fa9f266

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67900 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25639 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5797 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34023 "Found 1 new test failure: accessibility/noscript-ignored.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94728 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75991 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20382 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8135 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15149 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20450 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->