### PR TITLE
Add support for referenceTarget.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/aria-labelledby-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/aria-labelledby-expected.txt
@@ -1,6 +1,6 @@
   Label 2
 
-FAIL Label 1 assert_equals: <input class="ex" aria-labelledby="x-label1" data-expectedlabel="Label 1"> expected "Label 1" but got "FAIL IF INCLUDED Label 1"
-FAIL Label 2 assert_equals: <input class="ex" aria-labelledby="x-label2" data-expectedlabel="Label 2"> expected "Label 2" but got "FAIL IF INCLUDED Label 2"
-FAIL Label 3 assert_equals: <input id="input3" class="ex" data-expectedlabel="Label 3" aria-labelledby=""> expected "Label 3" but got "FAIL IF INCLUDED Label 3"
+PASS Label 1
+PASS Label 2
+PASS Label 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/dom-mutation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/dom-mutation-expected.txt
@@ -1,10 +1,10 @@
 
 
-FAIL Changing the ID of the referenced element results in an empty computed label assert_equals: expected "Label 1" but got "Outside the label Label 1 Label 2"
-FAIL Removing the referenced element results in an empty computed label assert_equals: expected "Label 1" but got "Outside the label Label 1 Label 2"
-FAIL New referenced element prepended to the shadow supercedes the existing label assert_equals: expected "Label 1" but got "Outside the label Label 1 Label 2"
-FAIL The existing label supercedes new element (with same id as the existing label) appended to the shadow assert_equals: expected "Label 1" but got "Outside the label Label 1 Label 2"
-FAIL Changing the reference target ID updates the computed label assert_equals: expected "Label 1" but got "Outside the label Label 1 Label 2"
-FAIL Changing the nested referenceTarget to reference a different element updates the computed label assert_equals: expected "Real Label 1" but got "shadow tree level 1 shadow tree level 2 Real Label 1 Real Label 2"
-FAIL Changing the ID of the nested referenced element results in an empty computed label assert_equals: expected "Real Label 1" but got "shadow tree level 1 shadow tree level 2 Real Label 1 Real Label 2"
+PASS Changing the ID of the referenced element results in an empty computed label
+PASS Removing the referenced element results in an empty computed label
+PASS New referenced element prepended to the shadow supercedes the existing label
+PASS The existing label supercedes new element (with same id as the existing label) appended to the shadow
+PASS Changing the reference target ID updates the computed label
+PASS Changing the nested referenceTarget to reference a different element updates the computed label
+PASS Changing the ID of the nested referenced element results in an empty computed label
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/label-descendant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/label-descendant-expected.txt
@@ -2,8 +2,8 @@ Input 1
 Input 1 via Options
 Input 2 Input 2 via Options
 
-FAIL Label applies to descendant custom element that uses shadowrootreferencetarget (Input 1) assert_equals: expected "Input 1" but got ""
-FAIL Label applies to descendant custom element that uses shadowrootreferencetarget (Input 1 via Options) assert_equals: expected "Input 1 via Options" but got ""
-FAIL Label applies to multiple layers of descendant custom elements that use shadowrootreferencetarget (Input 2) assert_equals: expected "Input 2" but got ""
-FAIL Label applies to multiple layers of descendant custom elements that use shadowrootreferencetarget (Input 2 via Options) assert_equals: expected "Input 2 via Options" but got ""
+PASS Label applies to descendant custom element that uses shadowrootreferencetarget (Input 1)
+PASS Label applies to descendant custom element that uses shadowrootreferencetarget (Input 1 via Options)
+PASS Label applies to multiple layers of descendant custom elements that use shadowrootreferencetarget (Input 2)
+PASS Label applies to multiple layers of descendant custom elements that use shadowrootreferencetarget (Input 2 via Options)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/label-for-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/label-for-expected.txt
@@ -1,7 +1,7 @@
 Input 1 Input 2 A F Input 4
 
-FAIL Label for attribute targets a custom element using shadowrootreferencetarget assert_equals: expected "Input 1" but got ""
-FAIL Label for attribute targets a custom element using shadowrootreferencetarget inside multiple layers of shadow roots assert_equals: expected "Input 2" but got ""
-FAIL Multiple labels targeting a custom element using shadowrootreferencetarget inside multiple layers of shadow roots assert_equals: expected "A B C D E F" but got "C D"
-FAIL Setting .htmlFor property to target a custom element using shadowrootreferencetarget assert_equals: expected "Input 4" but got ""
+PASS Label for attribute targets a custom element using shadowrootreferencetarget
+PASS Label for attribute targets a custom element using shadowrootreferencetarget inside multiple layers of shadow roots
+PASS Multiple labels targeting a custom element using shadowrootreferencetarget inside multiple layers of shadow roots
+PASS Setting .htmlFor property to target a custom element using shadowrootreferencetarget
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/popovertarget-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/popovertarget-expected.txt
@@ -1,6 +1,6 @@
 Toggle the popover  Toggle the popover  Toggle the popover
 
-FAIL Shadow root reference target works with popovertarget attribute. assert_equals: showCount expected 1 but got 0
-FAIL Shadow root reference target works with popovertarget attribute via options. assert_equals: showCount expected 1 but got 0
-FAIL Shadow root reference target works with .popoverTargetElement property. assert_equals: showCount expected 1 but got 0
+PASS Shadow root reference target works with popovertarget attribute.
+PASS Shadow root reference target works with popovertarget attribute via options.
+PASS Shadow root reference target works with .popoverTargetElement property.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/property-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/property-reflection-expected.txt
@@ -1254,9 +1254,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to button with reference targetappendTestDeclaratively
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to button with reference targetappendTestDeclaratively
 PASS label.form has reflection behavior IsNull when pointing to button with reference targetappendTestDeclaratively
-FAIL label.control has reflection behavior ReflectsHost when pointing to button with reference targetappendTestDeclaratively assert_equals: expected Element node <div id="host-id">
-
-        </div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to button with reference targetappendTestDeclaratively
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to input with reference targetappendTestDeclaratively
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to input with reference targetappendTestDeclaratively
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to input with reference targetappendTestDeclaratively
@@ -1267,9 +1265,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to input with reference targetappendTestDeclaratively
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to input with reference targetappendTestDeclaratively
 PASS label.form has reflection behavior IsNull when pointing to input with reference targetappendTestDeclaratively
-FAIL label.control has reflection behavior ReflectsHost when pointing to input with reference targetappendTestDeclaratively assert_equals: expected Element node <div id="host-id">
-
-        </div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to input with reference targetappendTestDeclaratively
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to meter with reference targetappendTestDeclaratively
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to meter with reference targetappendTestDeclaratively
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to meter with reference targetappendTestDeclaratively
@@ -1280,9 +1276,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to meter with reference targetappendTestDeclaratively
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to meter with reference targetappendTestDeclaratively
 PASS label.form has reflection behavior IsNull when pointing to meter with reference targetappendTestDeclaratively
-FAIL label.control has reflection behavior ReflectsHost when pointing to meter with reference targetappendTestDeclaratively assert_equals: expected Element node <div id="host-id">
-
-        </div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to meter with reference targetappendTestDeclaratively
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to output with reference targetappendTestDeclaratively
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to output with reference targetappendTestDeclaratively
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to output with reference targetappendTestDeclaratively
@@ -1293,9 +1287,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to output with reference targetappendTestDeclaratively
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to output with reference targetappendTestDeclaratively
 PASS label.form has reflection behavior IsNull when pointing to output with reference targetappendTestDeclaratively
-FAIL label.control has reflection behavior ReflectsHost when pointing to output with reference targetappendTestDeclaratively assert_equals: expected Element node <div id="host-id">
-
-        </div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to output with reference targetappendTestDeclaratively
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to progress with reference targetappendTestDeclaratively
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to progress with reference targetappendTestDeclaratively
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to progress with reference targetappendTestDeclaratively
@@ -1306,9 +1298,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to progress with reference targetappendTestDeclaratively
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to progress with reference targetappendTestDeclaratively
 PASS label.form has reflection behavior IsNull when pointing to progress with reference targetappendTestDeclaratively
-FAIL label.control has reflection behavior ReflectsHost when pointing to progress with reference targetappendTestDeclaratively assert_equals: expected Element node <div id="host-id">
-
-        </div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to progress with reference targetappendTestDeclaratively
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to select with reference targetappendTestDeclaratively
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to select with reference targetappendTestDeclaratively
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to select with reference targetappendTestDeclaratively
@@ -1319,9 +1309,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to select with reference targetappendTestDeclaratively
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to select with reference targetappendTestDeclaratively
 PASS label.form has reflection behavior IsNull when pointing to select with reference targetappendTestDeclaratively
-FAIL label.control has reflection behavior ReflectsHost when pointing to select with reference targetappendTestDeclaratively assert_equals: expected Element node <div id="host-id">
-
-        </div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to select with reference targetappendTestDeclaratively
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to textarea with reference targetappendTestDeclaratively
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to textarea with reference targetappendTestDeclaratively
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to textarea with reference targetappendTestDeclaratively
@@ -1332,9 +1320,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to textarea with reference targetappendTestDeclaratively
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to textarea with reference targetappendTestDeclaratively
 PASS label.form has reflection behavior IsNull when pointing to textarea with reference targetappendTestDeclaratively
-FAIL label.control has reflection behavior ReflectsHost when pointing to textarea with reference targetappendTestDeclaratively assert_equals: expected Element node <div id="host-id">
-
-        </div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to textarea with reference targetappendTestDeclaratively
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to div with reference targetappendTestDeclaratively
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to div with reference targetappendTestDeclaratively
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to div with reference targetappendTestDeclaratively
@@ -3323,7 +3309,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to button with reference targetappendTestWithOptions
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to button with reference targetappendTestWithOptions
 PASS label.form has reflection behavior IsNull when pointing to button with reference targetappendTestWithOptions
-FAIL label.control has reflection behavior ReflectsHost when pointing to button with reference targetappendTestWithOptions assert_equals: expected Element node <div id="host-id"></div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to button with reference targetappendTestWithOptions
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to input with reference targetappendTestWithOptions
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to input with reference targetappendTestWithOptions
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to input with reference targetappendTestWithOptions
@@ -3334,7 +3320,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to input with reference targetappendTestWithOptions
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to input with reference targetappendTestWithOptions
 PASS label.form has reflection behavior IsNull when pointing to input with reference targetappendTestWithOptions
-FAIL label.control has reflection behavior ReflectsHost when pointing to input with reference targetappendTestWithOptions assert_equals: expected Element node <div id="host-id"></div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to input with reference targetappendTestWithOptions
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to meter with reference targetappendTestWithOptions
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to meter with reference targetappendTestWithOptions
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to meter with reference targetappendTestWithOptions
@@ -3345,7 +3331,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to meter with reference targetappendTestWithOptions
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to meter with reference targetappendTestWithOptions
 PASS label.form has reflection behavior IsNull when pointing to meter with reference targetappendTestWithOptions
-FAIL label.control has reflection behavior ReflectsHost when pointing to meter with reference targetappendTestWithOptions assert_equals: expected Element node <div id="host-id"></div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to meter with reference targetappendTestWithOptions
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to output with reference targetappendTestWithOptions
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to output with reference targetappendTestWithOptions
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to output with reference targetappendTestWithOptions
@@ -3356,7 +3342,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to output with reference targetappendTestWithOptions
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to output with reference targetappendTestWithOptions
 PASS label.form has reflection behavior IsNull when pointing to output with reference targetappendTestWithOptions
-FAIL label.control has reflection behavior ReflectsHost when pointing to output with reference targetappendTestWithOptions assert_equals: expected Element node <div id="host-id"></div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to output with reference targetappendTestWithOptions
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to progress with reference targetappendTestWithOptions
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to progress with reference targetappendTestWithOptions
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to progress with reference targetappendTestWithOptions
@@ -3367,7 +3353,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to progress with reference targetappendTestWithOptions
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to progress with reference targetappendTestWithOptions
 PASS label.form has reflection behavior IsNull when pointing to progress with reference targetappendTestWithOptions
-FAIL label.control has reflection behavior ReflectsHost when pointing to progress with reference targetappendTestWithOptions assert_equals: expected Element node <div id="host-id"></div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to progress with reference targetappendTestWithOptions
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to select with reference targetappendTestWithOptions
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to select with reference targetappendTestWithOptions
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to select with reference targetappendTestWithOptions
@@ -3378,7 +3364,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to select with reference targetappendTestWithOptions
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to select with reference targetappendTestWithOptions
 PASS label.form has reflection behavior IsNull when pointing to select with reference targetappendTestWithOptions
-FAIL label.control has reflection behavior ReflectsHost when pointing to select with reference targetappendTestWithOptions assert_equals: expected Element node <div id="host-id"></div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to select with reference targetappendTestWithOptions
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to textarea with reference targetappendTestWithOptions
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to textarea with reference targetappendTestWithOptions
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to textarea with reference targetappendTestWithOptions
@@ -3389,7 +3375,7 @@ PASS label.ariaLabelledByElements has reflection behavior ReflectsHostInArray wh
 PASS label.ariaOwnsElements has reflection behavior ReflectsHostInArray when pointing to textarea with reference targetappendTestWithOptions
 PASS label.htmlFor has reflection behavior ReflectsHostID when pointing to textarea with reference targetappendTestWithOptions
 PASS label.form has reflection behavior IsNull when pointing to textarea with reference targetappendTestWithOptions
-FAIL label.control has reflection behavior ReflectsHost when pointing to textarea with reference targetappendTestWithOptions assert_equals: expected Element node <div id="host-id"></div> but got null
+PASS label.control has reflection behavior ReflectsHost when pointing to textarea with reference targetappendTestWithOptions
 PASS label.ariaControlsElements has reflection behavior ReflectsHostInArray when pointing to div with reference targetappendTestWithOptions
 PASS label.ariaActiveDescendantElement has reflection behavior ReflectsHost when pointing to div with reference targetappendTestWithOptions
 PASS label.ariaDescribedByElements has reflection behavior ReflectsHostInArray when pointing to div with reference targetappendTestWithOptions

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/reference-target-basics-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/reference-target-basics-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL ShadowRoot.referenceTarget defaults to empty string when shadow is created declaratively assert_equals: expected (string) "" but got (undefined) undefined
-FAIL <template> shadowrootreferencetarget sets referenceTarget on shadow root assert_equals: expected (string) "targetID" but got (undefined) undefined
-FAIL ShadowRoot.referenceTarget defaults to empty string when shadow is created imperatively assert_equals: expected (string) "" but got (undefined) undefined
-FAIL ShadowRootInitDict can be used to set referenceTarget on shadow root assert_equals: expected (string) "targetID" but got (undefined) undefined
+PASS ShadowRoot.referenceTarget defaults to empty string when shadow is created declaratively
+PASS <template> shadowrootreferencetarget sets referenceTarget on shadow root
+PASS ShadowRoot.referenceTarget defaults to empty string when shadow is created imperatively
+PASS ShadowRootInitDict can be used to set referenceTarget on shadow root
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6809,6 +6809,21 @@ ServiceWorkersUserGestureEnabled:
     WebCore:
       default: true
 
+ShadowRootReferenceTargetEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "referenceTarget"
+  humanReadableDescription: "Enable setting a referenceTarget on shadow roots"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 # When enabling this, don't enable on watchOS or the macOS base system (which don't have Vision.framework).
 # You can detect these by running isVisionFrameworkAvailable().
 ShapeDetection:

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2716,9 +2716,9 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         if (RefPtr label = dynamicDowncast<HTMLLabelElement>(element)) {
             updateLabelFor(*label);
 
-            if (RefPtr oldControl = element->treeScope().getElementById(oldValue))
+            if (RefPtr oldControl = element->treeScope().elementByIdResolvingReferenceTarget(oldValue))
                 postNotification(oldControl.get(), AXNotification::TextChanged);
-            if (RefPtr newControl = element->treeScope().getElementById(newValue))
+            if (RefPtr newControl = element->treeScope().elementByIdResolvingReferenceTarget(newValue))
                 postNotification(newControl.get(), AXNotification::TextChanged);
         }
     } else if (attrName == requiredAttr)
@@ -5342,7 +5342,7 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
 
     SpaceSplitString ids(value, SpaceSplitString::ShouldFoldCase::No);
     for (auto& id : ids) {
-        RefPtr target = origin.treeScope().getElementById(id);
+        RefPtr target = origin.treeScope().elementByIdResolvingReferenceTarget(id);
         if (!target || target == &origin)
             continue;
 

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -92,7 +92,7 @@ RefPtr<Element> CustomElementDefaultARIA::elementForAttribute(const Element& thi
     RefPtr<Element> result;
     std::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
         if (thisElement.isInTreeScope())
-            result = thisElement.treeScope().getElementById(stringValue);
+            result = thisElement.treeScope().elementByIdResolvingReferenceTarget(stringValue);
     }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) {
         RefPtr elementValue = weakElementValue.get();
         if (elementValue && isElementVisible(*elementValue, thisElement))
@@ -118,7 +118,8 @@ Vector<Ref<Element>> CustomElementDefaultARIA::elementsForAttribute(const Elemen
         if (thisElement.isInTreeScope()) {
             SpaceSplitString idList { stringValue, SpaceSplitString::ShouldFoldCase::No };
             result = WTF::compactMap(idList, [&](auto& id) {
-                return thisElement.treeScope().getElementById(id);
+                RefPtr elementForId = thisElement.treeScope().getElementById(id);
+                return elementForId ? elementForId->resolveReferenceTarget() : nullptr;
             });
         }
     }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -409,10 +409,13 @@ public:
 
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
     RefPtr<ShadowRoot> shadowRootForBindings(JSC::JSGlobalObject&) const;
+    RefPtr<Element> resolveReferenceTarget() const;
+    RefPtr<Element> retargetReferenceTargetForBindings(RefPtr<Element>) const;
 
     enum class CustomElementRegistryKind : bool { Window, Null };
+
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, CustomElementRegistryKind = CustomElementRegistryKind::Window);
-    ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, CustomElementRegistryKind);
+    ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, String referenceTarget, CustomElementRegistryKind);
 
     WEBCORE_EXPORT ShadowRoot* userAgentShadowRoot() const;
     RefPtr<ShadowRoot> protectedUserAgentShadowRoot() const;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -63,9 +63,9 @@ public:
 
     static Ref<ShadowRoot> create(Document& document, ShadowRootMode type, SlotAssignmentMode assignmentMode = SlotAssignmentMode::Named,
         DelegatesFocus delegatesFocus = DelegatesFocus::No, Clonable clonable = Clonable::No, Serializable serializable = Serializable::No, AvailableToElementInternals availableToElementInternals = AvailableToElementInternals::No,
-        RefPtr<CustomElementRegistry>&& registry = nullptr, ScopedCustomElementRegistry scopedRegistry = ScopedCustomElementRegistry::No)
+        RefPtr<CustomElementRegistry>&& registry = nullptr, ScopedCustomElementRegistry scopedRegistry = ScopedCustomElementRegistry::No, const AtomString& referenceTarget = nullAtom())
     {
-        return adoptRef(*new ShadowRoot(document, type, assignmentMode, delegatesFocus, clonable, serializable, availableToElementInternals, WTFMove(registry), scopedRegistry));
+        return adoptRef(*new ShadowRoot(document, type, assignmentMode, delegatesFocus, clonable, serializable, availableToElementInternals, WTFMove(registry), scopedRegistry, referenceTarget));
     }
 
     static Ref<ShadowRoot> create(Document& document, std::unique_ptr<SlotAssignment>&& assignment)
@@ -152,8 +152,16 @@ public:
 
     Vector<RefPtr<WebAnimation>> getAnimations();
 
+    bool hasReferenceTarget() const { return !m_referenceTarget.isNull(); }
+    const AtomString& referenceTarget() const { return m_referenceTarget; }
+    void setReferenceTarget(const AtomString&);
+    RefPtr<Element> referenceTargetElement() const
+    {
+        return m_referenceTarget.isNull() ? nullptr : getElementById(m_referenceTarget);
+    }
+
 private:
-    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, DelegatesFocus, Clonable, Serializable, AvailableToElementInternals, RefPtr<CustomElementRegistry>&&, ScopedCustomElementRegistry);
+    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, DelegatesFocus, Clonable, Serializable, AvailableToElementInternals, RefPtr<CustomElementRegistry>&&, ScopedCustomElementRegistry, const AtomString& referenceTarget);
     ShadowRoot(Document&, std::unique_ptr<SlotAssignment>&&);
 
     bool childTypeAllowed(NodeType) const override;
@@ -182,6 +190,8 @@ private:
     std::unique_ptr<Style::Scope> m_styleScope;
     std::unique_ptr<SlotAssignment> m_slotAssignment;
     mutable std::optional<PartMappings> m_partMappings;
+
+    AtomString m_referenceTarget;
 };
 
 inline Element* ShadowRoot::activeElement() const

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -37,6 +37,7 @@
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] readonly attribute boolean serializable;
     readonly attribute Element host;
     attribute EventHandler onslotchange;
+    [EnabledBySetting=ShadowRootReferenceTargetEnabled] attribute [AtomString] DOMString referenceTarget;
 
     [ImplementedAs=registryForBindings, EnabledBySetting=ScopedCustomElementRegistryEnabled] readonly attribute CustomElementRegistry? customElements;
 };

--- a/Source/WebCore/dom/ShadowRootInit.h
+++ b/Source/WebCore/dom/ShadowRootInit.h
@@ -38,6 +38,7 @@ struct ShadowRootInit {
     bool serializable { false };
     SlotAssignmentMode slotAssignment { SlotAssignmentMode::Named };
     RefPtr<CustomElementRegistry> customElements;
+    String referenceTarget;
 };
 
 }

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -32,4 +32,5 @@ dictionary ShadowRootInit {
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
     [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry customElements = null;
+    [EnabledBySetting=ShadowRootReferenceTargetEnabled] DOMString referenceTarget;
 };

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -176,6 +176,12 @@ RefPtr<Element> TreeScope::getElementById(StringView elementId) const
     return nullptr;
 }
 
+RefPtr<Element> TreeScope::elementByIdResolvingReferenceTarget(const AtomString& elementId) const
+{
+    RefPtr elementForId = getElementById(elementId);
+    return elementForId ? elementForId->resolveReferenceTarget() : nullptr;
+}
+
 const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* TreeScope::getAllElementsById(const AtomString& elementId) const
 {
     if (elementId.isEmpty())
@@ -225,7 +231,6 @@ void TreeScope::removeElementByName(const AtomString& name, Element& element)
         return;
     m_elementsByName->remove(name, element);
 }
-
 
 Ref<Node> TreeScope::retargetToScope(Node& node) const
 {

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -83,6 +83,7 @@ public:
     WEBCORE_EXPORT RefPtr<Element> getElementById(const AtomString&) const;
     WEBCORE_EXPORT RefPtr<Element> getElementById(const String&) const;
     RefPtr<Element> getElementById(StringView) const;
+    RefPtr<Element> elementByIdResolvingReferenceTarget(const AtomString&) const;
     const Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* getAllElementsById(const AtomString&) const;
     inline bool hasElementWithId(const AtomString&) const; // Defined in TreeScopeInlines.h.
     inline bool containsMultipleElementsWithId(const AtomString& id) const; // Defined in TreeScopeInlines.h.

--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -37,7 +37,8 @@ FormAssociatedElement::FormAssociatedElement(HTMLFormElement* form)
 
 HTMLFormElement* FormAssociatedElement::formForBindings() const
 {
-    return form();
+    // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
+    return dynamicDowncast<HTMLFormElement>(asHTMLElement().retargetReferenceTargetForBindings(form())).get();
 }
 
 void FormAssociatedElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -108,7 +108,10 @@ static RefPtr<HTMLFormElement> findAssociatedForm(const HTMLElement& element, HT
             if (!newFormCandidate)
                 return nullptr;
             if (&element.traverseToRootNode() == &element.treeScope().rootNode()) {
-                ASSERT(&element.traverseToRootNode() == &newFormCandidate->traverseToRootNode());
+                if (element.document().settings().shadowRootReferenceTargetEnabled())
+                    ASSERT(&element.traverseToRootNode() == &(element.treeScope().retargetToScope(*newFormCandidate))->treeScope().rootNode());
+                else
+                    ASSERT(&element.traverseToRootNode() == &newFormCandidate->traverseToRootNode());
                 return newFormCandidate;
             }
         }

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -394,6 +394,7 @@ shadowrootclonable
 shadowrootcustomelements
 shadowrootdelegatesfocus
 shadowrootmode
+shadowrootreferencetarget
 shadowrootserializable
 shape
 size

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -539,7 +539,11 @@ unsigned HTMLFormElement::formElementIndex(FormListedElement& listedElement)
     // Treats separately the case where this element has the form attribute
     // for performance consideration.
     if (listedHTMLElement.hasAttributeWithoutSynchronization(formAttr) && listedHTMLElement.isConnected()) {
-        unsigned short position = compareDocumentPosition(listedHTMLElement);
+        unsigned short position;
+        if (document().settings().shadowRootReferenceTargetEnabled())
+            position = listedHTMLElement.treeScope().retargetToScope(*this)->compareDocumentPosition(listedHTMLElement);
+        else
+            position = compareDocumentPosition(listedHTMLElement);
         ASSERT(!(position & DOCUMENT_POSITION_DISCONNECTED));
         if (position & DOCUMENT_POSITION_PRECEDING) {
             ++m_listedElementsBeforeIndex;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1885,7 +1885,8 @@ Vector<Color> HTMLInputElement::suggestedColors() const
 
 RefPtr<HTMLElement> HTMLInputElement::list() const
 {
-    return dataList();
+    // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
+    return dynamicDowncast<HTMLDataListElement>(retargetReferenceTargetForBindings(dataList()));
 }
 
 bool HTMLInputElement::hasDataList() const

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -58,7 +58,8 @@ HTMLFormElement* HTMLLegendElement::form() const
 
 HTMLFormElement* HTMLLegendElement::formForBindings() const
 {
-    return form();
+    // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).get();
 }
     
 } // namespace

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -147,7 +147,8 @@ HTMLFormElement* HTMLOptionElement::form() const
 
 HTMLFormElement* HTMLOptionElement::formForBindings() const
 {
-    return form();
+    // FIXME: The downcast should be unnecessary, but the WPT was written before https://github.com/WICG/webcomponents/issues/1072 was resolved. Update once the WPT has been updated.
+    return dynamicDowncast<HTMLFormElement>(retargetReferenceTargetForBindings(form())).get();
 }
 
 int HTMLOptionElement::index() const

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -39,4 +39,5 @@
     [CEReactions=NotNeeded, Reflect=shadowrootclonable] attribute boolean shadowRootClonable;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled, CEReactions=NotNeeded, Reflect=shadowrootserializable] attribute boolean shadowRootSerializable;
     [EnabledBySetting=ScopedCustomElementRegistryEnabled, CEReactions=NotNeeded, Reflect=shadowrootcustomelements] attribute boolean shadowRootCustomElements;
+    [CEReactions=NotNeeded, EnabledBySetting=ShadowRootReferenceTargetEnabled, Reflect=shadowrootreferencetarget] attribute DOMString shadowRootReferenceTarget;
 };

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -556,6 +556,7 @@ void HTMLConstructionSite::insertHTMLTemplateElement(AtomHTMLToken&& token)
         auto delegatesFocus = ShadowRootDelegatesFocus::No;
         auto clonable = ShadowRootClonable::No;
         auto serializable = ShadowRootSerializable::No;
+        String referenceTarget;
         auto registryKind = Element::CustomElementRegistryKind::Window;
         for (auto& attribute : token.attributes()) {
             if (attribute.name() == HTMLNames::shadowrootmodeAttr) {
@@ -569,11 +570,13 @@ void HTMLConstructionSite::insertHTMLTemplateElement(AtomHTMLToken&& token)
                 clonable = ShadowRootClonable::Yes;
             else if (attribute.name() == HTMLNames::shadowrootserializableAttr)
                 serializable = ShadowRootSerializable::Yes;
+            else if (document().settings().shadowRootReferenceTargetEnabled() && attribute.name() == HTMLNames::shadowrootreferencetargetAttr)
+                referenceTarget = AtomString(attribute.value());
             else if (attribute.name() == HTMLNames::shadowrootcustomelementsAttr)
                 registryKind = Element::CustomElementRegistryKind::Null;
         }
         if (mode && is<Element>(currentNode())) {
-            auto exceptionOrShadowRoot = currentElement().attachDeclarativeShadow(*mode, delegatesFocus, clonable, serializable, registryKind);
+            auto exceptionOrShadowRoot = currentElement().attachDeclarativeShadow(*mode, delegatesFocus, clonable, serializable, referenceTarget, registryKind);
             if (!exceptionOrShadowRoot.hasException()) {
                 Ref shadowRoot = exceptionOrShadowRoot.releaseReturnValue();
                 auto element = createHTMLElement(token);


### PR DESCRIPTION
#### c638de65783f7bdc50e27c165eac138956d000d6
<pre>
Add support for referenceTarget.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285634">https://bugs.webkit.org/show_bug.cgi?id=285634</a>

Reviewed by Ryosuke Niwa.

Explainer: <a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/reference-target-explainer.md">https://github.com/WICG/webcomponents/blob/gh-pages/proposals/reference-target-explainer.md</a>

Reference Target is a feature to enable using IDREF attributes such as for and
aria-labelledby to refer to elements inside a component&apos;s shadow DOM, while
maintaining encapsulation of the internal details of the shadow DOM. The main
goal of this feature is to enable ARIA to work across shadow root boundaries.

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/aria-labelledby-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/dom-mutation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/label-descendant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/label-for-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/popovertarget-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/property-reflection-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/reference-target-basics-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::elementForAttribute const):
(WebCore::CustomElementDefaultARIA::elementsForAttribute const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::elementForAttributeInternal const):
(WebCore::Element::getElementAttributeForBindings const):
(WebCore::Element::elementsArrayForAttributeInternal const):
(WebCore::Element::getElementsArrayAttributeForBindings const):
(WebCore::Element::resolveReferenceTarget const):
(WebCore::Element::retargetReferenceTargetForBindings const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::ShadowRoot):
(WebCore::ShadowRoot::setReferenceTarget):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/dom/ShadowRootInit.h:
* Source/WebCore/dom/ShadowRootInit.idl:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::elementByIdResolvingReferenceTarget const):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/html/FormAssociatedElement.cpp:
(WebCore::FormAssociatedElement::formForBindings const):
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::findAssociatedForm):
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::formElementIndex):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::list const):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::control const):
(WebCore::HTMLLabelElement::controlForBindings const):
(WebCore::HTMLLabelElement::formForBindings const):
* Source/WebCore/html/HTMLLegendElement.cpp:
(WebCore::HTMLLegendElement::formForBindings const):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::formForBindings const):
* Source/WebCore/html/HTMLTemplateElement.idl:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLTemplateElement):

Canonical link: <a href="https://commits.webkit.org/290529@main">https://commits.webkit.org/290529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c974090fa851068ff9dd960d07c2668a6d9113b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27109 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36301 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40228 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83125 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97149 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89099 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78519 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20800 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10768 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22846 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111590 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17260 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26709 "Failed to checkout and rebase branch from PR 39742") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->