### PR TITLE
StylePropertyMap::append is not properly verifying that we don't append CSSVariableReferenceValue style values

### DIFF
--- a/LayoutTests/fast/css/create-columns-onload-crash.html
+++ b/LayoutTests/fast/css/create-columns-onload-crash.html
@@ -1,9 +1,19 @@
 <script>
-    if (window.testRunner)
+    if (window.testRunner) {
         testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+  }
   onload = () => {
-    let cssStyleValue = CSSMathValue.parseAll('columns', 'auto')[0];
-    document.body.attributeStyleMap.append('grid-auto-columns', cssStyleValue);
+    function run() {
+      try {
+        let cssStyleValue = CSSMathValue.parseAll('columns', 'auto')[0];
+        document.body.attributeStyleMap.append('grid-auto-columns', cssStyleValue);
+      } finally {
+        if (window.testRunner)
+          testRunner.notifyDone();
+      }
+    }
+    setTimeout(run, 20);
   };
 </script>
 <div>This test should not crash</div>

--- a/LayoutTests/fast/css/stylepropertymap-append-not-checking-for-variablereferencevalue-expected.txt
+++ b/LayoutTests/fast/css/stylepropertymap-append-not-checking-for-variablereferencevalue-expected.txt
@@ -1,0 +1,10 @@
+This test passes if there is not crash and there is a TypeError exception. This verifies that attributeStyleMap.append throws an exception when appending a CSSVariableReferenceValue property
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS p.attributeStyleMap.append('background-size', body.computedStyleMap().get('-webkit-mask-position')) threw exception TypeError: Values cannot contain a CSSVariableReferenceValue.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/stylepropertymap-append-not-checking-for-variablereferencevalue.html
+++ b/LayoutTests/fast/css/stylepropertymap-append-not-checking-for-variablereferencevalue.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../resources/js-test.js"></script>
+    <script>
+      description("This test passes if there is not crash and there is a TypeError exception. This verifies that attributeStyleMap.append throws an exception when appending a CSSVariableReferenceValue property");
+// see: https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-append
+      window.jsTestIsAsync = true;
+
+      function runTest() {
+          p = document.getElementById('element');
+          body = document.getElementById('body');
+          shouldThrowErrorName("p.attributeStyleMap.append('background-size', body.computedStyleMap().get('-webkit-mask-position'))", "TypeError");
+
+          finishJSTest();
+      }
+    </script>
+  </head>
+  <body id="body" onload="setTimeout(runTest, 20)">
+    <p id="element"></p>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt
@@ -8,6 +8,7 @@ PASS Calling StylePropertyMap.append with an invalid String value throws TypeErr
 PASS Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError
 PASS Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError
 PASS Calling StylePropertyMap.append with a var ref throws TypeError
+PASS Calling StylePropertyMap.append with a CSSVariableReferenceValue property throws TypeError
 PASS Appending a list-valued property with CSSStyleValue or String updates its values
 PASS Appending a list-valued property with list-valued string updates its values
 PASS StylePropertyMap.append is case-insensitive

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative.html
@@ -19,6 +19,7 @@ const gInvalidTestCases = [
   { property: 'transition-duration', values: [CSS.s(1), '10px', CSS.px(10)], desc: 'a mix of valid and invalid values' },
   { property: 'transition-duration', values: [new CSSUnparsedValue([])], desc: 'a CSSUnparsedValue' },
   { property: 'transition-duration', values: ['var(--A)'], desc: 'a var ref' },
+  { property: 'background-size', values: [document.getElementsByTagName('title')[0].computedStyleMap().get('mask-position')], desc: 'a CSSVariableReferenceValue property' },
 ];
 
 for (const {property, values, desc} of gInvalidTestCases) {

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -171,9 +171,16 @@ ExceptionOr<void> StylePropertyMap::append(Document& document, const AtomString&
     auto styleValues = styleValuesOrException.releaseReturnValue();
     for (auto& styleValue : styleValues) {
         if (is<CSSUnparsedValue>(styleValue.get()))
-            return Exception { ExceptionCode::TypeError, "Values cannot contain a CSSVariableReferenceValue or a CSSUnparsedValue"_s };
-        if (auto cssValue = styleValue->toCSSValueWithProperty(propertyID))
-            list.append(cssValue.releaseNonNull());
+            return Exception { ExceptionCode::TypeError, "Values cannot contain a CSSUnparsedValue"_s };
+
+        auto cssValue = styleValue->toCSSValueWithProperty(propertyID);
+
+        if (!cssValue)
+            continue;
+        if (is<CSSVariableReferenceValue>(*cssValue))
+            return Exception { ExceptionCode::TypeError, "Values cannot contain a CSSVariableReferenceValue"_s };
+
+        list.append(cssValue.releaseNonNull());
     }
 
     if (!setProperty(propertyID, CSSValueList::create(CSSProperty::listValuedPropertySeparator(propertyID), WTFMove(list))))


### PR DESCRIPTION
#### f2e814363ebf5a9a7902e5cd656ad300053dc129
<pre>
StylePropertyMap::append is not properly verifying that we don&apos;t append CSSVariableReferenceValue style values
<a href="https://rdar.apple.com/147350835">rdar://147350835</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286767">https://bugs.webkit.org/show_bug.cgi?id=286767</a>

Reviewed by Chris Dumez.

 This fixes the bug by checking that the CSSValue for the style value is
not a variable reference value and throwing an exception if it is. This
commit also modifies an older test that started failing after this change
so that it now passes and still reproduces the crash on versions previous
to its introduction.

* LayoutTests/fast/css/create-columns-onload-crash.html:
* LayoutTests/fast/css/stylepropertymap-append-not-checking-for-variablereferencevalue-expected.txt: Added.
* LayoutTests/fast/css/stylepropertymap-append-not-checking-for-variablereferencevalue.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative.html:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::append):

Canonical link: <a href="https://commits.webkit.org/292377@main">https://commits.webkit.org/292377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75aef3f52dc11ae78bc1281cdaaf49a0c99646b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72962 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30219 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53296 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22728 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16588 "Found 1 new test failure: imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81358 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3402 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/16069 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27849 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22355 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->