### PR TITLE
[UIIntelligenceSupport] beckta.com: Siri fails to find text after scrolling to the bottom of the page

### DIFF
--- a/LayoutTests/fast/text-extraction/text-extraction-visible-overflow-expected.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-visible-overflow-expected.html
@@ -1,0 +1,75 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html, body {
+    margin: 0;
+    font-family: monospace;
+    font-size: 16px;
+    width: 100%;
+}
+
+body {
+    position: relative;
+}
+
+.container {
+    margin: 20px;
+    border: 1px solid red;
+    width: calc(100% - 40px);
+    height: 300px;
+    box-sizing: border-box;
+    text-align: center;
+    line-height: 300px;
+    font-size: 24px;
+    -webkit-text-size-adjust: none;
+}
+
+.image-wrapper {
+    text-align: center;
+}
+
+img {
+    height: 44px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+addEventListener("load", async () => {
+    window.internals?.setUsesOverlayScrollbars(true);
+    window.testRunner?.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestTextExtraction({
+        clipToBounds: true,
+        includeRects: true
+    });
+
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="container">One</div>
+    <div class="image-wrapper"><img alt="Image one" src="../images/resources/dice.png"></div>
+    <div class="container">Two</div>
+    <div class="image-wrapper"><img alt="Image two" src="../images/resources/dice.png"></div>
+    <div class="container">Three</div>
+    <div class="image-wrapper"><img alt="Image three" src="../images/resources/dice.png"></div>
+    <div class="container">Four</div>
+    <div class="image-wrapper"><img alt="Image four" src="../images/resources/dice.png"></div>
+    <div class="container">Five</div>
+    <div class="image-wrapper"><img alt="Image five" src="../images/resources/dice.png"></div>
+    <div class="container">Six</div>
+    <div class="image-wrapper"><img alt="Image six" src="../images/resources/dice.png"></div>
+    <div class="container">Seven</div>
+    <div class="image-wrapper"><img alt="Image seven" src="../images/resources/dice.png"></div>
+    <div class="container">Eight</div>
+    <div class="image-wrapper"><img alt="Image eight" src="../images/resources/dice.png"></div>
+    <div class="container">Nine</div>
+    <div class="image-wrapper"><img alt="Image nine" src="../images/resources/dice.png"></div>
+    <div class="container">Ten</div>
+    <div class="image-wrapper"><img alt="Image ten" src="../images/resources/dice.png"></div>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/text-extraction-visible-overflow.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-visible-overflow.html
@@ -1,0 +1,76 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html, body {
+    margin: 0;
+    font-family: monospace;
+    font-size: 16px;
+    width: 100%;
+    height: 100%;
+}
+
+body {
+    position: relative;
+}
+
+.container {
+    margin: 20px;
+    border: 1px solid red;
+    width: calc(100% - 40px);
+    height: 300px;
+    box-sizing: border-box;
+    text-align: center;
+    line-height: 300px;
+    font-size: 24px;
+    -webkit-text-size-adjust: none;
+}
+
+.image-wrapper {
+    text-align: center;
+}
+
+img {
+    height: 44px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+addEventListener("load", async () => {
+    window.internals?.setUsesOverlayScrollbars(true);
+    window.testRunner?.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestTextExtraction({
+        clipToBounds: true,
+        includeRects: true
+    });
+
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="container">One</div>
+    <div class="image-wrapper"><img alt="Image one" src="../images/resources/dice.png"></div>
+    <div class="container">Two</div>
+    <div class="image-wrapper"><img alt="Image two" src="../images/resources/dice.png"></div>
+    <div class="container">Three</div>
+    <div class="image-wrapper"><img alt="Image three" src="../images/resources/dice.png"></div>
+    <div class="container">Four</div>
+    <div class="image-wrapper"><img alt="Image four" src="../images/resources/dice.png"></div>
+    <div class="container">Five</div>
+    <div class="image-wrapper"><img alt="Image five" src="../images/resources/dice.png"></div>
+    <div class="container">Six</div>
+    <div class="image-wrapper"><img alt="Image six" src="../images/resources/dice.png"></div>
+    <div class="container">Seven</div>
+    <div class="image-wrapper"><img alt="Image seven" src="../images/resources/dice.png"></div>
+    <div class="container">Eight</div>
+    <div class="image-wrapper"><img alt="Image eight" src="../images/resources/dice.png"></div>
+    <div class="container">Nine</div>
+    <div class="image-wrapper"><img alt="Image nine" src="../images/resources/dice.png"></div>
+    <div class="container">Ten</div>
+    <div class="image-wrapper"><img alt="Image ten" src="../images/resources/dice.png"></div>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -224,10 +224,18 @@ static inline FloatRect rootViewBounds(Node& node)
     if (UNLIKELY(!view))
         return { };
 
-    if (!node.renderer())
+    CheckedPtr renderer = node.renderer();
+    if (!renderer)
         return { };
 
-    return view->contentsToRootView(node.renderer()->absoluteBoundingBoxRect());
+    IntRect absoluteRect;
+    if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(*renderer); renderElement && renderElement->firstChild())
+        absoluteRect = renderer->pixelSnappedAbsoluteClippedOverflowRect();
+
+    if (absoluteRect.isEmpty())
+        absoluteRect = renderer->absoluteBoundingBoxRect();
+
+    return view->contentsToRootView(absoluteRect);
 }
 
 static inline String labelText(HTMLElement& element)


### PR DESCRIPTION
#### 17bb2c1ed7680330e1e28f4afe756151d688c064
<pre>
[UIIntelligenceSupport] beckta.com: Siri fails to find text after scrolling to the bottom of the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=286748">https://bugs.webkit.org/show_bug.cgi?id=286748</a>
<a href="https://rdar.apple.com/141776975">rdar://141776975</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Adjust our approach when extracting bounding rects for context retrieval via UIIntelligenceSupport.
IntelligenceFlow currently ignores all items, whose bounding rect is entirely outside of the bounds
of its parent container.

However, in WebKit, we simply use `absoluteBoundingBoxRect` to extract element bounds, which
ignores all visible layout overflow. On beckta.com, where the `body` and `html` elements are both
`width: 100%;` and `height: 100%;` (the initial containing block size), this means that any content
that visually overflows the body is effectively invisible to context retrieval, and thus invisible
to Siri.

To fix this, we use `absoluteClippedOverflowRectForRepaint` instead for all renderers with children,
which includes visible overflow. Note that for leaves in the render tree, we continue to use
`absoluteBoundingBoxRect`, such that bounding rects around rendered text, images and other widgets
like form controls will still tightly fit around the rendered content, instead of stretching to the
repaint rect.

* LayoutTests/fast/text-extraction/text-extraction-visible-overflow-expected.html: Added.
* LayoutTests/fast/text-extraction/text-extraction-visible-overflow.html: Added.

Add a layout test to exercise this change; before this fix, the `height: 100%;` on the `body` causes
its bounding rect to only be as tall as the initial containing block. After this fix, it correctly
expands to fill the height of the page.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::rootViewBounds):

Canonical link: <a href="https://commits.webkit.org/289594@main">https://commits.webkit.org/289594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/286438b4022379135ef28540e6d370e4e49d955e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67525 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25262 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33496 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94156 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14574 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10694 "Found 1 new test failure: fast/css/view-transitions-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75568 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18592 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19887 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17779 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->