### PR TITLE
[libpas] PGM does not respect alignment

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
@@ -74,10 +74,8 @@ static bool pas_hash_map_entry_callback(pas_enumerator* enumerator, pas_ptr_hash
 {
     PAS_ASSERT_WITH_DETAIL(!arg);
 
-    pas_pgm_storage* allocation = ((pas_pgm_storage*)entry->value);
-    size_t mem_to_alloc = (2 * allocation->page_size) + allocation->allocation_size_requested + allocation->mem_to_waste;
-    
-    pas_enumerator_record(enumerator, (void*)((char*)entry->key - allocation->mem_to_waste - pas_page_malloc_alignment()), mem_to_alloc, pas_enumerator_object_record);
+    pas_pgm_storage* allocation = (pas_pgm_storage*)entry->value;
+    pas_enumerator_record(enumerator, (void*)allocation->start_of_allocated_pages, allocation->size_of_allocated_pages, pas_enumerator_object_record);
     pas_enumerator_record(enumerator, (void*)entry->value, sizeof(pas_pgm_storage), pas_enumerator_meta_record);
 
     return true;

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -69,10 +69,9 @@ static void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas
 #pragma mark ALLOC/DEALLOC
 #endif
 
-pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, pas_allocation_mode allocation_mode,
+pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, size_t alignment, pas_allocation_mode allocation_mode,
                                                               const pas_heap_config* heap_config, pas_physical_memory_transaction* transaction)
 {
-    size_t alignment;
     const pas_heap_type* type;
     static const bool verbose = false;
 
@@ -81,7 +80,7 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     pas_allocation_result result = pas_allocation_result_create_failure();
 
     if (verbose)
-        pas_log("Memory requested to allocate %zu\n", size);
+        pas_log("Memory requested to allocate %zu with alignment %zu\n", size, alignment);
 
     if (!large_heap || !size || !heap_config || !transaction)
         return result;
@@ -89,14 +88,35 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     const size_t page_size = pas_page_malloc_alignment();
 
     type = pas_heap_for_large_heap(large_heap)->type;
-    alignment = heap_config->get_type_alignment(type);
+    alignment = PAS_MAX(alignment, heap_config->get_type_alignment(type));
     alignment = PAS_MAX(alignment, heap_config->large_alignment);
+    PAS_ASSERT(page_size >= heap_config->large_alignment);
 
-    size = pas_round_up_to_power_of_2(size, alignment);
+    size_t mem_to_waste = 0;
+    size_t mem_to_alloc = 0;
+    if (alignment >= page_size) {
+        /*
+         * In this case, slide becomes always n * page_size since alignment is n * page_size.
+         * Also, to achieve this alignment request, we need this expanded size, and this is not something wasted for PGM.
+         * So we set 0 to mem_to_waste.
+         * The worst scenario is the allocated pointer is off by one page from the alignment boundary. In that case, we need
+         * to add (alignment - page_size) to obtain the next alignment boundary. This means we need to allocate at least
+         * size + (alignment - page_size) memory to find alignment boundary with size.
+         */
+        size_t size_with_alignment_reservation = pas_round_up(size + alignment - page_size, page_size);
+        mem_to_waste = 0;
+        mem_to_alloc = (2 * page_size) + size_with_alignment_reservation;
+    } else {
+        /*
+         * Since both page_size and alignment are power-of-two and alignment is smaller than page_size,
+         * page_size is always n * alignment. Since size_with_alignment_reservation is m * alignment,
+         * mem_to_waste is also x * alignment. Thus right-align will be guaranteed to be aligned.
+         */
+        size_t size_with_alignment_reservation = pas_round_up(size, alignment);
+        mem_to_waste = (page_size - (size_with_alignment_reservation % page_size)) % page_size;
+        mem_to_alloc = (2 * page_size) + size_with_alignment_reservation + mem_to_waste;
+    }
 
-    size_t mem_to_waste = (page_size - (size % page_size)) % page_size;
-    if (mem_to_waste > free_wasted_mem)
-        return result;
     /*
      * calculate virtual memory
      *
@@ -104,7 +124,9 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
      * | lower guard page | | user alloc pages | | upper guard page |
      * *------------------* *------------------* *------------------*
      */
-    size_t mem_to_alloc = (2 * page_size) + size + mem_to_waste;
+    if (mem_to_waste > free_wasted_mem)
+        return result;
+
     if (mem_to_alloc > free_virtual_mem)
         return result;
 
@@ -112,49 +134,62 @@ pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* la
     if (!result.did_succeed)
         return result;
 
-    /* protect guard pages from being accessed */
-    uintptr_t lower_guard_page = result.begin;
-    uintptr_t upper_guard_page = result.begin + (mem_to_alloc - page_size);
-
-    int mprotect_res = mprotect( (void *) lower_guard_page, page_size, PROT_NONE);
-    PAS_ASSERT(!mprotect_res);
-
-    mprotect_res = mprotect( (void *) upper_guard_page, page_size, PROT_NONE);
-    PAS_ASSERT(!mprotect_res);
-
-    /*
-     * ensure physical addresses are released
-     * TODO: investigate using MADV_FREE_REUSABLE instead
-     */
-    int madvise_res = madvise((void *) upper_guard_page, page_size, MADV_FREE);
-    PAS_ASSERT(!madvise_res);
-
-    madvise_res = madvise((void *) lower_guard_page, page_size, MADV_FREE);
-    PAS_ASSERT(!madvise_res);
-
     /*
      * the key is the location where the user's starting memory address is located.
      * allocations are right aligned, so the end backs up to the upper guard page.
      *
      * Take random decision to right align or left align in order to be able to catch
      * overflow and underflow conditions with equal probability.
+     *
+     * If alignment >= page_size, then there is only one region we can use to meet the
+     * alignment requirement. Thus we do not consider about right_align.
      */
-    uint8_t right_align = pas_get_fast_random(2);
+    uintptr_t key = pas_round_up(result.begin + page_size, alignment);
+    uint8_t right_align = 0;
+    if (alignment < page_size) {
+        if (pas_get_fast_random(2)) {
+            key = result.begin + page_size + mem_to_waste;
+            right_align = 1;
+        }
+    }
 
-    uintptr_t key = (right_align ? (result.begin + page_size + mem_to_waste) : (result.begin + page_size));
+    /* protect guard pages from being accessed */
+    uintptr_t lower_guard = result.begin;
+    size_t lower_guard_size = pas_round_down(key - lower_guard, page_size);
+    uintptr_t upper_guard = pas_round_up(key + size, page_size);
+    size_t upper_guard_size = (result.begin + mem_to_alloc) - upper_guard;
+
+    int mprotect_res = mprotect((void*)lower_guard, lower_guard_size, PROT_NONE);
+    PAS_ASSERT(!mprotect_res);
+
+    mprotect_res = mprotect((void*)upper_guard, upper_guard_size, PROT_NONE);
+    PAS_ASSERT(!mprotect_res);
+
+    /*
+     * ensure physical addresses are released
+     * TODO: investigate using MADV_FREE_REUSABLE instead
+     */
+    int madvise_res = madvise((void*)upper_guard, upper_guard_size, MADV_FREE);
+    PAS_ASSERT(!madvise_res);
+
+    madvise_res = madvise((void*)lower_guard, lower_guard_size, MADV_FREE);
+    PAS_ASSERT(!madvise_res);
+
     PAS_PROFILE(PGM_ALLOCATE, heap_config, key);
 
     /* create struct to hold hash map value */
-    pas_pgm_storage *value = pas_utility_heap_try_allocate(sizeof(pas_pgm_storage), "pas_pgm_hash_map_VALUE");
+    pas_pgm_storage* value = pas_utility_heap_try_allocate(sizeof(pas_pgm_storage), "pas_pgm_hash_map_VALUE");
     PAS_ASSERT(value);
 
-    value->mem_to_waste               = mem_to_waste;
-    value->size_of_data_pages         = size + mem_to_waste;
-    value->start_of_data_pages        = result.begin + page_size;
-    value->allocation_size_requested  = size;
-    value->page_size                  = page_size;
-    value->large_heap                 = large_heap;
-    value->right_align                = right_align;
+    value->mem_to_waste                = mem_to_waste;
+    value->size_of_data_pages          = mem_to_alloc - (lower_guard_size + upper_guard_size);
+    value->start_of_data_pages         = result.begin + lower_guard_size;
+    value->size_of_allocated_pages     = mem_to_alloc;
+    value->start_of_allocated_pages    = result.begin;
+    value->allocation_size_requested   = size;
+    value->page_size                   = page_size;
+    value->large_heap                  = large_heap;
+    value->right_align                 = right_align;
 
     pas_ptr_hash_map_add_result add_result = pas_ptr_hash_map_add(&pas_pgm_hash_map, (void*)key, NULL, &pas_large_utility_free_heap_allocation_config);
     PAS_ASSERT(add_result.is_new_entry);
@@ -185,7 +220,7 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
     if (verbose)
         pas_log("Memory Address Requested to Deallocate %p\n", mem);
 
-    uintptr_t key = (uintptr_t) mem;
+    uintptr_t key = (uintptr_t)mem;
     PAS_PROFILE(PGM_DEALLOCATE, key);
 
     pas_ptr_hash_map_entry* entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void*)key);
@@ -204,7 +239,7 @@ void pas_probabilistic_guard_malloc_deallocate(void* mem)
     PAS_ASSERT(!madvise_res);
 
     free_wasted_mem  += value->mem_to_waste;
-    free_virtual_mem += (2 * value->page_size) + value->allocation_size_requested + value->mem_to_waste;
+    free_virtual_mem += value->size_of_allocated_pages;
 
     /*
      * Mark the physical memory status free and check if the max entries reached.
@@ -234,7 +269,7 @@ bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem)
     if (verbose)
         pas_log("Checking if is PGM entry\n");
 
-    pas_ptr_hash_map_entry* entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void*) mem);
+    pas_ptr_hash_map_entry* entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void*)mem);
     return (entry && entry->value);
 }
 
@@ -248,9 +283,9 @@ pas_large_map_entry pas_probabilistic_guard_malloc_return_as_large_map_entry(uin
     if (verbose)
         pas_log("Grabbing PGM allocated size\n");
 
-    pas_ptr_hash_map_entry * entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void *) mem);
+    pas_ptr_hash_map_entry* entry = pas_ptr_hash_map_find(&pas_pgm_hash_map, (void*)mem);
     if (entry && entry->value) {
-        pas_pgm_storage *entry_val = (pas_pgm_storage *) entry->value;
+        pas_pgm_storage* entry_val = (pas_pgm_storage*)entry->value;
         ret.begin = mem;
         ret.end = mem + entry_val->allocation_size_requested;
         ret.heap = entry_val->large_heap;
@@ -329,6 +364,11 @@ void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(uint16_t pgm_rando
 
 void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_storage* value, const char* operation)
 {
+    uintptr_t lower_guard = value->start_of_allocated_pages;
+    size_t lower_guard_size = value->start_of_data_pages - value->start_of_allocated_pages;
+    uintptr_t upper_guard = value->start_of_data_pages + value->size_of_data_pages;
+    size_t upper_guard_size = value->size_of_allocated_pages - lower_guard_size - value->size_of_data_pages;
+
     pas_log("******************************************************\n"
         " %s\n\n"
         " Overall System Stats"
@@ -339,10 +379,12 @@ void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_st
         " Allocation Size Requested : %zu \n"
         " Page Size                 : %hu \n"
         " Memory Wasted             : %hu \n"
-        " Size of Data Pages        : %zu \n"
-        " Start of Data Pages       : %p  \n"
-        " Lower Guard Page          : %p  \n"
-        " Upper Guard Page          : %p  \n"
+        " Data Pages                : %p  \n"
+        " Data Pages Size           : %zu \n"
+        " Lower Guard               : %p  \n"
+        " Lower Guard Size          : %zu \n"
+        " Upper Guard               : %p  \n"
+        " Upper Guard Size          : %zu \n"
         " Memory Address for User   : %p  \n"
         "******************************************************\n\n\n",
         operation,
@@ -351,10 +393,12 @@ void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_st
         value->allocation_size_requested,
         value->page_size,
         value->mem_to_waste,
+        ((void*)value->start_of_data_pages),
         value->size_of_data_pages,
-        (uintptr_t*) value->start_of_data_pages,
-        (uintptr_t*) value->start_of_data_pages - value->page_size,
-        (uintptr_t*) value->start_of_data_pages + value->size_of_data_pages,
+        ((void*)lower_guard),
+        lower_guard_size,
+        ((void*)upper_guard),
+        upper_guard_size,
         key);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -66,6 +66,8 @@ struct pas_pgm_storage {
     size_t allocation_size_requested;
     size_t size_of_data_pages;
     uintptr_t start_of_data_pages;
+    size_t size_of_allocated_pages;
+    uintptr_t start_of_allocated_pages;
 
     /*
      * These parameter below rely on page sizes being less than 65536.
@@ -114,7 +116,7 @@ extern PAS_API bool pas_probabilistic_guard_malloc_is_initialized;
 extern PAS_API uint16_t pas_probabilistic_guard_malloc_random;
 extern PAS_API uint16_t pas_probabilistic_guard_malloc_counter;
 
-pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, pas_allocation_mode allocation_mode, const pas_heap_config* heap_config, pas_physical_memory_transaction* transaction);
+pas_allocation_result pas_probabilistic_guard_malloc_allocate(pas_large_heap* large_heap, size_t size, size_t alignment, pas_allocation_mode allocation_mode, const pas_heap_config* heap_config, pas_physical_memory_transaction* transaction);
 void pas_probabilistic_guard_malloc_deallocate(void* memory);
 
 size_t pas_probabilistic_guard_malloc_get_free_virtual_memory(void);

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash.c
@@ -37,17 +37,17 @@
 #ifdef __APPLE__
 static crash_reporter_memory_reader_t memory_reader;
 
-static kern_return_t memory_reader_adapter(task_t task, vm_address_t address, vm_size_t size, void **local_memory)
+static kern_return_t memory_reader_adapter(task_t task, vm_address_t address, vm_size_t size, void** local_memory)
 {
     if (!local_memory)
         return KERN_FAILURE;
 
-    void *ptr = memory_reader(task, address, size);
+    void* ptr = memory_reader(task, address, size);
     *local_memory = ptr;
     return ptr ? KERN_SUCCESS : KERN_FAILURE;
 }
 
-static memory_reader_t * setup_memory_reader(crash_reporter_memory_reader_t crm_reader)
+static memory_reader_t* setup_memory_reader(crash_reporter_memory_reader_t crm_reader)
 {
     memory_reader = crm_reader;
     return memory_reader_adapter;
@@ -58,7 +58,7 @@ static PAS_ALWAYS_INLINE bool PAS_WARN_UNUSED_RETURN pas_fault_address_is_in_bou
     return (fault_address >= bottom) && (fault_address < top);
 }
 
-static PAS_ALWAYS_INLINE kern_return_t PAS_WARN_UNUSED_RETURN pas_update_report_crash_fields(pas_report_crash_pgm_report *report, const char *error_type, const char *confidence, vm_address_t fault_address, size_t allocation_size)
+static PAS_ALWAYS_INLINE kern_return_t PAS_WARN_UNUSED_RETURN pas_update_report_crash_fields(pas_report_crash_pgm_report* report, const char* error_type, const char* confidence, vm_address_t fault_address, size_t allocation_size)
 {
     report->error_type = error_type;
     report->confidence = confidence;
@@ -67,16 +67,18 @@ static PAS_ALWAYS_INLINE kern_return_t PAS_WARN_UNUSED_RETURN pas_update_report_
     return KERN_SUCCESS;
 }
 
-// This function will be called when a process crashes containing the JavaScriptCore framework.
-// The goal is to determine if the crash was caused by a PGM allocation, and if so whether the crash
-// was a UAF or OOB crash. These details will forwarded back to the Crash Reporter API, which will
-// add the information to the local crash log.
-kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader)
+/*
+ * This function will be called when a process crashes containing the JavaScriptCore framework.
+ * The goal is to determine if the crash was caused by a PGM allocation, and if so whether the crash
+ * was a UAF or OOB crash. These details will forwarded back to the Crash Reporter API, which will
+ * add the information to the local crash log.
+ */
+kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report* report, crash_reporter_memory_reader_t crm_reader)
 {
     if (version != pas_crash_report_version)
         return KERN_FAILURE;
 
-    memory_reader_t *reader = setup_memory_reader(crm_reader);
+    memory_reader_t* reader = setup_memory_reader(crm_reader);
 
     pas_root* read_pas_dead_root = NULL;
     pas_ptr_hash_map* hash_map = NULL;
@@ -85,86 +87,91 @@ kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, m
 
     size_t table_size = 0;
 
-    kern_return_t kr = reader(task, pas_dead_root, sizeof(pas_root), (void **) &read_pas_dead_root);
+    kern_return_t kr = reader(task, pas_dead_root, sizeof(pas_root), (void**)&read_pas_dead_root);
     if (kr != KERN_SUCCESS)
         return KERN_FAILURE;
 
-    kr = reader(task, (vm_address_t) read_pas_dead_root->pas_pgm_hash_map_instance, sizeof(pas_ptr_hash_map), (void **) &hash_map);
+    kr = reader(task, (vm_address_t)read_pas_dead_root->pas_pgm_hash_map_instance, sizeof(pas_ptr_hash_map), (void**)&hash_map);
     if (kr != KERN_SUCCESS)
         return KERN_FAILURE;
 
     table_size = hash_map->table_size;
 
     for (size_t i = 0; i < table_size; i++) {
-        kr = reader(task, (vm_address_t) (hash_map->table + i), sizeof(pas_ptr_hash_map_entry), (void **) &hash_map_entry);
+        kr = reader(task, (vm_address_t)(hash_map->table + i), sizeof(pas_ptr_hash_map_entry), (void**)&hash_map_entry);
         if (kr != KERN_SUCCESS)
             return KERN_FAILURE;
 
-        // Skip entry if not there
+        /* Skip entry if not there */
         if (hash_map_entry->key == (void*)UINTPTR_MAX)
             continue;
 
-        kr = reader(task, (vm_address_t) hash_map_entry->value, sizeof(pas_pgm_storage), (void **) &pgm_metadata);
+        kr = reader(task, (vm_address_t)hash_map_entry->value, sizeof(pas_pgm_storage), (void**)&pgm_metadata);
         if (kr != KERN_SUCCESS)
             return KERN_FAILURE;
 
-        addr64_t key = (addr64_t) hash_map_entry->key;
+        addr64_t key = (addr64_t)hash_map_entry->key;
+        addr64_t lower_guard = (addr64_t)pgm_metadata->start_of_allocated_pages;
+        size_t lower_guard_size = pgm_metadata->start_of_data_pages - pgm_metadata->start_of_allocated_pages;
+        addr64_t upper_guard = (addr64_t)(pgm_metadata->start_of_data_pages + pgm_metadata->size_of_data_pages);
+        size_t upper_guard_size = pgm_metadata->size_of_allocated_pages - lower_guard_size - pgm_metadata->size_of_data_pages;
 
         if (pgm_metadata->right_align) {
+            /* [ lower_guard ][ remaining ][ allocated ][ upper_guard ] */
             report->alignment = "address right-aligned";
 
-            // Right-aligned "Lower PGM OOB" checking
-            addr64_t bottom = (addr64_t) (key - pgm_metadata->mem_to_waste - pgm_metadata->page_size);
-            addr64_t top = (addr64_t) (key - pgm_metadata->mem_to_waste);
+            /* Right-aligned "Lower PGM OOB" checking */
+            addr64_t bottom = (addr64_t)lower_guard;
+            addr64_t top = (addr64_t)(lower_guard + lower_guard_size);
 
-            if (pas_fault_address_is_in_bounds(fault_address, bottom, top))
+            if (pas_fault_address_is_in_bounds(fault_address, lower_guard, top))
                 return pas_update_report_crash_fields(report, pgm_metadata->free_status ? "long-range UAF" : "long-range OOB", "low", fault_address, pgm_metadata->allocation_size_requested);
 
 
-            // Right-aligned "UAF + OOB" checking towards lower guard page
-            bottom = (addr64_t) (key - pgm_metadata->mem_to_waste);
-            top = (addr64_t) key;
+            /* Right-aligned "UAF + OOB" checking towards lower guard page */
+            bottom = (addr64_t)pgm_metadata->start_of_data_pages;
+            top = (addr64_t)key;
 
             if (pas_fault_address_is_in_bounds(fault_address, bottom, top))
                 return pas_update_report_crash_fields(report, pgm_metadata->free_status ? "UAF" : "OOB", "low", fault_address, pgm_metadata->allocation_size_requested);
 
-            // Right-aligned "Upper PGM OOB" checking
-            bottom = (addr64_t) (key - pgm_metadata->mem_to_waste + pgm_metadata->size_of_data_pages);
-            top = (addr64_t) (key - pgm_metadata->mem_to_waste + pgm_metadata->size_of_data_pages + pgm_metadata->page_size);
+            /* Right-aligned "Upper PGM OOB" checking */
+            bottom = (addr64_t)upper_guard;
+            top = (addr64_t)(upper_guard + upper_guard_size);
 
             if (pas_fault_address_is_in_bounds(fault_address, bottom, top))
                 return pas_update_report_crash_fields(report, pgm_metadata->free_status ? "UAF" : "OOB", "high", fault_address, pgm_metadata->allocation_size_requested);
 
         } else {
+            /* [ lower_guard ][ allocated ][ remaining ][ upper_guard ] */
             report->alignment = "address left-aligned";
 
-            // Left-aligned "Lower PGM OOB" checking
-            addr64_t bottom = key - pgm_metadata->page_size;
+            /* Left-aligned "Lower PGM OOB" checking */
+            addr64_t bottom = lower_guard;
             addr64_t top = key;
 
             if (pas_fault_address_is_in_bounds(fault_address, bottom, top))
                 return pas_update_report_crash_fields(report, pgm_metadata->free_status ? "UAF" : "OOB", "high", fault_address, pgm_metadata->allocation_size_requested);
 
-            // Left-aligned "UAF + OOB" checking towards upper guard page
-            bottom = (addr64_t) (key + pgm_metadata->size_of_data_pages - pgm_metadata->mem_to_waste);
-            top = (addr64_t) (key + pgm_metadata->size_of_data_pages);
+            /* Left-aligned "UAF + OOB" checking towards upper guard page */
+            bottom = (addr64_t)(key + pgm_metadata->allocation_size_requested);
+            top = (addr64_t)upper_guard;
 
             if (pas_fault_address_is_in_bounds(fault_address, bottom, top))
                 return pas_update_report_crash_fields(report, pgm_metadata->free_status ? "UAF" : "OOB", "low", fault_address, pgm_metadata->allocation_size_requested);
 
-            // Left-aligned "Upper PGM OOB" checking
-            bottom = (addr64_t) (key + pgm_metadata->size_of_data_pages);
-            top = (addr64_t) (key + pgm_metadata->size_of_data_pages + pgm_metadata->page_size);
+            /* Left-aligned "Upper PGM OOB" checking */
+            bottom = upper_guard;
+            top = upper_guard + upper_guard_size;
 
             if (pas_fault_address_is_in_bounds(fault_address, bottom, top))
                 return pas_update_report_crash_fields(report, pgm_metadata->free_status ? "long-range UAF" : "long-range OOB", "low", fault_address, pgm_metadata->allocation_size_requested);
 
         }
 
-        // Left-aligned "UAF" checking calculations are same as right-aligned checking
-        // "UAF" check
-        addr64_t bottom = (addr64_t) key;
-        addr64_t top = (addr64_t) (key - pgm_metadata->mem_to_waste + pgm_metadata->size_of_data_pages);
+        /* Left-aligned "UAF" checking calculations are same as right-aligned checking "UAF" check */
+        addr64_t bottom = (addr64_t)key;
+        addr64_t top = (addr64_t)(key + pgm_metadata->allocation_size_requested);
 
         if (pas_fault_address_is_in_bounds(fault_address, bottom, top))
             return pas_update_report_crash_fields(report, pgm_metadata->free_status ? "UAF" : "undefined", "low", fault_address, pgm_metadata->allocation_size_requested);

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash.h
@@ -38,7 +38,7 @@
 extern "C" {
 #endif
 
-PAS_API kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t, pas_report_crash_pgm_report *, crash_reporter_memory_reader_t crm_reader);
+PAS_API kern_return_t pas_report_crash_extract_pgm_failure(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t, pas_report_crash_pgm_report*, crash_reporter_memory_reader_t crm_reader);
 
 #ifdef __cplusplus
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -103,6 +103,7 @@ pas_try_allocate_pgm(
     bool verbose,
     pas_heap* heap,
     size_t size,
+    size_t alignment,
     pas_allocation_mode allocation_mode,
     pas_heap_config config)
 {
@@ -126,7 +127,7 @@ pas_try_allocate_pgm(
         pas_physical_memory_transaction_begin(&transaction);
         pas_heap_lock_lock();
 
-        result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, size, allocation_mode, config.config_ptr, &transaction);
+        result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, size, alignment, allocation_mode, config.config_ptr, &transaction);
 
         pas_heap_lock_unlock();
     } while (!pas_physical_memory_transaction_end(&transaction));
@@ -189,7 +190,7 @@ pas_try_allocate_common_impl_slow(
         break;
     }
 
-    result = pas_try_allocate_pgm(verbose, heap, size, allocation_mode, config);
+    result = pas_try_allocate_pgm(verbose, heap, size, alignment, allocation_mode, config);
     if (PAS_UNLIKELY(result.did_succeed))
         return pas_msl_malloc_logging(size, result);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -342,9 +342,9 @@ pas_try_reallocate(void* old_ptr,
         pas_heap_lock_lock();
 
         // Check for PGM case for slow path if object is using PGM large heap
-        if (config.pgm_enabled && pas_probabilistic_guard_malloc_check_exists(begin)) {
+        if (config.pgm_enabled && pas_probabilistic_guard_malloc_check_exists(begin))
             entry = pas_probabilistic_guard_malloc_return_as_large_map_entry(begin);
-        } else {
+        else {
             entry = pas_large_map_find(begin);
             if (pas_large_map_entry_is_empty(entry))
                 pas_reallocation_did_fail("Source object not allocated", NULL, heap, old_ptr, 0, new_size);

--- a/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
+++ b/Source/bmalloc/libpas/src/test/EnumerationTests.cpp
@@ -230,13 +230,13 @@ void testPGMEnumerationBasic() {
     pas_heap_lock_lock();
 
     size_t alloc_size = 16384;
-    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
+    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, 1, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, 1, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, 1, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
     pas_heap_lock_unlock();
@@ -261,13 +261,13 @@ void testPGMEnumerationAddAndFree() {
     pas_heap_lock_lock();
 
     size_t alloc_size = 16384;
-    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
+    pas_allocation_result result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, 1, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, 1, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
-    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
+    result = pas_probabilistic_guard_malloc_allocate(&heap->large_heap, alloc_size, 1, pas_non_compact_allocation_mode, &iso_heap_config, &transaction);
     CHECK(result.begin);
 
     pas_probabilistic_guard_malloc_deallocate((void*) result.begin);


### PR DESCRIPTION
#### 06235d829da16c4218a606419b3044ab2b11adf2
<pre>
[libpas] PGM does not respect alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=286708">https://bugs.webkit.org/show_bug.cgi?id=286708</a>
<a href="https://rdar.apple.com/143847878">rdar://143847878</a>

Reviewed by Mark Lam.

PGM code is ignoring user-specified alignment. This does not work at all
since the user expects aligned allocations but PGM returns unrelated
pointers. This patch wires alignment correctly to PGM and fixes address
computation.

We also fixed PGMTests.cpp as it cannot be compiled. Also fixes so many
style issues around PGM code.

* Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c:
(pas_hash_map_entry_callback):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_check_exists):
(pas_probabilistic_guard_malloc_return_as_large_map_entry):
(pas_probabilistic_guard_malloc_debug_info):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_report_crash.c:
(memory_reader_adapter):
(setup_memory_reader):
(pas_update_report_crash_fields):
(pas_report_crash_extract_pgm_failure):
* Source/bmalloc/libpas/src/libpas/pas_report_crash.h:
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
(pas_try_allocate_pgm):
(pas_try_allocate_common_impl_slow):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):
* Source/bmalloc/libpas/src/test/EnumerationTests.cpp:
(std::testPGMEnumerationBasic):
(std::testPGMEnumerationAddAndFree):
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(std::testPGMSingleAlloc):
(std::testPGMMultipleAlloc):
(std::testPGMAlignedAlloc):
(std::testPGMRealloc):
(std::testPGMMetaData):
(std::testPGMErrors):
(std::testPGMMetadataVectorManagement):
(std::testPGMMetadataVectorManagementFewDeallocations):
(std::testPGMMetadataDoubleFreeBehavior):
(std::testPGMMetadataVectorManagementRehash):
(addPGMTests):

Canonical link: <a href="https://commits.webkit.org/289637@main">https://commits.webkit.org/289637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d204cab57da7485c975b68d5920996efeeee88b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87467 "58 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92329 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38206 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89518 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67556 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25295 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33537 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37322 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80262 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94214 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86241 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76383 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75607 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7570 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13642 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14650 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108733 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14393 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26151 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->