### PR TITLE
[CoordinatedGraphics] Setting the same image contents on a layer might cause an unnecessary flush

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -68,6 +68,10 @@ public:
     WEBCORE_EXPORT void replaceBackend(UniqueRef<NativeImageBackend>);
     NativeImageBackend& backend() { return m_backend.get(); }
     const NativeImageBackend& backend() const { return m_backend.get(); }
+
+#if USE(COORDINATED_GRAPHICS)
+    uint64_t uniqueID() const;
+#endif
 protected:
     NativeImage(UniqueRef<NativeImageBackend>, RenderingResourceIdentifier);
 

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -78,6 +78,15 @@ void NativeImage::clearSubimages()
 {
 }
 
+#if USE(COORDINATED_GRAPHICS)
+uint64_t NativeImage::uniqueID() const
+{
+    if (auto& image = platformImage())
+        return getSurfaceUniqueID(image.get());
+    return 0;
+}
+#endif
+
 } // namespace WebCore
 
 #endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -168,6 +168,15 @@ void NativeImage::clearSubimages()
 {
 }
 
+#if USE(COORDINATED_GRAPHICS)
+uint64_t NativeImage::uniqueID() const
+{
+    if (auto& image = platformImage())
+        return image->uniqueID();
+    return 0;
+}
+#endif
+
 } // namespace WebCore
 
 #endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp
@@ -30,10 +30,6 @@
 #include "CoordinatedPlatformLayerBufferNativeImage.h"
 #include "NativeImage.h"
 
-#if USE(CAIRO)
-#include "CairoUtilities.h"
-#endif
-
 namespace WebCore {
 
 Ref<CoordinatedImageBackingStore> CoordinatedImageBackingStore::create(Ref<NativeImage>&& nativeImage)
@@ -48,18 +44,9 @@ CoordinatedImageBackingStore::CoordinatedImageBackingStore(Ref<NativeImage>&& na
 
 CoordinatedImageBackingStore::~CoordinatedImageBackingStore() = default;
 
-uint64_t CoordinatedImageBackingStore::uniqueIDForNativeImage(const NativeImage& nativeImage)
-{
-#if USE(CAIRO)
-    return getSurfaceUniqueID(nativeImage.platformImage().get());
-#elif USE(SKIA)
-    return nativeImage.platformImage()->uniqueID();
-#endif
-}
-
 bool CoordinatedImageBackingStore::isSameNativeImage(const NativeImage& nativeImage)
 {
-    return uniqueIDForNativeImage(nativeImage) == uniqueIDForNativeImage(downcast<CoordinatedPlatformLayerBufferNativeImage>(*m_buffer).image());
+    return nativeImage.uniqueID() == downcast<CoordinatedPlatformLayerBufferNativeImage>(*m_buffer).image().uniqueID();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
@@ -38,7 +38,6 @@ public:
     static Ref<CoordinatedImageBackingStore> create(Ref<NativeImage>&&);
     ~CoordinatedImageBackingStore();
 
-    static uint64_t uniqueIDForNativeImage(const NativeImage&);
     bool isSameNativeImage(const NativeImage&);
     CoordinatedPlatformLayerBuffer* buffer() const { return m_buffer.get(); }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -148,7 +148,7 @@ public:
     void replaceCurrentContentsBufferWithCopy();
 #endif
     void setContentsBufferNeedsDisplay();
-    void setContentsImage(RefPtr<NativeImage>&&);
+    void setContentsImage(NativeImage*);
     void setContentsColor(const Color&);
     void setContentsTileSize(const FloatSize&);
     void setContentsTilePhase(const FloatSize&);
@@ -180,7 +180,6 @@ public:
     void flushCompositingState(TextureMapper&);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
-    bool hasImageBackingStore() const { return !!m_imageBackingStore; }
     bool isCompositionRequiredOrOngoing() const;
     void requestComposition();
     RunLoop* compositingRunLoop() const;
@@ -275,9 +274,10 @@ private:
     RefPtr<CoordinatedBackingStoreProxy> m_backingStoreProxy WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedBackingStore> m_backingStore WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient WTF_GUARDED_BY_LOCK(m_lock);
-    RefPtr<CoordinatedImageBackingStore> m_imageBackingStore WTF_GUARDED_BY_LOCK(m_lock);
-    RefPtr<CoordinatedImageBackingStore> m_committedImageBackingStore WTF_GUARDED_BY_LOCK(m_lock);
-    bool m_imageBackingStoreVisible WTF_GUARDED_BY_LOCK(m_lock) { false };
+    struct {
+        RefPtr<CoordinatedImageBackingStore> current;
+        RefPtr<CoordinatedImageBackingStore> committed;
+    } m_imageBackingStore WTF_GUARDED_BY_LOCK(m_lock);
     struct {
         std::unique_ptr<CoordinatedPlatformLayerBuffer> pending;
         std::unique_ptr<CoordinatedPlatformLayerBuffer> committed;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -212,7 +212,7 @@ private:
     bool m_needsUpdateLayerTransform { false };
     RefPtr<CoordinatedPlatformLayerBufferProxy> m_contentsBufferProxy;
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_contentsDisplayDelegate;
-    RefPtr<NativeImage> m_pendingContentsImage;
+    RefPtr<NativeImage> m_contentsImage;
     Color m_contentsColor;
     RefPtr<CoordinatedPlatformLayer> m_backdropLayer;
     TextureMapperAnimations m_animations;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -429,7 +429,7 @@ Cairo::PaintingEngine& LayerTreeHost::paintingEngine()
 
 Ref<CoordinatedImageBackingStore> LayerTreeHost::imageBackingStore(Ref<NativeImage>&& nativeImage)
 {
-    auto nativeImageID = CoordinatedImageBackingStore::uniqueIDForNativeImage(nativeImage.get());
+    auto nativeImageID = nativeImage->uniqueID();
     auto addResult = m_imageBackingStores.ensure(nativeImageID, [&] {
         return CoordinatedImageBackingStore::create(WTFMove(nativeImage));
     });


### PR DESCRIPTION
#### b5e34083e2c1437c1484eaaec2fb5a558ad557f2
<pre>
[CoordinatedGraphics] Setting the same image contents on a layer might cause an unnecessary flush
<a href="https://bugs.webkit.org/show_bug.cgi?id=286740">https://bugs.webkit.org/show_bug.cgi?id=286740</a>

Reviewed by Miguel Gomez.

It can happen that the same image is set for a layer causing an
unnecessary flush (if nothing else changed) because we reset the pending
image on the first flush after being set.
This patch also removes the optimization of removing the layer contents
when the image is not visible, since the image will be clipped out
anyway, and it can cause problems with CSS 3D animations if the image
is not visible at the beginning of the animation.

* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp:
(WebCore::NativeImage::uniqueID const):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::uniqueID const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.cpp:
(WebCore::CoordinatedImageBackingStore::isSameNativeImage):
(WebCore::CoordinatedImageBackingStore::uniqueIDForNativeImage): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::invalidateTarget):
(WebCore::CoordinatedPlatformLayer::setContentsImage):
(WebCore::CoordinatedPlatformLayer::updateContents):
(WebCore::CoordinatedPlatformLayer::purgeBackingStores):
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
(WebCore::CoordinatedPlatformLayer::hasPendingTilesCreation const):
(WebCore::CoordinatedPlatformLayer::hasImageBackingStore const): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::setContentsToImage):
(WebCore::GraphicsLayerCoordinated::usesContentsLayer const):
(WebCore::GraphicsLayerCoordinated::commitLayerChanges):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:

Canonical link: <a href="https://commits.webkit.org/289601@main">https://commits.webkit.org/289601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/356f2e35a229bc4452592927468086e99e99bd01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38075 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67486 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25218 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33422 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94084 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86109 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14497 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10677 "Found 1 new test failure: fast/writing-mode/english-rl-text-with-spelling-marker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76299 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75507 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19926 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7430 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13625 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19809 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14261 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->