### PR TITLE
Pass along authorization token for touch events

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7492,6 +7492,8 @@ imported/w3c/web-platform-tests/css/css-color/deprecated-sameas-002.html [ Image
 http/tests/site-isolation/touch-events [ Skip ]
 http/tests/site-isolation/iframe-dark-mode-print.html [ ImageOnlyFailure ]
 
+fast/events/ios/single-tap-verify-user-gesture.html [ Skip ]
+
 # CSS syntax
 imported/w3c/web-platform-tests/css/css-scoping/scoped-reference-animation-002.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/fast/events/ios/single-tap-verify-user-gesture-expected.txt
+++ b/LayoutTests/fast/events/ios/single-tap-verify-user-gesture-expected.txt
@@ -1,0 +1,2 @@
+PASS
+PASS

--- a/LayoutTests/fast/events/ios/single-tap-verify-user-gesture.html
+++ b/LayoutTests/fast/events/ios/single-tap-verify-user-gesture.html
@@ -1,0 +1,63 @@
+<!-- webkit-test-runner [ JavaScriptCanOpenWindowsAutomatically=true VerifyWindowOpenUserGestureFromUIProcess=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>This tests that we can verify a touch event from the UI process</title>
+<script src="../../../resources/basic-gestures.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+
+body {
+    margin: 0;
+}
+
+#target #target-fake {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    display: contents;
+}
+</style>
+</head>
+<body>
+<div id="target">FAIL</div>
+<div id="target-fake">FAIL</div>
+<script>
+testRunner.waitUntilDone();
+testRunner.dumpAsText();
+
+
+(async function() {
+    const targetForFakeClick = document.getElementById("target-fake");
+    window.addEventListener("touchstart", (event) => {
+        win = window.open("about:blank");
+        if (!win)
+            target.innerText = "PASS";
+    });
+
+    window.addEventListener("touchmove", (event) => {
+        win = window.open("about:blank");
+        if (win)
+            target.innerText = "FAIL";
+    });
+
+    window.addEventListener("touchend", (event) => {
+        win = window.open("about:blank");
+        if (!win)
+            target.innerText = "FAIL";
+        targetForFakeClick.click();
+    });
+
+    targetForFakeClick.addEventListener("click", (event) => {
+        win = window.open("about:blank");
+        if (!win)
+            targetForFakeClick.innerText = "PASS";
+        testRunner.notifyDone();
+    })
+
+    await UIHelper.tapAt(5, 5);
+})();
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -5068,8 +5068,7 @@ HandleUserInputEventResult EventHandler::handleTouchEvent(const PlatformTouchEve
     std::array<Touches, PlatformTouchPoint::TouchStateEnd> changedTouches;
 
     const Vector<PlatformTouchPoint>& points = event.touchPoints();
-
-    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(event));
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(event), UserGestureIndicator::ProcessInteractionStyle::Immediate, event.authorizationToken());
 
     bool freshTouchEvents = true;
     bool allTouchReleased = true;

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -377,6 +377,7 @@ public:
         m_isPotentialTap = webEvent.isPotentialTap();
         m_position = webEvent.position();
         m_globalPosition = webEvent.position();
+        m_authorizationToken = webEvent.authorizationToken();
 #else
         // PlatformTouchEvent
         for (size_t i = 0; i < webEvent.touchPoints().size(); ++i)

--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -67,6 +67,7 @@ public:
     WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy() const { return m_navigationActionData.shouldOpenExternalURLsPolicy; }
 
     bool isProcessingUserGesture() const { return m_userInitiatedAction; }
+    bool isProcessingUnconsumedUserGesture() const { return m_userInitiatedAction && !m_userInitiatedAction->consumed(); }
     UserInitiatedAction* userInitiatedAction() const { return m_userInitiatedAction.get(); }
 
     Navigation* mainFrameNavigation() const { return m_mainFrameNavigation.get(); }

--- a/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp
@@ -59,3 +59,8 @@ WKFrameNavigationType WKNavigationActionGetNavigationType(WKNavigationActionRef 
 {
     return WebKit::toAPI(WebKit::toImpl(action)->navigationType());
 }
+
+WK_EXPORT bool WKNavigationActionHasUnconsumedUserGesture(WKNavigationActionRef action)
+{
+    return WebKit::toImpl(action)->isProcessingUnconsumedUserGesture();
+}

--- a/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.h
@@ -40,6 +40,7 @@ WK_EXPORT WKURLRequestRef WKNavigationActionCopyRequest(WKNavigationActionRef ac
 WK_EXPORT bool WKNavigationActionGetShouldOpenExternalSchemes(WKNavigationActionRef action);
 WK_EXPORT WKFrameInfoRef WKNavigationActionCopyTargetFrameInfo(WKNavigationActionRef action);
 WK_EXPORT WKFrameNavigationType WKNavigationActionGetNavigationType(WKNavigationActionRef action);
+WK_EXPORT bool WKNavigationActionHasUnconsumedUserGesture(WKNavigationActionRef action);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -678,6 +678,11 @@ bool WKPreferencesGetMainContentUserGestureOverrideEnabled(WKPreferencesRef pref
     return toImpl(preferencesRef)->mainContentUserGestureOverrideEnabled();
 }
 
+bool WKPreferencesGetVerifyUserGestureInUIProcessEnabled(WKPreferencesRef preferencesRef)
+{
+    return toImpl(preferencesRef)->verifyWindowOpenUserGestureFromUIProcess();
+}
+
 void WKPreferencesSetManagedMediaSourceLowThreshold(WKPreferencesRef preferencesRef, double threshold)
 {
     toImpl(preferencesRef)->setManagedMediaSourceLowThreshold(threshold);

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -173,6 +173,8 @@ WK_EXPORT bool WKPreferencesGetAudioPlaybackRequiresUserGesture(WKPreferencesRef
 WK_EXPORT void WKPreferencesSetMainContentUserGestureOverrideEnabled(WKPreferencesRef preferencesRef, bool flag);
 WK_EXPORT bool WKPreferencesGetMainContentUserGestureOverrideEnabled(WKPreferencesRef preferencesRef);
 
+WK_EXPORT bool WKPreferencesGetVerifyUserGestureInUIProcessEnabled(WKPreferencesRef preferencesRef);
+
 // Defaults to 10.0.
 WK_EXPORT void WKPreferencesSetManagedMediaSourceLowThreshold(WKPreferencesRef preferencesRef, double threshold);
 WK_EXPORT double WKPreferencesGetManagedMediaSourceLowThreshold(WKPreferencesRef preferencesRef);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4333,6 +4333,9 @@ void WebPageProxy::handleGestureEvent(const NativeWebGestureEvent& event)
 #if ENABLE(IOS_TOUCH_EVENTS)
 void WebPageProxy::sendPreventableTouchEvent(WebCore::FrameIdentifier frameID, const NativeWebTouchEvent& event)
 {
+    if (event.type() == WebEventType::TouchEnd && protectedPreferences()->verifyWindowOpenUserGestureFromUIProcess())
+        protectedLegacyMainFrameProcess()->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
+
     if (event.isActivationTriggeringEvent())
         internals().lastActivationTimestamp = MonotonicTime::now();
 
@@ -4464,6 +4467,9 @@ void WebPageProxy::didBeginTouchPoint(FloatPoint locationInRootView)
 
 void WebPageProxy::sendUnpreventableTouchEvent(WebCore::FrameIdentifier frameID, const NativeWebTouchEvent& event)
 {
+    if (event.type() == WebEventType::TouchEnd && protectedPreferences()->verifyWindowOpenUserGestureFromUIProcess())
+        protectedLegacyMainFrameProcess()->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
+
     if (event.isActivationTriggeringEvent())
         internals().lastActivationTimestamp = MonotonicTime::now();
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -442,6 +442,9 @@ WKPageRef TestController::createOtherPage(PlatformWebView* parentView, WKPageCon
     auto* platformWebView = createOtherPlatformWebView(parentView, configuration, navigationAction, windowFeatures);
     if (!platformWebView)
         return nullptr;
+    auto preferences = WKPageConfigurationGetPreferences(configuration);
+    if (WKPreferencesGetVerifyUserGestureInUIProcessEnabled(preferences) && !WKNavigationActionHasUnconsumedUserGesture(navigationAction))
+        return nullptr;
 
     auto* page = platformWebView->page();
     WKRetain(page);
@@ -1202,6 +1205,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         if (enableAllExperimentalFeatures) {
             WKPreferencesEnableAllExperimentalFeatures(preferences);
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("SiteIsolationEnabled").get());
+            WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("VerifyWindowOpenUserGestureFromUIProcess").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, true, toWK("WebGPUEnabled").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("HTTPSByDefaultEnabled").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("WebRTCL4SEnabled").get()); // FIXME: Remove this once L4S SDP negotation is supported.

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -141,6 +141,7 @@ const TestFeatures& TestOptions::defaults()
             { "ScrollToTextFragmentIndicatorEnabled", false },
             { "ShowModalDialogEnabled", false },
             { "SpeakerSelectionRequiresUserGesture", false },
+            { "VerifyWindowOpenUserGestureFromUIProcess", false },
             { "TabsToLinks", false },
             { "TextAutosizingEnabled", false },
             { "TextAutosizingUsesIdempotentMode", false },


### PR DESCRIPTION
#### 312e1f95f86f42d48b464e54109375a036572cde
<pre>
Pass along authorization token for touch events
<a href="https://bugs.webkit.org/show_bug.cgi?id=286775">https://bugs.webkit.org/show_bug.cgi?id=286775</a>
<a href="https://rdar.apple.com/problem/143917525">rdar://problem/143917525</a>

Reviewed by Charlie Wolfe.

We pass along authorization tokens for mouse and keyboard events for later verifying in the UI process, we should do the same for touch events.

I have added a layout test to exercise this behavior. This also requires an internal change that is related in the radar.

* LayoutTests/fast/events/ios/single-tap-verify-user-gesture-expected.txt: Added.
* LayoutTests/fast/events/ios/single-tap-verify-user-gesture.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleTouchEvent):
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchEvent::WebKit2PlatformTouchEvent):
* Source/WebKit/UIProcess/API/APINavigationAction.h:
* Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp:
(WKNavigationActionHasUnconsumedUserGesture):
* Source/WebKit/UIProcess/API/C/WKNavigationActionRef.h:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesGetVerifyUserGestureInUIProcessEnabled):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::sendUnpreventableTouchEvent):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createOtherPage):
(WTR::TestController::createOtherPlatformWebView):

Canonical link: <a href="https://commits.webkit.org/289612@main">https://commits.webkit.org/289612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04f2c731c0605dca663a0907d115b7ac0559228e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87548 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92411 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15231 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90550 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79229 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/47973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33622 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37405 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94298 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14716 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75078 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18604 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/20058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18483 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14732 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->