### PR TITLE
Authorization tokens should not be created for mouse events that do not create a user gesture

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3827,7 +3827,8 @@ static std::optional<NativeWebMouseEvent> removeOldRedundantEvent(Deque<NativeWe
 
 void WebPageProxy::sendMouseEvent(FrameIdentifier frameID, const NativeWebMouseEvent& event, std::optional<Vector<SandboxExtensionHandle>>&& sandboxExtensions)
 {
-    protectedLegacyMainFrameProcess()->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
+    if (event.type() == WebEventType::MouseDown || event.type() == WebEventType::MouseUp)
+        protectedLegacyMainFrameProcess()->recordUserGestureAuthorizationToken(webPageIDInMainFrameProcess(), event.authorizationToken());
     if (event.isActivationTriggeringEvent())
         internals().lastActivationTimestamp = MonotonicTime::now();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
@@ -38,7 +38,7 @@
 namespace TestWebKitAPI {
 
 #if PLATFORM(MAC)
-static void testWindowOpenMouseEvent(const String& event)
+static void testWindowOpenMouseEvent(const String& event, bool expectOpenedWindow)
 {
     auto openerHTML = makeString("<script>"
     "addEventListener('"_s, event, "', () => {"
@@ -59,10 +59,10 @@ static void testWindowOpenMouseEvent(const String& event)
     [openerWebView setNavigationDelegate:navigationDelegate.get()];
     [openerWebView setUIDelegate:uiDelegate.get()];
 
-    __block BOOL consumed = NO;
+    __block BOOL consumedOrNoUserInitiatedAction = NO;
     __block RetainPtr<TestWKWebView> openedWebView;
     uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *navigationAction, WKWindowFeatures *) {
-        consumed = navigationAction._userInitiatedAction.consumed;
+        consumedOrNoUserInitiatedAction = !navigationAction._userInitiatedAction || navigationAction._userInitiatedAction.consumed;
         openedWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
         return openedWebView.get();
     };
@@ -72,24 +72,39 @@ static void testWindowOpenMouseEvent(const String& event)
     [openerWebView evaluateJavaScript:@"window.open('https://domain2.com/opened');" completionHandler:nil];
     while (!openedWebView)
         Util::spinRunLoop();
-    EXPECT_TRUE(consumed);
+    EXPECT_TRUE(consumedOrNoUserInitiatedAction);
 
     openedWebView = nullptr;
-    [openerWebView mouseDownAtPoint:CGPointMake(50, 50) simulatePressure:NO];
-    [openerWebView mouseUpAtPoint:CGPointMake(50, 50)];
+    auto point = CGPointMake(50, 50);
+    if (expectOpenedWindow) {
+        [openerWebView mouseDownAtPoint:point simulatePressure:NO];
+        [openerWebView mouseUpAtPoint:point];
+    } else
+        [openerWebView mouseMoveToPoint:point withFlags:0];
+    [openerWebView waitForPendingMouseEvents];
     while (!openedWebView)
         Util::spinRunLoop();
-    EXPECT_FALSE(consumed);
+    EXPECT_EQ(consumedOrNoUserInitiatedAction, expectOpenedWindow ? NO : YES);
 }
 
 TEST(VerifyUserGesture, WindowOpenMouseDown)
 {
-    testWindowOpenMouseEvent("mousedown"_s);
+    testWindowOpenMouseEvent("mousedown"_s, true);
 }
 
 TEST(VerifyUserGesture, WindowOpenMouseUp)
 {
-    testWindowOpenMouseEvent("mouseup"_s);
+    testWindowOpenMouseEvent("mouseup"_s, true);
+}
+
+TEST(VerifyUserGesture, WindowOpenMouseMove)
+{
+    testWindowOpenMouseEvent("mousemove"_s, false);
+}
+
+TEST(VerifyUserGesture, WindowOpenMouseOver)
+{
+    testWindowOpenMouseEvent("mouseover"_s, false);
 }
 
 TEST(VerifyUserGesture, WindowOpenKeyEvent)


### PR DESCRIPTION
#### 24199a5fb09e9449ce4c038cc214b3050550f2a3
<pre>
Authorization tokens should not be created for mouse events that do not create a user gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=286789">https://bugs.webkit.org/show_bug.cgi?id=286789</a>
<a href="https://rdar.apple.com/143931977">rdar://143931977</a>

Reviewed by Pascoe.

Only mouse down and up events create a user gesture.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sendMouseEvent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm:
(TestWebKitAPI::testWindowOpenMouseEvent):
(TestWebKitAPI::TEST(VerifyUserGesture, WindowOpenMouseDown)):
(TestWebKitAPI::TEST(VerifyUserGesture, WindowOpenMouseUp)):
(TestWebKitAPI::TEST(VerifyUserGesture, WindowOpenMouseMove)):
(TestWebKitAPI::TEST(VerifyUserGesture, WindowOpenMouseOver)):

Canonical link: <a href="https://commits.webkit.org/289618@main">https://commits.webkit.org/289618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b668ad91464dfd3e6eca83f0779b07421a8b492b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67560 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25302 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33545 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94217 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14635 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10734 "Found 2 new test failures: fast/css/viewport-height-border.html imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76385 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75609 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7573 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13633 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19948 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14396 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->