### PR TITLE
Blank page on photoshop.adobe.com when tapping in url bar, then pressing enter

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -7782,6 +7782,74 @@ TEST(ProcessSwap, MainFrameURLAfterServerSideRedirectToCOOP)
     EXPECT_WK_STREQ(server.request("/destination.html"_s).URL.absoluteString, [[createdWebView _mainFrameURL] absoluteString]);
 }
 
+TEST(ProcessSwap, COOPAndCOEPOn304Response)
+{
+    using namespace TestWebKitAPI;
+    HTTPResponse response({ { { "Content-Type"_s, "text/html"_s }, { "Cross-Origin-Opener-Policy"_s, "same-origin"_s }, { "cross-origin-embedder-policy"_s, "require-corp"_s }, { "Etag"_s, "123456789"_s } }, "foo"_s });
+    response.setShouldRespondWith304ToConditionalRequests({ { "Cross-Origin-Opener-Policy"_s, "same-origin"_s }, { "cross-origin-embedder-policy"_s, "require-corp"_s } });
+    HTTPServer server({
+        { "/index.html"_s, WTFMove(response) },
+    }, HTTPServer::Protocol::Https);
+
+    auto processPoolConfiguration = psonProcessPoolConfiguration();
+    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    auto webView1Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [webView1Configuration setProcessPool:processPool.get()];
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
+            [[webView1Configuration preferences] _setEnabled:YES forFeature:feature];
+        else if ([feature.key isEqualToString:@"CrossOriginEmbedderPolicyEnabled"])
+            [[webView1Configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView1Configuration.get()]);
+    auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    [webView1 setNavigationDelegate:navigationDelegate.get()];
+
+    done = false;
+    [webView1 loadRequest:server.request("/index.html"_s)];
+    Util::run(&done);
+
+    done = false;
+    [webView1 _evaluateJavaScriptWithoutUserGesture:@"document.body.innerHTML" completionHandler:^(id result, NSError* error) {
+        NSString* resultString = result;
+        EXPECT_TRUE(!error);
+        EXPECT_WK_STREQ(resultString, @"foo");
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+
+    auto webView2Configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [webView2Configuration setProcessPool:processPool.get()];
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"CrossOriginOpenerPolicyEnabled"])
+            [[webView2Configuration preferences] _setEnabled:YES forFeature:feature];
+        else if ([feature.key isEqualToString:@"CrossOriginEmbedderPolicyEnabled"])
+            [[webView2Configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    webView2Configuration.get()._relatedWebView = webView1.get(); // webView2 will be related to webView1 and webView1's URL will be used for process swap decision.
+    ALLOW_DEPRECATED_DECLARATIONS_END
+    auto webView2 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webView2Configuration.get()]);
+    [webView2 setNavigationDelegate:navigationDelegate.get()];
+
+    done = false;
+    [webView2 loadRequest:server.request("/index.html"_s)];
+    Util::run(&done);
+
+    done = false;
+    [webView2 _evaluateJavaScriptWithoutUserGesture:@"document.body.innerHTML" completionHandler:^(id result, NSError* error) {
+        NSString* resultString = result;
+        EXPECT_TRUE(!error);
+        EXPECT_WK_STREQ(resultString, @"foo");
+        done = true;
+    }];
+    Util::run(&done);
+    done = false;
+}
+
 TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCOOP)
 {
     using namespace TestWebKitAPI;

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -111,6 +111,12 @@ struct HTTPResponse {
     HTTPResponse& operator=(const HTTPResponse&) = default;
     HTTPResponse& operator=(HTTPResponse&&) = default;
 
+    void setShouldRespondWith304ToConditionalRequests(HashMap<String, String>&& headerFields = { })
+    {
+        shouldRespondWith304ToConditionalRequests = true;
+        headerFieldsFor304 = WTFMove(headerFields);
+    }
+
     enum class IncludeContentLength : bool { No, Yes };
     Vector<uint8_t> serialize(IncludeContentLength = IncludeContentLength::Yes) const;
     static Vector<uint8_t> bodyFromString(const String&);
@@ -119,6 +125,8 @@ struct HTTPResponse {
     HashMap<String, String> headerFields;
     Vector<uint8_t> body;
     Behavior behavior { Behavior::SendResponseNormally };
+    bool shouldRespondWith304ToConditionalRequests { false };
+    HashMap<String, String> headerFieldsFor304;
 };
 
 namespace H2 {

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -33,9 +33,11 @@
 #import <wtf/CallbackAggregator.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/ThreadSafeRefCounted.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/MakeString.h>
+#import <wtf/text/ParsingUtilities.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/WTFString.h>
 
@@ -316,6 +318,8 @@ static ASCIILiteral statusText(unsigned statusCode)
         return "Found"_s;
     case 303:
         return "See Other"_s;
+    case 304:
+        return "Not Modified"_s;
     case 404:
         return "Not Found"_s;
     case 503:
@@ -325,9 +329,27 @@ static ASCIILiteral statusText(unsigned statusCode)
     return "Unknown Status Code"_s;
 }
 
-static void appendUTF8ToVector(Vector<uint8_t>& vector, const String& string)
+static Vector<uint8_t> toUTF8Vector(const String& string)
 {
-    vector.append(string.utf8().span());
+    Vector<uint8_t> result;
+    string.tryGetUTF8([&](std::span<const char8_t> utf8) {
+        result.append(byteCast<uint8_t>(utf8));
+        return true;
+    });
+    return result;
+}
+
+static Vector<uint8_t> serialize304Response(const HashMap<String, String>& headerFields)
+{
+    constexpr int statusCode = 304;
+
+    StringBuilder responseBuilder;
+    responseBuilder.append("HTTP/1.1 "_s, statusCode, ' ', statusText(statusCode), "\r\n"_s);
+    for (auto& pair : headerFields)
+        responseBuilder.append(pair.key, ": "_s, pair.value, "\r\n"_s);
+    responseBuilder.append("\r\n"_s);
+
+    return toUTF8Vector(responseBuilder.toString());
 }
 
 String HTTPServer::parsePath(const Vector<char>& request)
@@ -357,6 +379,24 @@ String HTTPServer::parseBody(const Vector<char>& request)
     return request.subspan(headerLength);
 }
 
+static bool isConditionalRequest(std::span<const char> request)
+{
+    auto endOfHeaders = find(request, "\r\n\r\n"_span);
+    if (endOfHeaders == notFound)
+        return false;
+    auto headers = request.first(endOfHeaders);
+    constexpr auto newLine = "\r\n"_span;
+    while (!headers.empty()) {
+        if (spanHasPrefixIgnoringASCIICase(headers, "If-None-Match:"_span))
+            return true;
+        size_t endOfLine = find(headers, newLine);
+        if (endOfLine == notFound)
+            return false;
+        skip(headers, endOfLine + newLine.size());
+    }
+    return false;
+}
+
 void HTTPServer::respondToRequests(Connection connection, Ref<RequestData> requestData)
 {
     connection.receiveHTTPRequest([connection, requestData] (Vector<char>&& request) mutable {
@@ -368,6 +408,14 @@ void HTTPServer::respondToRequests(Connection connection, Ref<RequestData> reque
         ASSERT_WITH_MESSAGE(requestData->requestMap.contains(path), "This HTTPServer does not know how to respond to a request for %s", path.utf8().data());
 
         auto response = requestData->requestMap.get(path);
+        if (response.shouldRespondWith304ToConditionalRequests) {
+            if (isConditionalRequest(request.span())) {
+                return connection.send(serialize304Response(response.headerFieldsFor304), [connection, requestData] {
+                    respondToRequests(connection, requestData);
+                });
+            }
+        }
+
         switch (response.behavior) {
         case HTTPResponse::Behavior::TerminateConnectionAfterReceivingResponse:
             return connection.terminate();
@@ -431,9 +479,7 @@ WKWebViewConfiguration *HTTPServer::httpsProxyConfiguration() const
 
 Vector<uint8_t> HTTPResponse::bodyFromString(const String& string)
 {
-    Vector<uint8_t> vector;
-    appendUTF8ToVector(vector, string);
-    return vector;
+    return toUTF8Vector(string);
 }
 
 Vector<uint8_t> HTTPResponse::serialize(IncludeContentLength includeContentLength) const
@@ -446,8 +492,7 @@ Vector<uint8_t> HTTPResponse::serialize(IncludeContentLength includeContentLengt
         responseBuilder.append(pair.key, ": "_s, pair.value, "\r\n"_s);
     responseBuilder.append("\r\n"_s);
     
-    Vector<uint8_t> bytesToSend;
-    appendUTF8ToVector(bytesToSend, responseBuilder.toString());
+    auto bytesToSend = toUTF8Vector(responseBuilder.toString());
     bytesToSend.appendVector(body);
     return bytesToSend;
 }


### PR DESCRIPTION
#### 8d5ea3dad3eb952a9af07e1846f1632d42475729
<pre>
Blank page on photoshop.adobe.com when tapping in url bar, then pressing enter
<a href="https://bugs.webkit.org/show_bug.cgi?id=286771">https://bugs.webkit.org/show_bug.cgi?id=286771</a>
<a href="https://rdar.apple.com/143916165">rdar://143916165</a>

Reviewed by Darin Adler.

photoshop.adobe.com serves the `Cross-Origin-Opener-Policy: same-origin` and
`Cross-Origin-Embedder-Policy: require-corp` HTTP headers on responses in
order because they use SharedArrayBuffer. These headers may cause us to
process-swap when receiving such a response and the origin of the source
and destination differ.

In the reproduction case, the user would first load the photoshop URL,
which would serve those headers. They would then tap the URL bar and hit
Enter. This would cause Safari to load the same URL in a *new* WKWebView
backed by the same WebProcess (thanks to the _relatedWebView SPI).
Because the same process is used, the second load would find the main
resource in the memory cache and try to revalidate it from the server
(The response has an ETag header). We would send the conditional/revalidation
request to the server and the server would repond with a bodyless 304
HTTP response, meant to allow us to reuse the cached resource. However,
the 304 response also contained the COOP &amp; COEP headers. When seeing those
headers, we would decide to process-swap because the source origin is null
(the new WebView has not loaded anything yet) and is thus different than
the destination origin. We would spin a new WebProcess, swap to it and send
it the 304 response. Because the new WebProcess does not have the resource
in its memory cache and it is receiving a bodyless 304 response, it just
displays an empty document.

To address the issue, we no longer attempt to revalidate resources when
the load is a navigation and the cached response has a Cross-Origin-Opener-Policy
header other than &quot;unsafe-none&quot;, since those are likely to cause a process
swap and we wouldn&apos;t know how to swap in case of 304 response.

I have verified manually on photoshop.adobe.com that this addresses the issue
and this is covered by a new API test.

* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::determineRevalidationPolicy const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, COOPAndCOEPOn304Response)):
* Tools/TestWebKitAPI/cocoa/HTTPServer.h:
(TestWebKitAPI::HTTPResponse::setShouldRespondWith304ToConditionalRequests):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::statusText):
(TestWebKitAPI::serialize304Response):
(TestWebKitAPI::HTTPServer::respondToRequests):

Canonical link: <a href="https://commits.webkit.org/289631@main">https://commits.webkit.org/289631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f320a984a8cc601956604779ee0396233108f2ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92432 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15245 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25382 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5486 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33634 "Found 60 new test failures: fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/emoji-glyph-overflow-repaint-fail.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html http/tests/websocket/tests/hybi/client-close-2.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94313 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14730 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76467 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20071 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7681 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14746 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->