### PR TITLE
MediaRecorderPrivateEncoder can write frames out of order

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html
@@ -21,6 +21,8 @@
 <script>
     var context;
     var drawStartTime;
+    // Needs to be a globabl variable to avoid being GCed (webkit.org/b/271227)
+    var oscillator;
 
     function createVideoStream() {
         const canvas = document.getElementById("canvas");
@@ -61,10 +63,11 @@
 
     promise_test(async (test) => {
         const ac = new AudioContext();
-        const osc = ac.createOscillator();
+        oscillator = ac.createOscillator();
         const dest = ac.createMediaStreamDestination();
         const audio = dest.stream;
-        osc.connect(dest);
+        oscillator.connect(dest);
+        oscillator.start();
 
         const video = createVideoStream();
         assert_equals(video.getAudioTracks().length, 0, "video mediastream starts with no audio track");

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable-expected.txt
@@ -1,0 +1,5 @@
+
+
+
+PASS MediaRecorder can successfully record the video for an audio-video stream into a webm file
+

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html>
+<head>
+    <title>MediaRecorder Dataavailable</title>
+    <link rel="help" href="https://w3c.github.io/mediacapture-record/MediaRecorder.html#mediarecorder">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="../common/canvas-tests.js"></script>
+</head>
+<body>
+<div>
+    <video id="player">
+    </video>
+</div>
+<div>
+    <canvas id="canvas" width="200" height="200">
+    </canvas>
+    <canvas id="frame" width="200" height="200">
+    </canvas>
+</div>
+<script>
+    const MIMETYPE = 'video/webm; codecs=vp8,opus';
+    var context;
+    var blobData = new Blob();
+    var paintingState = 0;
+    var canPlayReceived = false;
+    var playbackStarted = false;
+    // Needs to be a globabl variable to avoid being GCed (webkit.org/b/271227)
+    var oscillator;
+
+    function createVideoStream() {
+        const canvas = document.getElementById("canvas");
+        context = canvas.getContext('2d');
+        return canvas.captureStream();
+    }
+
+    function doRedImageDraw() {
+        if (context) {
+            context.fillStyle = "#ff0000";
+            context.fillRect(0, 0, 200, 200);
+            if (paintingState == 0)
+                window.requestAnimationFrame(doRedImageDraw);
+        }
+    }
+
+    function doGreenImageDraw() {
+        if (context) {
+            context.fillStyle = "#00ff00";
+            context.fillRect(0, 0, 200, 200);
+            if (paintingState == 1)
+                window.requestAnimationFrame(doGreenImageDraw);
+        }
+    }
+
+    function maybeStartPlayback() {
+        if (canPlayReceived && player.duration > 1 && !playbackStarted) {
+            playbackStarted = true;
+            player.play();
+        }
+    }
+
+    async_test(t => {
+        const ac = new AudioContext();
+        oscillator = ac.createOscillator();
+        const dest = ac.createMediaStreamDestination();
+        const audio = dest.stream;
+        oscillator.connect(dest);
+        oscillator.start();
+
+        const video = createVideoStream();
+        assert_equals(video.getAudioTracks().length, 0, "video mediastream starts with no audio track");
+        assert_equals(audio.getAudioTracks().length, 1, "audio mediastream starts with one audio track");
+        video.addTrack(audio.getAudioTracks()[0]);
+        assert_equals(video.getAudioTracks().length, 1, "video mediastream starts with one audio track");
+        const recorder = new MediaRecorder(video, { mimeType: MIMETYPE });
+        let mode = 0;
+
+        recorder.ondataavailable = t.step_func(blobEvent => {
+            assert_true(blobEvent instanceof BlobEvent, 'the type of event should be BlobEvent');
+            assert_equals(blobEvent.type, 'dataavailable', 'the event type should be dataavailable');
+            assert_true(blobEvent.isTrusted, 'isTrusted should be true when the event is created by C++');
+            assert_true(blobEvent.data instanceof Blob, 'the type of data should be Blob');
+            assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
+            blobData = new Blob([blobData, blobEvent.data]);
+
+            if (blobEvent.timecode == 0)
+                return;
+            if (blobEvent.timecode >= 0.2 && paintingState == 0) {
+                paintingState = 1;
+                doGreenImageDraw();
+                return;
+            }
+            assert_greater_than(blobEvent.timecode, .4, "more than .4s recorded");
+            if (++paintingState == 2) {
+                recorder.stop();
+                ac.close();
+                return;
+            }
+            player.src = window.URL.createObjectURL(blobData);
+            const resFrame = document.getElementById("frame");
+            const resContext = resFrame.getContext('2d');
+            player.load();
+
+            player.oncanplay = t.step_func(() => {
+                canPlayReceived = true;
+                maybeStartPlayback();
+            });
+            player.ondurationchange = t.step_func(() => {
+                maybeStartPlayback();
+            });
+            player.onplay = () => {
+                player.pause();
+                assert_greater_than(player.duration, .4, 'the duration should be greater than .4s')
+                player.currentTime = player.duration - 0.05;
+            };
+            player.onseeked = t.step_func(() => {
+                resContext.drawImage(player, 0, 0);
+                if (!mode) {
+                    _assertPixelApprox(resFrame, 20, 20, 20, 255, 0, 255, "20, 20", "0, 255, 0, 255", 50);
+                    _assertPixelApprox(resFrame, 199, 199, 20, 255, 0, 255, "199, 199", "0, 255, 0, 255", 50);
+                    player.currentTime = 0;
+                    mode = 1;
+                } else {
+                    _assertPixelApprox(resFrame, 25, 25, 255, 0, 0, 255, "25, 25", "255, 0, 0, 255", 50);
+                    _assertPixelApprox(resFrame, 50, 50, 255, 0, 0, 255, "50, 50", "255, 0, 0, 255", 50);
+                    t.done();
+                }
+            });
+        });
+
+        doRedImageDraw();
+        recorder.start(200);
+        assert_equals(recorder.state, 'recording', 'MediaRecorder has been started successfully');
+
+        setTimeout(() => {
+            paintingState = 3;
+            recorder.stop();
+            ac.close();
+            assert_unreached("recording didn't finish on time");
+        }, 5000);
+    }, 'MediaRecorder can successfully record the video for an audio-video stream into a webm file');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -174,9 +174,9 @@ private:
     bool m_firstVideoFrameProcessed WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     std::optional<MonotonicTime> m_currentVideoSegmentStartTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     uint64_t m_previousSegmentVideoDurationUs WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { 0 };
+    MediaTime m_lastRawVideoFrameReceived WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { MediaTime::negativeInfiniteTime() };
     MediaTime m_lastEnqueuedRawVideoFrame WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { MediaTime::negativeInfiniteTime() };
     MediaTime m_lastVideoKeyframeTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    MediaTime m_lastReceivedCompressedVideoFrame WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { MediaTime::negativeInfiniteTime() };
     std::optional<CGAffineTransform> m_videoTransform;
     RefPtr<GenericNonExclusivePromise> m_videoEncoderCreationPromise;
 


### PR DESCRIPTION
#### 4366e9326ff6f41042ca4b61d99e32d1105b1c53
<pre>
MediaRecorderPrivateEncoder can write frames out of order
<a href="https://bugs.webkit.org/show_bug.cgi?id=286805">https://bugs.webkit.org/show_bug.cgi?id=286805</a>
<a href="https://rdar.apple.com/143956063">rdar://143956063</a>

Reviewed by Youenn Fablet.

When we write to the container the video frame, we must first ensure that
we have written any earlier audio frames as WebM requires monotonically increasing timestamps.
To do so, the code could wait on in-flight audio frames prior writing the video.
However, if we paused or stopped the recorder, the waiting promise would be
immediately rejected which caused the video frame to be immediately written
only to drain/finish the audio converter which could retrieve audio frames
with a timestamp lesser than the video written.
This used to cause an assertion which was changed to a release log error instead in
287869@main.

Another issue was that it was assume we always had an audio frame with the same
presentation time as the latest video frame (as the audio clock drives the time)
However, if two video frames arrive in a burst before new audio is received
and to avoid having the video frames with the same timestamp we add 1us.
This could cause the wait for pending audio to never ends as this amended.

We can now remove some of the debug assertions we added in 287869@main and
re-introduce the ASSERT.

Added a test that exercising the code by creating a MediaRecorder with a short
timeslice.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html: Make oscillator variable global to get around webkit.org/b/271227
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html: Added.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::pause):
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::waitForMatchingAudio):
(WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame):
(WebCore::MediaRecorderPrivateEncoder::stopRecording):
(WebCore::MediaRecorderPrivateEncoder::flushPendingData):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:

Canonical link: <a href="https://commits.webkit.org/289643@main">https://commits.webkit.org/289643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/860245d966cbea1e7ec367d3e94baad92adbb157

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42002 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15306 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/92486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90623 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79284 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33681 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/37478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94372 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/14789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/15043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75136 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18619 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14805 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/17993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->