### PR TITLE
[CookieStoreAPI] If cookie name begins with "__Host-", passed-in domain must be null and path must be null or "/"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
@@ -2,10 +2,18 @@
 PASS cookieStore.set with __Secure- name on secure origin
 PASS cookieStore.set of expired __Secure- cookie name on secure origin
 PASS cookieStore.delete with __Secure- name on secure origin
+PASS cookieStore.set with __secure- name on secure origin
+PASS cookieStore.set of expired __secure- cookie name on secure origin
+PASS cookieStore.delete with __secure- name on secure origin
 PASS cookieStore.set with __Host- name on secure origin
 PASS cookieStore.set of expired __Host- cookie name on secure origin
 PASS cookieStore.delete with __Host- name on secure origin
-FAIL cookieStore.set with __Host- prefix and a domain option assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __Host- prefix a path option assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set with __host- name on secure origin
+PASS cookieStore.set of expired __host- cookie name on secure origin
+PASS cookieStore.delete with __host- name on secure origin
+PASS cookieStore.set with __Host- prefix and a domain option
+PASS cookieStore.set with __Host- prefix a path option
+PASS cookieStore.set with __host- prefix and a domain option
+PASS cookieStore.set with __host- prefix a path option
 PASS cookieStore.set with malformed name.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-['__Secure-', '__Host-'].forEach(prefix => {
+['__Secure-', '__secure-', '__Host-', '__host-'].forEach(prefix => {
   promise_test(async testCase => {
     await cookieStore.set(`${prefix}cookie-name`, `secure-cookie-value`);
     assert_equals(
@@ -32,25 +32,27 @@
   }, `cookieStore.delete with ${prefix} name on secure origin`);
 });
 
-promise_test(async testCase => {
-  const currentUrl = new URL(self.location.href);
-  const currentDomain = currentUrl.hostname;
-  await promise_rejects_js(testCase, TypeError,
-      cookieStore.set({ name: '__Host-cookie-name', value: 'cookie-value',
-                        domain: currentDomain }));
-}, 'cookieStore.set with __Host- prefix and a domain option');
+['__Host-', '__host-'].forEach(prefix => {
+  promise_test(async testCase => {
+    const currentUrl = new URL(self.location.href);
+    const currentDomain = currentUrl.hostname;
+    await promise_rejects_js(testCase, TypeError,
+        cookieStore.set({ name: `${prefix}cookie-name`, value: 'cookie-value',
+                          domain: currentDomain }));
+  }, `cookieStore.set with ${prefix} prefix and a domain option`);
 
-promise_test(async testCase => {
-  await cookieStore.set({ name: '__Host-cookie-name', value: 'cookie-value',
-                          path: "/" });
+  promise_test(async testCase => {
+    await cookieStore.set({ name: `${prefix}cookie-name`, value: 'cookie-value',
+                            path: "/" });
 
-  assert_equals(
-      (await cookieStore.get(`__Host-cookie-name`)).value, "cookie-value");
+    assert_equals(
+        (await cookieStore.get(`${prefix}cookie-name`)).value, "cookie-value");
 
-  await promise_rejects_js(testCase, TypeError,
-      cookieStore.set( { name: '__Host-cookie-name', value: 'cookie-value',
-                         path: "/path" }));
-}, 'cookieStore.set with __Host- prefix a path option');
+    await promise_rejects_js(testCase, TypeError,
+        cookieStore.set( { name: `${prefix}cookie-name`, value: 'cookie-value',
+                          path: "/path" }));
+  }, `cookieStore.set with ${prefix} prefix a path option`);
+});
 
 promise_test(async testCase => {
     let exceptionThrown = false;

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
@@ -2,10 +2,18 @@
 PASS cookieStore.set with __Secure- name on secure origin
 PASS cookieStore.set of expired __Secure- cookie name on secure origin
 PASS cookieStore.delete with __Secure- name on secure origin
+PASS cookieStore.set with __secure- name on secure origin
+PASS cookieStore.set of expired __secure- cookie name on secure origin
+PASS cookieStore.delete with __secure- name on secure origin
 PASS cookieStore.set with __Host- name on secure origin
 PASS cookieStore.set of expired __Host- cookie name on secure origin
 PASS cookieStore.delete with __Host- name on secure origin
-FAIL cookieStore.set with __Host- prefix and a domain option assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __Host- prefix a path option assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set with __host- name on secure origin
+PASS cookieStore.set of expired __host- cookie name on secure origin
+PASS cookieStore.delete with __host- name on secure origin
+PASS cookieStore.set with __Host- prefix and a domain option
+PASS cookieStore.set with __Host- prefix a path option
+PASS cookieStore.set with __host- prefix and a domain option
+PASS cookieStore.set with __host- prefix a path option
 PASS cookieStore.set with malformed name.
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -427,6 +427,18 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
         }
     }
 
+    if (cookie.name.startsWithIgnoringASCIICase("__Host-"_s)) {
+        if (!options.domain.isNull()) {
+            promise->reject(Exception { ExceptionCode::TypeError, "If the cookie name begins with \"__Host-\", the domain must not be specified."_s });
+            return;
+        }
+
+        if (!options.path.isNull() && options.path != "/"_s)  {
+            promise->reject(Exception { ExceptionCode::TypeError, "If the cookie name begins with \"__Host-\", the path must either not be specified or be \"/\"."_s });
+            return;
+        }
+    }
+
     cookie.domain = options.domain.isNull() ? domain : options.domain;
     if (!cookie.domain.isNull()) {
         if (cookie.domain.startsWith('.')) {


### PR DESCRIPTION
#### 50e2f240433f42147a6517e478185371bc44d31f
<pre>
[CookieStoreAPI] If cookie name begins with &quot;__Host-&quot;, passed-in domain must be null and path must be null or &quot;/&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=286794">https://bugs.webkit.org/show_bug.cgi?id=286794</a>
<a href="https://rdar.apple.com/143940790">rdar://143940790</a>

Reviewed by Anne van Kesteren and Chris Dumez.

As per the Cookie Store API spec (<a href="https://wicg.github.io/cookie-store/#prefixes">https://wicg.github.io/cookie-store/#prefixes</a> and
Step 21 of <a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#section-5.7)">https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#section-5.7)</a>:

If a cookie name begins with &quot;__Host-&quot; (case-insensitive), the API must &quot;disallow
overwriting with an explicit Domain or non-&apos;/&apos; Path attribute&quot;.

Testing covered by some WPT layout tests. I also added new tests for case-insensitive and
will upstream to WPT.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.js:
(string_appeared_here.forEach.prefix.promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):

Canonical link: <a href="https://commits.webkit.org/289667@main">https://commits.webkit.org/289667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ffa9425a967dfa6bb93cf92037b69d9a38aae5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67669 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25411 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90637 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5746 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48032 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33696 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75934 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34560 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94386 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14803 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10855 "Found 4 new test failures: fast/text/font-face-set-cssom.html ipc/create-media-source-with-invalid-constraints-crash.html media/media-session/actionHandler-no-document-leak.html svg/custom/use-image-in-g.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76516 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75740 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20115 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7754 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13657 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20120 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14563 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->