### PR TITLE
[WPE][GTK] Document remote web inspector usage

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -597,6 +597,7 @@ GI_DOCGEN(WebKit${WEBKITGTK_API_INFIX} gtk/gtk${GTK_API_VERSION}-webkitgtk.toml.
         gtk/gtk${GTK_API_VERSION}-urlmap.js
         glib/environment-variables.md
         glib/profiling.md
+        glib/remote-inspector.md
 )
 
 if (ENABLE_2022_GLIB_API)

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -755,6 +755,7 @@ GI_DOCGEN(WPEWebKit wpe/wpewebkit.toml.in
     CONTENT_TEMPLATES
         glib/environment-variables.md
         glib/profiling.md
+        glib/remote-inspector.md
 )
 
 if (ENABLE_2022_GLIB_API)

--- a/Source/WebKit/glib/environment-variables.md.in
+++ b/Source/WebKit/glib/environment-variables.md.in
@@ -38,3 +38,14 @@ You can ask WebKit to try to use a format instead the one that is recommended by
 Example: `AR24:0:scanout`
 
 #endif
+
+
+## Remote Web Inspector Variables
+
+- `WEBKIT_INSPECTOR_SERVER`: The address and port in `ip:port` format (e.g.
+  `127.0.0.1:10000`) where the remote inspector service will listen for
+  connections.
+- `WEBKIT_INSPECTOR_HTTP_SERVER`: The address and port in `ip:port` format
+  where the remote inspector service will listen for HTTP connections.
+
+See [Remote Web Inspector](remote-inspector.html) for more details.

--- a/Source/WebKit/glib/remote-inspector.md.in
+++ b/Source/WebKit/glib/remote-inspector.md.in
@@ -1,0 +1,64 @@
+Title: Remote Web Inspector
+Slug: remote-inspector
+
+# Remote Web Inspector
+
+The remote Web Inspector enables debugging of web pages from a different
+device. This may be particularly useful in environments where it may not be
+feasible to use the Web Inspector in the same screen, or when input devices
+(keyboard, mouse) are not available.
+
+#if WPE
+
+Note WPE WebKit only supports using the Web Inspector remotely, as embedded
+devices often lack input devices, have smaller screens, use custom windowing
+systems, or may even be headless (no screen at all).
+
+#endif
+
+## Server
+
+To run an application with the remote inspector server enabled:
+
+- When running the application, set the environment variable
+  `WEBKIT_INSPECTOR_SERVER` or `WEBKIT_INSPECTOR_HTTP_SERVER` to configure
+  on which address and port the server will open its listening socket.
+- The application **must** enable
+  [property@WebKitSettings:enable-developer-extras]. This determines whether
+  the Web Inspector may be used at all.
+
+As an example, the `MiniBrowser` program included in the WebKit source code
+distribution may be used as a server for remote inspection:
+
+```sh
+export WEBKIT_INSPECTOR_SERVER=192.168.0.50:5000
+MiniBrowser --enable-developer-extras=true https://wpewebkit.org
+```
+
+
+## Client
+
+::: important
+
+    The Web Inspector uses current Web APIs as supported by WebKit; browser
+    support varies. For the best experience it is recommended to use a
+    WebKit-based browser with a version matching (or newer than) the one
+    running the server.
+
+    Chromium and derivatives tend to work well when using the HTTP inspector
+    server, too.
+
+Browsers based on [WebKitGTK](https://webkitgtk.org) may be used as clients
+for the remote Web Inspector service. The client is started by opening an
+URI with the `inspector://` scheme, plus the address and port where the
+server is listening, e.g.:
+
+```sh
+MiniBrowser inspector://192.168.0.50:5000
+```
+
+The Web Inspector is an application written using Web technologies itself,
+and it may be loaded on non-WebKit browsers. If enabled, the [inspector
+server](#server) will listen for HTTP incoming requests, and
+`inspector://` may be replaced by the `http://` scheme.
+

--- a/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk3-webkitgtk.toml.in
@@ -43,4 +43,5 @@ urlmap_file = "gtk@GTK_API_VERSION@-urlmap.js"
 content_files = [
     "environment-variables.md",
     "profiling.md",
+    "remote-inspector.md",
 ]

--- a/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
+++ b/Source/WebKit/gtk/gtk4-webkitgtk.toml.in
@@ -42,6 +42,7 @@ content_files = [
     "overview.md",
     "environment-variables.md",
     "profiling.md",
+    "remote-inspector.md",
     "migrating-to-webkitgtk-6.0.md"
 ]
 

--- a/Source/WebKit/wpe/wpewebkit.toml.in
+++ b/Source/WebKit/wpe/wpewebkit.toml.in
@@ -37,4 +37,5 @@ urlmap_file = "wpe@WPE_API_MAJOR_VERSION@-urlmap.js"
 content_files = [
     "environment-variables.md",
     "profiling.md",
+    "remote-inspector.md",
 ]


### PR DESCRIPTION
#### 98b62abac986c1500a00f7412c22394bd660cc10
<pre>
[WPE][GTK] Document remote web inspector usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=286799">https://bugs.webkit.org/show_bug.cgi?id=286799</a>

Reviewed by Carlos Garcia Campos.

Add a new Markdown page for the GTK and WPE port documentation
explaining how to run the remote Web Inspector server, and how
to connect to it from another browser.

* Source/WebKit/PlatformGTK.cmake: List new Markdown template.
* Source/WebKit/PlatformWPE.cmake: Ditto.
* Source/WebKit/glib/environment-variables.md.in: Add variables related
  to the remote inspector server.
* Source/WebKit/glib/remote-inspector.md.in: Added.
* Source/WebKit/gtk/gtk3-webkitgtk.toml.in: List new Markdown page.
* Source/WebKit/gtk/gtk4-webkitgtk.toml.in: Ditto.
* Source/WebKit/wpe/wpewebkit.toml.in: Ditto.

Canonical link: <a href="https://commits.webkit.org/289603@main">https://commits.webkit.org/289603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1f1025778874a48df41e9ff4ef77258870c93eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38249 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25332 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5430 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37364 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94256 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14674 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75644 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20021 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7621 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13627 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19987 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14435 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->