### PR TITLE
[JSC] Make JSGlobalObject and derived cells as usePreciseAllocationsOnly

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -628,6 +628,8 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable | OverridesGetOwnPropertySlot | OverridesPut | IsImmutablePrototypeExoticObject;
 
     static constexpr bool needsDestruction = true;
+    static constexpr bool usePreciseAllocationsOnly = true;
+    static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -65,6 +65,7 @@ public:
     static void destroy(JSCell*);
 
     static constexpr bool usePreciseAllocationsOnly = true;
+    static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {


### PR DESCRIPTION
#### 014612b7263cc8566c31f386ab2bc7bda324f140
<pre>
[JSC] Make JSGlobalObject and derived cells as usePreciseAllocationsOnly
<a href="https://bugs.webkit.org/show_bug.cgi?id=286795">https://bugs.webkit.org/show_bug.cgi?id=286795</a>
<a href="https://rdar.apple.com/143942002">rdar://143942002</a>

Reviewed by Mark Lam.

It is enumerously large (roughly 4KB), and using MarkedBlock for that is
wasteful since it requires many data structures additionally. We should
just make it always PreciseAllocations for efficiency.

* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/289625@main">https://commits.webkit.org/289625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcdb64f14431a6825a81ee2646b6b207236beae8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38233 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67577 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25320 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33567 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37349 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80289 "Found 1241 new JSC stress test failures: basic-tests.yaml/stress-test.js.ftl-eager-no-cjit, basic-tests.yaml/stress-test.js.lockdown, microbenchmarks/abc-forward-loop-equal.js.ftl-eager-no-cjit, microbenchmarks/arguments-named-and-reflective.js.ftl-eager-no-cjit, microbenchmarks/array-filter-inline.js.lockdown, microbenchmarks/array-from-arraylike.js.lockdown, microbenchmarks/array-from-object-func.js.ftl-eager-no-cjit, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-map.js.ftl-eager-no-cjit, microbenchmarks/array-prototype-concat-copy-double.js.ftl-eager-no-cjit ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94241 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86268 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14659 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10767 "Found 5 new test failures: fast/canvas/check-stale-putImageData.html fast/dom/crash-with-bad-url.html media/media-session/actionHandler-no-document-leak.html svg/custom/use-image-in-g.svg tables/mozilla_expected_failures/collapsing_borders/bug41262-1.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76403 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75630 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7598 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13637 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19972 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108761 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14420 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26161 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->