### PR TITLE
Added a style checker for SAFE_PRINTF

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1842,40 +1842,35 @@ class CppStyleTest(CppStyleTestBase):
     def test_insecure_string_operations(self):
         self.assert_lint(
             'sprintf(destination, "%s", arg)',
-            'Never use sprintf.  Use snprintf instead.'
+            'Never use sprintf.  Use SAFE_SPRINTF instead.'
             '  [security/printf] [5]')
         self.assert_lint(
             'strcat(destination, append)',
-            'Almost always, snprintf is better than strcat.'
+            'Almost always, SAFE_SPRINTF is better than strcat.'
             '  [security/printf] [4]')
         self.assert_lint(
             'strcpy(destination, source)',
-            'Almost always, snprintf is better than strcpy.'
+            'Almost always, SAFE_SPRINTF is better than strcpy.'
             '  [security/printf] [4]')
 
-    # Test potential format string bugs like printf(foo).
+    # Test potential format string bugs like SAFE_PRINTF(foo).
     def test_format_strings(self):
-        self.assert_lint('printf("foo")', '')
-        self.assert_lint('printf("foo: %s", foo)', '')
+        self.assert_lint('SAFE_PRINTF("foo")', '')
+        self.assert_lint('SAFE_PRINTF("foo: %s", foo)', '')
         self.assert_lint('DocidForPrintf(docid)', '')  # Should not trigger.
         self.assert_lint(
-            'printf(foo)',
-            'Potential format string bug. Do printf("%s", foo) instead.'
+            'SAFE_PRINTF(foo)',
+            'Potential format string bug. Do SAFE_PRINTF("%s", foo) instead.'
             '  [security/printf] [4]')
         self.assert_lint(
-            'printf(foo.c_str())',
+            'SAFE_PRINTF(foo.c_str())',
             'Potential format string bug. '
-            'Do printf("%s", foo.c_str()) instead.'
+            'Do SAFE_PRINTF("%s", foo.c_str()) instead.'
             '  [security/printf] [4]')
         self.assert_lint(
-            'printf(foo->c_str())',
+            'SAFE_PRINTF(foo->c_str())',
             'Potential format string bug. '
-            'Do printf("%s", foo->c_str()) instead.'
-            '  [security/printf] [4]')
-        self.assert_lint(
-            'StringPrintf(foo)',
-            'Potential format string bug. Do StringPrintf("%s", foo) instead.'
-            ''
+            'Do SAFE_PRINTF("%s", foo->c_str()) instead.'
             '  [security/printf] [4]')
 
     # Test for insecure temp file creation.
@@ -2638,7 +2633,7 @@ class CppStyleTest(CppStyleTestBase):
         self.assert_lint('}// namespace foo',
                          'One space before end of line comments'
                          '  [whitespace/comments] [5]')
-        self.assert_lint('printf("foo"); // Outside quotes.',
+        self.assert_lint('SAFE_PRINTF("foo"); // Outside quotes.',
                          '')
         self.assert_lint('int i = 0; // Having one space is fine.', '')
         self.assert_lint('int i = 0;  // Having two spaces is bad.',
@@ -2655,9 +2650,9 @@ class CppStyleTest(CppStyleTestBase):
                          '    { // An indented scope is opening.', '')
         self.assert_lint('if (foo) { // not a pure scope',
                          '')
-        self.assert_lint('printf("// In quotes.")', '')
-        self.assert_lint('printf("\\"%s // In quotes.")', '')
-        self.assert_lint('printf("%s", "// In quotes.")', '')
+        self.assert_lint('SAFE_PRINTF("// In quotes.")', '')
+        self.assert_lint('SAFE_PRINTF("\\"%s // In quotes.")', '')
+        self.assert_lint('SAFE_PRINTF("%s", "// In quotes.")', '')
 
     def test_one_spaces_after_punctuation_in_comments(self):
         self.assert_lint('int a; // This is a sentence.',
@@ -3038,17 +3033,17 @@ class CppStyleTest(CppStyleTestBase):
 
     def test_build_printf_format(self):
         self.assert_lint(
-            r'printf("\%%d", value);',
+            r'SAFE_PRINTF("\%%d", value);',
             '%, [, (, and { are undefined character escapes.  Unescape them.'
             '  [build/printf_format] [3]')
 
         self.assert_lint(
-            r'snprintf(buffer, sizeof(buffer), "\[%d", value);',
+            r'SAFE_SPRINTF(buffer, "\[%d", value);',
             '%, [, (, and { are undefined character escapes.  Unescape them.'
             '  [build/printf_format] [3]')
 
         self.assert_lint(
-            r'fprintf(file, "\(%d", value);',
+            r'SAFE_FPRINTF(file, "\(%d", value);',
             '%, [, (, and { are undefined character escapes.  Unescape them.'
             '  [build/printf_format] [3]')
 
@@ -3058,37 +3053,37 @@ class CppStyleTest(CppStyleTestBase):
             '  [build/printf_format] [3]')
 
         # Don't warn if double-slash precedes the symbol
-        self.assert_lint(r'printf("\\%%%d", value);',
+        self.assert_lint(r'SAFE_PRINTF("\\%%%d", value);',
                          '')
 
     def test_runtime_printf_format(self):
         self.assert_lint(
-            r'fprintf(file, "%q", value);',
+            r'SAFE_FPRINTF(file, "%q", value);',
             '%q in format strings is deprecated.  Use %ll instead.'
             '  [runtime/printf_format] [3]')
 
         self.assert_lint(
-            r'aprintf(file, "The number is %12q", value);',
+            r'SAFE_PRINTF("The number is %12q", value);',
             '%q in format strings is deprecated.  Use %ll instead.'
             '  [runtime/printf_format] [3]')
 
         self.assert_lint(
-            r'printf(file, "The number is" "%-12q", value);',
+            r'SAFE_SPRINTF(buffer, "The number is" "%-12q", value);',
             '%q in format strings is deprecated.  Use %ll instead.'
             '  [runtime/printf_format] [3]')
 
         self.assert_lint(
-            r'printf(file, "The number is" "%+12q", value);',
+            r'SAFE_PRINTF("The number is" "%+12q", value);',
             '%q in format strings is deprecated.  Use %ll instead.'
             '  [runtime/printf_format] [3]')
 
         self.assert_lint(
-            r'printf(file, "The number is" "% 12q", value);',
+            r'SAFE_PRINTF("The number is" "% 12q", value);',
             '%q in format strings is deprecated.  Use %ll instead.'
             '  [runtime/printf_format] [3]')
 
         self.assert_lint(
-            r'snprintf(file, "Never mix %d and %1$d parmaeters!", value);',
+            r'SAFE_PRINTF("Never mix %d and %1$d parmaeters!", value);',
             '%N$ formats are unconventional.  Try rewriting to avoid them.'
             '  [runtime/printf_format] [2]')
 
@@ -6326,6 +6321,21 @@ class WebKitStyleTest(CppStyleTestBase):
         self.assert_lint(
             'int result = strncmp(a, "foo", 3);',
             'strncmp() is unsafe.  [safercpp/strncmp] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'printf("%s", s);',
+            'printf is unsafe. Use SAFE_PRINTF instead.  [safercpp/printf] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'fprintf(file, "%s", s);',
+            'fprintf is unsafe. Use SAFE_FPRINTF instead.  [safercpp/printf] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'snprintf(buffer, "%s", s);',
+            'snprintf is unsafe. Use SAFE_SPRINTF instead.  [safercpp/printf] [4]',
             'foo.cpp')
 
         self.assert_lint(


### PR DESCRIPTION
#### 3c908c67e15d5ddba8e8e8678e35d04e510f236b
<pre>
Added a style checker for SAFE_PRINTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=286826">https://bugs.webkit.org/show_bug.cgi?id=286826</a>
<a href="https://rdar.apple.com/143980601">rdar://143980601</a>

Reviewed by Chris Dumez.

Forbid use of printf, fprintf, snprintf because %s is not bounds safe, and an
upcoming compiler will turn this into an error. (sprintf was already forbidden.)

Update existing format string checkers to check SAFE_PRINTF format strings.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_for_non_standard_constructs):
(check_safer_cpp):
(check_language):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest):
(WebKitStyleTest.test_safer_cpp):

Canonical link: <a href="https://commits.webkit.org/289642@main">https://commits.webkit.org/289642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3ec6647ee901df0b5d9c8da0eac9cb23f8c6bd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15274 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25389 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48003 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/87087 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94341 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14758 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76485 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75708 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20085 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7709 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13647 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14774 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->