### PR TITLE
navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: { exact : false } } }) is failing with OverConstrained error

### DIFF
--- a/LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt
+++ b/LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt
@@ -1,3 +1,5 @@
 
 PASS echoCancellation should be on by default if not explictly disabled
+PASS echoCancellation should be off with exact false echoCancellation
+PASS Check capabilities with devices with only echo cancellation or without echo cancellation
 

--- a/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
@@ -8,4 +8,33 @@ promise_test(async () => {
     const stream2 = await navigator.mediaDevices.getUserMedia({ audio: true });
     assert_true(stream2.getAudioTracks()[0].getSettings().echoCancellation);
 }, "echoCancellation should be on by default if not explictly disabled");
+
+promise_test(async () => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: { exact : false } } });
+    assert_false(stream1.getAudioTracks()[0].getSettings().echoCancellation);
+}, "echoCancellation should be off with exact false echoCancellation");
+
+promise_test(async () => {
+    const stream0 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    assert_true(stream0.getAudioTracks()[0].getSettings().echoCancellation);
+    assert_array_equals(stream0.getAudioTracks()[0].getCapabilities().echoCancellation, [true, false]);
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    let deviceWithOnlyEchoCancellation, deviceWithoutEchoCancellation;
+    for (const device of devices) {
+        if (device.label === "Mock audio device 2")
+             deviceWithoutEchoCancellation = device;
+        else if (device.label === "Mock audio device 3")
+             deviceWithOnlyEchoCancellation = device;
+    }
+
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { deviceId : deviceWithOnlyEchoCancellation.deviceId } });
+    assert_true(stream1.getAudioTracks()[0].getSettings().echoCancellation);
+    assert_array_equals(stream1.getAudioTracks()[0].getCapabilities().echoCancellation, [true]);
+
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio: { deviceId : deviceWithoutEchoCancellation.deviceId } });
+    assert_false(stream2.getAudioTracks()[0].getSettings().echoCancellation);
+    assert_array_equals(stream2.getAudioTracks()[0].getCapabilities().echoCancellation, [false]);
+}, "Check capabilities with devices with only echo cancellation or without echo cancellation");
+
 </script>

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -71,9 +71,18 @@ static Vector<bool> capabilityBooleanVector(RealtimeMediaSourceCapabilities::Ech
 {
     Vector<bool> result;
     result.reserveInitialCapacity(2);
-    result.append(true);
-    if (cancellation == RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite)
+    switch (cancellation) {
+    case RealtimeMediaSourceCapabilities::EchoCancellation::On:
+        result.append(true);
+        break;
+    case RealtimeMediaSourceCapabilities::EchoCancellation::Off:
         result.append(false);
+        break;
+    case RealtimeMediaSourceCapabilities::EchoCancellation::OnOrOff:
+        result.append(true);
+        result.append(false);
+        break;
+    }
     return result;
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -717,10 +717,10 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
 
     switch (constraintType) {
     case MediaConstraintType::EchoCancellation:
-        if (!capabilities.supportsEchoCancellation())
+        if (!capabilities.supportsEchoCancellation() || capabilities.echoCancellation() == RealtimeMediaSourceCapabilities::EchoCancellation::OnOrOff)
             return 0;
 
-        return constraint.fitnessDistance(capabilities.echoCancellation() == RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
+        return constraint.fitnessDistance(capabilities.echoCancellation() == RealtimeMediaSourceCapabilities::EchoCancellation::On);
     case MediaConstraintType::Torch:
         if (!capabilities.supportsTorch())
             return 0;
@@ -799,6 +799,13 @@ void RealtimeMediaSource::setSizeFrameRateAndZoom(const VideoPresetConstraints& 
         setZoom(*constraints.zoom);
 }
 
+static bool booleanSettingFromConstraint(const BooleanConstraint& boolConstraint)
+{
+    bool setting = true;
+    boolConstraint.getExact(setting) || boolConstraint.getIdeal(setting);
+    return setting;
+}
+
 void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, const MediaConstraint& constraint)
 {
     ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER, constraintType);
@@ -852,17 +859,24 @@ void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, co
         break;
     }
 
-    case MediaConstraintType::EchoCancellation: {
+    case MediaConstraintType::EchoCancellation:
         ASSERT(constraint.isBoolean());
         if (!capabilities.supportsEchoCancellation())
             return;
 
-        bool setting;
-        const BooleanConstraint& boolConstraint = downcast<BooleanConstraint>(constraint);
-        if (boolConstraint.getExact(setting) || boolConstraint.getIdeal(setting))
-            setEchoCancellation(setting);
+        setEchoCancellation([&] -> bool {
+            switch (capabilities.echoCancellation()) {
+            case RealtimeMediaSourceCapabilities::EchoCancellation::Off:
+                return false;
+            case RealtimeMediaSourceCapabilities::EchoCancellation::On:
+                return true;
+            case RealtimeMediaSourceCapabilities::EchoCancellation::OnOrOff:
+                return booleanSettingFromConstraint(downcast<BooleanConstraint>(constraint));
+            };
+            ASSERT_NOT_REACHED();
+            return true;
+        }());
         break;
-    }
 
     case MediaConstraintType::FacingMode: {
         ASSERT(constraint.isString());

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -82,9 +82,10 @@ public:
     {
     }
     
-    enum class EchoCancellation : bool {
-        ReadOnly = 0,
-        ReadWrite = 1,
+    enum class EchoCancellation : uint8_t {
+        Off = 0,
+        On = 1,
+        OnOrOff,
     };
     enum class BackgroundBlur : uint8_t {
         Off,
@@ -204,7 +205,7 @@ private:
     DoubleCapabilityRange m_volume;
     LongCapabilityRange m_sampleRate;
     LongCapabilityRange m_sampleSize;
-    EchoCancellation m_echoCancellation { EchoCancellation::ReadOnly };
+    EchoCancellation m_echoCancellation { EchoCancellation::On };
     String m_deviceId;
     String m_groupId;
     DoubleCapabilityRange m_focusDistance;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -40,7 +40,7 @@ static DoubleCapabilityRange defaultVolumeCapability()
 {
     return { 0.0, 1.0 };
 }
-const static RealtimeMediaSourceCapabilities::EchoCancellation defaultEchoCancellationCapability = RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite;
+const static RealtimeMediaSourceCapabilities::EchoCancellation defaultEchoCancellationCapability = RealtimeMediaSourceCapabilities::EchoCancellation::OnOrOff;
 
 GST_DEBUG_CATEGORY(webkit_audio_capture_source_debug);
 #define GST_CAT_DEFAULT webkit_audio_capture_source_debug

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -97,9 +97,14 @@ CaptureSourceOrError CoreAudioCaptureSource::create(const CaptureDevice& device,
     return initializeCoreAudioCaptureSource(WTFMove(source), constraints);
 }
 
-CaptureSourceOrError CoreAudioCaptureSource::createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
+CaptureSourceOrError CoreAudioCaptureSource::createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier, std::optional<bool> echoCancellation)
 {
     auto source = adoptRef(*new CoreAudioCaptureSource(CaptureDevice { WTFMove(deviceID), CaptureDevice::DeviceType::Microphone, WTFMove(label) }, 0, WTFMove(hashSalts), pageIdentifier));
+    if (echoCancellation) {
+        source->m_echoCancellationCapability = *echoCancellation;
+        source->initializeEchoCancellation(*echoCancellation);
+    }
+
     return initializeCoreAudioCaptureSource(WTFMove(source), constraints);
 }
 
@@ -263,7 +268,7 @@ const RealtimeMediaSourceCapabilities& CoreAudioCaptureSource::capabilities()
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
         capabilities.setDeviceId(hashedId());
         capabilities.setGroupId(hashedGroupId());
-        capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
+        capabilities.setEchoCancellation(m_echoCancellationCapability ? (*m_echoCancellationCapability ? RealtimeMediaSourceCapabilities::EchoCancellation::On : RealtimeMediaSourceCapabilities::EchoCancellation::Off) : RealtimeMediaSourceCapabilities::EchoCancellation::OnOrOff);
         capabilities.setVolume({ 0.0, 1.0 });
         capabilities.setSampleRate(unit.sampleRateCapacities());
         m_capabilities = WTFMove(capabilities);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -54,7 +54,7 @@ class WebAudioSourceProviderAVFObjC;
 class CoreAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CoreAudioCaptureSource, WTF::DestructionThread::MainRunLoop> {
 public:
     WEBCORE_EXPORT static CaptureSourceOrError create(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
-    static CaptureSourceOrError createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
+    static CaptureSourceOrError createForTesting(String&& deviceID, AtomString&& label, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>, std::optional<bool>);
 
     WEBCORE_EXPORT static AudioCaptureFactory& factory();
 
@@ -109,7 +109,8 @@ private:
 
     bool m_canResumeAfterInterruption { true };
     bool m_isReadyToStart { false };
-    
+
+    std::optional<bool> m_echoCancellationCapability;
     BaseAudioSharedUnit* m_overrideUnit { nullptr };
 };
 

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -89,7 +89,7 @@ CaptureSourceOrError MockRealtimeAudioSource::create(String&& deviceID, AtomStri
     if (!device)
         return CaptureSourceOrError({ "No mock microphone device"_s , MediaAccessDenialReason::PermissionDenied });
 
-    return CoreAudioCaptureSource::createForTesting(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), constraints, pageIdentifier);
+    return CoreAudioCaptureSource::createForTesting(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), constraints, pageIdentifier, std::get<MockMicrophoneProperties>(device->properties).echoCancellation);
 }
 
 class MockAudioSharedInternalUnitState : public ThreadSafeRefCounted<MockAudioSharedInternalUnitState> {

--- a/Source/WebCore/platform/mock/MockMediaDevice.h
+++ b/Source/WebCore/platform/mock/MockMediaDevice.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 struct MockMicrophoneProperties {
     int defaultSampleRate { 44100 };
+    std::optional<bool> echoCancellation;
 };
 
 struct MockSpeakerProperties {

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -82,7 +82,7 @@ MockRealtimeAudioSource::MockRealtimeAudioSource(String&& deviceID, AtomString&&
     m_device = *device;
 
     setSampleRate(std::get<MockMicrophoneProperties>(m_device.properties).defaultSampleRate);
-    initializeEchoCancellation(true);
+    initializeEchoCancellation(std::get<MockMicrophoneProperties>(m_device.properties).echoCancellation.value_or(true));
 }
 
 MockRealtimeAudioSource::~MockRealtimeAudioSource()
@@ -130,7 +130,9 @@ const RealtimeMediaSourceCapabilities& MockRealtimeAudioSource::capabilities()
         capabilities.setDeviceId(hashedId());
         capabilities.setGroupId(hashedGroupId());
         capabilities.setVolume({ 0.0, 1.0 });
-        capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
+
+        auto echoCancellation = std::get<MockMicrophoneProperties>(m_device.properties).echoCancellation;
+        capabilities.setEchoCancellation(echoCancellation ? (*echoCancellation ? RealtimeMediaSourceCapabilities::EchoCancellation::On : RealtimeMediaSourceCapabilities::EchoCancellation::Off) : RealtimeMediaSourceCapabilities::EchoCancellation::OnOrOff);
         capabilities.setSampleRate({ 44100, 96000 });
 
         m_capabilities = WTFMove(capabilities);

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -62,9 +62,9 @@ namespace WebCore {
 static inline Vector<MockMediaDevice> defaultDevices()
 {
     return Vector<MockMediaDevice> {
-        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 1"_s, { }, MockMicrophoneProperties { 44100 } },
-        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 2"_s, { },  MockMicrophoneProperties { 48000 } },
-        MockMediaDevice { "239c24b1-3b15-11e3-8224-0800200c9a66"_s, "Mock audio device 3"_s, { },  MockMicrophoneProperties { 96000 } },
+        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 1"_s, { }, MockMicrophoneProperties { 44100 , { } } },
+        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 2"_s, { },  MockMicrophoneProperties { 48000, { false } } },
+        MockMediaDevice { "239c24b1-3b15-11e3-8224-0800200c9a66"_s, "Mock audio device 3"_s, { },  MockMicrophoneProperties { 96000, { true } } },
 
         MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 1"_s, { },  MockSpeakerProperties { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, 44100 } },
         MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 2"_s, { },  MockSpeakerProperties { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, 48000 } },

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5702,7 +5702,12 @@ struct WebCore::CaptureDeviceWithCapabilities {
     WebCore::RealtimeMediaSourceCapabilities capabilities;
 };
 
-[Nested] enum class WebCore::RealtimeMediaSourceCapabilities::EchoCancellation : bool
+[Nested] enum class WebCore::RealtimeMediaSourceCapabilities::EchoCancellation : uint8_t {
+    Off,
+    On,
+    OnOrOff
+}
+
 [Nested] enum class WebCore::RealtimeMediaSourceCapabilities::BackgroundBlur : uint8_t {
     Off,
     On,
@@ -6396,6 +6401,7 @@ enum class WebCore::IdentityCredentialProtocol : uint8_t {
 header: <WebCore/MockMediaDevice.h>
 [CustomHeader] struct WebCore::MockMicrophoneProperties {
     int defaultSampleRate;
+    std::optional<bool> echoCancellation;
 };
 
 header: <WebCore/MockMediaDevice.h>


### PR DESCRIPTION
#### 7f097e69658b94b477ef4a790e79fad82cefc6c6
<pre>
navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: { exact : false } } }) is failing with OverConstrained error
<a href="https://rdar.apple.com/143820857">rdar://143820857</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286680">https://bugs.webkit.org/show_bug.cgi?id=286680</a>

Reviewed by Jean-Yves Avenard

Echo cancellation can have 3 values (on, off and support for both).
Before the patch, it would have only 2 values, meaning for supporting both would not be correctly handled for the fitness computation.
We update the code to handle all 3 values of echo cancellation support and update the fitness computation accordingly.

We also update how we apply constraints for devices that do not support both on and off values.

Covered by added test.

* LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt:
* LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::capabilityBooleanVector):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::booleanSettingFromConstraint):
(WebCore::RealtimeMediaSource::applyConstraint):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::createForTesting):
(WebCore::CoreAudioCaptureSource::capabilities):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockRealtimeAudioSource::create):
* Source/WebCore/platform/mock/MockMediaDevice.h:
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::m_timer):
(WebCore::MockRealtimeAudioSource::capabilities):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::defaultDevices):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/289609@main">https://commits.webkit.org/289609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2679397cfa95e721ce1a9168f6575eaceac5c9af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92407 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15227 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90547 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47971 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37400 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/34484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94295 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14713 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75676 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20056 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14728 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17915 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->