### PR TITLE
Fix UI process user gesture validation with mousedown

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1897,7 +1897,7 @@ HandleUserInputEventResult EventHandler::handleMousePressEvent(const PlatformMou
         return true;
 #endif
 
-    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent));
+    UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, frame->protectedDocument().get(), userGestureTypeForPlatformEvent(platformMouseEvent), UserGestureIndicator::ProcessInteractionStyle::Immediate, platformMouseEvent.authorizationToken());
 
     // FIXME (bug 68185): this call should be made at another abstraction layer
     frame->protectedLoader()->resetMultipleFormSubmissionProtection();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
@@ -33,17 +33,18 @@
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/_WKUserInitiatedAction.h>
+#import <wtf/text/MakeString.h>
 
 namespace TestWebKitAPI {
 
 #if PLATFORM(MAC)
-TEST(VerifyUserGesture, WindowOpenMouseEvent)
+static void testWindowOpenMouseEvent(const String& event)
 {
-    auto openerHTML = "<script>"
-    "addEventListener('mouseup', () => {"
+    auto openerHTML = makeString("<script>"
+    "addEventListener('"_s, event, "', () => {"
     "    window.open('https://domain2.com/opened');"
     "})"
-    "</script>"_s;
+    "</script>"_s);
     HTTPServer server({
         { "/opener"_s, { openerHTML } },
         { "/opened"_s, { ""_s } }
@@ -79,6 +80,16 @@ TEST(VerifyUserGesture, WindowOpenMouseEvent)
     while (!openedWebView)
         Util::spinRunLoop();
     EXPECT_FALSE(consumed);
+}
+
+TEST(VerifyUserGesture, WindowOpenMouseDown)
+{
+    testWindowOpenMouseEvent("mousedown"_s);
+}
+
+TEST(VerifyUserGesture, WindowOpenMouseUp)
+{
+    testWindowOpenMouseEvent("mouseup"_s);
 }
 
 TEST(VerifyUserGesture, WindowOpenKeyEvent)


### PR DESCRIPTION
#### 689621bd55798ee35d1df1e521e079c547abbef4
<pre>
Fix UI process user gesture validation with mousedown
<a href="https://bugs.webkit.org/show_bug.cgi?id=286782">https://bugs.webkit.org/show_bug.cgi?id=286782</a>
<a href="https://rdar.apple.com/143926374">rdar://143926374</a>

Reviewed by Abrar Rahman Protyasha and Pascoe.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm:
(TestWebKitAPI::testWindowOpenMouseEvent):
(TestWebKitAPI::TEST(VerifyUserGesture, WindowOpenMouseDown)):
(TestWebKitAPI::TEST(VerifyUserGesture, WindowOpenMouseUp)):
(TestWebKitAPI::TEST(VerifyUserGesture, WindowOpenMouseEvent)): Deleted.

Canonical link: <a href="https://commits.webkit.org/289590@main">https://commits.webkit.org/289590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65e5f4a80c4f1445f0bbbb21199da78a3fa05b14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15128 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25282 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47887 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33521 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37305 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14615 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75587 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18384 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13621 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14633 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14376 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->