### PR TITLE
[SwiftUI] Update WebPage to latest interface (Part 1)

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/DownloadCoordinator.swift
+++ b/Source/WebKit/UIProcess/API/Swift/DownloadCoordinator.swift
@@ -30,16 +30,16 @@ import Foundation
 @_spi(Private)
 public protocol DownloadCoordinator {
     @MainActor
-    func destination(forDownload download: WebPage_v0.DownloadID, response: URLResponse, suggestedFilename: String) async -> URL?
+    func destination(forDownload download: WebPage.DownloadID, response: URLResponse, suggestedFilename: String) async -> URL?
 
     @MainActor
-    func authenticationChallengeDisposition(forDownload download: WebPage_v0.DownloadID, challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
+    func authenticationChallengeDisposition(forDownload download: WebPage.DownloadID, challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
 
     @MainActor
-    func httpRedirectionPolicy(forDownload download: WebPage_v0.DownloadID, response: HTTPURLResponse, newRequest request: URLRequest) async -> WebPage_v0.Download.RedirectPolicy
+    func httpRedirectionPolicy(forDownload download: WebPage.DownloadID, response: HTTPURLResponse, newRequest request: URLRequest) async -> WebPage.Download.RedirectPolicy
 
     @MainActor
-    func placeholderPolicy(forDownload download: WebPage_v0.DownloadID) async -> WebPage_v0.Download.PlaceholderPolicy
+    func placeholderPolicy(forDownload download: WebPage.DownloadID) async -> WebPage.Download.PlaceholderPolicy
 }
 
 // MARK: Default implementation
@@ -47,22 +47,22 @@ public protocol DownloadCoordinator {
 @_spi(Private)
 public extension DownloadCoordinator {
     @MainActor
-    func destination(forDownload download: WebPage_v0.DownloadID, response: URLResponse, suggestedFilename: String) async -> URL? {
+    func destination(forDownload download: WebPage.DownloadID, response: URLResponse, suggestedFilename: String) async -> URL? {
         nil
     }
 
     @MainActor
-    func authenticationChallengeDisposition(forDownload download: WebPage_v0.DownloadID, challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+    func authenticationChallengeDisposition(forDownload download: WebPage.DownloadID, challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
         (.performDefaultHandling, nil)
     }
 
     @MainActor
-    func httpRedirectionPolicy(forDownload download: WebPage_v0.DownloadID, response: HTTPURLResponse, newRequest request: URLRequest) async -> WebPage_v0.Download.RedirectPolicy {
+    func httpRedirectionPolicy(forDownload download: WebPage.DownloadID, response: HTTPURLResponse, newRequest request: URLRequest) async -> WebPage.Download.RedirectPolicy {
         .allow
     }
 
     @MainActor
-    func placeholderPolicy(forDownload download: WebPage_v0.DownloadID) async -> WebPage_v0.Download.PlaceholderPolicy {
+    func placeholderPolicy(forDownload download: WebPage.DownloadID) async -> WebPage.Download.PlaceholderPolicy {
         .disable(alternatePlaceholder: nil)
     }
 }

--- a/Source/WebKit/UIProcess/API/Swift/WKDownloadDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKDownloadDelegateAdapter.swift
@@ -30,14 +30,14 @@ private struct DefaultDownloadCoordinator: DownloadCoordinator {
 
 @MainActor
 final class WKDownloadDelegateAdapter: NSObject, WKDownloadDelegate {
-    init(downloadProgressContinuation: AsyncStream<WebPage_v0.DownloadEvent>.Continuation, downloadCoordinator: (any DownloadCoordinator)?) {
+    init(downloadProgressContinuation: AsyncStream<WebPage.DownloadEvent>.Continuation, downloadCoordinator: (any DownloadCoordinator)?) {
         self.downloadProgressContinuation = downloadProgressContinuation
         self.downloadCoordinator = downloadCoordinator ?? DefaultDownloadCoordinator()
     }
 
-    weak var owner: WebPage_v0? = nil
+    weak var owner: WebPage? = nil
 
-    private let downloadProgressContinuation: AsyncStream<WebPage_v0.DownloadEvent>.Continuation
+    private let downloadProgressContinuation: AsyncStream<WebPage.DownloadEvent>.Continuation
     private let downloadCoordinator: any DownloadCoordinator
 
     // MARK: Progress reporting

--- a/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
@@ -40,10 +40,10 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegate {
         self.dialogPresenter = dialogPresenter ?? DefaultDialogPresenting()
     }
 
-    weak var owner: WebPage_v0? = nil
+    weak var owner: WebPage? = nil
 
 #if os(macOS) && !targetEnvironment(macCatalyst)
-    var menuBuilder: ((WebPage_v0.ElementInfo) -> NSMenu)? = nil
+    var menuBuilder: ((WebPage.ElementInfo) -> NSMenu)? = nil
 #endif
 
     private let dialogPresenter: any DialogPresenting
@@ -101,14 +101,14 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegate {
 
     // MARK: Context menu support
 
-#if os(macOS) && !targetEnvironment(macCatalyst)
+#if os(macOS)
     @objc(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:)
     func _webView(_ webView: WKWebView!, getContextMenuFromProposedMenu menu: NSMenu!, forElement element: _WKContextMenuElementInfo!, userInfo: (any NSSecureCoding)!) async -> NSMenu? {
         guard let menuBuilder else {
             return menu
         }
 
-        let info = WebPage_v0.ElementInfo(linkURL: element.hitTestResult.absoluteLinkURL)
+        let info = WebPage.ElementInfo(linkURL: element.hitTestResult.absoluteLinkURL)
         return menuBuilder(info)
     }
 #endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift
@@ -25,9 +25,8 @@
 
 import Foundation
 
-extension WebPage_v0 {
+extension WebPage {
     @MainActor
-    @_spi(Private)
     public struct BackForwardList: Equatable, Sendable {
         @MainActor
         public struct Item: Equatable, Identifiable, Sendable {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -26,7 +26,7 @@
 import Foundation
 internal import WebKit_Internal
 
-extension WebPage_v0 {
+extension WebPage {
     @MainActor
     @_spi(Private)
     public struct Configuration: Sendable {
@@ -39,11 +39,11 @@ extension WebPage_v0 {
 
         public var webExtensionController: WKWebExtensionController? = nil
 
-        public var defaultNavigationPreferences: WebPage_v0.NavigationPreferences = WebPage_v0.NavigationPreferences()
+        public var defaultNavigationPreferences: WebPage.NavigationPreferences = WebPage.NavigationPreferences()
 
         public var urlSchemeHandlers: [URLScheme_v0 : any URLSchemeHandler_v0] = [:]
 
-        public var deviceSensorAuthorization: WebPage_v0.DeviceSensorAuthorization = WebPage_v0.DeviceSensorAuthorization(decision: .prompt)
+        public var deviceSensorAuthorization: WebPage.DeviceSensorAuthorization = WebPage.DeviceSensorAuthorization(decision: .prompt)
 
         public var applicationNameForUserAgent: String? = nil
 
@@ -65,7 +65,7 @@ extension WebPage_v0 {
     }
 }
 
-extension WebPage_v0 {
+extension WebPage {
     @_spi(Private)
     public struct DeviceSensorAuthorization {
         public enum Permission: Hashable, Sendable {
@@ -73,9 +73,9 @@ extension WebPage_v0 {
             case mediaCapture(WKMediaCaptureType)
         }
 
-        let decisionHandler: (Permission, WebPage_v0.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision
+        let decisionHandler: (Permission, WebPage.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision
 
-        public init(decisionHandler: @escaping (Permission, WebPage_v0.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision) {
+        public init(decisionHandler: @escaping (Permission, WebPage.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision) {
             self.decisionHandler = decisionHandler
         }
 
@@ -88,7 +88,7 @@ extension WebPage_v0 {
 // MARK: Adapters
 
 extension WKWebViewConfiguration {
-    convenience init(_ wrapped: WebPage_v0.Configuration) {
+    convenience init(_ wrapped: WebPage.Configuration) {
         self.init()
 
         self.websiteDataStore = wrapped.websiteDataStore

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
@@ -27,17 +27,20 @@ import Foundation
 
 // MARK: Supporting types
 
-extension WebPage_v0 {
+extension WebPage {
+    @_spi(Private)
     public enum JavaScriptConfirmResult: Hashable, Sendable {
         case ok
         case cancel
     }
 
+    @_spi(Private)
     public enum JavaScriptPromptResult: Hashable, Sendable {
         case ok(String)
         case cancel
     }
 
+    @_spi(Private)
     public enum FileInputPromptResult: Hashable, Sendable {
         case ok([URL])
         case cancel
@@ -49,37 +52,37 @@ extension WebPage_v0 {
 @_spi(Private)
 public protocol DialogPresenting {
     @MainActor
-    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage_v0.FrameInfo) async
+    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async
 
     @MainActor
-    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.JavaScriptConfirmResult
+    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult
 
     @MainActor
-    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.JavaScriptPromptResult
+    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult
 
     @MainActor
-    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.FileInputPromptResult
+    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult
 }
 
 // MARK: Default implementation
 
 public extension DialogPresenting {
     @MainActor
-    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage_v0.FrameInfo) async {
+    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async {
     }
 
     @MainActor
-    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.JavaScriptConfirmResult {
+    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult {
         .cancel
     }
 
     @MainActor
-    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.JavaScriptPromptResult {
+    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult {
         .cancel
     }
 
     @MainActor
-    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.FileInputPromptResult {
+    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult {
         .cancel
     }
 }

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Download.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Download.swift
@@ -25,8 +25,9 @@
 
 import Foundation
 
-extension WebPage_v0 {
+extension WebPage {
     @MainActor
+    @_spi(Private)
     public struct Download: Sendable {
         public enum RedirectPolicy: Sendable {
             case allow
@@ -48,7 +49,7 @@ extension WebPage_v0 {
 
         public var isUserInitiated: Bool { wrapped.isUserInitiated }
 
-        public var originatingFrame: WebPage_v0.FrameInfo { .init(wrapped.originatingFrame) }
+        public var originatingFrame: WebPage.FrameInfo { .init(wrapped.originatingFrame) }
 
         public var progress: Progress { wrapped.progress }
 
@@ -69,7 +70,8 @@ extension WebPage_v0 {
     }
 }
 
-extension WebPage_v0 {
+extension WebPage {
+    @_spi(Private)
     public struct DownloadID: Sendable, Hashable, Equatable {
         let rawValue: ObjectIdentifier
 
@@ -78,6 +80,7 @@ extension WebPage_v0 {
         }
     }
 
+    @_spi(Private)
     public struct DownloadEvent: Sendable {
         public enum Kind: Sendable {
             case started
@@ -92,14 +95,14 @@ extension WebPage_v0 {
         }
 
         @_spi(Testing)
-        public init(kind: Kind, download: WebPage_v0.Download) {
+        public init(kind: Kind, download: WebPage.Download) {
             self.kind = kind
             self.download = download
         }
 
         public let kind: Kind
 
-        public let download: WebPage_v0.Download
+        public let download: WebPage.Download
     }
 
     @_spi(Private)
@@ -122,9 +125,9 @@ extension WebPage_v0 {
     }
 }
 
-extension WebPage_v0.Downloads {
+extension WebPage.Downloads {
     public struct Iterator: AsyncIteratorProtocol {
-        public typealias Element = WebPage_v0.DownloadEvent
+        public typealias Element = WebPage.DownloadEvent
 
         public typealias Failure = Never
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+ElementInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+ElementInfo.swift
@@ -26,7 +26,7 @@
 import Foundation
 internal import WebKit_Internal
 
-extension WebPage_v0 {
+extension WebPage {
     @MainActor
     @_spi(Private)
     public struct ElementInfo: Sendable {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
@@ -26,9 +26,11 @@
 import Foundation
 internal import WebKit_Internal
 
-extension WebPage_v0 {
+extension WebPage {
     @MainActor
-    @_spi(Private)
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public struct FrameInfo: Sendable {
         init(_ wrapped: WKFrameInfo) {
             self.wrapped = wrapped

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -25,7 +25,8 @@
 
 import Foundation
 
-extension WebPage_v0 {
+extension WebPage {
+    /// An opaque identifier which can be used to uniquely identify a load request for a web page.
     public struct NavigationID: Sendable, Hashable, Equatable {
         let rawValue: ObjectIdentifier
 
@@ -34,19 +35,28 @@ extension WebPage_v0 {
         }
     }
 
-    @_spi(Private)
+    /// A particular state that occurs during the progression of a navigation.
     public struct NavigationEvent: Sendable {
+        /// A set of values representing the possible types a NavigationEvent can represent.
         public enum Kind: Sendable {
+            /// This event occurs when the web page receives provisional approval to process a navigation request,
+            /// but before it receives a response to that request.
             case startedProvisionalNavigation
 
+            /// This event occurs when the web page received a server redirect for a request.
             case receivedServerRedirect
 
+            /// This event occurs when the web page has started to receive content for the main frame.
+            /// This happens immediately before the web page starts to update the main frame.
             case committed
 
+            /// This event occurs once the navigation is complete.
             case finished
 
+            /// This event indicates an error occurs during the early navigation process.
             case failedProvisionalNavigation(underlyingError: any Error)
 
+            /// This event indicates an error occurred during navigation.
             case failed(underlyingError: any Error)
         }
 
@@ -56,47 +66,11 @@ extension WebPage_v0 {
             self.navigationID = navigationID
         }
 
+        /// The type of this navigation event.
         public let kind: Kind
 
+        /// The ID of the navigation that triggered this event. Multiple sequential events will have the same navigation identifier.
         public let navigationID: NavigationID
-    }
-
-    @_spi(Private)
-    public struct Navigations: AsyncSequence, Sendable {
-        public typealias AsyncIterator = Iterator
-        
-        public typealias Element = NavigationEvent
-
-        public typealias Failure = Never
-
-        init(source: AsyncStream<Element>) {
-            self.source = source
-        }
-
-        private let source: AsyncStream<Element>
-        
-        public func makeAsyncIterator() -> AsyncIterator {
-            Iterator(source: source.makeAsyncIterator())
-        }
-    }
-}
-
-extension WebPage_v0.Navigations {
-    @_spi(Private)
-    public struct Iterator: AsyncIteratorProtocol {
-        public typealias Element = WebPage_v0.NavigationEvent
-
-        public typealias Failure = Never
-
-        init(source: AsyncStream<Element>.AsyncIterator) {
-            self.source = source
-        }
-
-        private var source: AsyncStream<Element>.AsyncIterator
-        
-        public mutating func next() async -> Element? {
-            await source.next()
-        }
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
@@ -27,7 +27,7 @@ import Foundation
 
 // MARK: Supporting types
 
-extension WebPage_v0 {
+extension WebPage {
     @MainActor
     @_spi(Private)
     public struct NavigationAction: Sendable {
@@ -77,10 +77,10 @@ extension WebPage_v0 {
 @_spi(Private)
 public protocol NavigationDeciding {
     @MainActor
-    func decidePolicy(for action: WebPage_v0.NavigationAction, preferences: inout WebPage_v0.NavigationPreferences) async -> WKNavigationActionPolicy
+    func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy
 
     @MainActor
-    func decidePolicy(for response: WebPage_v0.NavigationResponse) async -> WKNavigationResponsePolicy
+    func decidePolicy(for response: WebPage.NavigationResponse) async -> WKNavigationResponsePolicy
 
     @MainActor
     func decideAuthenticationChallengeDisposition(for challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
@@ -91,12 +91,12 @@ public protocol NavigationDeciding {
 @_spi(Private)
 public extension NavigationDeciding {
     @MainActor
-    func decidePolicy(for action: WebPage_v0.NavigationAction, preferences: inout WebPage_v0.NavigationPreferences) async -> WKNavigationActionPolicy {
+    func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy {
         .allow
     }
 
     @MainActor
-    func decidePolicy(for response: WebPage_v0.NavigationResponse) async -> WKNavigationResponsePolicy {
+    func decidePolicy(for response: WebPage.NavigationResponse) async -> WKNavigationResponsePolicy {
         .allow
     }
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -26,7 +26,7 @@
 import Foundation
 internal import WebKit_Internal
 
-extension WebPage_v0 {
+extension WebPage {
     @MainActor
     @_spi(Private)
     public struct NavigationPreferences: Sendable {
@@ -63,7 +63,7 @@ extension WebPage_v0 {
 // MARK: Adapters
 
 extension WKWebpagePreferences.ContentMode {
-    init(_ wrapped: WebPage_v0.NavigationPreferences.ContentMode) {
+    init(_ wrapped: WebPage.NavigationPreferences.ContentMode) {
         self = switch wrapped {
         case .recommended: .recommended
         case .mobile: .mobile
@@ -73,7 +73,7 @@ extension WKWebpagePreferences.ContentMode {
 }
 
 extension WKWebpagePreferences.UpgradeToHTTPSPolicy {
-    init(_ wrapped: WebPage_v0.NavigationPreferences.UpgradeToHTTPSPolicy) {
+    init(_ wrapped: WebPage.NavigationPreferences.UpgradeToHTTPSPolicy) {
         self = switch wrapped {
         case .keepAsRequested: .keepAsRequested
         case .automaticFallbackToHTTP: .automaticFallbackToHTTP
@@ -84,7 +84,7 @@ extension WKWebpagePreferences.UpgradeToHTTPSPolicy {
 }
 
 extension WKWebpagePreferences {
-    convenience init(_ wrapped: WebPage_v0.NavigationPreferences) {
+    convenience init(_ wrapped: WebPage.NavigationPreferences) {
         self.init()
 
         self.preferredContentMode = .init(wrapped.preferredContentMode)
@@ -97,7 +97,7 @@ extension WKWebpagePreferences {
     }
 }
 
-extension WebPage_v0.NavigationPreferences.ContentMode {
+extension WebPage.NavigationPreferences.ContentMode {
     init(_ wrapped: WKWebpagePreferences.ContentMode) {
         self = switch wrapped {
         case .recommended: .recommended
@@ -109,7 +109,7 @@ extension WebPage_v0.NavigationPreferences.ContentMode {
     }
 }
 
-extension WebPage_v0.NavigationPreferences.UpgradeToHTTPSPolicy {
+extension WebPage.NavigationPreferences.UpgradeToHTTPSPolicy {
     init(_ wrapped: WKWebpagePreferences.UpgradeToHTTPSPolicy) {
         self = switch wrapped {
         case .keepAsRequested: .keepAsRequested
@@ -122,7 +122,7 @@ extension WebPage_v0.NavigationPreferences.UpgradeToHTTPSPolicy {
     }
 }
 
-extension WebPage_v0.NavigationPreferences {
+extension WebPage.NavigationPreferences {
     init(_ wrapped: WKWebpagePreferences) {
         self.init()
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -68,19 +68,54 @@ extension WebPageWebView {
     }
 }
 
-@_spi(Private)
+
+/// An object that controls and manages the behavior of interactive web content.
 @MainActor
 @Observable
-public class WebPage_v0 {
-    public enum FullscreenState: Hashable, Sendable {
-        case enteringFullscreen
-        case exitingFullscreen
-        case inFullscreen
-        case notInFullscreen
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+final public class WebPage {
+    /// A CSS media type as defined by the [CSS specification](https://www.w3.org/TR/mediaqueries-4/#media-types), or an arbitrary media type value.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public struct CSSMediaType: Hashable, RawRepresentable, Sendable {
+        /// Corresponds to the "all" media type.
+        public static let all = CSSMediaType(rawValue: "all")
+
+        /// Corresponds to the "screen" media type.
+        public static let screen = CSSMediaType(rawValue: "screen")
+
+        /// Corresponds to the "print" media type.
+        public static let print = CSSMediaType(rawValue: "print")
+
+        /// Create a media type with an arbitrary value. Use the static type properties for the defined canonical CSS media type options.
+        /// - Parameter rawValue: The raw value of the media type.
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        /// The raw value of the media type.
+        public let rawValue: String
     }
 
-    public static func handlesURLScheme(_ scheme: String) -> Bool {
-        WKWebView.handlesURLScheme(scheme)
+    /// The set of possible fullscreen states a webpage may be in.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public enum FullscreenState: Hashable, Sendable {
+        /// The page is entering fullscreen.
+        case enteringFullscreen
+
+        /// The page is exiting fullscreen.
+        case exitingFullscreen
+
+        /// The page is currently in a fullscreen state.
+        case inFullscreen
+
+        /// The page is not currently in a fullscreen state.
+        case notInFullscreen
     }
 
     // MARK: Initializers
@@ -93,10 +128,6 @@ public class WebPage_v0 {
     ) {
         self.configuration = _configuration
 
-        // FIXME: Consider whether we want to have a single value here or if the getter for `navigations` should return a fresh sequence every time.
-        let (navigationStream, navigationContinuation) = AsyncStream.makeStream(of: NavigationEvent.self)
-        navigations = Navigations(source: navigationStream)
-
         let (downloadStream, downloadContinuation) = AsyncStream.makeStream(of: DownloadEvent.self)
         downloads = Downloads(source: downloadStream)
 
@@ -108,7 +139,6 @@ public class WebPage_v0 {
             dialogPresenter: dialogPresenter
         )
         backingNavigationDelegate = WKNavigationDelegateAdapter(
-            navigationProgressContinuation: navigationContinuation,
             downloadProgressContinuation: downloadContinuation,
             navigationDecider: navigationDecider
         )
@@ -118,6 +148,7 @@ public class WebPage_v0 {
         backingDownloadDelegate.owner = self
     }
 
+    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding,
@@ -127,6 +158,7 @@ public class WebPage_v0 {
         self.init(_configuration: configuration, _navigationDecider: navigationDecider, _dialogPresenter: dialogPresenter, _downloadCoordinator: downloadCoordinator)
     }
 
+    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding,
@@ -135,6 +167,7 @@ public class WebPage_v0 {
         self.init(_configuration: configuration, _navigationDecider: navigationDecider, _dialogPresenter: dialogPresenter, _downloadCoordinator: nil)
     }
 
+    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding,
@@ -143,6 +176,7 @@ public class WebPage_v0 {
         self.init(_configuration: configuration, _navigationDecider: navigationDecider, _dialogPresenter: nil, _downloadCoordinator: downloadCoordinator)
     }
 
+    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         dialogPresenter: some DialogPresenting,
@@ -151,6 +185,7 @@ public class WebPage_v0 {
         self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: dialogPresenter, _downloadCoordinator: downloadCoordinator)
     }
 
+    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         dialogPresenter: some DialogPresenting
@@ -158,6 +193,7 @@ public class WebPage_v0 {
         self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: dialogPresenter, _downloadCoordinator: nil)
     }
 
+    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding
@@ -165,6 +201,7 @@ public class WebPage_v0 {
         self.init(_configuration: configuration, _navigationDecider: navigationDecider, _dialogPresenter: nil, _downloadCoordinator: nil)
     }
 
+    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         downloadCoordinator: some DownloadCoordinator
@@ -172,26 +209,42 @@ public class WebPage_v0 {
         self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: nil, _downloadCoordinator: downloadCoordinator)
     }
 
+    @_spi(Private)
     public convenience init(
-        configuration: Configuration = Configuration()
+        configuration: Configuration = Configuration(),
     ) {
         self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: nil, _downloadCoordinator: nil)
     }
 
     // MARK: Properties
 
-    public let navigations: Navigations
+    /// The current navigation event, or `nil` if there have been no navigations so far.
+    ///
+    /// This property may be used to observe changes to both an individual navigation, and across navigations.
+    ///
+    /// A new navigation begins when a `NavigationEvent` has a type of `startedProvisionalNavigation`, and is finished once a
+    /// navigation event with a type of `.finished`, `.failedProvisionalNavigation`, or `.failed`.
+    public internal(set) var currentNavigationEvent: WebPage.NavigationEvent? = nil
 
+    @_spi(Private)
     public let downloads: Downloads
 
+    @_spi(Private)
     public let configuration: Configuration
 
+    /// The webpage's back-forward list.
     public internal(set) var backForwardList: BackForwardList = BackForwardList()
 
+    /// The URL for the current webpage.
+    ///
+    /// This property contains the URL for the webpage currently being presented. Use this URL in places
+    /// where you reflect the webpage address in your app’s user interface. If the webpage has not loaded
+    /// any content yet, this value will be `nil`.
     public var url: URL? {
         backingProperty(\.url, backedBy: \.url)
     }
 
+    /// The page title.
     public var title: String {
         backingProperty(\.title, backedBy: \.title) { backingValue in
             // The title property is annotated as optional in WKWebView, but is never actually `nil`.
@@ -199,50 +252,88 @@ public class WebPage_v0 {
         }
     }
 
+    /// An estimate of completion percentage of the current navigation.
+    ///
+    /// The value ranges from `0.0` to `1.0` based on the total number of bytes received, including the main
+    /// document and all of its potential subresources. After navigation loading completes, the `estimatedProgress`
+    /// value remains at `1.0` until a new navigation starts, at which point the `estimatedProgress` value resets
+    /// to `0.0`.
     public var estimatedProgress: Double {
         backingProperty(\.estimatedProgress, backedBy: \.estimatedProgress)
     }
 
+    /// Indicates whether the webpage is currently loading content.
+    ///
+    /// - Returns: `true` if the receiver is still loading content, otherwise, `false`.
     public var isLoading: Bool {
         backingProperty(\.isLoading, backedBy: \.isLoading)
     }
 
+    /// The trust management object you use to evaluate trust for the current webpage.
+    ///
+    /// Use the object in this property to validate the webpage’s certificate and associated credentials.
     public var serverTrust: SecTrust? {
         backingProperty(\.serverTrust, backedBy: \.serverTrust)
     }
 
+    /// Indicates whether the webpage loaded all resources on the page through securely encrypted connections.
     public var hasOnlySecureContent: Bool {
         backingProperty(\.hasOnlySecureContent, backedBy: \.hasOnlySecureContent)
     }
 
+    /// Indicates whether Writing Tools is active for the view.
     public var isWritingToolsActive: Bool {
         backingProperty(\.isWritingToolsActive, backedBy: \.isWritingToolsActive)
     }
 
-    public var fullscreenState: WebPage_v0.FullscreenState {
+    /// The fullscreen state the page is currently in.
+    public var fullscreenState: WebPage.FullscreenState {
         backingProperty(\.fullscreenState, backedBy: \.fullscreenState) { backingValue in
-            WebPage_v0.FullscreenState(backingValue)
+            WebPage.FullscreenState(backingValue)
         }
     }
 
+    /// Indicates whether the webpage is using the camera to capture images or video.
     public var cameraCaptureState: WKMediaCaptureState {
         backingProperty(\.cameraCaptureState, backedBy: \.cameraCaptureState)
     }
 
+    /// Indicates whether the webpage is using the microphone to capture audio.
     public var microphoneCaptureState: WKMediaCaptureState {
         backingProperty(\.microphoneCaptureState, backedBy: \.microphoneCaptureState)
     }
 
-    public var mediaType: String? {
-        get { backingWebView.mediaType }
-        set { backingWebView.mediaType = newValue }
+    /// The media type for the contents of the web view.
+    ///
+    /// When the value of this property is `nil`, the webpage derives the current media type from the CSS
+    /// media property of its content. If you assign a value other than `nil` to this property, the webpage
+    /// uses the value you provide instead.
+    ///
+    /// The default value of this property is `nil`.
+    public var mediaType: WebPage.CSSMediaType? {
+        get { backingWebView.mediaType.map(CSSMediaType.init(rawValue:)) }
+        set { backingWebView.mediaType = newValue?.rawValue }
     }
 
+    /// The custom user agent string.
+    ///
+    /// Use this property to specify a custom user agent string for the webpage.
+    ///
+    /// The default value of this property is `nil`.
     public var customUserAgent: String? {
         get { backingWebView.customUserAgent }
         set { backingWebView.customUserAgent = newValue }
     }
 
+    /// Indicates whether you can inspect the view with Safari Web Inspector.
+    ///
+    /// Set to true at any point in the view’s lifetime to allow Safari Web Inspector access to inspect the view’s content.
+    /// Then, select your view in Safari’s Develop menu for either your computer or an attached device to inspect it.
+    ///
+    /// If you set this value to false during inspection, the system immediately closes Safari Web Inspector and does not
+    /// provide any further information about the web content.
+    ///
+    /// The default value of this property is `false`.
     public var isInspectable: Bool {
         get { backingWebView.isInspectable }
         set { backingWebView.isInspectable = newValue }
@@ -252,9 +343,9 @@ public class WebPage_v0 {
     private let backingNavigationDelegate: WKNavigationDelegateAdapter
     let backingDownloadDelegate: WKDownloadDelegateAdapter
 
-#if os(macOS) && !targetEnvironment(macCatalyst)
+#if os(macOS)
     @_spi(CrossImportOverlay)
-    public func setMenuBuilder(_ menuBuilder: ((WebPage_v0.ElementInfo) -> NSMenu)?) {
+    public func setMenuBuilder(_ menuBuilder: ((WebPage.ElementInfo) -> NSMenu)?) {
         backingUIDelegate.menuBuilder = menuBuilder
     }
 #endif
@@ -280,11 +371,31 @@ public class WebPage_v0 {
 
     // MARK: Loading functions
 
+    /// Loads the web content that the specified URL request object references and navigates to that content.
+    ///
+    /// Use this method to load a page from a local or network-based URL. For example, you might use this method
+    /// to navigate to a network-based webpage.
+    ///
+    /// Provide the source of this load request for app activity data by setting the attribution parameter on your request.
+    ///
+    /// - Parameter request: A URL request that specifies the resource to display.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
     public func load(_ request: URLRequest) -> NavigationID? {
         backingWebView.load(request).map(NavigationID.init(_:))
     }
 
+    /// Loads the content of the specified data object and navigates to it.
+    ///
+    /// Use this method to navigate to a webpage that you loaded yourself and saved in a data object. For example,
+    /// if you previously wrote HTML content to a data object, use this method to navigate to that content.
+    ///
+    /// - Parameters:
+    ///   - data: The data to use as the contents of the webpage.
+    ///   - mimeType: The MIME type of the information in the data parameter. This parameter must not contain an empty string.
+    ///   - encoding: The data's character encoding.
+    ///   - baseURL: A URL that you use to resolve relative URLs within the document.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
     public func load(_ data: Data, mimeType: String, characterEncoding: String.Encoding, baseURL: URL) -> NavigationID? {
         let cfEncoding = CFStringConvertNSStringEncodingToEncoding(characterEncoding.rawValue)
@@ -299,16 +410,47 @@ public class WebPage_v0 {
         return backingWebView.load(data, mimeType: mimeType, characterEncodingName: convertedEncoding, baseURL: baseURL).map(NavigationID.init(_:))
     }
 
+    /// Loads the contents of the specified HTML string and navigates to it.
+    ///
+    /// Use this method to navigate to a webpage that you loaded or created yourself. For example, you might use
+    /// this method to load HTML content that your app generates programmatically.
+    ///
+    /// This method sets the source of this load request for app activity data to NSURLRequest.Attribution.developer.
+    ///
+    /// - Parameters:
+    ///   - html: The string to use as the contents of the webpage.
+    ///   - baseURL: The base URL to use when the system resolves relative URLs within the HTML string.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
-    public func load(htmlString: String, baseURL: URL) -> NavigationID? {
-        backingWebView.loadHTMLString(htmlString, baseURL: baseURL).map(NavigationID.init(_:))
+    public func load(html: String, baseURL: URL) -> NavigationID? {
+        backingWebView.loadHTMLString(html, baseURL: baseURL).map(NavigationID.init(_:))
     }
 
+    /// Loads the web content from the specified file and navigates to it.
+    ///
+    /// - Parameters:
+    ///   - fileURL: The URL of a file that contains web content. This URL must be a file-based URL.
+    ///   - readAccessURL: The URL of a file or directory containing web content that you grant the system permission
+    ///   to read. This URL must be a file-based URL and must not be empty. To prevent WebKit from reading any other
+    ///   content, specify the same value as the URL parameter. To read additional files related to the content file,
+    ///   specify a directory.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
     public func load(fileURL url: URL, allowingReadAccessTo readAccessURL: URL) -> NavigationID? {
         backingWebView.loadFileURL(url, allowingReadAccessTo: readAccessURL).map(NavigationID.init(_:))
     }
 
+    /// Loads the web content from the file the URL request object specifies and navigates to that content.
+    ///
+    /// Provide the source of this load request for app activity data by setting the `attribution` parameter on your request.
+    ///
+    /// - Parameters:
+    ///   - request: A URL request that specifies the file to display. The URL in this request must be a file-based URL.
+    ///   - readAccessURL: The URL of a file or directory containing web content that you grant the system permission
+    ///   to read. This URL must be a file-based URL and must not be empty. To prevent WebKit from reading any other
+    ///   content, specify the same value as the URL parameter. To read additional files related to the content file,
+    ///   specify a directory.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
     public func load(fileRequest request: URLRequest, allowingReadAccessTo readAccessURL: URL) -> NavigationID? {
         // `WKWebView` annotates this method as returning non-nil, but it may return nil.
@@ -317,6 +459,13 @@ public class WebPage_v0 {
         return navigation.map(NavigationID.init(_:))
     }
 
+    /// Loads the web content from the data you provide as if the data were the response to the request.
+    ///
+    /// - Parameters:
+    ///   - request: A URL request that specifies the base URL and other loading details the system uses to interpret the data you provide.
+    ///   - response: A response the system uses to interpret the data you provide.
+    ///   - responseData: The data to use as the contents of the webpage.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
     public func load(simulatedRequest request: URLRequest, response: URLResponse, responseData: Data) -> NavigationID? {
         // `WKWebView` annotates this method as returning non-nil, but it may return nil.
@@ -325,49 +474,104 @@ public class WebPage_v0 {
         return navigation.map(NavigationID.init(_:))
     }
 
+    /// Loads the web content from the HTML you provide as if the HTML were the response to the request.
+    ///
+    /// - Parameters:
+    ///   - request: A URL request that specifies the base URL and other loading details the system uses to interpret the HTML you provide.
+    ///   - htmlString: The HTML code you provide in a string to use as the contents of the webpage.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
-    public func load(simulatedRequest request: URLRequest, responseHTML: String) -> NavigationID? {
+    public func load(simulatedRequest request: URLRequest, responseHTML htmlString: String) -> NavigationID? {
         // `WKWebView` annotates this method as returning non-nil, but it may return nil.
 
-        let navigation = backingWebView.loadSimulatedRequest(request, responseHTML: responseHTML) as WKNavigation?
+        let navigation = backingWebView.loadSimulatedRequest(request, responseHTML: htmlString) as WKNavigation?
         return navigation.map(NavigationID.init(_:))
     }
 
+    /// Navigates to an item from the back-forward list and sets it as the current item.
+    ///
+    /// - Parameters:
+    ///   - item: The item to navigate to. The item must be in the webpage's back-forward list.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
-    public func load(backForwardItem: BackForwardList.Item) -> NavigationID? {
-        backingWebView.go(to: backForwardItem.wrapped).map(NavigationID.init(_:))
+    public func load(_ item: BackForwardList.Item) -> NavigationID? {
+        backingWebView.go(to: item.wrapped).map(NavigationID.init(_:))
     }
 
+    /// Reloads the current webpage.
+    ///
+    /// - Parameter fromOrigin: If `true`, end-to-end revalidation of the content using cache-validating conditionals
+    /// is performed, if possible.
+    /// - Returns: A navigation identifier you use to track the loading progress of the request.
     @discardableResult
     public func reload(fromOrigin: Bool = false) -> NavigationID? {
         let navigation = fromOrigin ? backingWebView.reloadFromOrigin() : backingWebView.reload()
         return navigation.map(NavigationID.init(_:))
     }
 
+    /// Stops loading all resources on the current page.
     public func stopLoading() {
         backingWebView.stopLoading()
     }
 
     // MARK: Utility functions
 
-    public func callAsyncJavaScript(_ functionBody: String, arguments: [String : Any] = [:], in frame: FrameInfo? = nil, contentWorld: WKContentWorld = .page) async throws -> Any? {
-        try await backingWebView.callAsyncJavaScript(functionBody, arguments: arguments, in: frame?.wrapped, contentWorld: contentWorld)
+    /// Executes the specified string as an async JavaScript function.
+    ///
+    /// Don’t format the string in the functionBody parameter as a function-like callable object, as you would in pure
+    /// JavaScript. Instead, put only the body of the function in the string. For example, the following string shows a valid function body that takes x, y, and z arguments and returns a result.
+    ///
+    /// ```javascript
+    /// return x ? y : z;
+    /// ```
+    ///
+    /// If your JavaScript code returns an object with a callable then property, WebKit calls that property on
+    /// the resulting object and waits for its resolution. If resolution succeeds, WebKit returns the resulting
+    /// object. If resolution fails, WebKit throws a `WKErrorJavaScriptAsyncFunctionResultRejected` error. If the
+    /// garbage collector reclaims the object before resolution finishes, WebKit throws a `WKErrorJavaScriptAsyncFunctionResultUnreachable` error.
+    ///
+    /// Because this method calls your JavaScript code asynchronously, you can call `await` on objects with a
+    /// `then` property inside your function body. The following code example illustrates this technique.
+    ///
+    /// ```javascript
+    /// var p = new Promise(function (f) {
+    ///   window.setTimeout("f(42)", 1000);
+    /// });
+    /// await p;
+    /// return p;
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - functionBody: The JavaScript string to use as the function body. This method treats the string as an anonymous
+    ///   JavaScript function body and calls it with the named arguments in the `arguments` parameter.
+    ///
+    ///   - arguments: A dictionary of the arguments to pass to the function call. Each key in the dictionary corresponds
+    ///   to the name of an argument in the `functionBody` string, and the value of that key is the value to use during
+    ///   the evaluation of the code. Supported value types are `Numeric`, `String`, `Date`, and arrays, dictionaries,
+    ///   and optional values of those types.
+    ///
+    ///   - frame: The frame in which to evaluate the JavaScript code. Specify `nil` to target the main frame. If this
+    ///   frame is no longer valid when script evaluation begins, this function throws an error with the
+    ///   `WKError.Code.javaScriptInvalidFrameTarget` code.
+    ///
+    ///   - contentWorld: The namespace in which to evaluate the JavaScript code. THis parameter doesn't apply to changes
+    ///   you make in the underlying web content, such as the document's DOM structure. Those changes remain visible to
+    ///   all scripts, regardless of which content world you specify. For more information about content worlds, see `WKContentWorld`.
+    ///
+    /// - Returns: The result of the script evaluation. If your function body doesn't return an explicit value, `nil` is returned.
+    ///  If your function body explicitly returns `null`, then `NSNull` is returned.
+    public func callJavaScript(_ functionBody: String, arguments: [String : Any] = [:], in frame: FrameInfo? = nil, contentWorld: WKContentWorld? = nil) async throws -> Any? {
+        try await backingWebView.callAsyncJavaScript(functionBody, arguments: arguments, in: frame?.wrapped, contentWorld: contentWorld ?? .page)
     }
 
-#if canImport(UIKit)
-    public func snapshot(configuration: WKSnapshotConfiguration = .init()) async throws -> UIImage {
-        try await backingWebView.takeSnapshot(configuration: configuration)
-    }
-#else
-    public func snapshot(configuration: WKSnapshotConfiguration = .init()) async throws -> NSImage {
-        try await backingWebView.takeSnapshot(configuration: configuration)
-    }
-#endif
-
+    /// Generates PDF data from the webpage's contents
+    /// - Parameter configuration: The object that specifies the portion of the web view to capture as PDF data.
+    /// - Returns: A data object that contains the PDF data to use for rendering the contents of the webpage.
     public func pdf(configuration: WKPDFConfiguration = .init()) async throws -> Data {
         try await backingWebView.pdf(configuration: configuration)
     }
 
+    /// Creates a web archive of the webpage's current contents.
     public func webArchiveData() async throws -> Data {
         try await withCheckedThrowingContinuation { continuation in
             backingWebView.createWebArchiveData {
@@ -378,26 +582,36 @@ public class WebPage_v0 {
 
     // MARK: Media functions
 
+    /// Pauses playback of all media in the web view.
     public func pauseAllMediaPlayback() async {
         await backingWebView.pauseAllMediaPlayback()
     }
 
+    /// Determine the playback status of media in the page.
+    /// - Returns: The current state of media playback within the page.
     public func mediaPlaybackState() async -> WKMediaPlaybackState {
         await backingWebView.requestMediaPlaybackState()
     }
 
+    /// Changes whether the webpage is suspending playback of all media in the page.
+    /// - Parameter suspended: Indicates whether the webpage should suspend media playback.
     public func setAllMediaPlaybackSuspended(_ suspended: Bool) async {
         await backingWebView.setAllMediaPlaybackSuspended(suspended)
     }
 
+    /// Closes all media the webpage is presenting, including picture-in-picture video and fullscreen video.
     public func closeAllMediaPresentations() async {
         await backingWebView.closeAllMediaPresentations()
     }
 
+    /// Changes whether the webpage is using the camera to capture images or video.
+    /// - Parameter state: The new capture state the page should use.
     public func setCameraCaptureState(_ state: WKMediaCaptureState) async {
         await backingWebView.setCameraCaptureState(state)
     }
 
+    /// Changes whether the webpage is using the microphone to capture audio.
+    /// - Parameter state: The new capture state the page should use.
     public func setMicrophoneCaptureState(_ state: WKMediaCaptureState) async {
         await backingWebView.setMicrophoneCaptureState(state)
     }
@@ -407,19 +621,21 @@ public class WebPage_v0 {
     // For these to work, a custom implementation of `DownloadCoordinator.destination(forDownload:response:suggestedFilename:) async -> URL?`
     // must be provided so that the downloads are not immediately cancelled.
 
-    public func startDownload(using request: URLRequest) async -> WebPage_v0.DownloadID {
+    @_spi(Private)
+    public func startDownload(using request: URLRequest) async -> WebPage.DownloadID {
         let cocoaDownload = await backingWebView.startDownload(using: request)
-        return WebPage_v0.DownloadID(cocoaDownload)
+        return WebPage.DownloadID(cocoaDownload)
     }
 
-    public func resumeDownload(fromResumeData resumeData: Data) async -> WebPage_v0.DownloadID {
+    @_spi(Private)
+    public func resumeDownload(fromResumeData resumeData: Data) async -> WebPage.DownloadID {
         let cocoaDownload = await backingWebView.resumeDownload(fromResumeData: resumeData)
-        return WebPage_v0.DownloadID(cocoaDownload)
+        return WebPage.DownloadID(cocoaDownload)
     }
 
     // MARK: Private helper functions
 
-    private func createObservation<Value, BackingValue>(for keyPath: KeyPath<WebPage_v0, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, BackingValue>) -> NSKeyValueObservation {
+    private func createObservation<Value, BackingValue>(for keyPath: KeyPath<WebPage, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, BackingValue>) -> NSKeyValueObservation {
         let boxed = UncheckedSendableKeyPathBox(keyPath: keyPath)
 
         return backingWebView.observe(backingKeyPath, options: [.prior, .old, .new]) { [_$observationRegistrar, unowned self] _, change in
@@ -432,7 +648,7 @@ public class WebPage_v0 {
     }
 
     @_spi(CrossImportOverlay)
-    public func backingProperty<Value, BackingValue>(_ keyPath: KeyPath<WebPage_v0, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, BackingValue>, _ transform: (BackingValue) -> Value) -> Value {
+    public func backingProperty<Value, BackingValue>(_ keyPath: KeyPath<WebPage, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, BackingValue>, _ transform: (BackingValue) -> Value) -> Value {
         if observations.contents[keyPath] == nil {
             observations.contents[keyPath] = createObservation(for: keyPath, backedBy: backingKeyPath)
         }
@@ -444,12 +660,12 @@ public class WebPage_v0 {
     }
 
     @_spi(CrossImportOverlay)
-    public func backingProperty<Value>(_ keyPath: KeyPath<WebPage_v0, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, Value>) -> Value {
+    public func backingProperty<Value>(_ keyPath: KeyPath<WebPage, Value>, backedBy backingKeyPath: KeyPath<WebPageWebView, Value>) -> Value {
         backingProperty(keyPath, backedBy: backingKeyPath) { $0 }
     }
 }
 
-extension WebPage_v0.FullscreenState {
+extension WebPage.FullscreenState {
     init(_ wrapped: WKWebView.FullscreenState) {
         self = switch wrapped {
         case .enteringFullscreen: .enteringFullscreen
@@ -462,9 +678,9 @@ extension WebPage_v0.FullscreenState {
     }
 }
 
-extension WebPage_v0 {
+extension WebPage {
     private struct KeyValueObservations: ~Copyable {
-        var contents: [PartialKeyPath<WebPage_v0> : NSKeyValueObservation] = [:]
+        var contents: [PartialKeyPath<WebPage> : NSKeyValueObservation] = [:]
 
         deinit {
             for (_, observation) in contents {

--- a/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
@@ -90,9 +90,9 @@ extension View {
     }
 
     @_spi(Private)
-    public func webViewContextMenu<M>(@ViewBuilder menuItems: @escaping (WebPage_v0.ElementInfo) -> M) -> some View where M: View {
+    public func webViewContextMenu<M>(@ViewBuilder menuItems: @escaping (WebPage.ElementInfo) -> M) -> some View where M: View {
 #if os(macOS)
-        let converted = { (info: WebPage_v0.ElementInfo) in
+        let converted = { (info: WebPage.ElementInfo) in
             let menuView = menuItems(info)
             return NSHostingMenu(rootView: menuView)
         }
@@ -106,7 +106,7 @@ extension View {
 
 struct ContextMenuContext {
 #if os(macOS)
-    let menu: (WebPage_v0.ElementInfo) -> NSMenu
+    let menu: (WebPage.ElementInfo) -> NSMenu
 #endif
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/WebPage+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebPage+SwiftUI.swift
@@ -25,7 +25,8 @@ import Foundation
 public import SwiftUI
 @_spi(Private) @_spi(CrossImportOverlay) import WebKit
 
-extension WebPage_v0 {
+extension WebPage {
+    /// The theme color that the system gets from the first valid meta tag in the webpage.
     public var themeColor: Color? {
         self.backingProperty(\.themeColor, backedBy: \.themeColor) { backingValue in
             // The themeColor property is a UIColor/NSColor in WKWebView.
@@ -35,5 +36,19 @@ extension WebPage_v0 {
             return backingValue.map(Color.init(nsColor:))
 #endif
         }
+    }
+
+    /// Generates an image from the web view’s contents.
+    ///
+    /// - Parameter configuration: The object that specifies the portion of the web page to capture, and other capture-related behaviors.
+    /// - Returns: An image that contains the specified portion of the web page.
+    public func snapshot(_ configuration: WKSnapshotConfiguration = .init()) async throws -> Image? {
+        let cocoaImage = try await backingWebView.takeSnapshot(configuration: configuration)
+
+#if canImport(UIKit)
+        return Image(uiImage: cocoaImage)
+#else
+        return Image(nsImage: cocoaImage)
+#endif
     }
 }

--- a/Source/WebKit/_WebKit_SwiftUI/WebPageNavigationAction+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebPageNavigationAction+SwiftUI.swift
@@ -25,7 +25,7 @@ import Foundation
 public import SwiftUI
 @_spi(Private) @_spi(CrossImportOverlay) import WebKit
 
-extension WebPage_v0.NavigationAction {
+extension WebPage.NavigationAction {
     public var modifierFlags: EventModifiers { EventModifiers(wrapped.modifierFlags) }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebView.swift
@@ -24,15 +24,15 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 public import SwiftUI
-@_spi(Private) @_spi(CrossImportOverlay) import WebKit
+public import WebKit
 
 @_spi(Private)
 public struct WebView_v0: View {
-    public init(_ page: WebPage_v0) {
+    public init(_ page: WebPage) {
         self.page = page
     }
 
-    let page: WebPage_v0
+    let page: WebPage
 
     public var body: some View {
         WebViewRepresentable(owner: self)

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -46,8 +46,6 @@ struct OpenRequest: Equatable {
 @Observable
 @MainActor
 final class BrowserViewModel {
-    typealias WebPage = WebPage_v0
-
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: String(describing: BrowserViewModel.self))
 
     private static func decideSensorAuthorization(permission: WebPage.DeviceSensorAuthorization.Permission, frame: WebPage.FrameInfo, origin: WKSecurityOrigin) async -> WKPermissionDecision {

--- a/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
@@ -29,8 +29,8 @@ final class DialogPresenter: DialogPresenting {
     struct Dialog: Hashable, Identifiable, Sendable {
         enum Configuration: Sendable {
             case alert(String, @Sendable () -> Void)
-            case confirm(String, @Sendable (sending WebPage_v0.JavaScriptConfirmResult) -> Void)
-            case prompt(String, defaultText: String?, @Sendable (sending WebPage_v0.JavaScriptPromptResult) -> Void)
+            case confirm(String, @Sendable (sending WebPage.JavaScriptConfirmResult) -> Void)
+            case prompt(String, defaultText: String?, @Sendable (sending WebPage.JavaScriptPromptResult) -> Void)
         }
 
         let id = UUID()
@@ -48,30 +48,30 @@ final class DialogPresenter: DialogPresenting {
     struct FilePicker {
         let allowsMultipleSelection: Bool
         let allowsDirectories: Bool
-        let completion: @Sendable (sending WebPage_v0.FileInputPromptResult) -> Void
+        let completion: @Sendable (sending WebPage.FileInputPromptResult) -> Void
     }
 
     weak var owner: BrowserViewModel? = nil
 
-    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage_v0.FrameInfo) async {
+    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async {
         await withCheckedContinuation { continuation in
             owner?.currentDialog = Dialog(configuration: .alert(message, continuation.resume))
         }
     }
 
-    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.JavaScriptConfirmResult {
+    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult {
         await withCheckedContinuation { continuation in
             owner?.currentDialog = Dialog(configuration: .confirm(message, continuation.resume(returning:)))
         }
     }
 
-    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.JavaScriptPromptResult {
+    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult {
         await withCheckedContinuation { continuation in
             owner?.currentDialog = Dialog(configuration: .prompt(message, defaultText: defaultText, continuation.resume(returning:)))
         }
     }
 
-    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage_v0.FrameInfo) async -> WebPage_v0.FileInputPromptResult {
+    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult {
         await withCheckedContinuation { continuation in
             owner?.currentFilePicker = FilePicker(allowsMultipleSelection: parameters.allowsMultipleSelection, allowsDirectories: parameters.allowsDirectories, completion: continuation.resume(returning:))
         }

--- a/Tools/SwiftBrowser/Source/ViewModel/DownloadCoordinator.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/DownloadCoordinator.swift
@@ -34,7 +34,7 @@ final class DownloadCoordinator {
 
     var downloads: [DownloadCoordinator.DownloadItem] = []
 
-    func didReceiveDownloadEvent(_ event: WebPage_v0.DownloadEvent) {
+    func didReceiveDownloadEvent(_ event: WebPage.DownloadEvent) {
         Self.logger.info("Did receive download event \(String(describing: event.kind)) for download \(String(describing: event.download.id))")
 
         switch event.kind {
@@ -60,7 +60,7 @@ final class DownloadCoordinator {
 }
 
 extension DownloadCoordinator: WebKit.DownloadCoordinator {
-    func destination(forDownload download: WebPage_v0.DownloadID, response: URLResponse, suggestedFilename: String) async -> URL? {
+    func destination(forDownload download: WebPage.DownloadID, response: URLResponse, suggestedFilename: String) async -> URL? {
         let url = URL.downloadsDirectory.appending(component: suggestedFilename)
         guard !FileManager.default.fileExists(atPath: url.path()) else {
             Self.logger.error("\(url.path()) already exists")
@@ -79,19 +79,19 @@ extension DownloadCoordinator: WebKit.DownloadCoordinator {
 extension DownloadCoordinator {
     @MainActor
     struct DownloadItem: Downloadable {
-        init(source: WebPage_v0.Download) {
+        init(source: WebPage.Download) {
             self.id = source.id
             self.progress = source.progress
             self.source = source
         }
 
-        let id: WebPage_v0.DownloadID
+        let id: WebPage.DownloadID
         let progress: Progress
 
         var url: URL? = nil
         var finished: Bool = false
 
-        private let source: WebPage_v0.Download
+        private let source: WebPage.Download
 
         func cancel() async {
             await source.cancel()

--- a/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
@@ -29,7 +29,7 @@ import Foundation
 final class NavigationDecider: NavigationDeciding {
     weak var owner: BrowserViewModel? = nil
 
-    func decidePolicy(for action: WebPage_v0.NavigationAction, preferences: inout WebPage_v0.NavigationPreferences) async -> WKNavigationActionPolicy {
+    func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy {
         if action.shouldPerformDownload {
             return .download
         }
@@ -42,7 +42,7 @@ final class NavigationDecider: NavigationDeciding {
         return .allow
     }
 
-    func decidePolicy(for response: WebPage_v0.NavigationResponse) async -> WKNavigationResponsePolicy {
+    func decidePolicy(for response: WebPage.NavigationResponse) async -> WKNavigationResponsePolicy {
         response.canShowMimeType && !response.response.hasAttachment ? .allow : .download
     }
 }

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -33,9 +33,9 @@ private struct ToolbarBackForwardMenuView: View {
         let key: KeyEquivalent
     }
 
-    let list: [WebPage_v0.BackForwardList.Item]
+    let list: [WebPage.BackForwardList.Item]
     let label: LabelConfiguration
-    let navigateToItem: (WebPage_v0.BackForwardList.Item) -> Void
+    let navigateToItem: (WebPage.BackForwardList.Item) -> Void
 
     var body: some View {
         Menu {
@@ -232,9 +232,7 @@ struct ContentView: View {
                 .webViewAllowsElementFullscreen()
                 .webViewFindNavigator(isPresented: $findNavigatorIsPresented)
                 .task {
-                    for await event in viewModel.page.navigations {
-                        viewModel.didReceiveNavigationEvent(event)
-                    }
+                    // FIXME: Observe navigation changes.
                 }
                 .task {
                     for await event in viewModel.page.downloads {
@@ -289,13 +287,13 @@ struct ContentView: View {
                     } else {
                         if let previousItem = viewModel.page.backForwardList.backList.last {
                             Button("Back") {
-                                viewModel.page.load(backForwardItem: previousItem)
+                                viewModel.page.load(previousItem)
                             }
                         }
 
                         if let nextItem = viewModel.page.backForwardList.forwardList.first {
                             Button("Forward") {
-                                viewModel.page.load(backForwardItem: nextItem)
+                                viewModel.page.load(nextItem)
                             }
                         }
 
@@ -310,7 +308,7 @@ struct ContentView: View {
                             list: viewModel.page.backForwardList.backList.reversed(),
                             label: .init(text: "Backward", systemImage: "chevron.backward", key: "[")
                         ) {
-                            viewModel.page.load(backForwardItem: $0)
+                            viewModel.page.load($0)
                         }
 
                         #if os(iOS)
@@ -321,7 +319,7 @@ struct ContentView: View {
                             list: viewModel.page.backForwardList.forwardList,
                             label: .init(text: "Forward", systemImage: "chevron.forward", key: "]")
                         ) {
-                            viewModel.page.load(backForwardItem: $0)
+                            viewModel.page.load($0)
                         }
 
                         #if os(iOS)

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -88,10 +88,10 @@ struct URLSchemeHandlerTests {
         """.data(using: .utf8)!
 
         let handler = TestURLSchemeHandler(data: html, mimeType: "text/html")
-        var configuration = WebPage_v0.Configuration()
+        var configuration = WebPage.Configuration()
         configuration.urlSchemeHandlers[URLScheme_v0("testing")!] = handler
 
-        let page = WebPage_v0(configuration: configuration)
+        let page = WebPage(configuration: configuration)
 
         let url = URL(string: "testing:main")!
         let request = URLRequest(url: url)


### PR DESCRIPTION
#### 42e0d3664d57c157f406d25b1e86ff5edcb80834
<pre>
[SwiftUI] Update WebPage to latest interface (Part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286823">https://bugs.webkit.org/show_bug.cgi?id=286823</a>
<a href="https://rdar.apple.com/143977907">rdar://143977907</a>

Reviewed by Aditya Keerthi.

Update various definitions/declarations.

* Source/WebKit/UIProcess/API/Swift/DownloadCoordinator.swift:
(DownloadCoordinator.destination(forDownload:response:suggestedFilename:)):
(DownloadCoordinator.authenticationChallengeDisposition(forDownload:challenge:URLCredential:)):
(DownloadCoordinator.httpRedirectionPolicy(forDownload:response:newRequest:)):
(DownloadCoordinator.placeholderPolicy(forDownload:)):
* Source/WebKit/UIProcess/API/Swift/WKDownloadDelegateAdapter.swift:
(WKDownloadDelegateAdapter.owner):
* Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift:
(WKNavigationDelegateAdapter.owner):
(WKNavigationDelegateAdapter.yieldNavigationProgress(_:cocoaNavigation:)):
(WKNavigationDelegateAdapter.yieldDownloadProgress(_:download:)):
(WKNavigationDelegateAdapter.webView(_:decidePolicyFor:preferences:WKWebpagePreferences:)):
(WKNavigationDelegateAdapter.webView(_:decidePolicyFor:)):
* Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift:
(WKUIDelegateAdapter.owner):
(WKUIDelegateAdapter.menuBuilder):
(WKUIDelegateAdapter._webView(_:getContextMenuFromProposedMenu:forElement:userInfo:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+BackForwardList.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
(Configuration.defaultNavigationPreferences):
(Configuration.deviceSensorAuthorization):
* Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift:
(DialogPresenting.handleJavaScriptAlert(_:initiatedBy:)):
(DialogPresenting.handleJavaScriptConfirm(_:initiatedBy:)):
(DialogPresenting.handleJavaScriptPrompt(_:defaultText:initiatedBy:)):
(DialogPresenting.handleFileInputPrompt(_:initiatedBy:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+Download.swift:
(originatingFrame):
* Source/WebKit/UIProcess/API/Swift/WebPage+ElementInfo.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift:
(Navigations.makeAsyncIterator): Deleted.
(Iterator.source): Deleted.
(Iterator.next): Deleted.
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift:
(NavigationDeciding.decidePolicy(for:preferences:)):
(NavigationDeciding.decidePolicy(for:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(currentNavigationEvent):
(fullscreenState):
(mediaType):
(setMenuBuilder(_:)):
(load(_:baseURL:)):
(load(simulatedRequest:responseHTML:)):
(load(_:)):
(callJavaScript(_:arguments:in:contentWorld:)):
(startDownload(using:)):
(resumeDownload(fromResumeData:)):
(KeyValueObservations.contents):
(handlesURLScheme(_:)): Deleted.
(callAsyncJavaScript(_:arguments:in:contentWorld:)): Deleted.
(snapshot(_:)): Deleted.
* Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift:
* Source/WebKit/_WebKit_SwiftUI/WebPage+SwiftUI.swift:
(WebPage.snapshot(_:)):
(WebPage_v0.themeColor): Deleted.
* Source/WebKit/_WebKit_SwiftUI/WebPageNavigationAction+SwiftUI.swift:
(WebPage_v0.modifierFlags): Deleted.
* Source/WebKit/_WebKit_SwiftUI/WebView.swift:
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
* Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift:
(handleJavaScriptAlert(_:initiatedBy:)):
(handleJavaScriptConfirm(_:initiatedBy:)):
(handleJavaScriptPrompt(_:defaultText:initiatedBy:)):
(handleFileInputPrompt(_:initiatedBy:)):
* Tools/SwiftBrowser/Source/ViewModel/DownloadCoordinator.swift:
(DownloadCoordinator.didReceiveDownloadEvent(_:)):
(DownloadCoordinator.destination(forDownload:response:suggestedFilename:)):
* Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift:
(NavigationDecider.decidePolicy(for:preferences:)):
(NavigationDecider.decidePolicy(for:)):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):
* Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift:
(URLSchemeHandlerTests.basicSchemeHandling):
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift:
(TestNavigationDecider.preferencesMutation):
(TestNavigationDecider.decidePolicy(for:preferences:)):
(TestNavigationDecider.decidePolicy(for:)):
(WebPageTests.observableProperties):
(WebPageTests.decidePolicyForNavigationActionFragment):
(WebPageTests.javaScriptEvaluation):
(WebPageTests.decidePolicyForNavigationResponse):
(WebPageTests.basicNavigation): Deleted.
(WebPageTests.sequenceOfNavigations): Deleted.
(WebPageTests.navigationWithFailedProvisionalNavigationEvent): Deleted.
(WebPageTests.navigationPreferencesMutationDuringNavigation): Deleted.

Canonical link: <a href="https://commits.webkit.org/290097@main">https://commits.webkit.org/290097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/157290e6cdd42a3431ad602c1720e0459dc52107

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16686 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91980 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38846 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16158 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16414 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/21107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9241 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13939 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21483 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15913 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->