### PR TITLE
Non-unified source build fix of January 2025 (part 9)

### DIFF
--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.cpp
@@ -27,6 +27,7 @@
 #include "FileSystemWritableFileStream.h"
 
 #include "InternalWritableStream.h"
+#include "JSBlob.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSFileSystemWritableFileStream.h"

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "CSSRayFunction.h"
+#include "CSSValue.h"
 #include "RenderStyleConstants.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
+++ b/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
@@ -26,6 +26,7 @@
 
 #include "StylePrimitiveNumericConcepts.h"
 #include <wtf/Forward.h>
+#include <wtf/Ref.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### dd2f217014c97cbe59844a8e5075d05e36c8195c
<pre>
Non-unified source build fix of January 2025 (part 9)
<a href="https://bugs.webkit.org/show_bug.cgi?id=285486">https://bugs.webkit.org/show_bug.cgi?id=285486</a>

Unreviewed non-unified build fix.

* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.cpp:
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h:

Canonical link: <a href="https://commits.webkit.org/289710@main">https://commits.webkit.org/289710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba52b011b0ad91dbb8f1fe4d0e06b6f874b80cab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67553 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25289 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5383 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33528 "Found 1 new test failure: editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37307 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94199 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14617 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10721 "Found 1 new test failure: fast/css/viewport-height-border.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76378 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75600 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18391 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7555 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13684 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19930 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->