### PR TITLE
REGRESSION(286770@main): ING banking app is broken after login

### DIFF
--- a/LayoutTests/fast/custom-elements/scoped-custom-element-registry-disabled-expected.txt
+++ b/LayoutTests/fast/custom-elements/scoped-custom-element-registry-disabled-expected.txt
@@ -1,0 +1,10 @@
+This tests that attachShadow does not call "registry" attribute getter when scoped custom element registry is disabled
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS registryGetterWasCalled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/custom-elements/scoped-custom-element-registry-disabled.html
+++ b/LayoutTests/fast/custom-elements/scoped-custom-element-registry-disabled.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ScopedCustomElementRegistryEnabled=true ] -->
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests that attachShadow does not call "registry" attribute getter when scoped custom element registry is disabled');
+
+let registryGetterWasCalled = false;
+document.createElement('div').attachShadow({
+    mode: 'closed',
+    get registry2() {
+        registryGetterWasCalled = true;
+    }
+});
+shouldBeFalse('registryGetterWasCalled');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -31,5 +31,5 @@ dictionary ShadowRootInit {
     boolean clonable = false;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
-    CustomElementRegistry registry = null;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry registry = null;
 };


### PR DESCRIPTION
#### d02ecbd4170e4fdd67a86173347ae8d33ad265a2
<pre>
REGRESSION(286770@main): ING banking app is broken after login
<a href="https://bugs.webkit.org/show_bug.cgi?id=286787">https://bugs.webkit.org/show_bug.cgi?id=286787</a>

Reviewed by Chris Dumez.

The bug was caused by the website erroneously detecting that scoped custom element registry is turned on
when it&apos;s not due to ShadowRootInit&apos;s registry not being hidden behind a runtime flag.

* LayoutTests/fast/custom-elements/scoped-custom-element-registry-disabled-expected.txt: Added.
* LayoutTests/fast/custom-elements/scoped-custom-element-registry-disabled.html: Added.
* Source/WebCore/dom/ShadowRootInit.idl:

Canonical link: <a href="https://commits.webkit.org/289592@main">https://commits.webkit.org/289592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09e0f81d10b624a74b46b0092b3e98ac2cd7ec29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15151 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25299 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33550 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37326 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94218 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14636 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75610 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7574 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13623 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19949 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->