### PR TITLE
[JSC] Add fast path in `Array#with` for `ArrayWithArrayStorage`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-with-storage.js
+++ b/JSTests/microbenchmarks/array-prototype-with-storage.js
@@ -1,0 +1,10 @@
+var length = 1024;
+var array = new Array(1024);
+array.fill(99);
+ensureArrayStorage(array);
+
+var result;
+for (let i = 0; i < 1e5; i++) {
+    result = array.with(i % 1024, i);
+    result = array.with((i + 1) % 1024, i + 1);
+}

--- a/JSTests/stress/array-prototype-with-storage.js
+++ b/JSTests/stress/array-prototype-with-storage.js
@@ -1,0 +1,19 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected array length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+
+const arr = [];
+for (let i = 0; i < 10; i++) {
+    arr.push(i);
+}
+let result = arr.with(0, 42);
+sameArray(result, [42, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+result = result.with(6, 87);
+sameArray(result, [42, 1, 2, 3, 4, 5, 87, 7, 8, 9]);


### PR DESCRIPTION
#### 385df14809057b2e868e641996a97f7f83a4ebb5
<pre>
[JSC] Add fast path in `Array#with` for `ArrayWithArrayStorage`
<a href="https://bugs.webkit.org/show_bug.cgi?id=286798">https://bugs.webkit.org/show_bug.cgi?id=286798</a>

Reviewed by Yusuke Suzuki.

We already added fast paths to `Array#with` for ArrayWithInt32,
ArrayWithDouble, and ArrayWithContiguous[1].

This patch adds a fast path for ArrayWithArrayStorage.

                                      TipOfTree                  Patched

array-prototype-with-storage      931.2594+-41.9099    ^    181.3328+-17.4305       ^ definitely 5.1356x faster

[1]: <a href="https://commits.webkit.org/287431@main">https://commits.webkit.org/287431@main</a>

* JSTests/microbenchmarks/array-prototype-with-storage.js: Added.
* JSTests/stress/array-prototype-with-storage.js: Added.
(sameArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastWith):

Canonical link: <a href="https://commits.webkit.org/289782@main">https://commits.webkit.org/289782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adfd3a016415a15516c5d3adecd991b9dba306e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38790 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15734 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25698 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91042 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48326 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37897 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80838 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94836 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86816 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15208 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76816 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75506 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18693 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20450 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8221 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15226 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109309 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14968 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/26283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->