### PR TITLE
[CoreIPC] ASAN_TRAP in WebKit::ImageBufferShareableMappedIOSurfaceBackend::create

### DIFF
--- a/LayoutTests/ipc/create-image-buffer-crash-expected.txt
+++ b/LayoutTests/ipc/create-image-buffer-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/create-image-buffer-crash.html
+++ b/LayoutTests/ipc/create-image-buffer-crash.html
@@ -1,0 +1,57 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  window.setTimeout(async () => {
+    if (!window.IPC)
+      return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const connection = CoreIPC.newStreamConnection();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, { renderingBackendIdentifier: 393221, connectionHandle: connection });
+    const remoteBackend = connection.newInterface("RemoteRenderingBackend", 393221);
+
+    // The pixel formats to test
+    const pixelFormats = [
+      0, // BGRX8
+      1, // BGRA8
+      2, // RGB10
+      3, // RGB10A8
+      4  // RGBA16F (if HDR_SUPPORT is enabled)
+    ];
+
+    // Iterate through each pixel format and create image buffer
+    for (let format of pixelFormats) {
+      try {
+        remoteBackend.CreateImageBuffer({
+          logicalSize: { width: 69, height: 67 },
+          renderingMode: 1,
+          renderingPurpose: 2,
+          resolutionScale: 96,
+          colorSpace: {
+            serializableColorSpace: {
+              alias: {
+                m_cgColorSpace: {
+                  alias: {
+                    variantType: 'RetainPtr<CFStringRef>',
+                    variant: 'A'
+                  }
+                }
+              }
+            }
+          },
+          pixelFormat: format,
+          renderingResourceIdentifier: 393230 + format
+        });
+      } catch {}
+    }
+
+    window.testRunner?.notifyDone();
+  }, 10);
+</script>

--- a/Source/WebCore/platform/graphics/ImageBufferPixelFormat.h
+++ b/Source/WebCore/platform/graphics/ImageBufferPixelFormat.h
@@ -35,8 +35,10 @@ namespace WebCore {
 enum class ImageBufferPixelFormat : uint8_t {
     BGRX8,
     BGRA8,
+#if HAVE(IOSURFACE_RGB10)
     RGB10,
     RGB10A8,
+#endif
 #if HAVE(HDR_SUPPORT)
     RGBA16F,
 #endif
@@ -49,10 +51,12 @@ constexpr PixelFormat convertToPixelFormat(ImageBufferPixelFormat format)
         return PixelFormat::BGRX8;
     case ImageBufferPixelFormat::BGRA8:
         return PixelFormat::BGRA8;
+#if HAVE(IOSURFACE_RGB10)
     case ImageBufferPixelFormat::RGB10:
         return PixelFormat::RGB10;
     case ImageBufferPixelFormat::RGB10A8:
         return PixelFormat::RGB10A8;
+#endif
 #if HAVE(HDR_SUPPORT)
     case ImageBufferPixelFormat::RGBA16F:
         return PixelFormat::RGBA16F;

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -43,8 +43,10 @@ bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
         return true;
 
     case PixelFormat::BGRX8:
+#if HAVE(IOSURFACE_RGB10)
     case PixelFormat::RGB10:
     case PixelFormat::RGB10A8:
+#endif
         return false;
     }
 

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -62,8 +62,10 @@ static inline vImage_CGImageFormat makeVImageCGImageFormat(const PixelBufferForm
                 return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
 
         case PixelFormat::BGRX8:
+#if HAVE(IOSURFACE_RGB10)
         case PixelFormat::RGB10:
         case PixelFormat::RGB10A8:
+#endif
 #if HAVE(HDR_SUPPORT)
         case PixelFormat::RGBA16F:
 #endif
@@ -157,8 +159,10 @@ static void convertImagePixelsSkia(const ConstPixelBufferConversionView& source,
         case PixelFormat::BGRA8:
             return SkColorType::kBGRA_8888_SkColorType;
         case PixelFormat::BGRX8:
+#if HAVE(IOSURFACE_RGB10)
         case PixelFormat::RGB10:
         case PixelFormat::RGB10A8:
+#endif
             break;
         }
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/PixelFormat.cpp
+++ b/Source/WebCore/platform/graphics/PixelFormat.cpp
@@ -42,12 +42,14 @@ TextStream& operator<<(TextStream& ts, PixelFormat pixelFormat)
     case PixelFormat::BGRA8:
         ts << "BGRA8";
         break;
+#if HAVE(IOSURFACE_RGB10)
     case PixelFormat::RGB10:
         ts << "RGB10";
         break;
     case PixelFormat::RGB10A8:
         ts << "RGB10A8";
         break;
+#endif
 #if HAVE(HDR_SUPPORT)
     case PixelFormat::RGBA16F:
         ts << "RGBA16F";

--- a/Source/WebCore/platform/graphics/PixelFormat.h
+++ b/Source/WebCore/platform/graphics/PixelFormat.h
@@ -33,8 +33,10 @@ enum class PixelFormat : uint8_t {
     RGBA8,
     BGRX8,
     BGRA8,
+#if HAVE(IOSURFACE_RGB10)
     RGB10,
     RGB10A8,
+#endif
 #if HAVE(HDR_SUPPORT)
     RGBA16F,
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -80,7 +80,11 @@ private:
 
     bool isOpaque() const
     {
-        return m_pixelFormat == WebCore::ImageBufferPixelFormat::RGB10 || m_pixelFormat == WebCore::ImageBufferPixelFormat::BGRX8;
+#if HAVE(IOSURFACE_RGB10)
+        if (m_pixelFormat == WebCore::ImageBufferPixelFormat::RGB10)
+            return true;
+#endif
+        return m_pixelFormat == WebCore::ImageBufferPixelFormat::BGRX8;
     }
 
     const RemoteImageBufferSetIdentifier m_identifier;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -283,8 +283,10 @@ unsigned RemoteLayerBackingStore::bytesPerPixel() const
     switch (pixelFormat()) {
     case ImageBufferPixelFormat::BGRX8: return 4;
     case ImageBufferPixelFormat::BGRA8: return 4;
+#if HAVE(IOSURFACE_RGB10)
     case ImageBufferPixelFormat::RGB10: return 4;
     case ImageBufferPixelFormat::RGB10A8: return 5;
+#endif
 #if HAVE(HDR_SUPPORT)
     case ImageBufferPixelFormat::RGBA16F: return 8;
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2557,8 +2557,10 @@ enum class WebCore::PixelFormat : uint8_t {
     RGBA8,
     BGRX8,
     BGRA8,
+#if HAVE(IOSURFACE_RGB10)
     RGB10,
     RGB10A8,
+#endif
 #if HAVE(HDR_SUPPORT)
     RGBA16F,
 #endif
@@ -2567,8 +2569,10 @@ enum class WebCore::PixelFormat : uint8_t {
 enum class WebCore::ImageBufferPixelFormat : uint8_t {
     BGRX8,
     BGRA8,
+#if HAVE(IOSURFACE_RGB10)
     RGB10,
     RGB10A8,
+#endif
 #if HAVE(HDR_SUPPORT)
     RGBA16F,
 #endif


### PR DESCRIPTION
#### 45e0e3bd236dbae039329cfa14ce8a134e77f68f
<pre>
[CoreIPC] ASAN_TRAP in WebKit::ImageBufferShareableMappedIOSurfaceBackend::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=286756">https://bugs.webkit.org/show_bug.cgi?id=286756</a>
<a href="https://rdar.apple.com/143264721">rdar://143264721</a>

Reviewed by Said Abou-Hallawa.

Added HAVE(IOSURFACE_RGB10) guards around all RGB10|A8 format usage.

* LayoutTests/ipc/create-image-buffer-crash-expected.txt: Added.
* LayoutTests/ipc/create-image-buffer-crash.html: Added.
* Source/WebCore/platform/graphics/ImageBufferPixelFormat.h:
(WebCore::convertToPixelFormat):
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::supportedPixelFormat):
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::makeVImageCGImageFormat):
(WebCore::convertImagePixelsSkia):
* Source/WebCore/platform/graphics/PixelFormat.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PixelFormat.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
(WebKit::RemoteImageBufferSet::isOpaque const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::bytesPerPixel const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/289634@main">https://commits.webkit.org/289634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e12804f2f21b74dda639aa6e261e7a9456af53f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38301 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15240 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25378 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33632 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14725 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76464 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75088 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75687 "Found 2 new API test failures: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-empty-realm, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18618 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18493 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7676 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14741 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20042 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14485 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->