### PR TITLE
[scroll-animations] Have named timeline code use Styleable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline-expected.txt
@@ -1,0 +1,3 @@
+
+PASS named timeline on pseudo-element attaches to parent scroll container
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/pseudo-on-scroller-named-timeline.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Animating pseduo-element on scroller using named timeline</title>
+</head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="./support/testcommon.js"></script>
+<script src="testcommon.js"></script>
+<style type="text/css">
+.scroller {
+  overflow: scroll;
+  width: 100px;
+  height: 100px;
+  margin: 1em;
+  outline: 1px solid;
+  scroll-timeline: --t1 y;
+}
+.pseudo::before {
+  content: "";
+  display: block;
+  width: 50px;
+  height: 50px;
+  background: red;
+  animation: bg linear;
+  animation-timeline: --t1;
+}
+
+.content {
+    width: 200px;
+  height: 200px;
+    background-color: yellow;
+}
+@keyframes bg {
+  from {
+    background: rgb(0, 255, 0);
+  }
+  to {
+    background: rgb(0, 0, 255);
+  }
+}
+</style>
+<body>
+  <div class="scroller pseudo">
+    <div class="content">
+    </div>
+
+  </div>
+  <div id="log"></div>
+</body>
+<script type="text/javascript">
+  'use strict';
+
+  promise_test(async t => {
+    await waitForCSSScrollTimelineStyle();
+    const scroller = document.querySelector('.scroller');
+    assert_equals(getComputedStyle(scroller, ':before').backgroundColor,
+                  'rgb(0, 255, 0)');
+  }, `named timeline on pseudo-element attaches to parent scroll container`);
+</script>
+</html>

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -28,6 +28,7 @@
 #include "FrameRateAligner.h"
 #include "ReducedResolutionSeconds.h"
 #include "ScrollAxis.h"
+#include "Styleable.h"
 #include "TimelineScope.h"
 #include "Timer.h"
 #include <wtf/CancellableTask.h>
@@ -54,7 +55,7 @@ class AcceleratedEffectStackUpdater;
 
 struct ViewTimelineInsets;
 struct TimelineMapAttachOperation {
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> element;
+    WeakStyleable element;
     AtomString name;
     Ref<WebAnimation> animation;
 };
@@ -80,13 +81,13 @@ public:
     WEBCORE_EXPORT void resumeAnimations();
     bool animationsAreSuspended() const { return m_isSuspended; }
 
-    void registerNamedScrollTimeline(const AtomString&, Element&, ScrollAxis);
-    void registerNamedViewTimeline(const AtomString&, Element&, ScrollAxis, ViewTimelineInsets&&);
-    void unregisterNamedTimeline(const AtomString&, const Element&);
-    void setTimelineForName(const AtomString&, const Element&, WebAnimation&);
-    void updateNamedTimelineMapForTimelineScope(const TimelineScope&, const Element&);
+    void registerNamedScrollTimeline(const AtomString&, const Styleable&, ScrollAxis);
+    void registerNamedViewTimeline(const AtomString&, const Styleable&, ScrollAxis, ViewTimelineInsets&&);
+    void unregisterNamedTimeline(const AtomString&, const Styleable&);
+    void setTimelineForName(const AtomString&, const Styleable&, WebAnimation&);
+    void updateNamedTimelineMapForTimelineScope(const TimelineScope&, const Styleable&);
     void updateTimelineForTimelineScope(const Ref<ScrollTimeline>&, const AtomString&);
-    void unregisterNamedTimelinesAssociatedWithElement(const Element&);
+    void unregisterNamedTimelinesAssociatedWithElement(const Styleable&);
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
@@ -100,7 +101,7 @@ private:
     void maybeClearCachedCurrentTime();
 
     Vector<Ref<ScrollTimeline>>& timelinesForName(const AtomString&);
-    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> relatedTimelineScopeElements(const AtomString&);
+    Vector<WeakStyleable> relatedTimelineScopeElements(const AtomString&);
     void attachPendingOperations();
     bool isPendingTimelineAttachment(const WebAnimation&) const;
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
@@ -108,7 +109,7 @@ private:
     Ref<Document> protectedDocument() const { return m_document.get(); }
 
     Vector<TimelineMapAttachOperation> m_pendingAttachOperations;
-    Vector<std::pair<TimelineScope, WeakPtr<Element, WeakPtrImplWithEventTargetData>>> m_timelineScopeEntries;
+    Vector<std::pair<TimelineScope, WeakStyleable>> m_timelineScopeEntries;
     UncheckedKeyHashMap<AtomString, Vector<Ref<ScrollTimeline>>> m_nameToTimelineMap;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -157,7 +157,7 @@ void CSSAnimation::syncStyleOriginatedTimeline()
             setTimeline(keyword == Animation::TimelineKeyword::None ? nullptr : RefPtr { document->existingTimeline() });
         }, [&] (const AtomString& name) {
             CheckedRef timelinesController = document->ensureTimelinesController();
-            timelinesController->setTimelineForName(name, target, *this);
+            timelinesController->setTimelineForName(name, *owningElement(), *this);
         }, [&] (const Animation::AnonymousScrollTimeline& anonymousScrollTimeline) {
             auto scrollTimeline = ScrollTimeline::create(anonymousScrollTimeline.scroller, anonymousScrollTimeline.axis);
             scrollTimeline->setSource(*owningElement());

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -52,6 +52,7 @@ public:
     static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
     static Ref<ScrollTimeline> create(Scroller, ScrollAxis);
 
+    const WeakStyleable& sourceStyleable() const { return m_source; }
     virtual Element* source() const;
     void setSource(Element*);
     void setSource(const Styleable&);

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -49,6 +49,7 @@ public:
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
 
     const Element* subject() const;
+    const WeakStyleable subjectStyleable() const { return m_subject; }
     void setSubject(Element*);
     void setSubject(const Styleable&);
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -681,7 +681,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
 
         if ((oldStyle && oldStyle->timelineScope().type != TimelineScope::Type::None) || resolvedStyle.style->timelineScope().type != TimelineScope::Type::None) {
             CheckedRef timelinesController = element.protectedDocument()->ensureTimelinesController();
-            timelinesController->updateNamedTimelineMapForTimelineScope(resolvedStyle.style->timelineScope(), element);
+            timelinesController->updateNamedTimelineMapForTimelineScope(resolvedStyle.style->timelineScope(), styleable);
         }
 
         // The order in which CSS Transitions and CSS Animations are updated matters since CSS Transitions define the after-change style

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -303,7 +303,7 @@ void Styleable::cancelStyleOriginatedAnimations() const
 {
     cancelStyleOriginatedAnimations({ });
     if (CheckedPtr timelinesController = element.protectedDocument()->timelinesController())
-        timelinesController->unregisterNamedTimelinesAssociatedWithElement(element);
+        timelinesController->unregisterNamedTimelinesAssociatedWithElement(*this);
 }
 
 void Styleable::cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimations& animationsToCancelSilently) const
@@ -880,7 +880,7 @@ void Styleable::updateCSSScrollTimelines(const RenderStyle* currentStyle, const 
         for (size_t i = 0; i < currentTimelineNames.size(); ++i) {
             auto& name = currentTimelineNames[i];
             auto axis = numberOfAxes ? currentTimelineAxes[i % numberOfAxes] : ScrollAxis::Block;
-            timelinesController->registerNamedScrollTimeline(name, element, axis);
+            timelinesController->registerNamedScrollTimeline(name, *this, axis);
         }
 
         if (!currentStyle)
@@ -888,7 +888,7 @@ void Styleable::updateCSSScrollTimelines(const RenderStyle* currentStyle, const 
 
         for (auto& previousTimelineName : currentStyle->scrollTimelineNames()) {
             if (!currentTimelineNames.contains(previousTimelineName))
-                timelinesController->unregisterNamedTimeline(previousTimelineName, element);
+                timelinesController->unregisterNamedTimeline(previousTimelineName, *this);
         }
     };
 
@@ -930,7 +930,7 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
             auto& name = currentTimelineNames[i];
             auto axis = numberOfAxes ? currentTimelineAxes[i % numberOfAxes] : ScrollAxis::Block;
             auto insets = numberOfInsets ? ViewTimelineInsets(currentTimelineInsets[i % numberOfInsets]) : ViewTimelineInsets();
-            timelinesController->registerNamedViewTimeline(name, element, axis, WTFMove(insets));
+            timelinesController->registerNamedViewTimeline(name, *this, axis, WTFMove(insets));
         }
 
         if (!currentStyle)
@@ -938,7 +938,7 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
 
         for (auto& previousTimelineName : currentStyle->viewTimelineNames()) {
             if (!currentTimelineNames.contains(previousTimelineName))
-                timelinesController->unregisterNamedTimeline(previousTimelineName, element);
+                timelinesController->unregisterNamedTimeline(previousTimelineName, *this);
         }
     };
 
@@ -974,6 +974,18 @@ void Styleable::setCapturedInViewTransition(AtomString captureName)
         if (changed)
             element.invalidateStyleAndLayerComposition();
     }
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const Styleable& styleable)
+{
+    ts << styleable.element << ", " << styleable.pseudoElementIdentifier;
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const WeakStyleable& styleable)
+{
+    ts << styleable.element() << ", " << styleable.pseudoElementIdentifier();
+    return ts;
 }
 
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -229,4 +229,7 @@ private:
     std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
 };
 
+WTF::TextStream& operator<<(WTF::TextStream&, const Styleable&);
+WTF::TextStream& operator<<(WTF::TextStream&, const WeakStyleable&);
+
 } // namespace WebCore


### PR DESCRIPTION
#### f9880cf8ee2c4ddb9e6a5e7f91ff67a1ab34de31
<pre>
[scroll-animations] Have named timeline code use Styleable
<a href="https://bugs.webkit.org/show_bug.cgi?id=286781">https://bugs.webkit.org/show_bug.cgi?id=286781</a>
<a href="https://rdar.apple.com/143926206">rdar://143926206</a>

Reviewed by Antoine Quint.

Have named timeline code use Styleable.

* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::originatingElement):
(WebCore::originatingStyleableIncludingTimelineScope):
(WebCore::originatingElementExcludingTimelineScope):
(WebCore::AnimationTimelinesController::relatedTimelineScopeElements):
(WebCore::containsRenderer):
(WebCore::determineTreeOrder):
(WebCore::determineTimelineForElement):
(WebCore::AnimationTimelinesController::updateTimelineForTimelineScope):
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::attachPendingOperations):
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
(WebCore::AnimationTimelinesController::unregisterNamedTimeline):
(WebCore::AnimationTimelinesController::setTimelineForName):
(WebCore::updateTimelinesForTimelineScope):
(WebCore::AnimationTimelinesController::updateNamedTimelineMapForTimelineScope):
(WebCore::AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement):
(WebCore::originatingElementIncludingTimelineScope): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::setTimelineScopeStyleable):
(WebCore::ScrollTimeline::setTimelineScopeElement): Deleted.
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::sourceStyleable const):
(WebCore::ScrollTimeline::timelineScopeDeclaredStyleable const):
(WebCore::ScrollTimeline::clearTimelineScopeDeclaredStyleable):
(WebCore::ScrollTimeline::timelineScopeDeclaredElement const): Deleted.
(WebCore::ScrollTimeline::clearTimelineScopeDeclaredElement): Deleted.
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::cancelStyleOriginatedAnimations const):
(WebCore::Styleable::updateCSSScrollTimelines const):
(WebCore::Styleable::updateCSSViewTimelines const):

Canonical link: <a href="https://commits.webkit.org/289913@main">https://commits.webkit.org/289913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc419ee13bc8a3bd83b57638222f42706b348b20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68149 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25869 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6086 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34322 "Found 4 new test failures: accessibility/negative-tabindex-does-not-expose-label.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95155 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76265 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8567 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13815 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15546 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->