### PR TITLE
Include pas_utils_additions.c into pas_utils.c when available

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -69,6 +69,14 @@
 
 #endif
 
+#if defined(PAS_BMALLOC) && PAS_BMALLOC
+#if defined(__has_include)
+#if __has_include(<WebKitAdditions/pas_utils_additions.c>) && !PAS_ENABLE_TESTING
+#include <WebKitAdditions/pas_utils_additions.c>
+#endif // __has_include(<WebKitAdditions/pas_utils_additions.c>) && !PAS_ENABLE_TESTING
+#endif // defined(__has_include)
+#endif // defined(PAS_BMALLOC) && PAS_BMALLOC
+
 #if PAS_X86_64 || PAS_ARM64
 
 #if PAS_OS(DARWIN) && PAS_VA_OPT_SUPPORTED


### PR DESCRIPTION
#### 8175ee187349b11e8e7d1dfce53700985f30957b
<pre>
Include pas_utils_additions.c into pas_utils.c when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=286770">https://bugs.webkit.org/show_bug.cgi?id=286770</a>
<a href="https://rdar.apple.com/143912942">rdar://143912942</a>

Reviewed by Yusuke Suzuki.

Adds an include to pas_utils_additions.c when available to pas_utils.c,
akin to the existing header include in pas_utils.h.

* Source/bmalloc/libpas/src/libpas/pas_utils.c:

Canonical link: <a href="https://commits.webkit.org/289620@main">https://commits.webkit.org/289620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b807f4c257eda6b64c42d3f922678e8771bb9b55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38197 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67550 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25287 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33530 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37313 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80253 "Found 755 new JSC stress test failures: cdjs-tests.yaml/main.js.ftl-eager-no-cjit, cdjs-tests.yaml/main.js.lockdown, microbenchmarks/Int8Array-load-with-byteLength.js.ftl-eager-no-cjit, microbenchmarks/abc-simple-backward-loop.js.ftl-eager-no-cjit, microbenchmarks/abs-boolean.js.ftl-eager-no-cjit, microbenchmarks/array-concat-double-and-int32.js.ftl-eager-no-cjit, microbenchmarks/array-filter-boolean-constructor.js.lockdown, microbenchmarks/array-from-derived-object-func.js.lockdown, microbenchmarks/array-from-object.js.ftl-eager-no-cjit, microbenchmarks/array-prototype-concat-copy-int32.js.ftl-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94205 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86232 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14623 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10724 "Found 1 new test failure: fast/css/viewport-height-border.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76376 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75598 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7561 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14641 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108724 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14384 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26149 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->