### PR TITLE
Sync `svg/types` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt
@@ -1,0 +1,195 @@
+CONSOLE MESSAGE: Error: Invalid value for <circle> attribute cx="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <circle> attribute cy="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <circle> attribute r="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <ellipse> attribute cx="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <ellipse> attribute cy="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <ellipse> attribute rx="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <ellipse> attribute ry="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <filter> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <filter> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <filter> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <filter> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <feBlend> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <feBlend> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <feBlend> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <feBlend> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <foreignObject> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <foreignObject> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <foreignObject> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <foreignObject> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <image> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <image> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <image> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <image> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <line> attribute x1="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <line> attribute y1="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <line> attribute x2="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <line> attribute y2="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <linearGradient> attribute x1="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <linearGradient> attribute y1="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <linearGradient> attribute x2="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <linearGradient> attribute y2="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <marker> attribute refX="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <marker> attribute refY="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <marker> attribute markerWidth="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <marker> attribute markerHeight="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <mask> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <mask> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <mask> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <mask> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <pattern> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <pattern> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <pattern> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <pattern> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <radialGradient> attribute cx="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <radialGradient> attribute cy="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <radialGradient> attribute r="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <radialGradient> attribute fr="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <rect> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <rect> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <rect> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <rect> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <rect> attribute rx="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <rect> attribute ry="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <svg> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <svg> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <svg> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <svg> attribute height="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <text> attribute textLength="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <textPath> attribute startOffset="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <use> attribute x="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <use> attribute y="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <use> attribute width="foobar"
+CONSOLE MESSAGE: Error: Invalid value for <use> attribute height="foobar"
+
+PASS SVGAnimatedLength, initial values, SVGCircleElement.prototype.cx (remove)
+PASS SVGAnimatedLength, initial values, SVGCircleElement.prototype.cx (invalid value)
+PASS SVGAnimatedLength, initial values, SVGCircleElement.prototype.cy (remove)
+PASS SVGAnimatedLength, initial values, SVGCircleElement.prototype.cy (invalid value)
+PASS SVGAnimatedLength, initial values, SVGCircleElement.prototype.r (remove)
+PASS SVGAnimatedLength, initial values, SVGCircleElement.prototype.r (invalid value)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.cx (remove)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.cx (invalid value)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.cy (remove)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.cy (invalid value)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.rx (remove)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.rx (invalid value)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.ry (remove)
+PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.ry (invalid value)
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.x (remove) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.x (invalid value) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.y (remove) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.y (invalid value) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.width (remove) assert_equals: initial after expected "120%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.width (invalid value) assert_equals: initial after expected "120%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.height (remove) assert_equals: initial after expected "120%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.height (invalid value) assert_equals: initial after expected "120%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.x (remove) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.x (invalid value) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.y (remove) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.y (invalid value) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.width (remove) assert_equals: initial after expected "100%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.width (invalid value) assert_equals: initial after expected "100%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.height (remove) assert_equals: initial after expected "100%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.height (invalid value) assert_equals: initial after expected "100%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.height (invalid value)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGImageElement.prototype.height (invalid value)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.x1 (remove)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.x1 (invalid value)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.y1 (remove)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.y1 (invalid value)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.x2 (remove)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.x2 (invalid value)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.y2 (remove)
+PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.y2 (invalid value)
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x1 (remove) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x1 (invalid value) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y1 (remove) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y1 (invalid value) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x2 (remove) assert_equals: initial after expected "100%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x2 (invalid value) assert_equals: initial after expected "100%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y2 (remove) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y2 (invalid value) assert_equals: initial after expected "0%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refX (remove)
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refX (invalid value)
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refY (remove)
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refY (invalid value)
+FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerWidth (remove) assert_equals: initial after expected "3" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerWidth (invalid value) assert_equals: initial after expected "3" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerHeight (remove) assert_equals: initial after expected "3" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerHeight (invalid value) assert_equals: initial after expected "3" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.x (remove) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.x (invalid value) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.y (remove) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.y (invalid value) assert_equals: initial after expected "-10%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.width (remove) assert_equals: initial after expected "120%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.width (invalid value) assert_equals: initial after expected "120%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.height (remove) assert_equals: initial after expected "120%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.height (invalid value) assert_equals: initial after expected "120%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.height (invalid value)
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cx (remove) assert_equals: initial after expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cx (invalid value) assert_equals: initial after expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (remove) assert_equals: initial after expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (invalid value) assert_equals: initial after expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (remove) assert_equals: initial after expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (invalid value) assert_equals: initial after expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (remove) assert_equals: initial before expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (invalid value) assert_equals: initial before expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (remove) assert_equals: initial before expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (invalid value) assert_equals: initial before expected "50%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (remove) assert_equals: initial after expected "0%" but got "0"
+FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (invalid value) assert_equals: initial after expected "0%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.height (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.rx (remove)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.rx (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.ry (remove)
+PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.ry (invalid value)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGSVGElement.prototype.height (invalid value)
+PASS SVGAnimatedLength, initial values, SVGTextContentElement.prototype.textLength (remove)
+PASS SVGAnimatedLength, initial values, SVGTextContentElement.prototype.textLength (invalid value)
+PASS SVGAnimatedLength, initial values, SVGTextPathElement.prototype.startOffset (remove)
+PASS SVGAnimatedLength, initial values, SVGTextPathElement.prototype.startOffset (invalid value)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGUseElement.prototype.height (invalid value)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<title>SVGAnimatedLength, initial values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const objects = {
+  SVGCircleElement: 'circle',
+  SVGClipPathElement: 'clipPath',
+  SVGComponentTransferFunctionElement: 'feFuncA',
+  SVGEllipseElement: 'ellipse',
+  SVGFEBlendElement: 'feBlend',
+  SVGFEColorMatrixElement: 'feColorMatrix',
+  SVGFECompositeElement: 'feComposite',
+  SVGFEConvolveMatrixElement: 'feConvolveMatrix',
+  SVGFEDiffuseLightingElement: 'feDiffuseLighting',
+  SVGFEDisplacementMapElement: 'feDisplacementMap',
+  SVGFEDistantLightElement: 'feDistantLight',
+  SVGFEDropShadowElement: 'feDropShadow',
+  SVGFEGaussianBlurElement: 'feGaussianBlur',
+  SVGFEMorphologyElement: 'feMorphology',
+  SVGFEOffsetElement: 'feOffset',
+  SVGFEPointLightElement: 'fePointLight',
+  SVGFESpecularLightingElement: 'feSpecularLighting',
+  SVGFESpotLightElement: 'feSpotLight',
+  SVGFETurbulenceElement: 'feTurbulence',
+  SVGFilterElement: 'filter',
+  SVGFilterPrimitiveStandardAttributes: 'feBlend',
+  SVGForeignObjectElement: 'foreignObject',
+  SVGGeometryElement: 'rect',
+  SVGGradientElement: 'linearGradient',
+  SVGImageElement: 'image',
+  SVGLineElement: 'line',
+  SVGLinearGradientElement: 'linearGradient',
+  SVGMarkerElement: 'marker',
+  SVGMaskElement: 'mask',
+  SVGPatternElement: 'pattern',
+  SVGRadialGradientElement: 'radialGradient',
+  SVGRectElement: 'rect',
+  SVGSVGElement: 'svg',
+  SVGStopElement: 'stop',
+  SVGTextContentElement: 'text',
+  SVGTextPathElement: 'textPath',
+  SVGUseElement: 'use',
+};
+
+function assert_initial_values(attribute_map, config) {
+  if (typeof config == 'undefined')
+    config = {};
+  let getValue = config.getValue || function(value) { return value; };
+  for (let info of attribute_map) {
+    for (let attribute of info.attributes) {
+      let content_attribute = config.mapProperty && config.mapProperty[attribute] || attribute;
+      test(function() {
+        let e = document.createElementNS('http://www.w3.org/2000/svg', objects[info.interface]);
+        let initial = info[attribute] && info[attribute].initial || config.initial;
+        let valid = info[attribute] && info[attribute].valid || config.valid;
+        assert_equals(getValue(e[attribute].baseVal), initial, 'initial before');
+        e.setAttribute(content_attribute, valid);
+        assert_not_equals(getValue(e[attribute].baseVal), initial, 'new value');
+        e.removeAttribute(content_attribute);
+        assert_equals(getValue(e[attribute].baseVal), initial, 'initial after');
+      }, document.title + ', ' + info.interface + '.prototype.' + attribute + ' (remove)');
+
+      test(function() {
+        let e = document.createElementNS('http://www.w3.org/2000/svg', objects[info.interface]);
+        let initial = info[attribute] && info[attribute].initial || config.initial;
+        let valid = info[attribute] && info[attribute].valid || config.valid;
+        assert_equals(getValue(e[attribute].baseVal), initial, 'initial before');
+        e.setAttribute(content_attribute, valid);
+        assert_not_equals(getValue(e[attribute].baseVal), initial, 'new value');
+        e.setAttribute(content_attribute, 'foobar');
+        assert_equals(getValue(e[attribute].baseVal), initial, 'initial after');
+      }, document.title + ', ' + info.interface + '.prototype.' + attribute + ' (invalid value)');
+    }
+  }
+}
+</script>
+<script>
+// Initial values of '0' need not be specified.
+assert_initial_values([
+  { interface: 'SVGCircleElement', attributes: [ 'cx', 'cy', 'r' ] },
+  { interface: 'SVGEllipseElement', attributes: [ 'cx', 'cy', 'rx', 'ry' ] },
+  { interface: 'SVGFilterElement', attributes: [ 'x', 'y', 'width', 'height' ],
+    x: { initial: '-10%' }, y: { initial: '-10%' }, width: { initial: '120%' }, height: { initial: '120%' } },
+  { interface: 'SVGFilterPrimitiveStandardAttributes', attributes: [ 'x', 'y', 'width', 'height' ],
+    x: { initial: '0%' }, y: { initial: '0%' }, width: { initial: '100%' }, height: { initial: '100%' } },
+  { interface: 'SVGForeignObjectElement', attributes: [ 'x', 'y', 'width', 'height' ] },
+  { interface: 'SVGImageElement', attributes: [ 'x', 'y', 'width', 'height' ] },
+  { interface: 'SVGLineElement', attributes: [ 'x1', 'y1', 'x2', 'y2' ] },
+  { interface: 'SVGLinearGradientElement', attributes: [ 'x1', 'y1', 'x2', 'y2' ],
+    x1: { initial: '0%' }, y1: { initial: '0%' }, x2: { initial: '100%' }, y2: { initial: '0%' } },
+  { interface: 'SVGMarkerElement', attributes: [ 'refX', 'refY', 'markerWidth', 'markerHeight' ],
+    markerWidth: { initial: '3' }, markerHeight: { initial: '3' } },
+  { interface: 'SVGMaskElement', attributes: [ 'x', 'y', 'width', 'height' ],
+    x: { initial: '-10%' }, y: { initial: '-10%' }, width: { initial: '120%' }, height: { initial: '120%' } },
+  { interface: 'SVGPatternElement', attributes: [ 'x', 'y', 'width', 'height' ] },
+  { interface: 'SVGRadialGradientElement', attributes: [ 'cx', 'cy', 'r', 'fx', 'fy', 'fr' ],
+    cx: { initial: '50%' }, cy: { initial: '50%' }, r: { initial: '50%' },
+    fx: { initial: '50%' }, fy: { initial: '50%' }, fr: { initial: '0%' } },
+  { interface: 'SVGRectElement', attributes: [ 'x', 'y', 'width', 'height', 'rx', 'ry' ] },
+  { interface: 'SVGSVGElement', attributes: [ 'x', 'y', 'width', 'height' ],
+    width: { initial: '100%' }, height: { initial: '100%' } },
+  { interface: 'SVGTextContentElement', attributes: [ 'textLength' ] },
+  { interface: 'SVGTextPathElement', attributes: [ 'startOffset' ] },
+  { interface: 'SVGUseElement', attributes: [ 'x', 'y', 'width', 'height' ] },
+], { initial: '0', valid: '42', getValue: function(value) { return value.valueAsString } });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-01-expected.txt
@@ -4,4 +4,5 @@ FAIL SVGGeometryElement.prototype.getTotalLength(), getTotalLength - rect assert
 PASS SVGGeometryElement.prototype.getTotalLength(), getTotalLength - rect in document
 PASS SVGGeometryElement.prototype.getTotalLength(), getTotalLength - rect in document with percent units
 PASS SVGGeometryElement.prototype.getTotalLength(), getTotalLength - rect in document with display none
+FAIL SVGGeometryElement.prototype.getTotalLength(), getTotalLength - path modified with setPathData path.getPathData is not a function. (In 'path.getPathData()', 'path.getPathData' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-01.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-01.svg
@@ -3,7 +3,7 @@
   <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength"/>
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
-  <script>
+  <script><![CDATA[
 test(function() {
     let path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     path.setAttribute('d', 'M0,0L100,0L100,100');
@@ -69,5 +69,26 @@ test(function() {
       document.documentElement.removeChild(g);
     }
 }, document.title+', getTotalLength - rect in document with display none');
-  </script>
+
+test(function() {
+    let path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    document.documentElement.appendChild(path);
+    path.setAttribute("d", "M50,100l0,0l0,-50l100,0l86.3325,122.665z");
+    try {
+
+      assert_equals(path.getTotalLength(), 500);
+
+      let pathData = path.getPathData();
+      for (var i = 0; i < 2; i++) {
+        pathData = pathData.slice(0, -1);
+      }
+      path.setPathData(pathData);
+
+      assert_equals(path.getTotalLength(), 150);
+
+    } finally {
+      document.documentElement.removeChild(path);
+    }
+}, document.title+', getTotalLength - path modified with setPathData');
+  ]]></script>
 </svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log
@@ -33,6 +33,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-SVGTextPathElement.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLengthList.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber.html


### PR DESCRIPTION
#### 715eb1586369bc1f231090a3a40bdb45193e29cb
<pre>
Sync `svg/types` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=286731">https://bugs.webkit.org/show_bug.cgi?id=286731</a>
<a href="https://rdar.apple.com/143870047">rdar://143870047</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/7eb87d2740eeab49977b967906371a0ce83c8d38">https://github.com/web-platform-tests/wpt/commit/7eb87d2740eeab49977b967906371a0ce83c8d38</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-01-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getTotalLength-01.svg:
* LLayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values.html:
* LLayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/289573@main">https://commits.webkit.org/289573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e71dbd3816e1c31e9aa1b3dfd441a3994558482a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38055 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67471 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25200 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90317 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47798 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37172 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14477 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76285 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18580 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19900 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7410 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14496 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->