### PR TITLE
Remove unused m_word field in JSC::ExpressionInfo::Decoder

### DIFF
--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.h
@@ -166,8 +166,6 @@ public:
             m_wides[m_numWides++] = { id, value };
         }
 
-        unsigned m_word { 0 };
-
         Entry m_entry;
         EncodedInfo* m_startInfo { nullptr };
         EncodedInfo* m_endInfo { nullptr };


### PR DESCRIPTION
#### 03709bce9bd337c7064190d83326cc76b554d91d
<pre>
Remove unused m_word field in JSC::ExpressionInfo::Decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=286814">https://bugs.webkit.org/show_bug.cgi?id=286814</a>

Reviewed by Mark Lam.

This is probably a leftover from preliminary work in commit 273233@main.
This saves a few bytes in the JSC::ExpressionInfo::Decoder object.

* Source/JavaScriptCore/bytecode/ExpressionInfo.h:

Canonical link: <a href="https://commits.webkit.org/289622@main">https://commits.webkit.org/289622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43b72cc6a5f11721d65a6a5cb53383b0411b22ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38290 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15229 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25369 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33621 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37403 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80343 "Found 1467 new JSC stress test failures: microbenchmarks/Int16Array-bubble-sort.js.ftl-eager-no-cjit, microbenchmarks/Int8Array-load.js.ftl-eager-no-cjit, microbenchmarks/Number-isNaN.js.ftl-eager-no-cjit, microbenchmarks/abc-forward-loop-equal.js.ftl-eager-no-cjit, microbenchmarks/abc-postfix-backward-loop.js.ftl-eager-no-cjit, microbenchmarks/abc-skippy-loop.js.ftl-eager-no-cjit, microbenchmarks/arity-mismatch-inlining.js.ftl-eager-no-cjit, microbenchmarks/array-access-polymorphic-structure.js.ftl-eager-no-cjit, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-join-object.js.ftl-eager-no-cjit ... (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94296 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86321 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14714 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75679 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20055 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18482 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7665 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13634 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14730 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108814 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14474 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26172 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->