### PR TITLE
[CoordinatedGraphics] The layer backing store might not change after being set to nullptr

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -208,27 +208,28 @@ private:
         BackfaceVisibility           = 1 << 9,
         Opacity                      = 1 << 10,
         Children                     = 1 << 11,
-        ContentsVisible              = 1 << 12,
-        ContentsOpaque               = 1 << 13,
-        ContentsRect                 = 1 << 14,
-        ContentsRectClipsDescendants = 1 << 15,
-        ContentsClippingRect         = 1 << 16,
-        ContentsTiling               = 1 << 17,
-        ContentsBuffer               = 1 << 18,
-        ContentsImage                = 1 << 19,
-        ContentsColor                = 1 << 20,
-        Filters                      = 1 << 21,
-        Mask                         = 1 << 22,
-        Replica                      = 1 << 23,
-        Backdrop                     = 1 << 24,
-        BackdropRect                 = 1 << 25,
-        Animations                   = 1 << 26,
-        DebugIndicators              = 1 << 27,
+        BackingStore                 = 1 << 12,
+        ContentsVisible              = 1 << 13,
+        ContentsOpaque               = 1 << 14,
+        ContentsRect                 = 1 << 15,
+        ContentsRectClipsDescendants = 1 << 16,
+        ContentsClippingRect         = 1 << 17,
+        ContentsTiling               = 1 << 18,
+        ContentsBuffer               = 1 << 19,
+        ContentsImage                = 1 << 20,
+        ContentsColor                = 1 << 21,
+        Filters                      = 1 << 22,
+        Mask                         = 1 << 23,
+        Replica                      = 1 << 24,
+        Backdrop                     = 1 << 25,
+        BackdropRect                 = 1 << 26,
+        Animations                   = 1 << 27,
+        DebugIndicators              = 1 << 28,
 #if ENABLE(DAMAGE_TRACKING)
-        Damage                       = 1 << 28,
+        Damage                       = 1 << 29,
 #endif
 #if ENABLE(SCROLLING_THREAD)
-        ScrollingNode                = 1 << 29
+        ScrollingNode                = 1 << 30
 #endif
     };
 


### PR DESCRIPTION
#### 8702d7ebc9db4a191a88db87e679f62b4cb33438
<pre>
[CoordinatedGraphics] The layer backing store might not change after being set to nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=286742">https://bugs.webkit.org/show_bug.cgi?id=286742</a>

Reviewed by Miguel Gomez.

This is because CoordinatedPlatformLayer::flushCompositingState returns
early if there aren&apos;t pending changes and m_backingStoreProxy is
nullptr. So, if backing store is reset and nothing else changes we don&apos;t
change the target layer. Add BackingStore change to make sure there are
always pending changes when the backing store changes.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::updateContents):
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/289602@main">https://commits.webkit.org/289602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d7435b8337b59f82a652f8900042a731795fe1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92199 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37193 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14498 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10671 "Found 1 new test failure: fast/css/view-transitions-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76301 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75509 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7431 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13626 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14517 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19810 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->