### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ImmutableStyleProperties.cpp

### DIFF
--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -29,26 +29,27 @@
 #include "StylePropertiesInlines.h"
 #include <wtf/HashMap.h>
 #include <wtf/Hasher.h>
+#include <wtf/IndexedRange.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ImmutableStyleProperties);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-ImmutableStyleProperties::ImmutableStyleProperties(const CSSProperty* properties, unsigned length, CSSParserMode mode)
-    : StyleProperties(mode, length)
+ImmutableStyleProperties::ImmutableStyleProperties(std::span<const CSSProperty> properties, CSSParserMode mode)
+    : StyleProperties(mode, properties.size())
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     auto* metadataArray = const_cast<StylePropertyMetadata*>(this->metadataArray());
     auto* valueArray = std::bit_cast<PackedPtr<CSSValue>*>(this->valueArray());
-    for (unsigned i = 0; i < length; ++i) {
-        metadataArray[i] = properties[i].metadata();
-        RefPtr value = properties[i].value();
+    for (auto [i, property] : indexedRange(properties)) {
+        metadataArray[i] = property.metadata();
+        RefPtr value = property.value();
         valueArray[i] = value.get();
         value->ref();
     }
-}
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
 
 ImmutableStyleProperties::~ImmutableStyleProperties()
 {
@@ -59,10 +60,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
-Ref<ImmutableStyleProperties> ImmutableStyleProperties::create(const CSSProperty* properties, unsigned count, CSSParserMode mode)
+Ref<ImmutableStyleProperties> ImmutableStyleProperties::create(std::span<const CSSProperty> properties, CSSParserMode mode)
 {
-    void* slot = ImmutableStylePropertiesMalloc::malloc(objectSize(count));
-    return adoptRef(*new (NotNull, slot) ImmutableStyleProperties(properties, count, mode));
+    void* slot = ImmutableStylePropertiesMalloc::malloc(objectSize(properties.size()));
+    return adoptRef(*new (NotNull, slot) ImmutableStyleProperties(properties, mode));
 }
 
 static auto& deduplicationMap()
@@ -71,8 +72,7 @@ static auto& deduplicationMap()
     return map.get();
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-Ref<ImmutableStyleProperties> ImmutableStyleProperties::createDeduplicating(const CSSProperty* properties, unsigned count, CSSParserMode mode)
+Ref<ImmutableStyleProperties> ImmutableStyleProperties::createDeduplicating(std::span<const CSSProperty> properties, CSSParserMode mode)
 {
     static constexpr auto maximumDeduplicationMapSize = 1024u;
     if (deduplicationMap().size() >= maximumDeduplicationMapSize)
@@ -81,40 +81,39 @@ Ref<ImmutableStyleProperties> ImmutableStyleProperties::createDeduplicating(cons
     auto computeHash = [&] {
         Hasher hasher;
         add(hasher, mode);
-        for (auto* property = properties; property < properties + count; ++property) {
-            if (!property->value()->addHash(hasher))
+        for (auto& property : properties) {
+            if (!property.value()->addHash(hasher))
                 return 0u;
-            add(hasher, property->id(), property->isImportant());
+            add(hasher, property.id(), property.isImportant());
         }
         return hasher.hash();
     };
 
     auto hash = computeHash();
     if (!hash)
-        return create(properties, count, mode);
+        return create(properties, mode);
 
     auto result = deduplicationMap().ensure(hash, [&] {
-        return create(properties, count, mode);
+        return create(properties, mode);
     });
 
     auto isEqual = [&](auto& existingValue) {
-        if (existingValue.propertyCount() != count)
+        if (existingValue.propertyCount() != properties.size())
             return false;
         if (existingValue.cssParserMode() != mode)
             return false;
-        for (unsigned i = 0; i < count; ++i) {
-            if (existingValue.propertyAt(i).toCSSProperty() != *(properties + i))
+        for (auto [i, property] : indexedRange(properties)) {
+            if (existingValue.propertyAt(i).toCSSProperty() != property)
                 return false;
         }
         return true;
     };
 
     if (!result.isNewEntry && !isEqual(result.iterator->value.get()))
-        return create(properties, count, mode);
+        return create(properties, mode);
 
     return result.iterator->value;
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void ImmutableStyleProperties::clearDeduplicationMap()
 {

--- a/Source/WebCore/css/ImmutableStyleProperties.h
+++ b/Source/WebCore/css/ImmutableStyleProperties.h
@@ -35,8 +35,8 @@ public:
     inline void deref() const;
 
     WEBCORE_EXPORT ~ImmutableStyleProperties();
-    static Ref<ImmutableStyleProperties> create(const CSSProperty* properties, unsigned count, CSSParserMode);
-    static Ref<ImmutableStyleProperties> createDeduplicating(const CSSProperty* properties, unsigned count, CSSParserMode);
+    static Ref<ImmutableStyleProperties> create(std::span<const CSSProperty> properties, CSSParserMode);
+    static Ref<ImmutableStyleProperties> createDeduplicating(std::span<const CSSProperty> properties, CSSParserMode);
 
     unsigned propertyCount() const { return m_arraySize; }
     bool isEmpty() const { return !propertyCount(); }
@@ -58,7 +58,7 @@ public:
 private:
     PackedPtr<const CSSValue>* valueArray() const;
     const StylePropertyMetadata* metadataArray() const;
-    ImmutableStyleProperties(const CSSProperty*, unsigned count, CSSParserMode);
+    ImmutableStyleProperties(std::span<const CSSProperty>, CSSParserMode);
 };
 
 inline void ImmutableStyleProperties::deref() const

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -85,12 +85,12 @@ Ref<MutableStyleProperties> MutableStyleProperties::createEmpty()
 
 Ref<ImmutableStyleProperties> MutableStyleProperties::immutableCopy() const
 {
-    return ImmutableStyleProperties::create(m_propertyVector.data(), m_propertyVector.size(), cssParserMode());
+    return ImmutableStyleProperties::create(m_propertyVector.span(), cssParserMode());
 }
 
 Ref<ImmutableStyleProperties> MutableStyleProperties::immutableDeduplicatedCopy() const
 {
-    return ImmutableStyleProperties::createDeduplicating(m_propertyVector.data(), m_propertyVector.size(), cssParserMode());
+    return ImmutableStyleProperties::createDeduplicating(m_propertyVector.span(), cssParserMode());
 }
 
 inline bool MutableStyleProperties::removeShorthandProperty(CSSPropertyID propertyID, String* returnText)

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -163,7 +163,7 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
     filterProperties(IsImportant::Yes, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(IsImportant::No, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
 
-    Ref result = ImmutableStyleProperties::createDeduplicating(results.subspan(unusedEntries).data(), results.size() - unusedEntries, mode);
+    Ref result = ImmutableStyleProperties::createDeduplicating(results.subspan(unusedEntries), mode);
     parsedProperties.clear();
     return result;
 }


### PR DESCRIPTION
#### 36424385b378a7bbe98ab2553a02c739c1b8d5bf
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ImmutableStyleProperties.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286752">https://bugs.webkit.org/show_bug.cgi?id=286752</a>

Reviewed by Geoffrey Garen.

This tested as performance neutral on Speedometer.

* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::ImmutableStyleProperties::ImmutableStyleProperties):
(WebCore::ImmutableStyleProperties::create):
(WebCore::ImmutableStyleProperties::createDeduplicating):
* Source/WebCore/css/ImmutableStyleProperties.h:
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::immutableCopy const):
(WebCore::MutableStyleProperties::immutableDeduplicatedCopy const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::createStyleProperties):

Canonical link: <a href="https://commits.webkit.org/289578@main">https://commits.webkit.org/289578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0698c91d29268dccf98a5ee7fed18fa5c38675ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67501 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25234 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33447 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37212 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94104 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76318 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75526 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7459 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19835 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->