### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSParserTokenRange.cpp

### DIFF
--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -44,7 +44,7 @@ public:
         return adoptRef(*new CSSVariableData(range, context));
     }
 
-    CSSParserTokenRange tokenRange() const { return m_tokens; }
+    CSSParserTokenRange tokenRange() const LIFETIME_BOUND { return m_tokens; }
     const CSSParserContext& context() const { return m_context; }
 
     const Vector<CSSParserToken>& tokens() const { return m_tokens; }

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -42,26 +42,6 @@ CSSParserToken& CSSParserTokenRange::eofToken()
     return eofToken.get();
 }
 
-CSSParserTokenRange CSSParserTokenRange::makeSubRange(const CSSParserToken* first, const CSSParserToken* last) const
-{
-    if (first == &eofToken())
-        first = std::to_address(m_tokens.end());
-
-    if (last == &eofToken())
-        last = std::to_address(m_tokens.end());
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    ASSERT(first <= last);
-    return { std::span { first, last } };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
-CSSParserTokenRange CSSParserTokenRange::makeSubRange(std::span<const CSSParserToken> subrange) const
-{
-    ASSERT(std::to_address(subrange.end()) <= std::to_address(m_tokens.end()));
-    return { subrange };
-}
-
 CSSParserTokenRange CSSParserTokenRange::consumeBlock()
 {
     ASSERT(peek().getBlockType() == CSSParserToken::BlockStart);
@@ -76,8 +56,8 @@ CSSParserTokenRange CSSParserTokenRange::consumeBlock()
     } while (nestingLevel && !m_tokens.empty());
 
     if (nestingLevel)
-        return makeSubRange(start.first(m_tokens.data() - start.data())); // Ended at EOF
-    return makeSubRange(start.first(m_tokens.data() - start.data() - 1));
+        return start.first(m_tokens.data() - start.data()); // Ended at EOF
+    return start.first(m_tokens.data() - start.data() - 1);
 }
 
 CSSParserTokenRange CSSParserTokenRange::consumeBlockCheckingForEditability(StyleSheetContents* styleSheet)
@@ -97,8 +77,8 @@ CSSParserTokenRange CSSParserTokenRange::consumeBlockCheckingForEditability(Styl
     } while (nestingLevel && !m_tokens.empty());
 
     if (nestingLevel)
-        return makeSubRange(start.first(m_tokens.data() - start.data())); // Ended at EOF
-    return makeSubRange(start.first(m_tokens.data() - start.data() - 1));
+        return start.first(m_tokens.data() - start.data()); // Ended at EOF
+    return start.first(m_tokens.data() - start.data() - 1);
 }
 
 void CSSParserTokenRange::consumeComponentValue()

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -45,15 +45,16 @@ class CSSParserTokenRange {
 public:
     CSSParserTokenRange() = default;
 
+    CSSParserTokenRange(std::span<const CSSParserToken> span)
+        : m_tokens(span)
+    { }
+
     template<size_t inlineBuffer>
     CSSParserTokenRange(const Vector<CSSParserToken, inlineBuffer>& vector)
-        : m_tokens(vector.span())
-    {
-    }
+        : CSSParserTokenRange(vector.span())
+    { }
 
-    // This should be called on a range with tokens returned by that range.
-    CSSParserTokenRange makeSubRange(const CSSParserToken* first, const CSSParserToken* last) const;
-    CSSParserTokenRange makeSubRange(std::span<const CSSParserToken> subrange) const;
+    CSSParserTokenRange rangeUntil(const CSSParserTokenRange& end) const { return span().first(end.begin() - begin()); }
 
     bool atEnd() const { return m_tokens.empty(); }
 
@@ -108,10 +109,6 @@ public:
     static CSSParserToken& eofToken();
 
 private:
-    CSSParserTokenRange(std::span<const CSSParserToken> tokens)
-        : m_tokens(tokens)
-    { }
-
     std::span<const CSSParserToken> m_tokens;
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -884,10 +884,10 @@ RefPtr<CSSValueList> consumeFontFaceSrc(CSSParserTokenRange& range, const CSSPar
         return nullptr;
     };
     while (!range.atEnd()) {
-        auto begin = range.begin();
+        auto begin = range;
         while (!range.atEnd() && range.peek().type() != CSSParserTokenType::CommaToken)
             range.consumeComponentValue();
-        auto subrange = range.makeSubRange(begin, &range.peek());
+        auto subrange = begin.rangeUntil(range);
         if (RefPtr parsedValue = consumeSrcListComponent(subrange))
             values.append(parsedValue.releaseNonNull());
         if (!range.atEnd())

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -186,7 +186,7 @@ MutableCSSSelectorList CSSSelectorParser::consumeForgivingSelectorList(CSSParser
         auto initialRange = range;
         auto unknownSelector = [&] {
             auto unknownSelector = makeUnique<MutableCSSSelector>();
-            auto unknownRange = initialRange.makeSubRange(initialRange.begin(), range.begin());
+            auto unknownRange = initialRange.rangeUntil(range);
             unknownSelector->setMatch(CSSSelector::Match::ForgivingUnknown);
             // We store the complete range content for serialization.
             unknownSelector->setValue(AtomString { unknownRange.serialize() });

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -52,7 +52,7 @@ public:
     WEBCORE_EXPORT explicit CSSTokenizer(const String&);
     CSSTokenizer(const String&, CSSParserObserverWrapper&); // For the inspector
 
-    WEBCORE_EXPORT CSSParserTokenRange tokenRange() const;
+    WEBCORE_EXPORT CSSParserTokenRange tokenRange() const LIFETIME_BOUND;
     unsigned tokenCount();
 
     static bool isWhitespace(CSSParserTokenType);

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -117,22 +117,22 @@ bool SizesAttributeParser::parse(CSSParserTokenRange range, const CSSParserConte
 {
     // Split on a comma token and parse the result tokens as (media-condition, length) pairs
     while (!range.atEnd()) {
-        const CSSParserToken* mediaConditionStart = &range.peek();
+        auto mediaConditionStart = range;
         // The length is the last component value before the comma which isn't whitespace or a comment
-        const CSSParserToken* lengthTokenStart = &range.peek();
-        const CSSParserToken* lengthTokenEnd = &range.peek();
+        auto lengthTokenStart = range;
+        auto lengthTokenEnd = range;
         while (!range.atEnd() && range.peek().type() != CommaToken) {
-            lengthTokenStart = &range.peek();
+            lengthTokenStart = range;
             range.consumeComponentValue();
-            lengthTokenEnd = &range.peek();
+            lengthTokenEnd = range;
             range.consumeWhitespace();
         }
         range.consume();
 
-        auto length = calculateLengthInPixels(range.makeSubRange(lengthTokenStart, lengthTokenEnd));
+        auto length = calculateLengthInPixels(lengthTokenStart.rangeUntil(lengthTokenEnd));
         if (!length)
             continue;
-        auto mediaCondition = MQ::MediaQueryParser::parseCondition(range.makeSubRange(mediaConditionStart, lengthTokenStart), MediaQueryParserContext(context));
+        auto mediaCondition = MQ::MediaQueryParser::parseCondition(mediaConditionStart.rangeUntil(lengthTokenStart), MediaQueryParserContext(context));
         if (!mediaCondition)
             continue;
         bool matches = mediaConditionMatches(*mediaCondition);

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -79,11 +79,11 @@ MediaQueryList MediaQueryParser::consumeMediaQueryList(CSSParserTokenRange& rang
     MediaQueryList list;
 
     while (true) {
-        auto begin = range.begin();
+        auto begin = range;
         while (!range.atEnd() && range.peek().type() != CommaToken)
             range.consumeComponentValue();
 
-        auto subrange = range.makeSubRange(begin, &range.peek());
+        auto subrange = begin.rangeUntil(range);
 
         auto consumeMediaQueryOrNotAll = [&] {
             if (auto query = consumeMediaQuery(subrange, context))

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -438,14 +438,14 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::parse(Document& document, Str
     range.consumeWhitespace();
     if (range.atEnd())
         return Exception { ExceptionCode::SyntaxError, "Failed to parse CSS text"_s };
-    const CSSParserToken* componentValueStart = &range.peek();
+    auto componentValueStart = range;
     range.consumeComponentValue();
-    const CSSParserToken* componentValueEnd = &range.peek();
+    auto componentValueEnd = range;
     range.consumeWhitespace();
     if (!range.atEnd())
         return Exception { ExceptionCode::SyntaxError, "Failed to parse CSS text"_s };
 
-    auto componentValueRange = range.makeSubRange(componentValueStart, componentValueEnd);
+    auto componentValueRange = componentValueStart.rangeUntil(componentValueEnd);
     // https://drafts.css-houdini.org/css-typed-om/#reify-a-numeric-value
     switch (componentValueRange.peek().type()) {
     case CSSParserTokenType::DimensionToken:


### PR DESCRIPTION
#### 4447c02be14b1c9aab3cca765835f8aaafaca7c6
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSParserTokenRange.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286728">https://bugs.webkit.org/show_bug.cgi?id=286728</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeAtRule):
(WebCore::CSSParserImpl::consumeQualifiedRule):
(WebCore::CSSParserImpl::consumeFontFeatureValuesRuleBlock):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::observeSelectors):
(WebCore::CSSParserImpl::consumeBlockContent):
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
* Source/WebCore/css/parser/CSSParserTokenRange.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontFaceSrc):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeForgivingSelectorList):
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::parse):
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::MediaQueryParser::consumeMediaQueryList):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::CSSNumericValue::parse):

Canonical link: <a href="https://commits.webkit.org/289670@main">https://commits.webkit.org/289670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8e346c9da706477a5cca0704c3f39f87644805b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38409 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67687 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94416 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14833 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10876 "Found 2 new test failures: fast/canvas/check-stale-putImageData.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75764 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7784 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13659 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14849 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20150 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->