### PR TITLE
`getComputedStyle()` should be empty for non-rendered elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt
@@ -1,8 +1,8 @@
 
 PASS getComputedStyle returns no style for detached element
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) assert_true: expected true got false
-FAIL getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window assert_true: expected true got false
-FAIL getComputedStyle returns no style for element outside the flat tree assert_true: expected true got false
-FAIL getComputedStyle returns no style for descendant outside the flat tree assert_true: expected true got false
+PASS getComputedStyle returns no style for element in non-rendered iframe (display: none)
+PASS getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window
+PASS getComputedStyle returns no style for element outside the flat tree
+PASS getComputedStyle returns no style for descendant outside the flat tree
 PASS getComputedStyle returns no style for shadow tree outside of flattened tree
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1671,8 +1671,34 @@ StyleMedia& LocalDOMWindow::styleMedia()
     return *m_media;
 }
 
+static bool isInComposedTree(const Element& element)
+{
+    if (!element.isConnected())
+        return false;
+
+    for (const Node* current = &element; current; current = current->parentInComposedTree()) {
+        if (auto* parent = current->parentNode()) {
+            if (auto* parentElement = dynamicDowncast<Element>(*parent)) {
+                if (parentElement->shadowRoot() && !current->assignedSlot())
+                    return false;
+            }
+        }
+        if (!current)
+            return false;
+        if (current->isDocumentNode())
+            return true;
+    }
+
+    return false;
+}
+
 Ref<CSSStyleDeclaration> LocalDOMWindow::getComputedStyle(Element& element, const String& pseudoElt) const
 {
+    bool frameElementIsRendered = element.document().frame()->ownerElement() && element.document().frame()->ownerRenderer();
+
+    if (!frameElementIsRendered || !isInComposedTree(element))
+        return CSSComputedStyleDeclaration::createEmpty(element);
+
     if (!pseudoElt.startsWith(':'))
         return CSSComputedStyleDeclaration::create(element, std::nullopt);
 


### PR DESCRIPTION
#### 469923a3cae8306a9b4ee549629a3bd8b55b020c
<pre>
`getComputedStyle()` should be empty for non-rendered elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=232969">https://bugs.webkit.org/show_bug.cgi?id=232969</a>

Reviewed by NOBODY (OOPS!).

`getComputedStyle()` was incorrectly returning computed styles for elements that should not be rendered.
Return an empty CSSComputedStyleDeclaration, ensuring non-rendered elements have no computed style.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-detached-subtree-expected.txt:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getComputedStyle const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/469923a3cae8306a9b4ee549629a3bd8b55b020c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14368 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5151 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95150 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14521 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109121 "Failure limit exceed. At least found 492 new test failures: animations/3d/matrix-transform-type-animation.html animations/3d/replace-filling-transform.html animations/3d/transform-origin-vs-functions.html animations/3d/transform-perspective.html animations/animation-border-overflow.html animations/animation-direction-alternate-reverse.html animations/animation-direction-reverse-fill-mode-hardware.html animations/animation-direction-reverse-fill-mode.html animations/animation-direction-reverse-hardware-opacity.html animations/animation-direction-reverse-hardware.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78895 "Exiting early after 60 failures. 762 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144923 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11660 "Found 60 new test failures: accessibility/ios-simulator/taking-focus-should-refocus-page.html accessibility/smart-invert.html animations/3d/matrix-transform-type-animation.html animations/3d/replace-filling-transform.html animations/3d/transform-origin-vs-functions.html animations/3d/transform-perspective.html animations/animation-border-overflow.html animations/animation-direction-alternate-reverse.html animations/animation-direction-reverse-fill-mode-hardware.html animations/animation-direction-reverse-fill-mode.html ... (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127421 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90017 "Found 2 new API test failures: WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/content-filter, WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-style-sheet (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11204 "Found 60 new test failures: imported/w3c/web-platform-tests/compat/webkit-text-fill-color-currentColor.html imported/w3c/web-platform-tests/content-security-policy/meta/combine-header-and-meta-policies.sub.html imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/dangling-html-or-body.html imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/nonce-hiding-move-document.html imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/script-nonces-hidden-meta.sub.html imported/w3c/web-platform-tests/content-security-policy/nonce-hiding/script-nonces-hidden.html imported/w3c/web-platform-tests/content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html imported/w3c/web-platform-tests/content-security-policy/style-src/style-src-hash-allowed.html imported/w3c/web-platform-tests/content-security-policy/style-src/style-src-hash-blocked.html imported/w3c/web-platform-tests/content-security-policy/style-src/style-src-hash-case-insensitive.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8854 "Found 86 new API test failures: TestWebKitAPI.DeviceScaleFactorOnBack.WebKit, TestWebKitAPI.WKWebExtensionAPIScripting.RemoveAllUserStyleSheetsDoesNotRemoveWebExtensionStyleSheets, TestWebKitAPI.DynamicDeviceScaleFactor.WebKit2, TestWebKitAPI.PasteHTML.PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor, TestWebKitAPI.WKWebExtensionAPITabs.CSSAuthorOrigin, TestWebKitAPI.WKWebExtensionAPILocalization.CSSLocalizationInContentScript, TestWebKitAPI.AppleVisualEffect.GlassMaterialParsing, TestWebKitAPI.WebKit2UserContentTest.RemoveAllUserStyleSheets, TestWebKitAPI.WebKit.ViewportSizeForViewportUnits, TestWebKitAPI.WKWebExtensionController.CSSUserOrigin ... (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/639 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120530 "Found 76 new API test failures: TestWebKitAPI.WKWebExtensionAPIScripting.RemoveAllUserStyleSheetsDoesNotRemoveWebExtensionStyleSheets, TestWebKitAPI.PasteHTML.PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor, TestWebKitAPI.WKWebExtensionAPITabs.CSSAuthorOrigin, TestWebKitAPI.WKWebExtensionAPILocalization.CSSLocalizationInContentScript, TestWebKitAPI.AppleVisualEffect.GlassMaterialParsing, TestWebKitAPI.WKWebExtensionController.CSSUserOrigin, TestWebKitAPI.DragAndDropTests.DragEventPageCoordinatesBasic, TestWebKitAPI.WKWebExtensionAPIScripting.RegisterContentScripts, TestWebKitAPI.WKUserContentController.UserStyleSheetAffectingOnlySpecificWebViewRemoval, TestWebKitAPI.WKUserContentController.UserStyleSheetAffectingSpecificWebViewInjectionImmediatelyAfterCreation ... (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/3880 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14049 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4528 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117201 "Failure limit exceed. At least found 488 new test failures: animations/3d/matrix-transform-type-animation.html animations/3d/replace-filling-transform.html animations/3d/transform-origin-vs-functions.html animations/3d/transform-perspective.html animations/animation-border-overflow.html animations/animation-direction-alternate-reverse.html animations/animation-direction-reverse-fill-mode-hardware.html animations/animation-direction-reverse-fill-mode.html animations/animation-direction-reverse-hardware-opacity.html animations/animation-direction-reverse-hardware.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14071 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12252 "Found 60 new test failures: accessibility/mac/alt-for-css-content.html animations/3d/matrix-transform-type-animation.html animations/3d/replace-filling-transform.html animations/animation-border-overflow.html animations/animation-direction-alternate-reverse.html animations/font-variations/font-stretch.html animations/font-variations/font-style.html animations/font-variations/font-variation-settings-order.html animations/font-variations/font-variation-settings.html animations/font-variations/font-weight.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117518 "Found 2 new API test failures: WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/content-filter, WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-style-sheet (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13565 "Found 1 new test failure: media/media-css-volume-locked.html (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124704 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14098 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3673 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13830 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77814 "Found 6 new failures in page/LocalDOMWindow.cpp") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->