### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CollatorICU.cpp

### DIFF
--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -397,11 +397,11 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeAtRule(CSSParserTokenRange& range, A
 {
     ASSERT(range.peek().type() == AtKeywordToken);
     const StringView name = range.consumeIncludingWhitespace().value();
-    const CSSParserToken* preludeStart = &range.peek();
+    auto preludeStart = range.span();
     while (!range.atEnd() && range.peek().type() != LeftBraceToken && range.peek().type() != SemicolonToken)
         range.consumeComponentValue();
 
-    CSSParserTokenRange prelude = range.makeSubRange(preludeStart, &range.peek());
+    CSSParserTokenRange prelude = range.makeSubRange(preludeStart.first(&range.peek() - preludeStart.data()));
     CSSAtRuleID id = cssAtRuleID(name);
 
     if (range.atEnd() || range.peek().type() == SemicolonToken) {
@@ -476,7 +476,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& r
         return isStyleNestedContext() && allowedRules <= AllowedRules::RegularRules;
     };
 
-    const CSSParserToken* preludeStart = &range.peek();
+    auto preludeStart = range.span();
 
     // Parsing a selector (aka a component value) should stop at the first semicolon (and goes to error recovery)
     // instead of consuming the whole list of declarations (in nested context).
@@ -513,7 +513,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& r
         }
     }
 
-    CSSParserTokenRange prelude = range.makeSubRange(preludeStart, &range.peek());
+    CSSParserTokenRange prelude = range.makeSubRange(preludeStart.first(&range.peek() - preludeStart.data()));
     CSSParserTokenRange block = range.consumeBlockCheckingForEditability(m_styleSheet.get());
 
     if (allowedRules <= AllowedRules::RegularRules)
@@ -831,12 +831,12 @@ RefPtr<StyleRuleFontFeatureValuesBlock> CSSParserImpl::consumeFontFeatureValuesR
             range.consume();
             break;
         case IdentToken: {
-            const CSSParserToken* declarationStart = &range.peek();
+            auto declarationStart = range.span();
 
             while (!range.atEnd() && range.peek().type() != SemicolonToken)
                 range.consumeComponentValue();
 
-            if (auto tag = consumeTag(range.makeSubRange(declarationStart, &range.peek()), maxValues))
+            if (auto tag = consumeTag(range.makeSubRange(declarationStart.first(&range.peek() - declarationStart.data())), maxValues))
                 tags.append(*tag);
 
             break;
@@ -1086,10 +1086,10 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
                 prelude.consumeIncludingWhitespace();
 
                 // Determine the range for the selector list
-                auto selectorListRangeStart = &prelude.peek();
+                auto selectorListRangeStart = prelude.span();
                 while (!prelude.atEnd() && prelude.peek().type() != RightParenthesisToken)
                     prelude.consumeComponentValue();
-                CSSParserTokenRange selectorListRange = prelude.makeSubRange(selectorListRangeStart, &prelude.peek());
+                CSSParserTokenRange selectorListRange = prelude.makeSubRange(selectorListRangeStart.first(&prelude.peek() - selectorListRangeStart.data()));
 
                 // Parse the selector list range
                 auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protectedStyleSheet().get(), ancestorRuleType, CSSParserEnum::IsForgiving::No);
@@ -1334,10 +1334,10 @@ static void observeSelectors(CSSParserObserverWrapper& wrapper, CSSParserTokenRa
     wrapper.observer().startRuleHeader(StyleRuleType::Style, wrapper.startOffset(originalRange));
 
     while (!selectors.atEnd()) {
-        const CSSParserToken* selectorStart = &selectors.peek();
+        auto selectorStart = selectors.span();
         while (!selectors.atEnd() && selectors.peek().type() != CommaToken)
             selectors.consumeComponentValue();
-        CSSParserTokenRange selector = selectors.makeSubRange(selectorStart, &selectors.peek());
+        CSSParserTokenRange selector = selectors.makeSubRange(selectorStart.first(&selectors.peek() - selectorStart.data()));
         selectors.consumeIncludingWhitespace();
 
         wrapper.observer().observeSelector(wrapper.startOffset(selector), wrapper.endOffset(selector));
@@ -1457,15 +1457,15 @@ void CSSParserImpl::consumeBlockContent(CSSParserTokenRange range, StyleRuleType
             range.consume();
             break;
         case IdentToken: {
-            const auto declarationStart = &range.peek();
+            auto declarationStart = range.span();
 
             if (useObserver)
                 m_observerWrapper->yieldCommentsBefore(range);
 
             consumeUntilSemicolon();
 
-            const auto declarationRange = range.makeSubRange(declarationStart, &range.peek());
-            const auto isValidDeclaration = consumeDeclaration(declarationRange, ruleType);
+            auto declarationRange = range.makeSubRange(declarationStart.first(&range.peek() - declarationStart.data()));
+            auto isValidDeclaration = consumeDeclaration(declarationRange, ruleType);
 
             if (useObserver)
                 m_observerWrapper->skipCommentsBefore(range, false);

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -42,20 +42,6 @@ CSSParserToken& CSSParserTokenRange::eofToken()
     return eofToken.get();
 }
 
-CSSParserTokenRange CSSParserTokenRange::makeSubRange(const CSSParserToken* first, const CSSParserToken* last) const
-{
-    if (first == &eofToken())
-        first = std::to_address(m_tokens.end());
-
-    if (last == &eofToken())
-        last = std::to_address(m_tokens.end());
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    ASSERT(first <= last);
-    return { std::span { first, last } };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-}
-
 CSSParserTokenRange CSSParserTokenRange::makeSubRange(std::span<const CSSParserToken> subrange) const
 {
     ASSERT(std::to_address(subrange.end()) <= std::to_address(m_tokens.end()));

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -52,7 +52,6 @@ public:
     }
 
     // This should be called on a range with tokens returned by that range.
-    CSSParserTokenRange makeSubRange(const CSSParserToken* first, const CSSParserToken* last) const;
     CSSParserTokenRange makeSubRange(std::span<const CSSParserToken> subrange) const;
 
     bool atEnd() const { return m_tokens.empty(); }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -884,10 +884,10 @@ RefPtr<CSSValueList> consumeFontFaceSrc(CSSParserTokenRange& range, const CSSPar
         return nullptr;
     };
     while (!range.atEnd()) {
-        auto begin = range.begin();
+        auto begin = range.span();
         while (!range.atEnd() && range.peek().type() != CSSParserTokenType::CommaToken)
             range.consumeComponentValue();
-        auto subrange = range.makeSubRange(begin, &range.peek());
+        auto subrange = range.makeSubRange(begin.first(&range.peek() - begin.data()));
         if (RefPtr parsedValue = consumeSrcListComponent(subrange))
             values.append(parsedValue.releaseNonNull());
         if (!range.atEnd())

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -185,7 +185,7 @@ MutableCSSSelectorList CSSSelectorParser::consumeForgivingSelectorList(CSSParser
         auto initialRange = range;
         auto unknownSelector = [&] {
             auto unknownSelector = makeUnique<MutableCSSSelector>();
-            auto unknownRange = initialRange.makeSubRange(initialRange.begin(), range.begin());
+            auto unknownRange = initialRange.makeSubRange(initialRange.span().first(range.begin() - initialRange.begin()));
             unknownSelector->setMatch(CSSSelector::Match::ForgivingUnknown);
             // We store the complete range content for serialization.
             unknownSelector->setValue(AtomString { unknownRange.serialize() });

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -117,22 +117,22 @@ bool SizesAttributeParser::parse(CSSParserTokenRange range, const CSSParserConte
 {
     // Split on a comma token and parse the result tokens as (media-condition, length) pairs
     while (!range.atEnd()) {
-        const CSSParserToken* mediaConditionStart = &range.peek();
+        auto mediaConditionStart = range.span();
         // The length is the last component value before the comma which isn't whitespace or a comment
-        const CSSParserToken* lengthTokenStart = &range.peek();
+        auto lengthTokenStart = range.span();
         const CSSParserToken* lengthTokenEnd = &range.peek();
         while (!range.atEnd() && range.peek().type() != CommaToken) {
-            lengthTokenStart = &range.peek();
+            lengthTokenStart = range.span();
             range.consumeComponentValue();
             lengthTokenEnd = &range.peek();
             range.consumeWhitespace();
         }
         range.consume();
 
-        auto length = calculateLengthInPixels(range.makeSubRange(lengthTokenStart, lengthTokenEnd));
+        auto length = calculateLengthInPixels(range.makeSubRange(lengthTokenStart.first(lengthTokenEnd - lengthTokenStart.data())));
         if (!length)
             continue;
-        auto mediaCondition = MQ::MediaQueryParser::parseCondition(range.makeSubRange(mediaConditionStart, lengthTokenStart), MediaQueryParserContext(context));
+        auto mediaCondition = MQ::MediaQueryParser::parseCondition(range.makeSubRange(mediaConditionStart.first(lengthTokenStart.data() - mediaConditionStart.data())), MediaQueryParserContext(context));
         if (!mediaCondition)
             continue;
         bool matches = mediaConditionMatches(*mediaCondition);

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -79,11 +79,11 @@ MediaQueryList MediaQueryParser::consumeMediaQueryList(CSSParserTokenRange& rang
     MediaQueryList list;
 
     while (true) {
-        auto begin = range.begin();
+        auto begin = range.span();
         while (!range.atEnd() && range.peek().type() != CommaToken)
             range.consumeComponentValue();
 
-        auto subrange = range.makeSubRange(begin, &range.peek());
+        auto subrange = range.makeSubRange(begin.first(&range.peek() - begin.data()));
 
         auto consumeMediaQueryOrNotAll = [&] {
             if (auto query = consumeMediaQuery(subrange, context))

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -437,14 +437,14 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::parse(Document& document, Str
     range.consumeWhitespace();
     if (range.atEnd())
         return Exception { ExceptionCode::SyntaxError, "Failed to parse CSS text"_s };
-    const CSSParserToken* componentValueStart = &range.peek();
+    auto componentValueStart = range.span();
     range.consumeComponentValue();
     const CSSParserToken* componentValueEnd = &range.peek();
     range.consumeWhitespace();
     if (!range.atEnd())
         return Exception { ExceptionCode::SyntaxError, "Failed to parse CSS text"_s };
 
-    auto componentValueRange = range.makeSubRange(componentValueStart, componentValueEnd);
+    auto componentValueRange = range.makeSubRange(componentValueStart.first(componentValueEnd - componentValueStart.data()));
     // https://drafts.css-houdini.org/css-typed-om/#reify-a-numeric-value
     switch (componentValueRange.peek().type()) {
     case CSSParserTokenType::DimensionToken:


### PR DESCRIPTION
#### 00ea6664c3ec91b988ca45dacc513f57b9db8c95
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CollatorICU.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286730">https://bugs.webkit.org/show_bug.cgi?id=286730</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::copyShortASCIIString):
(WTF::copyDefaultLocale):
(WTF::resolveDefaultLocale):
</pre>
----------------------------------------------------------------------
#### a2cba812a8636ffe448fde7c2233b23d9aa2d8d7
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSSParserTokenRange.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286728">https://bugs.webkit.org/show_bug.cgi?id=286728</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeAtRule):
(WebCore::CSSParserImpl::consumeQualifiedRule):
(WebCore::CSSParserImpl::consumeFontFeatureValuesRuleBlock):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::observeSelectors):
(WebCore::CSSParserImpl::consumeBlockContent):
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
* Source/WebCore/css/parser/CSSParserTokenRange.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontFaceSrc):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeForgivingSelectorList):
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
(WebCore::SizesAttributeParser::parse):
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::MediaQueryParser::consumeMediaQueryList):
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::CSSNumericValue::parse):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00ea6664c3ec91b988ca45dacc513f57b9db8c95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14898 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67469 "Failure limit exceed. At least found 499 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25198 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/additive-transform-animations.html animations/animation-border-overflow.html animations/animation-direction-alternate-reverse.html animations/animation-direction-normal.html animations/animation-direction-reverse.html animations/animation-direction.html animations/animation-end-event-destroy-renderer.html animations/animation-fill-forwards-removal.html compositing/animation/animation-compositing.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90315 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5436 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79020 "Found 151 new API test failures: TestWebKitAPI.WKNavigationAction.UserInputState, TestWebKitAPI.TextManipulation.StartTextManipulationExcludesTextRenderedAsIcons, TestWebKitAPI.UseSystemAppearance.UserStyleSheetParsing, TestWebKitAPI.WKWebExtensionController.CSSAuthorOrigin, TestWebKitAPI.WebKit.IFrameWithSameOriginAsMainFramePropagates, TestWebKitAPI.UseSystemAppearance.UserStyleSheetParsingWebKitLegacy, TestWebKitAPI.WebKit.ShouldOpenExternalURLsInTargetedLink, TestWebKitAPI.WKWebView.SnapshotWithoutAfterScreenUpdates, TestWebKitAPI.DrawingToPDF.BackgroundClipText, TestWebKitAPI.SiteIsolation.ThemeColor ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47796 "Found 229 new API test failures: /TestWebKit:WebKit.EvaluateJavaScriptThatCreatesBlob, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /WPE/TestWebKitWebView:/webkit/WebKitWebView/cors-allowlist, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEventsInReadOnlyField ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5208 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33401 "Found 60 new test failures: accessibility/animated-dropdown.html accessibility/aria-activedescendant-crash.html accessibility/aria-hidden-false-ignored.html accessibility/display-contents/element-roles.html accessibility/mac/attributed-string/attributed-string-text-styling.html animations/3d/transform-origin-vs-functions.html animations/additive-transform-animations.html compositing/backing/backing-store-attachment-empty-keyframe.html compositing/bounds-in-flipped-writing-mode.html compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37170 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80103 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34275 "Found 60 new test failures: animations/3d/transform-origin-vs-functions.html animations/additive-transform-animations.html applicationmanifest/display-mode-bad-manifest.html applicationmanifest/display-mode-no-manifest.html applicationmanifest/display-mode-subframe.html applicationmanifest/display-mode.html compositing/backing/backing-store-attachment-empty-keyframe.html compositing/bounds-in-flipped-writing-mode.html compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html compositing/checkerboard.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94062 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86087 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14475 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10538 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/custom-elements/autocomplete.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76281 "Failure limit exceed. At least found 496 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74876 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75489 "Found 256 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/deviceidhashsalt, /WebKitGTK/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/ephemeral, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestFrame:/webkit/WebKitFrame/uri, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/form-controls-associated-signal, /WebKitGTK/TestResources:/webkit/WebKitWebView/history-cache, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-request ... (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19823 "Found 60 new test failures: http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html http/wpt/webxr/xrFrame_getJointPose_missing_joint_pose.html http/wpt/webxr/xrHand.html ... (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18276 "Found 60 new test failures: accessibility/animated-dropdown.html accessibility/aria-activedescendant-crash.html accessibility/aria-controlled-table-row-visibility.html animations/3d/transform-origin-vs-functions.html animations/additive-transform-animations.html applicationmanifest/display-mode-bad-manifest.html applicationmanifest/display-mode-no-manifest.html applicationmanifest/display-mode-subframe.html applicationmanifest/display-mode.html compositing/backing/backing-store-attachment-empty-keyframe.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7407 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19787 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108581 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14239 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26126 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->