### PR TITLE
Improve <input type=color alpha> performance on macOS

### DIFF
--- a/LayoutTests/fast/forms/color/color-input-swatch-expected.txt
+++ b/LayoutTests/fast/forms/color/color-input-swatch-expected.txt
@@ -1,102 +1,85 @@
 initial state
 
 getComputedStyle(swatch).backgroundColor is rgb(0, 0, 0)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: limited-srgb, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 239, 213)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: limited-srgb, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(srgb 1 0.937255 0.835294)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: display-p3, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: display-p3, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: limited-srgb, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is rgb(68, 68, 68)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: limited-srgb, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: display-p3, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.266667 0.266667 0.266667)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: display-p3, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 0, 104)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 2 0 0.5)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is rgb(40, 40, 40)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: false, colorSpace: display-p3, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.156863 0.156863 0.156863)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 
 alpha: true, colorSpace: display-p3, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is
 

--- a/LayoutTests/fast/forms/color/color-input-swatch.html
+++ b/LayoutTests/fast/forms/color/color-input-swatch.html
@@ -4,8 +4,7 @@
 <script>
 function log(swatch) {
   evalAndLogResult("getComputedStyle(swatch).backgroundColor");
-  evalAndLogResult("getComputedStyle(swatch).backgroundImage");
-  evalAndLogResult("getComputedStyle(swatch).backgroundSize");
+  evalAndLogResult("swatch.innerHTML");
 }
 
 const control = document.querySelector("input");

--- a/LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt
@@ -1,102 +1,85 @@
 initial state
 
 getComputedStyle(swatch).backgroundColor is rgb(0, 0, 0)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 239, 213)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(srgb 1 0.937255 0.835294)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: false, colorSpace: display-p3, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: papayawhip
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.989244 0.939427 0.846367)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is rgb(68, 68, 68)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is auto
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: #44444444
 
-getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
-getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23121212'/><polygon points='1,0 1,1 0,1' fill='%23cdcdcd'/></svg>")
-getComputedStyle(swatch).backgroundSize is 100% 100%
+getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(18, 18, 18);"></div>
 
 alpha: false, colorSpace: display-p3, value: #44444444
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.266667 0.266667 0.266667)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is 100% 100%
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: #44444444
 
-getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
-getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23121212'/><polygon points='1,0 1,1 0,1' fill='%23cdcdcd'/></svg>")
-getComputedStyle(swatch).backgroundSize is 100% 100%
+getComputedStyle(swatch).backgroundColor is rgb(205, 205, 205)
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(18, 18, 18);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is rgb(255, 0, 104)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is 100% 100%
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: color(display-p3 2 none .5 / .7)
 
-getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
-getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23b30049'/><polygon points='1,0 1,1 0,1' fill='%23ff4c95'/></svg>")
-getComputedStyle(swatch).backgroundSize is 100% 100%
+getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(179, 0, 73);"></div>
 
 alpha: false, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 2 0 0.5)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is 100% 100%
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: color(display-p3 2 none .5 / .7)
 
-getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
-getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23b30049'/><polygon points='1,0 1,1 0,1' fill='%23ff4c95'/></svg>")
-getComputedStyle(swatch).backgroundSize is 100% 100%
+getComputedStyle(swatch).backgroundColor is rgb(255, 76, 149)
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(179, 0, 73);"></div>
 
 alpha: false, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is rgb(40, 40, 40)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is 100% 100%
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: limited-srgb, value: rgba(40,40,40,.6)
 
-getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
-getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23181818'/><polygon points='1,0 1,1 0,1' fill='%237e7e7e'/></svg>")
-getComputedStyle(swatch).backgroundSize is 100% 100%
+getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(24, 24, 24);"></div>
 
 alpha: false, colorSpace: display-p3, value: rgba(40,40,40,.6)
 
 getComputedStyle(swatch).backgroundColor is color(display-p3 0.156863 0.156863 0.156863)
-getComputedStyle(swatch).backgroundImage is none
-getComputedStyle(swatch).backgroundSize is 100% 100%
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgba(0, 0, 0, 0);"></div>
 
 alpha: true, colorSpace: display-p3, value: rgba(40,40,40,.6)
 
-getComputedStyle(swatch).backgroundColor is rgba(0, 0, 0, 0)
-getComputedStyle(swatch).backgroundImage is url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1' preserveAspectRatio='none'><polygon points='0,0 1,0 0,1' fill='%23181818'/><polygon points='1,0 1,1 0,1' fill='%237e7e7e'/></svg>")
-getComputedStyle(swatch).backgroundSize is 100% 100%
+getComputedStyle(swatch).backgroundColor is rgb(126, 126, 126)
+swatch.innerHTML is <div style="height: 100%; width: 100%; clip-path: polygon(0px 0px, 100% 0px, 0px 100%); background-color: rgb(24, 24, 24);"></div>
 

--- a/LayoutTests/platform/mac/fast/forms/color/input-appearance-color-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/color/input-appearance-color-expected.txt
@@ -113,3 +113,41 @@ layer at (0,0) size 800x600
         RenderBlock {INPUT} at (0,0) size 100x30 [bgcolor=#FFFFFF] [border: none (2px inset #808080) none (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,1) size 94x28
             RenderBlock {DIV} at (2,4) size 90x19 [bgcolor=#FF0000]
+layer at (13,72) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (57,72) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (13,172) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (61,172) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (109,172) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (157,172) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (205,172) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (253,172) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (13,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (61,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (109,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (157,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (205,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (253,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (301,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (349,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (397,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (445,255) size 34x12
+  RenderBlock {DIV} at (0,0) size 34x12
+layer at (13,337) size 90x19
+  RenderBlock {DIV} at (0,0) size 90x19

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -222,6 +222,8 @@ void ColorInputType::createShadowSubtree()
     wrapperElement->setUserAgentPart(UserAgentParts::webkitColorSwatchWrapper());
     colorSwatch->setUserAgentPart(UserAgentParts::webkitColorSwatch());
 
+    RenderTheme::singleton().createColorWellSwatchSubtree(colorSwatch.get());
+
     updateColorSwatch();
 }
 
@@ -332,7 +334,7 @@ void ColorInputType::endColorChooser()
 
 void ColorInputType::updateColorSwatch()
 {
-    RefPtr<HTMLElement> colorSwatch = shadowColorSwatch();
+    RefPtr colorSwatch = shadowColorSwatch();
     if (!colorSwatch)
         return;
 

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -208,6 +208,7 @@ public:
     virtual bool shouldHaveSpinButton(const HTMLInputElement&) const;
     virtual bool shouldHaveCapsLockIndicator(const HTMLInputElement&) const { return false; }
 
+    virtual void createColorWellSwatchSubtree(HTMLElement&) { }
     virtual void setColorWellSwatchBackground(HTMLElement&, Color);
 
     // Functions for <select> elements.

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -81,6 +81,7 @@ public:
     FloatSize meterSizeForBounds(const RenderMeter&, const FloatRect&) const final;
     bool supportsMeter(StyleAppearance) const final;
 
+    void createColorWellSwatchSubtree(HTMLElement&) final;
     void setColorWellSwatchBackground(HTMLElement&, Color) final;
 
     IntRect progressBarRectForBounds(const RenderProgress&, const IntRect&) const final;


### PR DESCRIPTION
#### c6709039985b45fbabb8cf2256cb1d1b00baf724
<pre>
Improve &lt;input type=color alpha&gt; performance on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=286803">https://bugs.webkit.org/show_bug.cgi?id=286803</a>
<a href="https://rdar.apple.com/143955048">rdar://143955048</a>

Reviewed by Aditya Keerthi.

Using data: URLs here resulted in annoying flickering when moving the
alpha slider quickly.

Using SVG directly in the shadow tree ran into
<a href="https://bugs.webkit.org/show_bug.cgi?id=287472">https://bugs.webkit.org/show_bug.cgi?id=287472</a> so therefore we use a
div element with a polygon clip-path. This results in additional render
layers, but websites will likely not have a lot of these controls so
that seems okay.

* LayoutTests/fast/forms/color/color-input-swatch-expected.txt:
* LayoutTests/fast/forms/color/color-input-swatch.html:
* LayoutTests/platform/mac/fast/forms/color/color-input-swatch-expected.txt:
* LayoutTests/platform/mac/fast/forms/color/input-appearance-color-expected.txt:
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::createShadowSubtree):
(WebCore::ColorInputType::updateColorSwatch):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::createColorWellSwatchSubtree):
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::createColorWellSwatchSubtree):
(WebCore::RenderThemeMac::setColorWellSwatchBackground):

Canonical link: <a href="https://commits.webkit.org/290228@main">https://commits.webkit.org/290228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cebe08f2d848044f08afce00f85b55ba23ced45e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9205 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/17142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68799 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35426 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39161 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96108 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12095 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77673 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76972 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21388 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9602 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/13994 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21798 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->