### PR TITLE
Disable RespondToThermalPressureAggressively by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6254,13 +6254,10 @@ RespondToThermalPressureAggressively:
   humanReadableDescription: "Enable responding to thermal pressure aggressively"
   defaultValue:
     WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": true
       default: false
     WebKit:
-      "PLATFORM(IOS_FAMILY)": true
       default: false
     WebCore:
-      "PLATFORM(IOS_FAMILY)": true
       default: false
 
 RubberBandingForSubScrollableRegionsEnabled:


### PR DESCRIPTION
#### a8c0b8ffdaf70de2ab49cc33db5955e7cc1766bb
<pre>
Disable RespondToThermalPressureAggressively by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=286776">https://bugs.webkit.org/show_bug.cgi?id=286776</a>
<a href="https://rdar.apple.com/143918242">rdar://143918242</a>

Reviewed by Sihui Liu.

In 287858@main I added the RespondToThermalPressureAggressively preference and enabled it by
default. However, this doesn&apos;t work as expected for a couple of reasons:

1. `HAVE_APPLE_THERMAL_MITIGATION_SUPPORT` is only enabled for visionOS. So even non-aggressive
thermal mitigation was doing nothing on iOS. After defining this and enabling this on iOS, we
realized aggressive mitigation causes a MotionMark regression, so it can&apos;t be enabled as-is.

2. On visionOS, the system is in charge of throttling the global framerate for all processes when it
detects thermal pressure. So if we were to then also throttle the frame rate in response to thermal
pressure in WebKit specifically as we do in 287858@main, that could lead to something like 1/4 the
normal frame rate on webpages. That&apos;s not what we want.

For now, let&apos;s disable this preference while we refine the policy.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/289621@main">https://commits.webkit.org/289621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5e154099636d2bc97db39c6b95a93d6b4a4b35c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38166 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67538 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25276 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33507 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37282 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80222 "Found 251 new JSC stress test failures: basic-tests.yaml/stress-test.js.lockdown, microbenchmarks/arguments-named-and-reflective.js.lockdown, microbenchmarks/arguments-strict-mode.js.lockdown, microbenchmarks/arguments.js.lockdown, microbenchmarks/array-map.js.lockdown, microbenchmarks/array-prototype-sort-medium-array-comparator.js.lockdown, microbenchmarks/array-prototype-sort-medium-array.js.lockdown, microbenchmarks/array-prototype-toReversed-double.js.lockdown, microbenchmarks/array-prototype-toReversed-int32.js.lockdown, microbenchmarks/array-prototype-toReversed-object.js.lockdown ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94174 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86201 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76357 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75572 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7530 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19905 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108693 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14353 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26146 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16136 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->