### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSCalcTree+Parser.cpp

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -1466,16 +1466,16 @@ std::optional<TypedChild> parseCalcSum(CSSParserTokenRange& tokens, int depth, P
     auto sumType = firstValue->type;
     Children children;
 
+    auto originalTokens = tokens.span();
     while (!tokens.atEnd()) {
         auto& token = tokens.peek();
         char operatorCharacter = token.type() == DelimiterToken ? token.delimiter() : 0;
         if (operatorCharacter != static_cast<char>(Calculation::Operator::Sum) && operatorCharacter != static_cast<char>(Calculation::Operator::Negate))
             break;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (!CSSTokenizer::isWhitespace((&tokens.peek() - 1)->type()))
+        auto previousToken = originalTokens[tokens.begin() - originalTokens.data() - 1];
+        if (!CSSTokenizer::isWhitespace(previousToken.type()))
             return std::nullopt; // calc(1px+ 2px) is invalid
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         tokens.consume();
         if (!CSSTokenizer::isWhitespace(tokens.peek().type()))


### PR DESCRIPTION
#### a4af661503b7a81bc7f60534814dcc34364d6f06
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSCalcTree+Parser.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286727">https://bugs.webkit.org/show_bug.cgi?id=286727</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::parseCalcSum):

Canonical link: <a href="https://commits.webkit.org/289546@main">https://commits.webkit.org/289546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80e8a330fd440e8f9c2552d93834327037cbbb21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14891 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90308 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47790 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33395 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37163 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94055 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14468 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75483 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18567 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19817 "Found 60 new test failures: http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html http/wpt/webxr/xrFrame_getJointPose_missing_joint_pose.html http/wpt/webxr/xrHand.html ... (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18270 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14487 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14232 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->