### PR TITLE
Fixes Model Process resources deallocation.

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -97,6 +97,8 @@ HTMLModelElement::~HTMLModelElement()
         m_resource->removeClient(*this);
         m_resource = nullptr;
     }
+
+    deleteModelPlayer();
 }
 
 Ref<HTMLModelElement> HTMLModelElement::create(const QualifiedName& tagName, Document& document)

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -133,6 +133,8 @@ public:
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
     void setHasPortal(bool) final;
 
+    USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
+
 private:
     ModelProcessModelPlayerProxy(ModelProcessModelPlayerManagerProxy&, WebCore::ModelPlayerIdentifier, Ref<IPC::Connection>&&);
 
@@ -149,6 +151,8 @@ private:
     RefPtr<WebCore::REModel> m_model;
     RetainPtr<WKSRKEntity> m_modelRKEntity;
     REPtr<RESceneRef> m_scene;
+    REPtr<REEntityRef> m_hostingEntity;
+    REPtr<REEntityRef> m_containerEntity;
     RetainPtr<WKModelProcessModelPlayerProxyObjCAdapter> m_objCAdapter;
 
     WebCore::Color m_backgroundColor;

--- a/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.h
+++ b/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.h
@@ -7,7 +7,7 @@
 #if ENABLE(MODEL_PROCESS)
 
 #import <QuartzCore/QuartzCore.h>
-#import <wtf/RefPtr.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebKit {
 class ModelProcessModelPlayerProxy;
@@ -15,7 +15,7 @@ class ModelProcessModelPlayerProxy;
 
 @interface WKModelProcessModelLayer : CALayer
 
-@property (direct) RefPtr<WebKit::ModelProcessModelPlayerProxy> player;
+@property (direct) WeakPtr<WebKit::ModelProcessModelPlayerProxy> player;
 
 @end
 

--- a/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
+++ b/Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm
@@ -5,21 +5,22 @@
 #import "config.h"
 
 #if ENABLE(MODEL_PROCESS)
+
 #import "WKModelProcessModelLayer.h"
 
 #import "ModelProcessModelPlayerProxy.h"
 #import <wtf/RefPtr.h>
 
 @implementation WKModelProcessModelLayer {
-    RefPtr<WebKit::ModelProcessModelPlayerProxy> _player;
+    WeakPtr<WebKit::ModelProcessModelPlayerProxy> _player;
 }
 
-- (void)setPlayer:(RefPtr<WebKit::ModelProcessModelPlayerProxy>)player
+- (void)setPlayer:(WeakPtr<WebKit::ModelProcessModelPlayerProxy>)player
 {
-    _player = WTFMove(player);
+    _player = player;
 }
 
-- (RefPtr<WebKit::ModelProcessModelPlayerProxy>)player
+- (WeakPtr<WebKit::ModelProcessModelPlayerProxy>)player
 {
     return _player;
 }
@@ -28,19 +29,18 @@
 {
     [super setOpacity:opacity];
 
-    if (_player)
-        _player->updateOpacity();
+    if (RefPtr strongPlayer = _player.get())
+        strongPlayer->updateOpacity();
 }
 
 - (void)layoutSublayers
 {
     [super layoutSublayers];
 
-    if (_player)
-        _player->updateTransform();
+    if (RefPtr strongPlayer = _player.get())
+        strongPlayer->updateTransform();
 }
 
 @end
-
 
 #endif // MODEL_PROCESS


### PR DESCRIPTION
#### 75ec68cfc5a707e4ec0d559131519403bd5c744c
<pre>
Fixes Model Process resources deallocation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286817">https://bugs.webkit.org/show_bug.cgi?id=286817</a>
<a href="https://rdar.apple.com/138060013">rdar://138060013</a>

Reviewed by Ada Chan.

A combination of fixes that guaranties memory deallocation used
for HTMLModelElement rendering.

Combined changes:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::~HTMLModelElement):
Explicitly calls deleteModelPlayer() in element&apos;s destructor to signal to
Model Process.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy):
(WebKit::ModelProcessModelPlayerProxy::createLayer):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
For manually created entities (REEntityCreate() call) adds calls of
REEntityRemoveFromSceneOrParent() to release them.

* Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.h:
* Source/WebKit/ModelProcess/cocoa/WKModelProcessModelLayer.mm:
(-[WKModelProcessModelLayer setPlayer:]):
(-[WKModelProcessModelLayer player]):
(-[WKModelProcessModelLayer setOpacity:]):
(-[WKModelProcessModelLayer layoutSublayers]):
Breaks cyclic dependency between ModelProcessModelPlayerProxy and
WKModelProcessModelLayer. Now the layer has WeakPtr to the player.

Canonical link: <a href="https://commits.webkit.org/289741@main">https://commits.webkit.org/289741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d61fc00c848b078b75153ce18d41862f46199c94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38543 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67788 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5666 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33843 "Found 1 new test failure: accessibility/noscript-ignored.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94545 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76637 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75873 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20243 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18677 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7963 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14977 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20280 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14721 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->