### PR TITLE
Tracking domains can set partitioned cookies

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -29,6 +29,7 @@
 #import "Logging.h"
 #import "NetworkProcess.h"
 #import "NetworkSession.h"
+#import "WebPrivacyHelpers.h"
 #import <WebCore/DNS.h>
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/Quirks.h>
@@ -316,6 +317,11 @@ WebCore::ThirdPartyCookieBlockingDecision NetworkTaskCocoa::requestThirdPartyCoo
         if (!shouldBlockCookies(thirdPartyCookieBlockingDecision))
             thirdPartyCookieBlockingDecision = networkStorageSession->thirdPartyCookieBlockingDecisionForRequest(request, frameID(), pageID(), shouldRelaxThirdPartyCookieBlocking());
     }
+
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS) && HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    if (thirdPartyCookieBlockingDecision == WebCore::ThirdPartyCookieBlockingDecision::AllExceptPartitioned && request.isThirdParty() && isKnownTrackerAddressOrDomain(request.url().host()))
+        return WebCore::ThirdPartyCookieBlockingDecision::All;
+#endif
     return thirdPartyCookieBlockingDecision;
 }
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -55,6 +55,7 @@ namespace WebKit {
 enum class RestrictedOpenerType : uint8_t;
 
 void configureForAdvancedPrivacyProtections(NSURLSession *);
+bool isKnownTrackerAddressOrDomain(StringView host);
 void requestLinkDecorationFilteringData(CompletionHandler<void(Vector<WebCore::LinkDecorationFilteringData>&&)>&&);
 
 class ListDataObserver : public RefCountedAndCanMakeWeakPtr<ListDataObserver> {

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -702,9 +702,24 @@ void configureForAdvancedPrivacyProtections(NSURLSession *session)
     });
 }
 
+bool isKnownTrackerAddressOrDomain(StringView host)
+{
+    TrackerAddressLookupInfo::populateIfNeeded();
+    TrackerDomainLookupInfo::populateIfNeeded();
+
+    if (auto address = URL::hostIsIPAddress(host) ? IPAddress::fromString(host.toStringWithoutCopying()) : std::nullopt) {
+        if (TrackerAddressLookupInfo::find(*address))
+            return true;
+    }
+
+    auto domain = WebCore::RegistrableDomain { URL { makeString("http://"_s, host) } };
+    return TrackerDomainLookupInfo::find(domain.string()).owner().length();
+}
+
 #else
 
 void configureForAdvancedPrivacyProtections(NSURLSession *) { }
+bool isKnownTrackerAddressOrDomain(StringView) { return false; }
 
 #endif
 


### PR DESCRIPTION
#### 48ce9a3d8430abcb9bfc8712cbe5cdb48c0d5578
<pre>
Tracking domains can set partitioned cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=286778">https://bugs.webkit.org/show_bug.cgi?id=286778</a>
<a href="https://rdar.apple.com/143914901">rdar://143914901</a>

Reviewed by Wenson Hsieh.

The vast majority of the partitioned cookies we currently see are being set by
tracking domains. This doesn&apos;t benefit users and only causes more memory usage.
This patch blocks third-party cookies if the request is for a tracking domain.

Tested manually, and adding a few API tests, but these tests don&apos;t cover
blocking cookies for a domain on the block list. That will require a more
invasive change, so I&apos;ll do that in a follow up.

* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::requestThirdPartyCookieBlockingDecision const):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::isKnownTrackerAddressOrDomain):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::setUpWebViewForTestingTrackerDomainBlocking):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotBlockFirstPartyPartitionedCookiesFromTrackerDomain)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotBlockThirdPartyPartitionedCookiesFromSameSiteDomain)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotBlockThirdPartyPartitionedCookies)):

Canonical link: <a href="https://commits.webkit.org/289641@main">https://commits.webkit.org/289641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f665b74721899f52678be97e9dff7d1bacf5818

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87607 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92472 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15291 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90609 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48019 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33674 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37464 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/34538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94358 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75129 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20100 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/7726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13646 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14791 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->