### PR TITLE
Link `parsePageSelector` to use in `CSSPageRule::setSelectorText` to handle selectors

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-003-expected.txt
@@ -1,6 +1,6 @@
 
 PASS contents for selector ['auto']
 PASS contents for selector ['_abcd']
-FAIL expected empty selector when assigning blank string assert_equals: unexpected selector when assigning blank string expected "" but got "auto"
+PASS expected empty selector when assigning blank string
 FAIL CSS Paged Media: parsing @page selectors assert_equals: missing @page selectors expected 0 but got 7
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-004-expected.txt
@@ -4,7 +4,7 @@ PASS adding a blank @page rule
 PASS assigning invalid selector text ['1']
 PASS assigning invalid selector text ['-3']
 FAIL assigning invalid selector text ['--a'] assert_equals: should not be able to assign an invalid selector expected "" but got "--a"
-FAIL assigning invalid selector text ['7cm'] assert_equals: should not be able to assign an invalid selector expected "" but got "--a"
-FAIL assigning invalid selector text ['0.17'] assert_equals: should not be able to assign an invalid selector expected "" but got "--a"
-FAIL assigning invalid selector text ['a, 123'] assert_equals: should not be able to assign an invalid selector expected "" but got "--a"
+PASS assigning invalid selector text ['7cm']
+PASS assigning invalid selector text ['0.17']
+PASS assigning invalid selector text ['a, 123']
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule-expected.txt
@@ -2,23 +2,23 @@
 PASS Sanity checks
 PASS Page selector is initially the empty string
 PASS Page selector 'cssText' is initially the @page { }
-FAIL Set selectorText to :left pseudo page assert_equals: expected ":left" but got ""
-FAIL Set cssText to :left pseudo page assert_equals: expected "@page :left { }" but got "@page { }"
+PASS Set selectorText to :left pseudo page
+PASS Set cssText to :left pseudo page
 PASS Set selectorText to named page
 PASS Set cssText to named page
-FAIL Set selectorText to named page with :first pseudo page assert_equals: expected "named:first" but got "named"
-FAIL Set cssText to named page with :first pseudo page assert_equals: expected "@page named:first { }" but got "@page named { }"
-FAIL Set selectorText to named page with case insensitive :first pseudo page assert_equals: expected "named:first" but got "named"
-FAIL Set cssText to named page with case insensitive :first pseudo page assert_equals: expected "@page named:first { }" but got "@page named { }"
-FAIL Set selectorText to named page with two :first pseudo page assert_equals: expected "named:first:first" but got "named"
-FAIL Set cssText to named page with two :first pseudo page assert_equals: expected "@page named:first:first { }" but got "@page named { }"
-FAIL Set selectorText to named page with pseudo pages of :first, :left, :right, :first in order. assert_equals: expected "named:first:left:right:first" but got "named"
-FAIL Set cssText to named page with pseudo pages of :first, :left, :right, :first in order. assert_equals: expected "@page named:first:left:right:first { }" but got "@page named { }"
-FAIL Cannot set selectorText to named page with pseudo, whitespace between assert_equals: expected "" but got "named"
-FAIL Cannot set cssText to named page with pseudo, whitespace between - return default @page { } assert_equals: expected "@page { }" but got "@page named { }"
-FAIL Cannot set selectorText to two pseudos, whitespace between assert_equals: expected "" but got "named"
-FAIL Cannot set cssText to two pseudos, whitespace between - return default @page { } assert_equals: expected "@page { }" but got "@page named { }"
-FAIL Cannot set selectorText to invalid pseudo page assert_equals: expected "" but got "named"
-FAIL Cannot set cssText to invalid pseudo page - return default @page { } assert_equals: expected "@page { }" but got "@page named { }"
+PASS Set selectorText to named page with :first pseudo page
+PASS Set cssText to named page with :first pseudo page
+PASS Set selectorText to named page with case insensitive :first pseudo page
+PASS Set cssText to named page with case insensitive :first pseudo page
+FAIL Set selectorText to named page with two :first pseudo page assert_equals: expected "named:first:first" but got ""
+FAIL Set cssText to named page with two :first pseudo page assert_equals: expected "@page named:first:first { }" but got "@page { }"
+FAIL Set selectorText to named page with pseudo pages of :first, :left, :right, :first in order. assert_equals: expected "named:first:left:right:first" but got ""
+FAIL Set cssText to named page with pseudo pages of :first, :left, :right, :first in order. assert_equals: expected "@page named:first:left:right:first { }" but got "@page { }"
+PASS Cannot set selectorText to named page with pseudo, whitespace between
+PASS Cannot set cssText to named page with pseudo, whitespace between - return default @page { }
+PASS Cannot set selectorText to two pseudos, whitespace between
+PASS Cannot set cssText to two pseudos, whitespace between - return default @page { }
+PASS Cannot set selectorText to invalid pseudo page
+PASS Cannot set cssText to invalid pseudo page - return default @page { }
 PASS Set selectorText to named page after rule was removed
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -229,7 +229,6 @@ css/CSSImageSetValue.cpp
 css/CSSImageValue.cpp
 css/CSSKeyframeRule.cpp
 css/CSSLayerBlockRule.cpp
-css/CSSPageRule.cpp
 css/CSSPrimitiveValue.cpp
 css/CSSPrimitiveValueMappings.h
 css/CSSRule.cpp

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -65,8 +65,7 @@ String CSSPageRule::selectorText() const
 void CSSPageRule::setSelectorText(const String& selectorText)
 {
     CSSParser parser(parserContext());
-    auto* sheet = parentStyleSheet();
-    auto selectorList = parser.parseSelectorList(selectorText, sheet ? &sheet->contents() : nullptr);
+    auto selectorList = parser.parsePageSelector(selectorText);
     if (!selectorList)
         return;
 

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -149,6 +149,11 @@ std::optional<CSSSelectorList> CSSParser::parseSelectorList(const String& string
     return parseCSSSelectorList(CSSTokenizer(string).tokenRange(), m_context, styleSheet, nestedContext);
 }
 
+std::optional<CSSSelectorList> CSSParser::parsePageSelector(const String& string)
+{
+    return CSSParserImpl::parsePageSelector(CSSTokenizer(string).tokenRange());
+}
+
 Ref<ImmutableStyleProperties> CSSParser::parseInlineStyleDeclaration(const String& string, const Element& element)
 {
     return CSSParserImpl::parseInlineStyleDeclaration(string, element);

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -77,6 +77,8 @@ public:
 
     WEBCORE_EXPORT std::optional<CSSSelectorList> parseSelectorList(const String&, StyleSheetContents* = nullptr, CSSParserEnum::NestedContext = { });
 
+    WEBCORE_EXPORT std::optional<CSSSelectorList> parsePageSelector(const String&);
+
     // FIXME: All callers are not getting the right Settings, keyword resolution and calc resolution when using this
     // function and should switch to the parseColorRaw() function in CSSPropertyParserConsumer+Color.h.
     WEBCORE_EXPORT static Color parseColorWithoutContext(const String&, bool strict = false);

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -240,7 +240,7 @@ void CSSParserImpl::parseStyleSheet(const String& string, const CSSParserContext
     styleSheet.shrinkToFit();
 }
 
-CSSSelectorList CSSParserImpl::parsePageSelector(CSSParserTokenRange range, StyleSheetContents* styleSheet)
+CSSSelectorList CSSParserImpl::parsePageSelector(CSSParserTokenRange range)
 {
     // We only support a small subset of the css-page spec.
     range.consumeWhitespace();
@@ -262,7 +262,7 @@ CSSSelectorList CSSParserImpl::parsePageSelector(CSSParserTokenRange range, Styl
 
     std::unique_ptr<MutableCSSSelector> selector;
     if (!typeSelector.isNull() && pseudo.isNull())
-        selector = makeUnique<MutableCSSSelector>(QualifiedName(nullAtom(), typeSelector, styleSheet->defaultNamespace()));
+        selector = makeUnique<MutableCSSSelector>(QualifiedName(nullAtom(), typeSelector, starAtom()));
     else {
         selector = makeUnique<MutableCSSSelector>();
         if (!pseudo.isNull()) {
@@ -271,7 +271,7 @@ CSSSelectorList CSSParserImpl::parsePageSelector(CSSParserTokenRange range, Styl
                 return { };
         }
         if (!typeSelector.isNull())
-            selector->prependTagSelector(QualifiedName(nullAtom(), typeSelector, styleSheet->defaultNamespace()));
+            selector->prependTagSelector(QualifiedName(nullAtom(), typeSelector, starAtom()));
     }
 
     selector->setForPage();
@@ -985,7 +985,7 @@ RefPtr<StyleRuleKeyframes> CSSParserImpl::consumeKeyframesRule(CSSParserTokenRan
 
 RefPtr<StyleRulePage> CSSParserImpl::consumePageRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    auto selectorList = parsePageSelector(prelude, protectedStyleSheet().get());
+    auto selectorList = parsePageSelector(prelude);
     if (selectorList.isEmpty())
         return nullptr; // Parse error, invalid @page selector
 

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -99,7 +99,7 @@ public:
     static bool parseDeclarationList(MutableStyleProperties*, const String&, const CSSParserContext&);
     static RefPtr<StyleRuleBase> parseRule(const String&, const CSSParserContext&, StyleSheetContents*, AllowedRules, CSSParserEnum::NestedContext = { });
     static void parseStyleSheet(const String&, const CSSParserContext&, StyleSheetContents&);
-    static CSSSelectorList parsePageSelector(CSSParserTokenRange, StyleSheetContents*);
+    static CSSSelectorList parsePageSelector(CSSParserTokenRange);
 
     static Vector<double> parseKeyframeKeyList(const String&);
 


### PR DESCRIPTION
#### 63a794bac63a9945b3a1007d8938fc9406f37e68
<pre>
Link `parsePageSelector` to use in `CSSPageRule::setSelectorText` to handle selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=286780">https://bugs.webkit.org/show_bug.cgi?id=286780</a>
<a href="https://rdar.apple.com/143920702">rdar://143920702</a>

Reviewed by NOBODY (OOPS!).

This pages leverages `parsePageSelector` to be used in CSSPageRule::setSelectorText,
to enable it to correctly handle valid and invalid selectors.

* Source/WebCore/css/CSSPageRule.cpp:
(WebCore::CSSPageRule::setSelectorText):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parsePageSelector):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parsePageSelector):
(WebCore::CSSParserImpl::consumePageRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssom-pagerule-expected.txt:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a794bac63a9945b3a1007d8938fc9406f37e68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67602 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25341 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33591 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37369 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76426 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7630 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19992 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->