### PR TITLE
Web Inspector: virtualize `WI.TreeOutline` in `WI.OpenResourceDialog`

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/ResourceQueryResult.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ResourceQueryResult.js
@@ -27,7 +27,7 @@ WI.ResourceQueryResult = class ResourceQueryResult extends WI.QueryResult
 {
     constructor(resource, searchString, matches, cookie)
     {
-        console.assert(resource instanceof WI.Resource, resource);
+        console.assert(resource instanceof WI.SourceCode, resource);
         super(resource, matches);
 
         this._searchString = searchString;

--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.css
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.css
@@ -101,7 +101,7 @@
     display: block;
 }
 
-.open-resource-dialog > .tree-outline {
+.open-resource-dialog > .scroll-container {
     display: flex;
     flex-direction: column;
     overflow-y: auto;
@@ -110,22 +110,22 @@
     border-bottom-right-radius: 4px;
 }
 
-.open-resource-dialog.has-results > .tree-outline {
+.open-resource-dialog.has-results .scroll-container {
     border-top: solid 1px var(--border-color);
 }
 
-.open-resource-dialog > .tree-outline .item {
+.open-resource-dialog .tree-outline .item {
     flex: none;
     padding-inline-start: 10px;
     border: none;
 }
 
-.open-resource-dialog > .tree-outline.large .item {
+.open-resource-dialog .tree-outline.large .item {
     height: 44px;
     line-height: 42px;
 }
 
-.open-resource-dialog > .tree-outline.large .item .icon {
+.open-resource-dialog .tree-outline.large .item .icon {
     width: 32px;
     height: 32px;
     margin-top: 6px;
@@ -150,19 +150,19 @@
     vertical-align: 1px;
 }
 
-.open-resource-dialog > .tree-outline .item.selected {
+.open-resource-dialog .tree-outline .item.selected {
     color: white;
     background-color: hsl(209, 100%, 49%);
 }
 
-.open-resource-dialog > .tree-outline .item.selected .highlighted {
+.open-resource-dialog .tree-outline .item.selected .highlighted {
     background-color: var(--selected-background-color-highlight);
 
     border-bottom: none;
     text-decoration: underline;
 }
 
-.open-resource-dialog > .tree-outline .item.selected .subtitle {
+.open-resource-dialog .tree-outline .item.selected .subtitle {
     color: hsla(0, 0%, 100%, 0.9);
 }
 
@@ -180,7 +180,7 @@
         color: var(--text-color-secondary);
     }
 
-    .open-resource-dialog > .tree-outline .item.selected {
+    .open-resource-dialog .tree-outline .item.selected {
         background-color: var(--selected-background-color);
         color: white;
     }

--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
@@ -55,7 +55,12 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
         this._treeOutline.addEventListener(WI.TreeOutline.Event.SelectionDidChange, this._treeSelectionDidChange, this);
         this._treeOutline.element.addEventListener("focus", () => { this._inputElement.focus(); });
 
-        this.element.appendChild(this._treeOutline.element);
+        let scrollContainer = this.element.appendChild(document.createElement("div"));
+        scrollContainer.className = "scroll-container";
+        scrollContainer.appendChild(this._treeOutline.element);
+
+        const treeItemHeight = 44;
+        this._treeOutline.registerScrollVirtualizer(scrollContainer, treeItemHeight);
 
         this._updateFilterThrottler = new Throttler(() => {
             this._updateFilter();

--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
@@ -963,7 +963,7 @@ WI.TreeOutline = class TreeOutline extends WI.Object
         let offsetFromContainer = calculateOffsetFromContainer(this._virtualizedTopSpacer.parentNode ? this._virtualizedTopSpacer : this.element, this._virtualizedScrollContainer);
         let numberVisible = Math.ceil(Math.max(0, this._virtualizedScrollContainer.offsetHeight - offsetFromContainer) / this._virtualizedTreeItemHeight);
         let extraRows = Math.max(numberVisible * 5, 50);
-        let firstItem = Math.floor((this._virtualizedScrollContainer.scrollTop - offsetFromContainer) / this._virtualizedTreeItemHeight) - extraRows;
+        let firstItem = Math.max(0, Math.floor((this._virtualizedScrollContainer.scrollTop - offsetFromContainer) / this._virtualizedTreeItemHeight) - extraRows);
         let lastItem = firstItem + numberVisible + (extraRows * 2);
 
         let shouldScroll = false;


### PR DESCRIPTION
#### 4f10dc814d0c21ce07c2fe213e2a6d3d065c6236
<pre>
Web Inspector: virtualize `WI.TreeOutline` in `WI.OpenResourceDialog`
<a href="https://bugs.webkit.org/show_bug.cgi?id=286724">https://bugs.webkit.org/show_bug.cgi?id=286724</a>

Reviewed by BJ Burg.

This should improve the performance of searching for and jumping to a resource when inspecting sites that have a lot of resources as there will be less elements in the DOM.

* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js:
(WI.OpenResourceDialog):

* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.css:
(.open-resource-dialog &gt; .scroll-container): Renamed from `.open-resource-dialog &gt; .tree-outline`.
(.open-resource-dialog.has-results .scroll-container): Renamed from `.open-resource-dialog.has-results &gt; .tree-outline`.
(.open-resource-dialog .tree-outline .item): Renamed from `.open-resource-dialog &gt; .tree-outline .item`.
(.open-resource-dialog .tree-outline.large .item): Renamed from `.open-resource-dialog &gt; .tree-outline.large .item`.
(.open-resource-dialog .tree-outline.large .item .icon): Renamed from `.open-resource-dialog &gt; .tree-outline.large .item .icon`.
(.open-resource-dialog .tree-outline .item.selected): Renamed from `.open-resource-dialog &gt; .tree-outline .item.selected`.
(.open-resource-dialog .tree-outline .item.selected .highlighted): Renamed from `.open-resource-dialog &gt; .tree-outline .item.selected .highlighted`.
(.open-resource-dialog .tree-outline .item.selected .subtitle): Renamed from `.open-resource-dialog &gt; .tree-outline .item.selected .subtitle`.
(@media (prefers-color-scheme: dark) .open-resource-dialog .tree-outline .item.selected): Renamed from `@media (prefers-color-scheme: dark) .open-resource-dialog &gt; .tree-outline .item.selected`.
Move the `WI.TreeOutline` into it&apos;s own container so that only it is scrolled without having to account for the `&lt;input&gt;`.

* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js:
(WI.TreeOutline.prototype._updateVirtualizedElements):
Drive-by: prevent the scrollbar from jumping around when scrolling from the top down by ensuring that the first item index will never be negative as that&apos;s used to calculate how tall to make the bottom spacer which affects the scrollbar size.

* Source/WebInspectorUI/UserInterface/Models/ResourceQueryResult.js:
(WI.ResourceQueryResult):

Drive-by: remove incorrect assertion since this can also be created with `WI.Script` and `WI.CSSStyleSheet`.
Canonical link: <a href="https://commits.webkit.org/289844@main">https://commits.webkit.org/289844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e29115c4f1e773cc55f552ead810f992f31518

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38043 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67463 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25192 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47787 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33392 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37160 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94052 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10669 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76271 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18727 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19814 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7397 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19777 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14229 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17672 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16010 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->