### PR TITLE
[WebGPU] optional counter sample indices are not respected

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286689-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286689-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286689.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286689.html
@@ -1,0 +1,13727 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxVertexBufferArrayStride: 2048,
+    maxTextureDimension2D: 8192,
+    maxUniformBufferBindingSize: 57063186,
+    maxStorageBufferBindingSize: 159775376,
+  },
+});
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 328,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer0 = device0.createBuffer({
+  size: 26970,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let texture0 = device0.createTexture({
+  size: [180, 80, 48],
+  mipLevelCount: 1,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture1 = device0.createTexture({
+  size: {width: 90, height: 40, depthOrArrayLayers: 159},
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+device0.queue.writeBuffer(buffer0, 1348, new DataView(new ArrayBuffer(8271)), 2330, 848);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer1 = device0.createBuffer({size: 1333, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder1 = device0.createCommandEncoder({});
+let textureView0 = texture0.createView({dimension: '2d'});
+let texture2 = device0.createTexture({
+  size: {width: 180, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'astc-4x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u7c78\u29ff\u628c\u0119\uac6c\ucf97',
+  entries: [
+    {
+      binding: 328,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup0 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView0}]});
+let texture3 = device0.createTexture({
+  size: {width: 90, height: 1, depthOrArrayLayers: 1},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView1 = texture3.createView({dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+let sampler0 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 74.89});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0, new Uint32Array(133), 11, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer2 = device0.createBuffer({size: 7296, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let textureView2 = texture2.createView({aspect: 'all', mipLevelCount: 1});
+try {
+device0.queue.writeBuffer(buffer0, 8128, new BigUint64Array(1036), 272, 8);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup1 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView0}]});
+let commandEncoder2 = device0.createCommandEncoder({});
+let computePassEncoder2 = commandEncoder2.beginComputePass();
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: false});
+let renderBundle0 = renderBundleEncoder0.finish({});
+let imageData0 = new ImageData(16, 4);
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  size: {width: 180},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView3 = texture4.createView({baseArrayLayer: 0});
+let computePassEncoder3 = commandEncoder3.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [{binding: 8, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let buffer3 = device0.createBuffer({size: 28776, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder4 = device0.createCommandEncoder();
+let computePassEncoder4 = commandEncoder4.beginComputePass();
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [{binding: 8, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let buffer4 = device0.createBuffer({size: 3459, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder5 = device0.createCommandEncoder({});
+let sampler1 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.60,
+  lodMaxClamp: 86.28,
+  maxAnisotropy: 8,
+});
+try {
+device0.queue.writeBuffer(buffer4, 696, new DataView(new ArrayBuffer(28614)), 2107, 84);
+} catch {}
+let textureView4 = texture0.createView({baseArrayLayer: 2, arrayLayerCount: 9});
+let computePassEncoder5 = commandEncoder5.beginComputePass({});
+let commandEncoder6 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  size: [180, 80, 43],
+  mipLevelCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture6 = device0.createTexture({
+  size: [90],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView5 = texture4.createView({baseMipLevel: 0});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0, new Uint32Array(1484), 89, 0);
+} catch {}
+let buffer5 = device0.createBuffer({size: 17138, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let computePassEncoder6 = commandEncoder6.beginComputePass();
+try {
+computePassEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0, new Uint32Array(559), 133, 0);
+} catch {}
+let bindGroup2 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 328, resource: textureView0}]});
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas0 = document.createElement('canvas');
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0, new Uint32Array(230), 11, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 20},
+  aspect: 'all',
+}, new Uint8Array(345).fill(229), /* required buffer size: 345 */
+{offset: 345, bytesPerRow: 80}, {width: 15, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup2, new Uint32Array(1659), 423, 0);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let computePassEncoder7 = commandEncoder7.beginComputePass({});
+try {
+canvas0.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder();
+let texture7 = device0.createTexture({
+  size: [517, 30, 11],
+  mipLevelCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler2 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 89.97});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup2, new Uint32Array(301), 26, 0);
+} catch {}
+try {
+commandEncoder8.insertDebugMarker('\u21ca');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 150, y: 27, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder();
+let texture8 = device0.createTexture({
+  size: {width: 180},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(86), 1, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(39).fill(181), /* required buffer size: 39 */
+{offset: 39, bytesPerRow: 51}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView6 = texture8.createView({});
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 492, buffer4, 2024, 128);
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup3 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView0}]});
+let commandEncoder10 = device0.createCommandEncoder({});
+let textureView7 = texture7.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+let textureView8 = texture3.createView({});
+let computePassEncoder8 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup3, new Uint32Array(4179), 794, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas0);
+await gc();
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView9 = texture7.createView({dimension: '2d', mipLevelCount: 1});
+let sampler3 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 97.44});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup3, new Uint32Array(483), 7, 0);
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1072 */
+  offset: 1072,
+  buffer: buffer5,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 16, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder8.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 440 widthInBlocks: 55 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 144 */
+  offset: 144,
+  bytesPerRow: 33024,
+  rowsPerImage: 379,
+  buffer: buffer4,
+}, {width: 55, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder();
+try {
+computePassEncoder8.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup1, new Uint32Array(526), 46, 0);
+} catch {}
+let imageData1 = new ImageData(188, 68);
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 92});
+let textureView10 = texture0.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+let computePassEncoder9 = commandEncoder12.beginComputePass({});
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 192 */
+  offset: 192,
+  bytesPerRow: 2816,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder9.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24 */
+  offset: 24,
+  buffer: buffer4,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas0.width = 2411;
+let commandEncoder13 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'timestamp', count: 836});
+try {
+commandEncoder8.resolveQuerySet(querySet0, 8, 1, buffer4, 0);
+} catch {}
+let buffer6 = device0.createBuffer({size: 14346, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let texture9 = device0.createTexture({
+  size: [129, 7, 119],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder10 = commandEncoder9.beginComputePass({});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData1,
+  origin: { x: 41, y: 4 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 26, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 55, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 236, buffer4, 1280, 608);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 12, y: 12, z: 0},
+  aspect: 'all',
+}, new Uint8Array(157).fill(197), /* required buffer size: 157 */
+{offset: 157, bytesPerRow: 159}, {width: 0, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(3, bindGroup3, new Uint32Array(3646), 1_907, 0);
+} catch {}
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 744 */
+  offset: 744,
+  rowsPerImage: 290,
+  buffer: buffer2,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 59, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1948, new Int16Array(12864), 8199, 672);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView11 = texture2.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 17},
+  aspect: 'all',
+}, new Uint8Array(189_288).fill(60), /* required buffer size: 189_288 */
+{offset: 8, bytesPerRow: 130, rowsPerImage: 56}, {width: 3, height: 0, depthOrArrayLayers: 27});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup4 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 328, resource: textureView8}]});
+let sampler4 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'linear', lodMinClamp: 13.33});
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 168 */
+  offset: 168,
+  buffer: buffer1,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 21},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\u58f2');
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'film', transfer: 'logSqrt'} });
+let commandEncoder15 = device0.createCommandEncoder({});
+let textureView12 = texture2.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.append(canvas0);
+let textureView13 = texture6.createView({aspect: 'all'});
+try {
+commandEncoder15.copyBufferToBuffer(buffer1, 36, buffer0, 780, 4);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 8, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(101).fill(93), /* required buffer size: 101 */
+{offset: 101, bytesPerRow: 184, rowsPerImage: 47}, {width: 28, height: 36, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let texture10 = device0.createTexture({
+  size: {width: 1035},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView14 = texture8.createView({arrayLayerCount: 1});
+let computePassEncoder11 = commandEncoder13.beginComputePass({
+  label: '\u3d81\u00ca\u014b\u{1fe96}\u{1fd47}\u3727\u318c\u0c69\u8d10',
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 409, endOfPassWriteIndex: 93},
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup3, new Uint32Array(359), 54, 0);
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView15 = texture3.createView({format: 'bgra8unorm'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle1 = renderBundleEncoder1.finish({});
+let sampler5 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'clamp-to-edge'});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup1);
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'bt2020_12bit'} });
+let buffer7 = device0.createBuffer({
+  size: 6203,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture11 = device0.createTexture({
+  size: {width: 180, height: 80, depthOrArrayLayers: 1},
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView16 = texture7.createView({aspect: 'depth-only', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 2});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer0, 532, 2116);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3584 */
+  offset: 3584,
+  bytesPerRow: 19712,
+  buffer: buffer0,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 16, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 35, depthOrArrayLayers: 0});
+} catch {}
+let buffer8 = device0.createBuffer({
+  size: 5231,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+commandEncoder15.pushDebugGroup('\u91c2');
+} catch {}
+let textureView17 = texture6.createView({dimension: '1d'});
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 120 */
+  offset: 120,
+  bytesPerRow: 5376,
+  buffer: buffer5,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 9, y: 25, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(8).fill(81), /* required buffer size: 8 */
+{offset: 8, rowsPerImage: 126}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let textureView18 = texture7.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder12 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4240 */
+  offset: 4240,
+  bytesPerRow: 11264,
+  rowsPerImage: 439,
+  buffer: buffer2,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 32, depthOrArrayLayers: 0});
+} catch {}
+let textureView19 = texture9.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder13 = commandEncoder15.beginComputePass({});
+let renderPassEncoder0 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{view: textureView19, depthSlice: 47, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet0,
+});
+let sampler6 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 9,
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(3);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer5, 16944, buffer4, 1064, 0);
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer0, 3316, 14088);
+} catch {}
+let textureView20 = texture0.createView({
+  label: '\u0eb4\u31da\u9ea1\u9493\u46d4\udfe3\u08b8\u{1f7e5}\u{1fd0f}',
+  dimension: '2d',
+  baseArrayLayer: 8,
+});
+let computePassEncoder14 = commandEncoder16.beginComputePass();
+let renderPassEncoder1 = commandEncoder11.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 36,
+  clearValue: { r: -478.2, g: -662.5, b: 491.1, a: -999.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 21473266,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup2, new Uint32Array(1236), 263, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1]);
+} catch {}
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 127,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup5 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView8}]});
+let buffer9 = device0.createBuffer({
+  size: 1541,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView21 = texture11.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let texture12 = device0.createTexture({
+  size: {width: 180, height: 1, depthOrArrayLayers: 29},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder15 = commandEncoder8.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setViewport(128.28148493240144, 4.7174450023150065, 0.55746547722769, 1.5472050963999802, 0.32419838567581283, 0.658593400637254);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 254,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 2, hasDynamicOffset: false },
+    },
+    {
+      binding: 578,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer10 = device0.createBuffer({
+  label: '\u0990\u0947\u0a13\udffb',
+  size: 24145,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture13 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView22 = texture5.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup4, new Uint32Array(3653), 166, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(868), 23, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 578, resource: {buffer: buffer8, offset: 0, size: 3920}},
+    {binding: 62, resource: textureView7},
+    {binding: 254, resource: {buffer: buffer7, offset: 256, size: 192}},
+  ],
+});
+let buffer11 = device0.createBuffer({
+  size: 13803,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture14 = device0.createTexture({
+  size: {width: 180},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler7 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMaxClamp: 94.31,
+  compare: 'less',
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup3, new Uint32Array(159), 20, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer10, 2_576, 1_809);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 17},
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView23 = texture14.createView({});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint16', 90, 4);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet0, 13, 1, buffer8, 0);
+} catch {}
+let buffer12 = device0.createBuffer({size: 2600, usage: GPUBufferUsage.COPY_DST});
+let sampler8 = device0.createSampler({addressModeU: 'mirror-repeat', minFilter: 'linear', compare: 'always', maxAnisotropy: 1});
+let texture16 = device0.createTexture({
+  size: {width: 90},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder16 = commandEncoder18.beginComputePass({});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup2, new Uint32Array(1870), 743, 0);
+} catch {}
+let texture17 = device0.createTexture({
+  size: {width: 360, height: 1, depthOrArrayLayers: 412},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler9 = device0.createSampler({
+  label: '\u024b\u08e4\u{1fbb0}\uafba\u21be\u006d\u08f6\u1bac',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.40,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup5, new Uint32Array(1743), 249, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+@group(0) @binding(254) var<storage, read> buffer13: array<T1, 1>;
+
+@group(0) @binding(578) var<storage, read> buffer14: array<array<array<vec2f, 1>, 408>>;
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4u,
+}
+
+struct T0 {
+  f0: array<array<f16, 1>, 1>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp0: T2 = T2();
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T2 {
+  f0: T1,
+}
+
+alias vec3b = vec3<bool>;
+
+/* used global variables: buffer14 */
+fn fn0(a0: ptr<storage, VertexOutput0, read_write>, a1: T1) -> array<T0, 1> {
+  var out: array<T0, 1>;
+  let ptr0: ptr<private, f16> = &vp0.f0.f0[unconst_u32(32)].f0[unconst_u32(193)][unconst_u32(265)];
+  var vf0: f16 = a1.f0[unconst_u32(83)].f0[unconst_u32(6)][0];
+  var vf1: f32 = (*&buffer14)[unconst_u32(92)][unconst_u32(56)][unconst_u32(387)][unconst_u32(46)];
+  let ptr1: ptr<private, array<f16, 1>> = &vp0.f0.f0[0].f0[unconst_u32(188)];
+  let vf2: array<T0, 1> = a1.f0;
+  vf0 -= vf2[unconst_u32(13)].f0[unconst_u32(135)][unconst_u32(364)];
+  while bool(vp0.f0.f0[0].f0[0][0]) {
+  var vf3: f32 = (*&buffer14)[arrayLength(&(*&buffer14))][407][unconst_u32(77)][unconst_u32(4)];
+  let ptr2: ptr<storage, vec2f, read> = &buffer14[unconst_u32(109)][407][unconst_u32(56)];
+  var vf4: vec4f = trunc(vec4f(unconst_f32(0.5814), unconst_f32(0.5536), unconst_f32(0.07831), unconst_f32(0.07599)));
+  _ = buffer14;
+}
+  (*a0).f2 -= vec4f(transpose(mat3x2h(unconst_f16(-16281.7), unconst_f16(-167.0), unconst_f16(28430.1), unconst_f16(-19912.8), unconst_f16(37634.7), unconst_f16(19911.3)))[unconst_i32(0)].xxzy);
+  let ptr3: ptr<storage, vec2f, read_write> = &(*a0).f0;
+  let ptr4: ptr<storage, vec2f, read> = &buffer14[unconst_u32(379)][407][unconst_u32(398)];
+  let vf5: vec2u = (vec2u(unconst_u32(183), unconst_u32(62)) << vec2u(unconst_u32(17), unconst_u32(67)));
+  let ptr5: ptr<storage, vec2f, read> = &buffer14[arrayLength(&buffer14)][unconst_u32(438)][bitcast<u32>((*a0).f0[0])];
+  return out;
+  _ = buffer14;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T1 {
+  f0: array<T0, 1>,
+}
+
+struct VertexOutput0 {
+  @location(11) f0: vec2f,
+  @location(4) f1: vec2i,
+  @invariant @builtin(position) f2: vec4f,
+}
+
+/* used global variables: buffer13 */
+@vertex
+fn vertex0(@location(12) a0: u32, @location(10) a1: vec2h, @location(1) @interpolate(flat, centroid) a2: vec4u, @location(14) @interpolate(flat, sample) a3: i32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  vp0.f0 = T1(array<T0, 1>(T0(array<array<f16, 1>, 1>(array<f16, 1>((*&buffer13)[0].f0[0].f0[unconst_u32(628)][unconst_u32(267)])))));
+  let ptr6: ptr<storage, f16, read> = &(*&buffer13)[0].f0[unconst_u32(162)].f0[0][0];
+  let ptr7: ptr<storage, T0, read> = &buffer13[0].f0[0];
+  return out;
+  _ = buffer13;
+}
+
+/* used global variables: buffer13 */
+@vertex
+fn vertex1() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let ptr8: ptr<storage, T0, read> = &(*&buffer13)[unconst_u32(3)].f0[u32((*&buffer13)[0].f0[0].f0[0][0])];
+  return out;
+  _ = buffer13;
+}
+
+/* used global variables: buffer14 */
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  {
+  let ptr9: ptr<private, f16> = &vp0.f0.f0[unconst_u32(232)].f0[unconst_u32(13)][0];
+  out.f1 += vec4u(u32(buffer14[arrayLength(&buffer14)][407][0][unconst_u32(14)]));
+  let ptr10: ptr<storage, array<array<vec2f, 1>, 408>, read> = &(*&buffer14)[arrayLength(&(*&buffer14)) - 1];
+  out.f1 = vec4u(u32(vp0.f0.f0[unconst_u32(223)].f0[0][0]));
+  _ = buffer14;
+}
+  let ptr11: ptr<storage, vec2f, read> = &buffer14[arrayLength(&buffer14)][407][unconst_u32(298)];
+  return out;
+  _ = buffer14;
+}
+
+/* used global variables: buffer14 */
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(global_invocation_id) a0: vec3u, @builtin(local_invocation_id) a1: vec3u, @builtin(workgroup_id) a2: vec3u) {
+  let ptr12: ptr<private, f16> = &vp0.f0.f0[unconst_u32(45)].f0[0][0];
+  vp0 = T2(T1(array<T0, 1>(T0(array<array<f16, 1>, 1>(array<f16, 1>(vec2h((*&buffer14)[unconst_u32(36)][unconst_u32(122)][0]).x))))));
+  {
+}
+  _ = buffer14;
+}`,
+});
+let bindGroup7 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 328, resource: textureView0}]});
+let commandEncoder19 = device0.createCommandEncoder({});
+let texture18 = device0.createTexture({size: [180, 80, 1], format: 'astc-10x5-unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView24 = texture6.createView({});
+let computePassEncoder17 = commandEncoder19.beginComputePass({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+let renderBundle3 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3, new Uint32Array(342), 39, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint32', 1_580, 4_947);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 7160, new Int16Array(923), 81, 160);
+} catch {}
+let promise0 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let bindGroup8 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView20}]});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup8, new Uint32Array(361), 150, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(119.04071851712945, 1.5459742370837843, 6.969392684679062, 2.2031063806166373, 0.44761016266913967, 0.805258928735308);
+} catch {}
+document.body.append(canvas0);
+let buffer15 = device0.createBuffer({size: 5494, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let sampler10 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 44.43,
+  compare: 'less-equal',
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView25 = texture15.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup8, new Uint32Array(382), 8, 0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let buffer16 = device0.createBuffer({
+  size: 3595,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let sampler11 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+renderPassEncoder1.setViewport(18.789418973302613, 1.6565598645944744, 22.56230228472548, 4.033621627278273, 0.08648802565561342, 0.08775980884649563);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint16', 168, 1_199);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  label: '\u0445\ube6d\u43a9\u3cac\ud974\u{1f9d1}\u3885\u0f2d\u0545',
+  size: [180],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView26 = texture19.createView({dimension: '1d', format: 'rgba16uint'});
+let renderPassEncoder2 = commandEncoder20.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 78,
+  clearValue: { r: 979.1, g: 272.3, b: -263.4, a: -114.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle2, renderBundle1, renderBundle0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(257).fill(71), /* required buffer size: 257 */
+{offset: 257, rowsPerImage: 27}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'unspecified', transfer: 'linear'} });
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint16', 8_592, 6_788);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 13, y: 25, z: 6},
+  aspect: 'all',
+}, new Uint8Array(13_980).fill(92), /* required buffer size: 13_980 */
+{offset: 299, bytesPerRow: 405, rowsPerImage: 3}, {width: 79, height: 1, depthOrArrayLayers: 12});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 16, y: 29, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+@group(0) @binding(578) var<storage, read> buffer18: array<array<array<i32, 24>, 34>>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* used global variables: buffer18 */
+fn fn2() {
+  fn0();
+  let vf16: u32 = arrayLength(&buffer18);
+  {
+  let vf17: vec4i = unpack4xI8(unconst_u32(94));
+}
+  fn0();
+  let ptr31: ptr<storage, array<i32, 24>, read> = &buffer18[unconst_u32(53)][33];
+  let ptr32: ptr<storage, array<array<i32, 24>, 34>, read> = &(*&buffer18)[unconst_u32(33)];
+  let ptr33: ptr<storage, array<i32, 24>, read> = &(*ptr32)[33];
+  let ptr34: ptr<storage, i32, read> = &(*ptr32)[unconst_u32(700)][unconst_u32(175)];
+  let ptr35: ptr<storage, array<i32, 24>, read> = &(*ptr31);
+  _ = buffer18;
+}
+
+struct T1 {
+  @align(32) @size(64) f0: vec4h,
+  @size(64) f1: atomic<i32>,
+  @align(8) @size(64) f2: atomic<u32>,
+  @align(64) @size(3072) f3: array<array<T0, 1>>,
+}
+
+struct T2 {
+  @size(216) f0: T0,
+}
+
+@group(0) @binding(254) var<storage, read> buffer17: f16;
+
+/* used global variables: buffer18 */
+fn fn1(a0: ptr<workgroup, T0>) -> f16 {
+  var out: f16;
+  loop {
+  for (var it0=arrayLength(&(*&buffer18)); it0<pack4x8unorm(asinh(vec4f(unconst_f32(0.3749), unconst_f32(0.1052), unconst_f32(0.06603), unconst_f32(0.09956)))); it0++) {
+  let vf11: vec2i = (vec2i(unconst_i32(71), unconst_i32(199)) / bitcast<vec2i>(min(vec2u(unconst_u32(281), unconst_u32(45)), vec2u(((vec2i(unconst_i32(45), unconst_i32(45)) / unconst_i32(-223)).rgg + unconst_i32(130)).br)))[0]);
+  var vf12: bool = all(bool(exp2(bitcast<vec2h>(buffer18[unconst_u32(408)][33][23])).g));
+  let ptr20: ptr<storage, i32, read> = &(*&buffer18)[unconst_u32(236)][33][23];
+  let ptr21: ptr<storage, array<array<i32, 24>, 34>, read> = &(*&buffer18)[unconst_i32(14)];
+  let ptr22: ptr<storage, i32, read> = &buffer18[unconst_u32(171)][unconst_u32(49)][unconst_u32(129)];
+  break;
+  _ = buffer18;
+}
+  let ptr23: ptr<storage, array<i32, 24>, read> = &buffer18[unconst_u32(363)][33];
+  let ptr24: ptr<storage, array<i32, 24>, read> = &(*&buffer18)[arrayLength(&(*&buffer18))][unconst_u32(75)];
+  break;
+  _ = buffer18;
+}
+  {
+  let ptr25: ptr<storage, i32, read> = &(*&buffer18)[arrayLength(&(*&buffer18))][unconst_u32(1000)][unconst_u32(265)];
+  let ptr26: ptr<storage, array<i32, 24>, read> = &(*&buffer18)[arrayLength(&(*&buffer18))][33];
+  switch (*&buffer18)[arrayLength(&(*&buffer18))][33][23] { 
+  default {
+  for (var it1=u32(buffer18[unconst_u32(104)][unconst_u32(80)][23]); it1<u32((*a0).f0); it1++) {
+  let vf13: vec3h = sqrt(vec3h(unconst_f16(7662.5), unconst_f16(2408.4), unconst_f16(6098.0)));
+  let ptr27: ptr<storage, array<array<i32, 24>, 34>, read> = &buffer18[arrayLength(&buffer18)];
+  _ = buffer18;
+}
+  out += f16((unconst_f16(12409.0) != unconst_f16(275.7)));
+  break;
+  _ = buffer18;
+}
+  }
+  _ = buffer18;
+}
+  (*a0).f0 += f16((*&buffer18)[unconst_u32(195)][unconst_u32(218)][23]);
+  var vf14: bool = (unconst_bool(false) && unconst_bool(true));
+  let vf15: vec2f = acosh(vec2f(unconst_f32(0.2151), unconst_f32(0.2704)));
+  (*a0) = T0(f16(buffer18[unconst_u32(167)][unconst_u32(35)][23]));
+  let ptr28: ptr<storage, i32, read> = &buffer18[unconst_u32(123)][33][unconst_u32(299)];
+  let ptr29: ptr<storage, i32, read> = &buffer18[unconst_u32(231)][33][23];
+  let ptr30: ptr<storage, i32, read> = &buffer18[unconst_u32(175)][unconst_u32(7)][unconst_u32(14)];
+  return out;
+  _ = buffer18;
+}
+
+var<workgroup> vw1: atomic<u32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(62) var tex1: texture_depth_2d;
+
+struct FragmentOutput1 {
+  @location(0) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+}
+
+/* used global variables: buffer18 */
+fn fn3(a0: ptr<private, T0>, a1: ptr<function, f32>) -> VertexOutput1 {
+  var out: VertexOutput1;
+  let ptr36: ptr<storage, array<i32, 24>, read> = &buffer18[unconst_u32(75)][unconst_u32(92)];
+  var vf18: vec4h = asinh(vec4h(countLeadingZeros(vec4i(unconst_i32(90), unconst_i32(413), unconst_i32(205), unconst_i32(43)))));
+  out.f4 -= vec4f(bitcast<f32>((*&buffer18)[pack4x8snorm(vec4f(unconst_f32(0.00103), unconst_f32(0.1698), unconst_f32(0.02991), unconst_f32(0.00843)))][unconst_u32(1000)][23]));
+  return out;
+  _ = buffer18;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput1 {
+  @location(4) f3: vec2u,
+  @builtin(position) f4: vec4f,
+  @location(14) f5: vec2u,
+}
+
+/* used global variables: buffer18 */
+fn fn0() {
+  let ptr13: ptr<storage, array<i32, 24>, read> = &(*&buffer18)[unconst_u32(61)][33];
+  while bool((*&buffer18)[arrayLength(&(*&buffer18))][unconst_u32(2)][unconst_u32(17)]) {
+  let ptr14: ptr<storage, array<i32, 24>, read> = &buffer18[arrayLength(&buffer18)][33];
+  let ptr15: ptr<storage, i32, read> = &buffer18[unconst_u32(164)][unconst_u32(280)][unconst_u32(57)];
+  let ptr16: ptr<storage, i32, read> = &(*&buffer18)[unconst_u32(160)][unconst_u32(136)][23];
+  let ptr17: ptr<storage, i32, read> = &(*&buffer18)[unconst_u32(72)][33][23];
+  while bool((*&buffer18)[unconst_u32(14)][33][23]) {
+  let vf6: vec3h = radians(vec3h(unconst_f16(5428.9), unconst_f16(1233.7), unconst_f16(1953.6)));
+  let vf7: vec3f = log(vec3f(unconst_f32(0.09610), unconst_f32(0.1589), unconst_f32(0.1038)));
+  break;
+}
+  _ = buffer18;
+}
+  let ptr18: ptr<storage, array<i32, 24>, read> = &buffer18[arrayLength(&buffer18)][33];
+  let vf8: vec2f = degrees(vec2f(bitcast<f32>(buffer18[unconst_u32(498)][33][bitcast<u32>((*ptr13)[23])])));
+  var vf9: vec2f = vf8;
+  vf9 *= vec2f(f32(buffer18[unconst_u32(229)][unconst_u32(27)][23]));
+  let ptr19: ptr<storage, i32, read> = &(*ptr18)[unconst_u32(58)];
+  vf9 += vec2f(bitcast<f32>(buffer18[arrayLength(&buffer18)][33][23]));
+  var vf10: vec3h = radians(vec3h(f16(buffer18[arrayLength(&buffer18)][33][unconst_u32(145)])));
+  _ = buffer18;
+}
+
+var<workgroup> vw2: T0;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  f0: f16,
+}
+
+var<workgroup> vw0: FragmentOutput1;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+/* used global variables: buffer17, buffer18, tex1 */
+@vertex
+fn vertex2(@location(13) @interpolate(flat) a0: vec2f, @location(12) a1: vec4h) -> VertexOutput1 {
+  var out: VertexOutput1;
+  let ptr37: ptr<storage, f16, read> = &buffer17;
+  out = VertexOutput1(vec2u(u32((*&buffer18)[arrayLength(&(*&buffer18))][33][23])), vec4f(f32((*&buffer18)[arrayLength(&(*&buffer18))][33][23])), vec2u(u32((*&buffer18)[arrayLength(&(*&buffer18))][33][23])));
+  let vf19: u32 = pack2x16unorm(vec2f(unconst_f32(0.1074), unconst_f32(0.1803)));
+  while bool(buffer18[arrayLength(&buffer18)][33][23]) {
+  if bool(buffer18[arrayLength(&buffer18)][33][unconst_u32(70)]) {
+  let ptr38: ptr<storage, i32, read> = &(*&buffer18)[arrayLength(&(*&buffer18))][unconst_u32(163)][unconst_u32(87)];
+  let ptr39: ptr<storage, array<i32, 24>, read> = &buffer18[unconst_u32(28)][unconst_u32(268)];
+  out.f3 = vec2u(u32((*&buffer18)[unconst_u32(345)][33][23]));
+  out.f5 &= vec2u(bitcast<u32>(ceil(unconst_f32(0.2872))));
+  _ = buffer18;
+}
+  out = VertexOutput1(vec2u(u32((*&buffer18)[arrayLength(&(*&buffer18))][33][23])), vec4f(bitcast<f32>((*&buffer18)[arrayLength(&(*&buffer18))][33][23])), vec2u(u32((*&buffer18)[arrayLength(&(*&buffer18))][33][23])));
+  let ptr40: ptr<storage, array<array<array<i32, 24>, 34>>, read> = &(*&buffer18);
+  out.f4 = vec4f(bitcast<f32>((*ptr40)[arrayLength(&(*ptr40))][33][unconst_u32(262)]));
+  break;
+  _ = buffer18;
+}
+  let ptr41: ptr<storage, f16, read> = &(*ptr37);
+  out.f5 >>= vec2u(bitcast<u32>(step(unconst_f32(0.3321), unconst_f32(-0.01603))));
+  var vf20: vec2u = textureDimensions(tex1);
+  let vf21: vec2h = clamp(vec2h(unconst_f16(20226.7), unconst_f16(-2625.5)), vec2h(unconst_f16(2755.4), unconst_f16(23875.4)), bitcast<vec2h>((*&buffer18)[unconst_u32(33)][unconst_u32(370)][23]));
+  vf20 |= vec2u(u32((*&buffer18)[unconst_u32(173)][unconst_u32(190)][23]));
+  let ptr42: ptr<storage, array<i32, 24>, read> = &buffer18[arrayLength(&buffer18)][unconst_u32(460)];
+  return out;
+  _ = buffer17;
+  _ = buffer18;
+  _ = tex1;
+}
+
+/* used global variables: buffer18 */
+@fragment
+fn fragment1(@location(14) a0: vec2u, @location(4) @interpolate(flat, either) a1: vec2u) -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  fn2();
+  var vf22: vec4i = countLeadingZeros(vec4i(unconst_i32(67), unconst_i32(192), unconst_i32(27), unconst_i32(127)));
+  out = FragmentOutput1(unpack4xU8(pack4xU8Clamp(vec4u(unconst_u32(136), unconst_u32(406), unconst_u32(101), unconst_u32(280)))), pack4xU8Clamp(vec4u(unconst_u32(136), unconst_u32(406), unconst_u32(101), unconst_u32(280))));
+  out = FragmentOutput1(unpack4xU8(bitcast<u32>(vf22[unconst_u32(175)])), bitcast<u32>(vf22[unconst_u32(175)]));
+  let ptr43: ptr<storage, i32, read> = &(*&buffer18)[unconst_u32(147)][unconst_u32(115)][23];
+  return out;
+  _ = buffer18;
+}
+
+/* used global variables: buffer18 */
+@compute @workgroup_size(3, 1, 1)
+fn compute1() {
+  _ = fn1(&vw2);
+  vw0.f1 &= pack4xU8Clamp((*&vw0).f0);
+  var vf23 = fn1(&vw2);
+  vf23 *= vec2h(quantizeToF16(vec2f(unconst_f32(-0.1672), unconst_f32(0.3891)))).y;
+  let vf24: f32 = tanh(unconst_f32(0.1239));
+  atomicMax(&vw1, unconst_u32(95));
+  vw0 = FragmentOutput1(vec4u(u32(vw2.f0)), u32(vw2.f0));
+  vw0 = FragmentOutput1(vec4u(quantizeToF16(vec2f(unconst_f32(0.07965), unconst_f32(0.07016))).rggg), u32(quantizeToF16(vec2f(unconst_f32(0.07965), unconst_f32(0.07016))).g));
+  var vf25: bool = (unconst_u32(361) != unconst_u32(32));
+  atomicAdd(&vw1, unconst_u32(188));
+  let ptr44: ptr<workgroup, FragmentOutput1> = &vw0;
+  _ = buffer18;
+}`,
+});
+let commandEncoder21 = device0.createCommandEncoder();
+let texture20 = device0.createTexture({
+  size: {width: 180, height: 1, depthOrArrayLayers: 12},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup8, new Uint32Array(4222), 720, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle2, renderBundle1, renderBundle1, renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint16', 2_480, 5_005);
+} catch {}
+let promise2 = shaderModule0.getCompilationInfo();
+try {
+commandEncoder21.copyBufferToBuffer(buffer16, 8, buffer12, 172, 1464);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1808 */
+  offset: 1808,
+  buffer: buffer3,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet1, 150, 95, buffer15, 256);
+} catch {}
+let textureView27 = texture20.createView({baseArrayLayer: 0});
+let computePassEncoder18 = commandEncoder21.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup7, new Uint32Array(1647), 120, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer0, 0, 2_194);
+} catch {}
+try {
+computePassEncoder2.pushDebugGroup('\udbd0');
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let textureView28 = texture4.createView({aspect: 'all'});
+try {
+buffer7.unmap();
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let buffer19 = device0.createBuffer({
+  size: 11635,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let computePassEncoder19 = commandEncoder22.beginComputePass({
+  label: '\u0327\u65d5\u7b8f\ud13f\u9a13\u{1feb2}\uded9\u{1fbe4}\u1d3c\u0425\u0c83',
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 627},
+});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 99.72,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer10);
+} catch {}
+document.body.append(canvas0);
+let shaderModule2 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override0: f32;
+
+struct VertexOutput2 {
+  @location(5) f6: vec4f,
+  @builtin(position) f7: vec4f,
+  @location(6) f8: vec4f,
+  @location(15) f9: f16,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(578) var<storage, read> buffer21: array<array<array<array<f16, 34>, 1>, 16>, 3>;
+
+struct T4 {
+  @size(3264) f0: array<T0>,
+}
+
+@id(2536) override override2: u32 = 78;
+
+override override1 = true;
+
+struct FragmentOutput2 {
+  @location(6) @interpolate(flat, center) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+  @location(0) @interpolate(flat) f2: vec4u,
+}
+
+struct T0 {
+  f0: f16,
+}
+
+struct T1 {
+  f0: array<f16, 1>,
+}
+
+struct T2 {
+  @size(896) f0: array<u32>,
+}
+
+struct T3 {
+  @align(16) @size(3264) f0: array<T1>,
+}
+
+/* used global variables: buffer21 */
+@vertex
+fn vertex3(@location(9) a0: vec2u, @location(11) a1: i32, @location(2) @interpolate(flat, centroid) a2: vec4h, @location(7) a3: vec4i, @location(13) @interpolate(flat) a4: u32, @location(6) a5: f16, @location(8) @interpolate(flat) a6: i32, @location(15) a7: f32, @location(4) a8: vec2f) -> VertexOutput2 {
+  var out: VertexOutput2;
+  var vf26: vec2u = a0;
+  out.f6 += vec4f(f32((*&buffer21)[unconst_u32(23)][15][unconst_u32(2)][33]));
+  for (var it2=pack2x16snorm(vec2f(unconst_f32(0.1815), unconst_f32(0.3736))); it2<u32((*&buffer21)[unconst_u32(349)][unconst_u32(6)][0][unconst_u32(18)]); it2++) {
+  var vf27: bool = override1;
+  break;
+  _ = override1;
+}
+  out.f7 = vec4f(f32(buffer21[2][15][unconst_u32(121)][33]));
+  var vf28: vec2i = firstTrailingBit(vec2i(unconst_i32(-231), unconst_i32(78)));
+  let ptr45: ptr<storage, f16, read> = &(*&buffer21)[2][unconst_u32(49)][unconst_u32(219)][33];
+  return out;
+  _ = override1;
+  _ = buffer21;
+}
+
+/* used global variables: buffer21 */
+@fragment
+fn fragment2(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4f, @location(14) a2: vec2u) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let ptr46: ptr<storage, f16, read> = &(*&buffer21)[unconst_u32(296)][15][0][33];
+  let ptr47: ptr<storage, array<array<array<f16, 34>, 1>, 16>, read> = &buffer21[unconst_u32(645)];
+  let ptr48: ptr<storage, f16, read> = &buffer21[unconst_u32(80)][15][0][33];
+  out.f2 -= vec4u(u32((*&buffer21)[u32(buffer21[2][unconst_u32(116)][0][unconst_u32(66)])][unconst_u32(223)][0][33]));
+  out.f0 ^= vec4u(u32((*&buffer21)[unconst_u32(237)][unconst_u32(124)][0][33]));
+  out.f2 |= vec4u(u32((*ptr47)[15][0][33]));
+  out.f0 |= unpack4xU8(u32((*&buffer21)[2][15][unconst_u32(86)][33]));
+  let ptr49: ptr<storage, array<f16, 34>, read> = &(*&buffer21)[2][15][unconst_u32(25)];
+  let ptr50: ptr<storage, f16, read> = &buffer21[unconst_u32(116)][unconst_u32(86)][unconst_u32(43)][33];
+  let ptr51: ptr<storage, array<f16, 34>, read> = &(*&buffer21)[unconst_u32(23)][u32(override1)][0];
+  return out;
+  _ = override1;
+  _ = buffer21;
+}
+
+/* used global variables: buffer21 */
+@compute @workgroup_size(6, 1, 1)
+fn compute2() {
+  let ptr52: ptr<storage, array<f16, 34>, read> = &(*&buffer21)[2][15][0];
+  let ptr53: ptr<storage, f16, read> = &(*&buffer21)[2][unconst_u32(82)][0][33];
+  let ptr54: ptr<storage, f16, read> = &buffer21[unconst_u32(147)][unconst_u32(125)][unconst_u32(154)][unconst_u32(76)];
+  let vf29: bool = (unconst_bool(false) || unconst_bool(true));
+  _ = buffer21;
+}`,
+});
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView29 = texture13.createView({
+  label: '\u0a0c\u{1fe36}\u0a08\u{1f69c}\u0bcd\u2052\u0791\uff77\u08f0',
+  dimension: 'cube',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 3,
+});
+let renderPassEncoder3 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 76,
+  clearValue: { r: 460.7, g: 219.4, b: 764.4, a: 379.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup2, new Uint32Array(179), 24, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup3, new Uint32Array(1900), 404, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer5, 4932, buffer4, 452, 600);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let textureView30 = texture10.createView({dimension: '1d'});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup5, new Uint32Array(3529), 634, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup6, new Uint32Array(3053), 378, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer3, 'uint32', 11_776, 1_530);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer7);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer16, 1700, buffer0, 12, 84);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T3 {
+  f0: array<f16, 1>,
+}
+
+struct T5 {
+  @size(3264) f0: array<array<atomic<u32>, 1>>,
+}
+
+@group(0) @binding(578) var<storage, read> buffer23: array<mat2x3f, 102>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T1 {
+  f0: array<f16>,
+}
+
+struct VertexOutput3 {
+  @location(8) @interpolate(flat, first) f10: vec2h,
+  @location(9) f11: vec2h,
+  @builtin(position) f12: vec4f,
+  @location(2) @interpolate(flat, either) f13: vec2h,
+}
+
+struct T4 {
+  @align(64) @size(64) f0: vec2h,
+  @align(8) @size(3200) f1: array<array<atomic<i32>, 11>>,
+}
+
+struct T2 {
+  f0: array<array<array<f16, 1>, 1>>,
+}
+
+override override3 = false;
+
+struct S0 {
+  @builtin(vertex_index) f0: u32,
+  @location(13) f1: i32,
+  @location(3) f2: vec2i,
+  @location(5) @interpolate(perspective, sample) f3: vec4f,
+  @location(11) f4: vec2u,
+}
+
+/* used global variables: buffer23 */
+fn fn0(a0: ptr<uniform, S0>) {
+  let ptr55: ptr<storage, mat2x3f, read> = &(*&buffer23)[unconst_u32(400)];
+  _ = buffer23;
+}
+
+var<workgroup> vw3: S0;
+
+struct T0 {
+  f0: array<f16>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+/* used global variables: buffer23 */
+@vertex
+fn vertex4(a0: S0, @location(14) a1: vec2h) -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f11 += vec2h(a0.f3.xx);
+  out.f10 += vec2h(a0.f3.bg);
+  out.f11 *= vec2h(buffer23[unconst_u32(151)][unconst_i32(1)].bg);
+  {
+  out.f10 -= bitcast<vec2h>(a0.f0);
+  var vf30: f32 = tan((*&buffer23)[unconst_u32(163)][unconst_i32(0)].z);
+  _ = buffer23;
+}
+  return out;
+  _ = buffer23;
+}
+
+/* used global variables: buffer23 */
+@compute @workgroup_size(3, 1, 1)
+fn compute3(@builtin(local_invocation_id) a0: vec3u) {
+  vw3 = S0(u32((*&buffer23)[unconst_u32(54)][unconst_u32(437)][unconst_u32(257)]), i32((*&buffer23)[unconst_u32(54)][unconst_u32(437)][unconst_u32(257)]), vec2i(bitcast<i32>((*&buffer23)[unconst_u32(54)][unconst_u32(437)][unconst_u32(257)])), vec4f((*&buffer23)[unconst_u32(54)][unconst_u32(437)][unconst_u32(257)]), vec2u(u32((*&buffer23)[unconst_u32(54)][unconst_u32(437)][unconst_u32(257)])));
+  vw3.f1 -= (*&vw3).f1;
+  let ptr56: ptr<workgroup, i32> = &vw3.f1;
+  vw3 = S0(bitcast<vec3u>(log2(vec3f(unconst_f32(0.4881), unconst_f32(-0.1979), unconst_f32(0.1226))))[2], i32(log2(vec3f(unconst_f32(0.4881), unconst_f32(-0.1979), unconst_f32(0.1226))).z), vec2i(log2(vec3f(unconst_f32(0.4881), unconst_f32(-0.1979), unconst_f32(0.1226))).xz), log2(vec3f(unconst_f32(0.4881), unconst_f32(-0.1979), unconst_f32(0.1226))).ggrr, bitcast<vec2u>(log2(vec3f(unconst_f32(0.4881), unconst_f32(-0.1979), unconst_f32(0.1226))).br));
+  {
+  vw3 = S0(u32((*&vw3).f1), (*&vw3).f1, vec2i((*&vw3).f1), vec4f(bitcast<f32>((*&vw3).f1)), vec2u(bitcast<u32>((*&vw3).f1)));
+  vw3 = (*&vw3);
+  {
+  var vf31: bool = (unconst_u32(79) > unconst_u32(123));
+  let vf32: vec2f = fract(vec2f(unconst_f32(-0.5949), unconst_f32(0.1992)));
+}
+}
+  vw3.f2 = vec2i(vw3.f4);
+  for (var it3=pack4x8snorm(vw3.f3); it3<pack4xI8Clamp(vec4i(unconst_i32(-8), unconst_i32(140), unconst_i32(306), unconst_i32(-19))); it3++) {
+  vw3.f1 = bitcast<vec4i>(countOneBits(vec4u(unconst_u32(500), unconst_u32(44), unconst_u32(7), unconst_u32(488)))).g;
+}
+  _ = buffer23;
+}`,
+});
+let texture21 = device0.createTexture({
+  size: [258, 15, 11],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder20 = commandEncoder23.beginComputePass({});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup1, new Uint32Array(1416), 80, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(4672), 315, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint16', 1_894, 1_212);
+} catch {}
+document.body.append(canvas0);
+let buffer24 = device0.createBuffer({
+  size: 4054,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+let renderPassEncoder4 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 1,
+  clearValue: { r: 296.4, g: -23.11, b: 259.3, a: 358.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 758},
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup3);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 425.6, g: -193.6, b: -482.9, a: 958.1, });
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer9);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(1, bindGroup6, new Uint32Array(2113), 910, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(5);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2, renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer19, 'uint32', 2_076, 1_085);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 24, y: 1, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView31 = texture14.createView({baseMipLevel: 0});
+let computePassEncoder21 = commandEncoder26.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup7, new Uint32Array(746), 6, 0);
+} catch {}
+let textureView32 = texture18.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup2, new Uint32Array(69), 1, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3, renderBundle2, renderBundle0, renderBundle3]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let buffer25 = device0.createBuffer({
+  size: 7643,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture22 = device0.createTexture({size: {width: 45}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint16', 2_096, 6_008);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture23 = device0.createTexture({
+  size: [45, 1, 4],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView33 = texture19.createView({});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(5), 3, 0);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 24},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 62, resource: textureView9},
+    {binding: 254, resource: {buffer: buffer16, offset: 256, size: 48}},
+    {binding: 578, resource: {buffer: buffer16, offset: 0, size: 3296}},
+  ],
+});
+let texture24 = device0.createTexture({
+  size: {width: 517, height: 30, depthOrArrayLayers: 11},
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder22 = commandEncoder27.beginComputePass();
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup3, new Uint32Array(440), 15, 0);
+} catch {}
+let promise3 = shaderModule2.getCompilationInfo();
+try {
+computePassEncoder5.insertDebugMarker('\u{1f64b}');
+} catch {}
+let textureView34 = texture2.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(2, bindGroup1, new Uint32Array(1516), 245, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(50, 1, 5, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer11, 'uint32', 448, 9_373);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer11, 0, 4_501);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(105).fill(144), /* required buffer size: 105 */
+{offset: 105, bytesPerRow: 132}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer26 = device0.createBuffer({
+  label: '\u0666\u0d7d\u{1fdae}\u0c3f\ueae1\u7980\u2506\uaba6\u9503\u4308\u69d0',
+  size: 16268,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView35 = texture15.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+let textureView36 = texture12.createView({dimension: '2d', format: 'rgba16uint', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 10, y: 4, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 168 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1272 */
+  offset: 1272,
+  bytesPerRow: 36864,
+  buffer: buffer4,
+}, {width: 21, height: 95, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+let buffer27 = device0.createBuffer({
+  size: 6615,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture25 = device0.createTexture({
+  size: [258, 15, 11],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup2, new Uint32Array(5361), 94, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer11, 912, 515);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let buffer28 = device0.createBuffer({size: 6408, usage: GPUBufferUsage.MAP_READ});
+let textureView37 = texture13.createView({dimension: 'cube', format: 'rgba16uint', mipLevelCount: 1});
+let computePassEncoder23 = commandEncoder28.beginComputePass({});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer8, 'uint16', 1_538, 539);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, undefined, 307_955_275, 393_416_362);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1344 */
+  offset: 1344,
+  bytesPerRow: 61696,
+  buffer: buffer25,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 86, y: 30, z: 4},
+  aspect: 'all',
+}, {width: 40, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData1,
+  origin: { x: 51, y: 41 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 8, y: 3, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 30, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let buffer29 = device0.createBuffer({
+  size: 7220,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder24 = commandEncoder29.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 398}});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, undefined, 2_233_370_197);
+} catch {}
+let texture26 = device0.createTexture({
+  size: [180, 80, 12],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView38 = texture22.createView({baseArrayLayer: 0});
+let sampler13 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.41,
+  compare: 'equal',
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer11, 'uint16', 3_910, 257);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer7, 988);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let buffer30 = device0.createBuffer({size: 7610, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 164, 88);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let commandEncoder30 = device0.createCommandEncoder({});
+let textureView39 = texture11.createView({baseArrayLayer: 0});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint32', 2_012, 5_233);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 1200 widthInBlocks: 150 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 600 */
+  offset: 600,
+  bytesPerRow: 44032,
+  buffer: buffer25,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 150, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder31 = device0.createCommandEncoder({});
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer10, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(930), 36, 0);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer11, 'uint32', 4_240, 51);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer7);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer4, 132, 480);
+} catch {}
+try {
+computePassEncoder13.pushDebugGroup('\ud8f2');
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame0);
+let textureView40 = texture7.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let texture27 = device0.createTexture({
+  size: [90, 40, 105],
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer11, 'uint32', 1_272, 8_406);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let pipeline0 = await promise0;
+let buffer31 = device0.createBuffer({size: 9057, usage: GPUBufferUsage.VERTEX});
+let commandEncoder32 = device0.createCommandEncoder({});
+let renderPassEncoder5 = commandEncoder30.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  clearValue: { r: 115.2, g: 403.5, b: -453.0, a: -52.90, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 4294967295},
+});
+let renderBundle4 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup8, new Uint32Array(2920), 284, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer7, 1_276);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer32 = device0.createBuffer({
+  size: 17529,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder6 = commandEncoder32.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 64,
+  clearValue: { r: -506.9, g: -956.4, b: -680.2, a: -526.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 155369861,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1, renderBundle2, renderBundle0]);
+} catch {}
+let imageData2 = new ImageData(60, 76);
+let buffer33 = device0.createBuffer({
+  size: 3264,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView41 = texture9.createView({mipLevelCount: 1});
+let textureView42 = texture2.createView({mipLevelCount: 1});
+let computePassEncoder25 = commandEncoder31.beginComputePass({});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup6, new Uint32Array(1911), 311, 0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer32, 'uint32', 460, 1_896);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer33, 16);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup0, new Uint32Array(2539), 342, 0);
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+let buffer34 = device0.createBuffer({size: 11101, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder33 = device0.createCommandEncoder({});
+let sampler14 = device0.createSampler({addressModeW: 'mirror-repeat', magFilter: 'linear', mipmapFilter: 'linear', maxAnisotropy: 1});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(2283), 426, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup1, new Uint32Array(1353), 36, 0);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2776 */
+  offset: 2776,
+  bytesPerRow: 3328,
+  buffer: buffer26,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 4, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 39, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 49, y: 1, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let bindGroup10 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 328, resource: textureView20}]});
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let computePassEncoder26 = commandEncoder33.beginComputePass({timestampWrites: {querySet: querySet1}});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup7, new Uint32Array(254), 84, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer25, 'uint16', 336, 1_646);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer27, 1_952, 187);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup3);
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({});
+let texture28 = device0.createTexture({
+  size: {width: 517, height: 30, depthOrArrayLayers: 62},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder27 = commandEncoder34.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup0, new Uint32Array(946), 212, 0);
+} catch {}
+try {
+  await promise3;
+} catch {}
+document.body.append(canvas0);
+let texture29 = device0.createTexture({
+  size: {width: 45},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup4, new Uint32Array(459), 15, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup6, new Uint32Array(1675), 674, 0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer1, 'uint32', 168, 9);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise4;
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView43 = texture20.createView({});
+let computePassEncoder28 = commandEncoder35.beginComputePass({});
+let sampler15 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.36,
+  maxAnisotropy: 12,
+});
+try {
+device0.queue.submit([]);
+} catch {}
+let autogeneratedBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let texture30 = device0.createTexture({
+  size: [90, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup2, new Uint32Array(1502), 4, 0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+let buffer35 = device0.createBuffer({
+  size: 15036,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture31 = device0.createTexture({
+  size: [45, 20, 25],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView44 = texture19.createView({dimension: '1d', baseArrayLayer: 0});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup10, new Uint32Array(1311), 313, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup10, new Uint32Array(145), 16, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 12, z: 9},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt709', transfer: 'gamma22curve'} });
+let textureView45 = texture0.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 4});
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder13.popDebugGroup();
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let autogeneratedBindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+try {
+computePassEncoder6.setBindGroup(1, bindGroup8, new Uint32Array(69), 15, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: [129, 7, 11],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder29 = commandEncoder36.beginComputePass({timestampWrites: {querySet: querySet1}});
+try {
+renderPassEncoder6.setBlendConstant({ r: 346.4, g: 83.99, b: -519.2, a: 615.2, });
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let bindGroup11 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 8, resource: externalTexture0}]});
+let texture33 = device0.createTexture({
+  size: [129, 7, 11],
+  mipLevelCount: 4,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+try {
+computePassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer29, 'uint16', 874, 305);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: canvas0,
+  origin: { x: 63, y: 4 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 13, y: 13, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise5;
+} catch {}
+let buffer36 = device0.createBuffer({size: 5337, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView46 = texture32.createView({dimension: '2d', baseArrayLayer: 0});
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.78,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(2, bindGroup3, new Uint32Array(1705), 167, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(2948), 121, 0);
+} catch {}
+try {
+renderBundleEncoder6.insertDebugMarker('\ub765');
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule0, constants: {}}});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 264});
+let texture34 = device0.createTexture({
+  size: [90, 1, 1],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder3.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer32, 'uint16', 6_748, 908);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(87).fill(76), /* required buffer size: 87 */
+{offset: 87}, {width: 74, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView47 = texture20.createView({});
+let texture35 = device0.createTexture({
+  size: {width: 1035, height: 60, depthOrArrayLayers: 11},
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer29, 'uint16', 562, 1_383);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer11, 1544, buffer10, 1472, 2296);
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 364 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1848 */
+  offset: 1848,
+  bytesPerRow: 37376,
+  buffer: buffer27,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 5, y: 26, z: 0},
+  aspect: 'all',
+}, {width: 91, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData1,
+  origin: { x: 7, y: 6 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 29, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 25, height: 19, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 328,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer37 = device0.createBuffer({size: 3627, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder37 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder11.finish({label: '\u0311\u213e\u{1f8d8}\u06a7\u0deb\u0f6c\u068e\u444f\u035e\ud4c4\uae9b'});
+let texture36 = device0.createTexture({
+  size: [90, 40, 1],
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder30 = commandEncoder37.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 52}});
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint32', 268, 70);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 6376, new DataView(new ArrayBuffer(19287)), 8086, 1904);
+} catch {}
+let textureView48 = texture13.createView({dimension: 'cube', mipLevelCount: 1});
+let texture37 = device0.createTexture({
+  size: [45],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+await gc();
+let buffer38 = device0.createBuffer({size: 1824, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(16, 0, 14, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame3});
+let buffer39 = device0.createBuffer({
+  size: 141,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture38 = device0.createTexture({
+  size: [22, 10, 33],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup9, new Uint32Array(2319), 238, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer25, 'uint16', 538, 290);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer19, 492);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3360 */
+  offset: 3360,
+  bytesPerRow: 8448,
+  buffer: buffer25,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 44, y: 12, z: 2},
+  aspect: 'all',
+}, {width: 20, height: 61, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup12 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 8, resource: externalTexture1}]});
+let texture39 = device0.createTexture({size: [517, 30, 11], format: 'rgba16uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView49 = texture23.createView({dimension: '2d', aspect: 'all'});
+let computePassEncoder31 = commandEncoder38.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 235, endOfPassWriteIndex: 379}});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame2});
+let bindGroup13 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView45}]});
+let buffer40 = device0.createBuffer({
+  size: 15876,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView50 = texture35.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let renderPassEncoder7 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  clearValue: { r: 472.9, g: -886.6, b: -444.0, a: -426.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 356},
+});
+try {
+renderPassEncoder7.executeBundles([renderBundle6]);
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'log'} });
+let texture40 = device0.createTexture({
+  size: {width: 517, height: 30, depthOrArrayLayers: 11},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler17 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 84.67,
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup11, new Uint32Array(1942), 440, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer39, 8, 100);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 180, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 578, resource: {buffer: buffer24, offset: 512, size: 3304}}],
+});
+let buffer41 = device0.createBuffer({
+  size: 1314,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView51 = texture33.createView({dimension: '2d', mipLevelCount: 2, baseArrayLayer: 5});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(1, bindGroup14, new Uint32Array(209), 103, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 76, 98);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer11, 0, 8_790);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas0);
+let canvas1 = document.createElement('canvas');
+let buffer42 = device0.createBuffer({size: 1402, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let texture41 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 31},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let buffer43 = device0.createBuffer({
+  size: 68,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder40 = device0.createCommandEncoder({});
+let textureView52 = texture23.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder32 = commandEncoder40.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 4294967295}});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup11, new Uint32Array(1336), 227, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint16', 2_196, 12_386);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture42 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup14, new Uint32Array(1437), 419, 0);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let pipeline2 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    buffers: [
+      {
+        arrayStride: 148,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 88, shaderLocation: 15},
+          {format: 'sint8x4', offset: 12, shaderLocation: 7},
+          {format: 'float32x4', offset: 24, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 6},
+          {format: 'uint8x4', offset: 4, shaderLocation: 13},
+          {format: 'uint8x4', offset: 0, shaderLocation: 9},
+          {format: 'sint8x2', offset: 8, shaderLocation: 8},
+          {format: 'sint16x4', offset: 36, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let imageBitmap1 = await createImageBitmap(canvas0);
+let autogeneratedBindGroupLayout3 = pipeline2.getBindGroupLayout(0);
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.85,
+});
+try {
+computePassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -952.1, g: -607.0, b: -623.5, a: -802.1, });
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer19, 'uint16', 1_184, 3_480);
+} catch {}
+let pipeline3 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex4',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 248,
+        attributes: [
+          {format: 'unorm8x4', offset: 12, shaderLocation: 14},
+          {format: 'sint8x4', offset: 0, shaderLocation: 3},
+          {format: 'float32x3', offset: 24, shaderLocation: 5},
+          {format: 'uint32x4', offset: 60, shaderLocation: 11},
+          {format: 'sint32', offset: 52, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({
+  size: [45],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView53 = texture11.createView({});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4064 */
+  offset: 4064,
+  buffer: buffer29,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let texture44 = device0.createTexture({
+  size: {width: 45, height: 1, depthOrArrayLayers: 12},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture45 = device0.createTexture({
+  size: [180, 1, 296],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView54 = texture21.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup9, new Uint32Array(6730), 827, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline3);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\u368e\ub0ff\ue68a\u5a98\u2cd1\u0731\u04cc',
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 578, resource: {buffer: buffer0, offset: 256, size: 4628}}],
+});
+let commandEncoder42 = device0.createCommandEncoder({});
+let computePassEncoder33 = commandEncoder42.beginComputePass();
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup10, new Uint32Array(98), 0, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer8);
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1544 */
+  offset: 1544,
+  bytesPerRow: 54016,
+  rowsPerImage: 63,
+  buffer: buffer5,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 21, z: 1},
+  aspect: 'all',
+}, {width: 20, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet2, 17, 19, buffer8, 0);
+} catch {}
+let buffer44 = device0.createBuffer({size: 3328, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView55 = texture13.createView({dimension: '2d', mipLevelCount: 1});
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2672 */
+  offset: 2672,
+  buffer: buffer11,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 10, z: 4},
+  aspect: 'all',
+}, new Uint8Array(62_225).fill(11), /* required buffer size: 62_225 */
+{offset: 173, bytesPerRow: 72, rowsPerImage: 170}, {width: 15, height: 12, depthOrArrayLayers: 6});
+} catch {}
+let pipeline4 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule3}});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(452), 173, 0);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 8, y: 3, z: 7},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 19536 */
+  offset: 1056,
+  bytesPerRow: 1024,
+  buffer: buffer0,
+}, {width: 6, height: 19, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img0 = await imageWithData(8, 101, '#10101010', '#20202020');
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 62,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 254,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 2, hasDynamicOffset: false },
+    },
+    {
+      binding: 578,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer45 = device0.createBuffer({
+  size: 20952,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder43 = device0.createCommandEncoder({});
+let textureView56 = texture38.createView({baseArrayLayer: 1, arrayLayerCount: 9});
+let sampler19 = device0.createSampler({
+  label: '\u3933\u005f',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.22,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup4, new Uint32Array(68), 19, 0);
+} catch {}
+let buffer46 = device0.createBuffer({
+  size: 1544,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView57 = texture13.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 12});
+let renderPassEncoder8 = commandEncoder41.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: -241.4, g: 466.7, b: -521.6, a: -59.35, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 112215601,
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder33.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer10, 'uint32', 3_072, 2_353);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer46, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer47 = device0.createBuffer({
+  size: 6989,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let computePassEncoder34 = commandEncoder43.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 741, endOfPassWriteIndex: 605}});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer29, 'uint16', 282, 474);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\u{1fe38}');
+} catch {}
+try {
+  await promise6;
+} catch {}
+let texture46 = device0.createTexture({
+  size: [180, 80, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView58 = texture31.createView({mipLevelCount: 1, arrayLayerCount: 2});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 308, new BigUint64Array(18420), 1847, 36);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup7, new Uint32Array(3605), 285, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder12.pushDebugGroup('\u25a4');
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({});
+let texture47 = device0.createTexture({
+  size: {width: 22, height: 10, depthOrArrayLayers: 55},
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView59 = texture16.createView({dimension: '1d'});
+let computePassEncoder35 = commandEncoder45.beginComputePass({});
+let sampler21 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 82.40, compare: 'equal'});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer45, 'uint16', 4_294, 5_139);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 14, y: 11, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpteRp431', transfer: 'hlg'} });
+let computePassEncoder36 = commandEncoder44.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup10, new Uint32Array(1868), 868, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle3]);
+} catch {}
+try {
+  await promise7;
+} catch {}
+let canvas2 = document.createElement('canvas');
+let bindGroup16 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 578, resource: {buffer: buffer5, offset: 0, size: 3808}}],
+});
+let texture48 = device0.createTexture({size: [90], dimension: '1d', format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder31.insertDebugMarker('\uce95');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 1680, new Float32Array(2648), 565, 76);
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder();
+let textureView60 = texture8.createView({});
+let computePassEncoder37 = commandEncoder46.beginComputePass();
+let sampler22 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.21,
+});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle7, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u2227');
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture49 = device0.createTexture({
+  size: [45],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView61 = texture13.createView({
+  label: '\u0169\u203a\u1486\u{1f838}',
+  dimension: 'cube-array',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 6,
+});
+let computePassEncoder38 = commandEncoder47.beginComputePass({timestampWrites: {querySet: querySet1}});
+try {
+computePassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint16', 692, 525);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+let promise8 = shaderModule3.getCompilationInfo();
+try {
+computePassEncoder12.popDebugGroup();
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let computePassEncoder39 = commandEncoder48.beginComputePass({});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 216, new Int16Array(65536), 13823, 4);
+} catch {}
+let texture50 = device0.createTexture({
+  size: {width: 90},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer46, 0, 97);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder28.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup3, new Uint32Array(928), 41, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+await gc();
+let bindGroup17 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 62, resource: textureView9},
+    {binding: 254, resource: {buffer: buffer25, offset: 2048, size: 1224}},
+    {binding: 578, resource: {buffer: buffer35, offset: 0}},
+  ],
+});
+let textureView62 = texture7.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+let textureView63 = texture32.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup7, new Uint32Array(5228), 616, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer29, 508); };
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\ud39e');
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'bt709'} });
+let bindGroup18 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView45}]});
+let commandEncoder49 = device0.createCommandEncoder();
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let buffer48 = device0.createBuffer({
+  size: 7369,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+  await buffer37.mapAsync(GPUMapMode.WRITE, 760, 588);
+} catch {}
+let computePassEncoder40 = commandEncoder24.beginComputePass();
+let renderPassEncoder9 = commandEncoder49.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 108.5, g: -183.8, b: -663.9, a: 178.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet1},
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup8, new Uint32Array(683), 76, 0);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle6, renderBundle5, renderBundle0, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 578, resource: {buffer: buffer5, offset: 2304, size: 5320}}],
+});
+let buffer49 = device0.createBuffer({
+  size: 10212,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder10 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: -289.6, g: 724.5, b: 261.6, a: 574.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup13, []);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup16, new Uint32Array(496), 55, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer10, 'uint16', 552, 3_384);
+} catch {}
+let imageData3 = new ImageData(8, 16);
+let bindGroup20 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 578, resource: {buffer: buffer25, offset: 0, size: 3760}}],
+});
+let commandEncoder50 = device0.createCommandEncoder();
+let computePassEncoder41 = commandEncoder50.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 261, endOfPassWriteIndex: 386}});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup14, new Uint32Array(2494), 181, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer34, 0);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer44, 0, 427);
+} catch {}
+try {
+computePassEncoder22.insertDebugMarker('\u0176');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 31}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 10, y: 75, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup21 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 328, resource: textureView0}]});
+let textureView64 = texture21.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 1});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+renderPassEncoder4.setIndexBuffer(buffer10, 'uint32', 2_548, 965);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 20, y: 62, z: 6},
+  aspect: 'all',
+}, new Uint8Array(342).fill(151), /* required buffer size: 342 */
+{offset: 342}, {width: 50, height: 1, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData4 = new ImageData(20, 44);
+let bindGroup22 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 578, resource: {buffer: buffer33, offset: 0, size: 3264}}],
+});
+let buffer50 = device0.createBuffer({size: 11295, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView65 = texture7.createView({aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 3});
+let sampler23 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 70.29, compare: 'always'});
+try {
+computePassEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup0, new Uint32Array(327), 10, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+let bindGroup23 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 328, resource: textureView39}]});
+let commandEncoder51 = device0.createCommandEncoder();
+let computePassEncoder42 = commandEncoder51.beginComputePass({});
+let sampler24 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder4.setStencilReference(1077);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer43, 'uint32', 8, 2);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline3);
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder();
+let textureView66 = texture1.createView({label: '\uad7d\u1410', aspect: 'all', baseMipLevel: 0, baseArrayLayer: 14, arrayLayerCount: 70});
+let sampler25 = device0.createSampler({addressModeW: 'repeat', minFilter: 'linear', lodMaxClamp: 77.78, maxAnisotropy: 1});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder52.resolveQuerySet(querySet0, 33, 0, buffer16, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(415).fill(28), /* required buffer size: 415 */
+{offset: 415}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 31}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 44, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let img1 = await imageWithData(36, 25, '#10101010', '#20202020');
+let texture51 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder43 = commandEncoder52.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 510}});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup10, new Uint32Array(3022), 221, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer10, 'uint16', 9_226, 5_427);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer45, 0, 67);
+} catch {}
+try {
+computePassEncoder5.insertDebugMarker('\udfd4');
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte170m', transfer: 'unspecified'} });
+let commandEncoder53 = device0.createCommandEncoder({});
+let textureView67 = texture51.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+let texture52 = device0.createTexture({
+  size: {width: 258, height: 15, depthOrArrayLayers: 155},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup15, new Uint32Array(2851), 657, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer29, 'uint16', 660, 2_373);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2).fill(216), /* required buffer size: 2 */
+{offset: 2, rowsPerImage: 68}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView68 = texture40.createView({dimension: '2d', format: 'rgba16float', baseArrayLayer: 1});
+let computePassEncoder44 = commandEncoder53.beginComputePass({
+  label: '\uff92\ud9a9\u0fc2\ud949\u{1fe93}\u4d6f',
+  timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 63},
+});
+let sampler26 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+let imageData5 = new ImageData(8, 104);
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout3, veryExplicitBindGroupLayout2]});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup7, new Uint32Array(84), 44, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer32, 'uint16', 168, 142);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+let imageData6 = new ImageData(12, 52);
+let buffer51 = device0.createBuffer({
+  label: '\uc0bc\ua815',
+  size: 16760,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder54 = device0.createCommandEncoder({});
+let sampler27 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 93.39});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer45, 0);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2000 */
+  offset: 2000,
+  bytesPerRow: 4096,
+  buffer: buffer27,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 63, y: 22, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise8;
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 578, resource: {buffer: buffer35, offset: 3584}}],
+});
+let computePassEncoder45 = commandEncoder54.beginComputePass({});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup5, new Uint32Array(133), 1, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup5, new Uint32Array(108), 7, 0);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(161);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer39, 0, 19);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let recycledExplicitBindGroupLayout0 = pipeline3.getBindGroupLayout(0);
+let sampler28 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 89.97, maxAnisotropy: 1});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer51, 'uint16', 1_302, 479);
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 578, resource: {buffer: buffer26, offset: 2816}}],
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+let texture53 = device0.createTexture({
+  size: [360, 1, 4],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView69 = texture39.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder46 = commandEncoder55.beginComputePass();
+let sampler29 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 90.09});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer39, 16); };
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 2328, new DataView(new ArrayBuffer(17311)), 236, 244);
+} catch {}
+let gpuCanvasContext0 = canvas2.getContext('webgpu');
+let buffer52 = device0.createBuffer({
+  size: 423,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView70 = texture9.createView({mipLevelCount: 1});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup5, new Uint32Array(2239), 721, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer35, 'uint32', 5_992, 215);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 1516, new Float32Array(15941), 4033, 324);
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 37, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {binding: 282, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let bindGroup26 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 37, resource: {buffer: buffer41, offset: 0, size: 380}},
+    {binding: 7, resource: textureView6},
+    {binding: 282, resource: externalTexture3},
+  ],
+});
+let commandEncoder56 = device0.createCommandEncoder({});
+let computePassEncoder47 = commandEncoder56.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 155, endOfPassWriteIndex: 396}});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer34);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder57 = device0.createCommandEncoder();
+try {
+computePassEncoder6.setBindGroup(0, bindGroup7, new Uint32Array(411), 30, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise10 = device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule0, constants: {}}});
+let imageBitmap2 = await createImageBitmap(imageBitmap0);
+let bindGroup27 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 578, resource: {buffer: buffer47, offset: 256, size: 3584}}],
+});
+let buffer53 = device0.createBuffer({
+  size: 4577,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder58 = device0.createCommandEncoder({});
+let computePassEncoder48 = commandEncoder57.beginComputePass({});
+let sampler30 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.41,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup17, new Uint32Array(3066), 699, 0);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline2);
+} catch {}
+let texture54 = device0.createTexture({
+  size: {width: 180, height: 1, depthOrArrayLayers: 72},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder49 = commandEncoder16.beginComputePass({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup4, new Uint32Array(3554), 537, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup27, new Uint32Array(59), 30, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup1, new Uint32Array(430), 56, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 208, new Int16Array(3226), 862, 280);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(261, 32);
+let buffer54 = device0.createBuffer({
+  size: 2655,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let textureView71 = texture13.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 8});
+let sampler31 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 60.77,
+  maxAnisotropy: 19,
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup22, new Uint32Array(1484), 34, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle5, renderBundle1, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 272 */
+  offset: 272,
+  rowsPerImage: 531,
+  buffer: buffer1,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({});
+let textureView72 = texture44.createView({format: 'rgba16uint', baseArrayLayer: 7, arrayLayerCount: 1});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(3, bindGroup8, new Uint32Array(141), 2, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer0, 'uint16', 32, 13_360);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(101).fill(32), /* required buffer size: 101 */
+{offset: 101}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView73 = texture24.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 4});
+let texture55 = gpuCanvasContext0.getCurrentTexture();
+let textureView74 = texture47.createView({mipLevelCount: 1, baseArrayLayer: 13, arrayLayerCount: 5});
+let computePassEncoder50 = commandEncoder59.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 494}});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(3, bindGroup23, new Uint32Array(644), 127, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer52, 4); };
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup23, new Uint32Array(3524), 57, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer9, 0, 190);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, undefined, 319_185_602, 431_251_670);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 20, new Int16Array(28993), 4803, 364);
+} catch {}
+document.body.append(img1);
+let commandEncoder61 = device0.createCommandEncoder();
+let texture56 = device0.createTexture({
+  size: {width: 45, height: 20, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView75 = texture34.createView({dimension: '2d', arrayLayerCount: 1});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+let sampler32 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.71,
+  lodMaxClamp: 82.18,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(2, bindGroup1, new Uint32Array(327), 196, 0);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle7]);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 31}
+*/
+{
+  source: canvas0,
+  origin: { x: 324, y: 25 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 7, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 31, depthOrArrayLayers: 0});
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x44a80172},
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32', offset: 92, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 60, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let buffer55 = device0.createBuffer({
+  size: 12654,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder62 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder7.finish();
+let textureView76 = texture15.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle9 = renderBundleEncoder10.finish({});
+let sampler33 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup9, new Uint32Array(923), 151, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(4.482802662299672, 1.6850106946102648, 12.070401516047225, 0.6255164615445679, 0.2716518573809854, 0.41868772271301874);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer39, 36, 3);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer43, 'uint32', 4, 2);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer25, 1212, buffer4, 1828, 68);
+} catch {}
+document.body.prepend(img0);
+let offscreenCanvas1 = new OffscreenCanvas(3, 162);
+let commandEncoder63 = device0.createCommandEncoder({});
+let renderPassEncoder11 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 73,
+  clearValue: { r: 326.1, g: -365.2, b: -206.7, a: -8.159, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 383, endOfPassWriteIndex: 142},
+});
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer7, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(7, buffer11, 0);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 32, y: 14, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+let texture57 = device0.createTexture({
+  size: [180, 1, 567],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder43.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(1, bindGroup14, new Uint32Array(881), 90, 0);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup21, new Uint32Array(783), 1, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer10);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer10, 'uint16', 1_016, 1_022);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer43, 0, buffer41, 852, 8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise9;
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline3.getBindGroupLayout(0);
+let commandEncoder64 = device0.createCommandEncoder({});
+let textureView77 = texture51.createView({dimension: 'cube', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder51 = commandEncoder64.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup23, new Uint32Array(129), 31, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup5, new Uint32Array(572), 33, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer34, 124, 822);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup15, new Uint32Array(2886), 564, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer11, 0, 2_574);
+} catch {}
+let arrayBuffer0 = buffer37.getMappedRange(760, 84);
+let videoFrame8 = new VideoFrame(canvas1, {timestamp: 0});
+let textureView78 = texture40.createView({dimension: '2d', baseArrayLayer: 1});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(0, bindGroup27, new Uint32Array(1491), 699, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup18, []);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup16, new Uint32Array(569), 71, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer3, 'uint16', 3_818, 239);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(3, buffer51);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline3.getBindGroupLayout(0);
+let commandEncoder65 = device0.createCommandEncoder({});
+let textureView79 = texture8.createView({});
+let renderBundle10 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(2, bindGroup16, new Uint32Array(1232), 263, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 24 */
+  offset: 24,
+  buffer: buffer11,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 3, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder();
+let texture58 = gpuCanvasContext0.getCurrentTexture();
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 75.52,
+});
+try {
+computePassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer51, 'uint32', 536, 307);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+computePassEncoder49.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 164 */
+  offset: 164,
+  bytesPerRow: 25856,
+  buffer: buffer24,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 9, y: 4, z: 3},
+  aspect: 'all',
+}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder58.insertDebugMarker('\u{1fff4}');
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte432', transfer: 'bt2020_12bit'} });
+let bindGroup28 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 8, resource: externalTexture0}]});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup17, new Uint32Array(957), 25, 0);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 146, y: 3, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 176,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup29 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 8, resource: externalTexture4}]});
+let computePassEncoder52 = commandEncoder62.beginComputePass();
+let sampler35 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', lodMinClamp: 80.41, lodMaxClamp: 80.45});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, undefined, 281_613_349, 1_055_198_143);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer49);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 288 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1536 */
+  offset: 1536,
+  buffer: buffer12,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder61.insertDebugMarker('\u0b95');
+} catch {}
+try {
+externalTexture6.label = '\ud506\u997e\u0b57\u0e49\u{1f83c}\u6d57\uf9af\u{1ffac}\u{1fd6f}\uaaff\u238b';
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder({});
+let renderPassEncoder12 = commandEncoder63.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: 336.8, g: -714.2, b: 793.0, a: -605.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 39950297,
+});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(3, bindGroup21, new Uint32Array(1977), 109, 0);
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 120 */
+  offset: 120,
+  buffer: buffer30,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet0, 12, 23, buffer48, 2304);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 64, new Int16Array(2089), 56, 220);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 69, y: 12, z: 2},
+  aspect: 'all',
+}, new Uint8Array(437).fill(88), /* required buffer size: 437 */
+{offset: 437, bytesPerRow: 63}, {width: 7, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup30 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 176, resource: textureView51}]});
+let commandEncoder68 = device0.createCommandEncoder();
+let textureView80 = texture0.createView({aspect: 'all', baseArrayLayer: 4, arrayLayerCount: 5});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup15, new Uint32Array(25), 0, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer11, 'uint16', 12_906, 4);
+} catch {}
+let buffer56 = device0.createBuffer({
+  size: 13866,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder69 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder61.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 12.45, g: 947.9, b: 594.1, a: -152.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup18, new Uint32Array(715), 50, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup20, new Uint32Array(1140), 165, 0);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+let pipeline7 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 468,
+        attributes: [
+          {format: 'uint32x3', offset: 60, shaderLocation: 12},
+          {format: 'float32x4', offset: 60, shaderLocation: 10},
+          {format: 'sint8x4', offset: 84, shaderLocation: 14},
+          {format: 'uint32x3', offset: 144, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list'},
+});
+try {
+textureView57.label = '\ueca5\u{1fc18}\u6958\u360c\u9a0c\u{1f73d}\u{1fce2}\u9d30\u1671\ua991\u06eb';
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({});
+let textureView81 = texture47.createView({dimension: '2d', format: 'rgba16float', mipLevelCount: 1, baseArrayLayer: 8});
+try {
+renderPassEncoder10.setViewport(219.7587381152212, 221.2458888162224, 30.52946723660021, 20.801184103972915, 0.18926556872827338, 0.3590990864088295);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer48, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: canvas0,
+  origin: { x: 154, y: 10 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 7, y: 6, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let bindGroup31 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 578, resource: {buffer: buffer5, offset: 1024, size: 6088}}],
+});
+try {
+renderPassEncoder11.setIndexBuffer(buffer19, 'uint16', 880, 331);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 116, new Float32Array(7777), 667, 356);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder({});
+let textureView82 = texture34.createView({dimension: '2d-array'});
+let computePassEncoder53 = commandEncoder69.beginComputePass({});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer32, 'uint16', 2_160, 75);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline3);
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({});
+let textureView83 = texture16.createView({});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 328,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer57 = device0.createBuffer({size: 6478, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandBuffer2 = commandEncoder70.finish();
+let textureView84 = texture1.createView({baseArrayLayer: 55, arrayLayerCount: 18});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup5, new Uint32Array(449), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+commandEncoder72.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 824 */
+  offset: 824,
+  buffer: buffer35,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 1, z: 24},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer58 = device0.createBuffer({
+  size: 16560,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder73 = device0.createCommandEncoder({});
+let texture59 = device0.createTexture({
+  size: {width: 129},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder54 = commandEncoder66.beginComputePass({});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup18, new Uint32Array(5213), 112, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(4, undefined, 9_278_134, 1_713_856_923);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4272 */
+  offset: 4272,
+  bytesPerRow: 17152,
+  buffer: buffer56,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 51, y: 12, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer59 = device0.createBuffer({
+  size: 10331,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder74 = device0.createCommandEncoder({});
+let renderPassEncoder14 = commandEncoder58.beginRenderPass({
+  colorAttachments: [{
+  view: textureView70,
+  depthSlice: 9,
+  clearValue: { r: 782.1, g: -992.6, b: 625.7, a: 314.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet1},
+});
+let sampler36 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder44.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle4, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer49);
+} catch {}
+try {
+commandEncoder67.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup32 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 62, resource: textureView9},
+    {binding: 578, resource: {buffer: buffer0, offset: 16384, size: 3604}},
+    {binding: 254, resource: {buffer: buffer49, offset: 1536}},
+  ],
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout2, veryExplicitBindGroupLayout8]});
+let commandEncoder75 = device0.createCommandEncoder({});
+let textureView85 = texture40.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+let texture60 = device0.createTexture({
+  size: {width: 180, height: 80, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(5, 0, 4, 0);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+let bindGroup33 = device0.createBindGroup({layout: veryExplicitBindGroupLayout11, entries: [{binding: 328, resource: textureView15}]});
+let texture61 = device0.createTexture({
+  size: {width: 256},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder55 = commandEncoder71.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 833}});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup28, new Uint32Array(2285), 308, 0);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup14, new Uint32Array(1202), 51, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer25, 'uint16', 814, 943);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer43, 0);
+} catch {}
+try {
+  await promise11;
+} catch {}
+await gc();
+let textureView86 = texture51.createView({dimension: 'cube', mipLevelCount: 1});
+let textureView87 = texture10.createView({});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder9.setViewport(39.710745992696296, 0.8895197618637867, 0.07733054050806067, 0.09207981643149393, 0.4886252956277245, 0.8465162056493859);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer7);
+} catch {}
+let gpuCanvasContext2 = canvas1.getContext('webgpu');
+let texture62 = device0.createTexture({
+  size: {width: 45, height: 1, depthOrArrayLayers: 504},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder56 = commandEncoder67.beginComputePass({});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], stencilReadOnly: false});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup20, new Uint32Array(1679), 647, 0);
+} catch {}
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer46, 'uint32', 148, 73);
+} catch {}
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 385});
+let texture63 = device0.createTexture({size: {width: 258}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder57 = commandEncoder72.beginComputePass();
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup4, new Uint32Array(1310), 69, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer10, 'uint16', 88, 11_679);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer43, 24, 7);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 664 widthInBlocks: 83 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 16 */
+  offset: 16,
+  buffer: buffer26,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 83, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 624, new Float32Array(19917), 111, 304);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.label = '\u3957\u{1fbe3}\u74c5';
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 61,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {binding: 89, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let texture64 = device0.createTexture({
+  size: [256, 256, 17],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle3, renderBundle9, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer34, 0, 604);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline8 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule0, targets: [{format: 'rgba16uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex4',
+    buffers: [
+      {
+        arrayStride: 380,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 12, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 14},
+          {format: 'sint16x4', offset: 16, shaderLocation: 13},
+          {format: 'float32x4', offset: 56, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 56, stepMode: 'instance', attributes: [{format: 'sint32', offset: 0, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let bindGroup34 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 8, resource: externalTexture0}]});
+let texture65 = device0.createTexture({
+  size: [45, 20, 22],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView88 = texture24.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder58 = commandEncoder47.beginComputePass({});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle12 = renderBundleEncoder12.finish();
+try {
+computePassEncoder56.setBindGroup(3, bindGroup29, new Uint32Array(624), 30, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer3, 'uint16', 9_664, 3_798);
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas1.getContext('webgpu');
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 20,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 483,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let texture66 = device0.createTexture({
+  size: {width: 90, height: 40, depthOrArrayLayers: 17},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView89 = texture19.createView({});
+let computePassEncoder59 = commandEncoder68.beginComputePass();
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup10, new Uint32Array(73), 0, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(60.54394840061331, 6.73042439314426, 16.21257657579405, 0.2594682970189832, 0.9988622505829411, 0.999969193056788);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer0, 'uint16', 3_484, 481);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 22, height: 10, depthOrArrayLayers: 55}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let imageData7 = new ImageData(24, 36);
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout1, veryExplicitBindGroupLayout6]});
+let commandEncoder76 = device0.createCommandEncoder();
+let texture67 = device0.createTexture({
+  size: {width: 360, height: 1, depthOrArrayLayers: 7},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(15);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle1, renderBundle4]);
+} catch {}
+let querySet4 = device0.createQuerySet({type: 'timestamp', count: 590});
+let textureView90 = texture67.createView({baseArrayLayer: 3, arrayLayerCount: 2});
+let texture68 = device0.createTexture({
+  size: {width: 45, height: 1, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler37 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 89.27});
+try {
+computePassEncoder31.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer50, 1348, buffer25, 240, 212);
+} catch {}
+let imageData8 = new ImageData(20, 60);
+let buffer60 = device0.createBuffer({label: '\u382d\u07ec', size: 7665, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder77 = device0.createCommandEncoder({});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer54, 'uint16', 688, 260);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline8);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 168 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1352 */
+  offset: 1352,
+  bytesPerRow: 22016,
+  buffer: buffer2,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder();
+let querySet5 = device0.createQuerySet({type: 'timestamp', count: 90});
+let textureView91 = texture67.createView({arrayLayerCount: 2});
+let sampler38 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', minFilter: 'linear', lodMinClamp: 20.91});
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(1, 49, 84, 81);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer8, 'uint32', 320, 2_531);
+} catch {}
+try {
+commandEncoder75.copyBufferToBuffer(buffer16, 1148, buffer11, 696, 356);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 848 */
+  offset: 848,
+  bytesPerRow: 7424,
+  buffer: buffer47,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder77.clearBuffer(buffer56, 16, 312);
+} catch {}
+let autogeneratedBindGroupLayout4 = pipeline2.getBindGroupLayout(0);
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 89, resource: {buffer: buffer11, offset: 256, size: 5584}},
+    {binding: 61, resource: textureView87},
+  ],
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup5, new Uint32Array(666), 56, 0);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 31}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 8, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer61 = device0.createBuffer({size: 24744, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture69 = device0.createTexture({
+  size: [1035, 60, 105],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder60 = commandEncoder75.beginComputePass({timestampWrites: {querySet: querySet4, endOfPassWriteIndex: 378}});
+let sampler39 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 95.93});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup34, new Uint32Array(1012), 108, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\uef6c');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+globalThis.someLabel = commandEncoder9.label;
+} catch {}
+let bindGroup36 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 176, resource: textureView75}]});
+let buffer62 = device0.createBuffer({
+  label: '\u9e3a\u{1fd6b}\uba10\ua080\u{1f9c5}',
+  size: 1919,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder15 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView70,
+  depthSlice: 36,
+  clearValue: { r: -903.0, g: -208.1, b: -376.3, a: 416.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup27, new Uint32Array(1099), 57, 0);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+commandEncoder77.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 368 */
+  offset: 368,
+  buffer: buffer60,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup37 = device0.createBindGroup({layout: veryExplicitBindGroupLayout11, entries: [{binding: 328, resource: textureView0}]});
+let textureView92 = texture34.createView({dimension: '2d-array', format: 'r8sint', baseArrayLayer: 0});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup16, new Uint32Array(3880), 779, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer51, 'uint32', 1_296, 4_804);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline3);
+} catch {}
+let bindGroup38 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 328, resource: textureView15}]});
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let commandEncoder79 = device0.createCommandEncoder({});
+let texture70 = device0.createTexture({
+  size: {width: 1035, height: 60, depthOrArrayLayers: 11},
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint32', 72, 425);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let bindGroup39 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 254, resource: {buffer: buffer27, offset: 1280, size: 1000}},
+    {binding: 62, resource: textureView7},
+    {binding: 578, resource: {buffer: buffer5, offset: 1024, size: 3844}},
+  ],
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+let computePassEncoder61 = commandEncoder73.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 467, endOfPassWriteIndex: 387}});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup37, new Uint32Array(3334), 186, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 39, y: 2, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout0]});
+let textureView93 = texture31.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder62 = commandEncoder77.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup10, new Uint32Array(139), 40, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData8,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 15, y: 4, z: 26},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 32, depthOrArrayLayers: 0});
+} catch {}
+let pipeline9 = device0.createComputePipeline({layout: pipelineLayout14, compute: {module: shaderModule1, constants: {}}});
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+/* zero global variables used */
+fn fn0(a0: FragmentOutput3) -> VertexOutput4 {
+  var out: VertexOutput4;
+  out = VertexOutput4(vec2u(a0.f0), unpack4x8unorm(a0.f0), vec4f(bitcast<f32>(a0.f0)));
+  let vf33: f32 = a0.f1[unconst_u32(96)];
+  var vf34: bool = all(vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true), unconst_bool(false)));
+  let vf35: u32 = a0.f0;
+  let vf36: vec2f = atan2(vec2f(unconst_f32(0.1913), unconst_f32(0.07219)), vec2f(unconst_f32(0.08853), unconst_f32(0.2058)));
+  let vf37: vec4f = a0.f1;
+  var vf38: vec2u = (vec2u(unconst_u32(181), unconst_u32(327)) ^ vec2u(unconst_u32(127), unconst_u32(302)));
+  var vf39: vec2u = insertBits(vec2u(unconst_u32(128), unconst_u32(102)), vec2u(unconst_u32(96), unconst_u32(146)), unconst_u32(68), unconst_u32(41));
+  let ptr57: ptr<function, vec2u> = &vf39;
+  return out;
+}
+
+/* zero global variables used */
+fn fn1() -> array<array<array<array<vec2i, 1>, 1>, 1>, 1> {
+  var out: array<array<array<array<vec2i, 1>, 1>, 1>, 1>;
+  var vf40 = fn0(FragmentOutput3(pack2x16snorm(vec2f(unconst_f32(0.00726), unconst_f32(0.1928))), unpack4x8snorm(pack2x16snorm(vec2f(unconst_f32(0.00726), unconst_f32(0.1928))))));
+  return out;
+}
+
+var<workgroup> vw17: VertexOutput4;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput3 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4f,
+}
+
+var<workgroup> vw9: T1;
+
+var<workgroup> vw12: FragmentOutput3;
+
+struct T0 {
+  @size(8) f0: array<atomic<i32>, 1>,
+  @size(72) f1: vec4h,
+}
+
+var<workgroup> vw10: vec2u;
+
+var<workgroup> vw4: mat2x4f;
+
+var<workgroup> vw15: atomic<i32>;
+
+var<workgroup> vw19: T0;
+
+struct T1 {
+  f0: array<array<atomic<i32>, 1>, 1>,
+}
+
+var<workgroup> vw7: mat4x2h;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput4 {
+  @location(11) f14: vec2u,
+  @builtin(position) f15: vec4f,
+  @location(15) @interpolate(perspective, center) f16: vec4f,
+}
+
+@group(0) @binding(176) var tex4: texture_2d<i32>;
+
+var<workgroup> vw11: VertexOutput4;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+/* used global variables: tex4 */
+fn fn2() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  let vf41: vec2u = textureDimensions(tex4, unconst_i32(31));
+  let vf42: vec2h = acos(vec2h(unconst_f16(1955.2), unconst_f16(-10198.8)));
+  out.f1 += (vec4f(unconst_f32(0.08235), unconst_f32(0.2925), unconst_f32(0.05619), unconst_f32(0.08426)) % f32(asin(unconst_f16(2481.0))));
+  {
+  var vf43 = fn1();
+  out = FragmentOutput3(vec2u(vf43[0][unconst_u32(426)][unconst_u32(243)][unconst_u32(126)])[0], bitcast<vec4f>(vf43[0][unconst_u32(426)][unconst_u32(243)][unconst_u32(126)].yxxy));
+  _ = fn1();
+  out.f0 *= (vec3u(unconst_u32(4), unconst_u32(118), unconst_u32(65)) << vec3u(unconst_u32(53), unconst_u32(72), unconst_u32(169)))[1];
+}
+  if bool(textureDimensions(tex4)[1]) {
+  var vf44 = fn1();
+  fn1();
+  let ptr58: ptr<function, vec2i> = &vf44[0][unconst_u32(290)][unconst_u32(13)][0];
+  out.f1 += vec4f(vf44[0][0][vec2u(vf44[unconst_u32(73)][0][0][0]).r][0].grgg);
+}
+  var vf45 = fn0(FragmentOutput3((unconst_u32(169) ^ unconst_u32(15)), vec4f(f32((unconst_u32(169) ^ unconst_u32(15))))));
+  var vf46 = fn1();
+  var vf47 = fn1();
+  return out;
+  _ = tex4;
+}
+
+var<workgroup> vw18: FragmentOutput3;
+
+/* used global variables: tex4 */
+@must_use 
+fn fn4() -> mat4x2h {
+  var out: mat4x2h;
+  let vf49: vec2u = textureDimensions(tex4, unconst_i32(59));
+  fn0(FragmentOutput3(vec4u(sqrt(vec4h(textureLoad(tex4, vec2i(unconst_i32(35), unconst_i32(116)), unconst_i32(1000)))))[1], vec4f(sqrt(vec4h(textureLoad(tex4, vec2i(unconst_i32(35), unconst_i32(116)), unconst_i32(1000)))))));
+  return out;
+  _ = tex4;
+}
+
+var<workgroup> vw5: T1;
+
+/* zero global variables used */
+fn fn3() -> mat2x4h {
+  var out: mat2x4h;
+  let vf48: vec4u = unpack4xU8(dot4U8Packed(unconst_u32(342), unconst_u32(220)));
+  return out;
+}
+
+var<workgroup> vw8: T1;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw16: FragmentOutput3;
+
+var<workgroup> vw6: T1;
+
+var<workgroup> vw14: atomic<u32>;
+
+var<workgroup> vw13: f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex5(@location(3) a0: vec4f) -> VertexOutput4 {
+  var out: VertexOutput4;
+  out.f16 = vec4f((vec2u(unconst_u32(87), unconst_u32(50)) < vec2u(unconst_u32(174), unconst_u32(81))).grrg);
+  var vf50 = fn0(FragmentOutput3(bitcast<u32>(degrees(vec2h(unconst_f16(31464.3), unconst_f16(6953.2)))), vec4f(degrees(vec2h(unconst_f16(31464.3), unconst_f16(6953.2))).rgrg)));
+  fn0(FragmentOutput3(u32(any((vec2u(unconst_u32(13), unconst_u32(174)) < vec2u(unconst_u32(313), unconst_u32(5))))), vec4f((vec2u(unconst_u32(13), unconst_u32(174)) < vec2u(unconst_u32(313), unconst_u32(5))).yyyy)));
+  return out;
+}
+
+/* used global variables: tex4 */
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  _ = fn4();
+  out.f0 ^= textureDimensions(tex4).y;
+  let vf51: vec2f = unpack2x16float(unconst_u32(504));
+  loop {
+  _ = fn0(FragmentOutput3(bitcast<u32>(dot4I8Packed(unconst_u32(204), unconst_u32(85))), vec4f(bitcast<f32>(dot4I8Packed(unconst_u32(204), unconst_u32(85))))));
+  break;
+}
+  while bool(cross(vec3f(unconst_f32(0.1741), unconst_f32(0.2778), unconst_f32(0.09554)), vec3f(unconst_f32(0.1206), unconst_f32(0.2615), unconst_f32(0.08417)))[2]) {
+  var vf52: vec3<bool> = (vec3h(unconst_f16(4432.2), unconst_f16(7437.7), unconst_f16(15926.2)) == vec3h(unconst_f16(3965.9), unconst_f16(11505.9), unconst_f16(648.4)));
+}
+  out = FragmentOutput3(u32(sign(unconst_i32(72))), vec4f(f32(sign(unconst_i32(72)))));
+  fn0(FragmentOutput3(pack2x16snorm(vec2f(unconst_f32(0.05110), unconst_f32(0.06849))), unpack4x8unorm(pack2x16snorm(vec2f(unconst_f32(0.05110), unconst_f32(0.06849))))));
+  _ = fn4();
+  out.f1 = vec4f((vec2u(u32(length(vec4h(unconst_f16(1391.7), unconst_f16(1463.7), unconst_f16(16164.5), unconst_f16(14574.9))))) < vec2u(unconst_u32(282), unconst_u32(322))).xyyx);
+  return out;
+  _ = tex4;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute4() {
+  let ptr59: ptr<workgroup, atomic<i32>> = &vw19.f0[0];
+  while bool(atomicLoad(&(*&vw5).f0[unconst_u32(35)][unconst_u32(1)])) {
+  var vf53 = fn3();
+  let ptr60: ptr<workgroup, vec4f> = &vw17.f16;
+  let ptr61: ptr<workgroup, vec4f> = &(*&vw16).f1;
+  let vf54: FragmentOutput3 = workgroupUniformLoad(&vw12);
+  fn3();
+}
+  vw11 = VertexOutput4(vec2u(u32(atomicLoad(&(*&vw5).f0[0][0]))), vec4f(bitcast<f32>(atomicLoad(&(*&vw5).f0[0][0]))), vec4f(f32(atomicLoad(&(*&vw5).f0[0][0]))));
+  let vf55: i32 = atomicLoad(&vw19.f0[unconst_u32(93)]);
+  atomicCompareExchangeWeak(&vw6.f0[unconst_u32(525)][0], unconst_i32(144), unconst_i32(40));
+  var vf56: i32 = atomicLoad(&vw19.f0[0]);
+}`,
+});
+let bindGroup40 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 127, resource: {buffer: buffer0, offset: 4096, size: 1996}},
+    {binding: 8, resource: textureView14},
+  ],
+});
+let commandEncoder81 = device0.createCommandEncoder();
+let textureView94 = texture61.createView({baseMipLevel: 0});
+try {
+renderPassEncoder11.beginOcclusionQuery(7);
+} catch {}
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({entries: [{binding: 3, visibility: GPUShaderStage.VERTEX, externalTexture: {}}]});
+let textureView95 = texture47.createView({dimension: '2d', format: 'rgba16float', mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 1});
+let computePassEncoder63 = commandEncoder81.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 637}});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer0, 0, 869);
+} catch {}
+let promise12 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 104, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 52, shaderLocation: 5},
+          {format: 'sint32x4', offset: 56, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 440,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 86, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 100, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder82 = device0.createCommandEncoder();
+let computePassEncoder64 = commandEncoder79.beginComputePass({timestampWrites: {querySet: querySet5, endOfPassWriteIndex: 38}});
+try {
+renderPassEncoder2.executeBundles([renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer45, 'uint16', 2_020, 1_343);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer25, 1272, buffer59, 3820, 92);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1024 */
+  offset: 1024,
+  bytesPerRow: 2304,
+  buffer: buffer2,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 26, y: 33, z: 1},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView96 = texture59.createView({label: '\u0921\u023b\u31e5\u1cc4\u0d3d\u{1f730}\u0e94'});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame7});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup36, new Uint32Array(1118), 308, 0);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer25, 'uint16', 842, 226);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 578, resource: {buffer: buffer8, offset: 0, size: 3400}},
+    {binding: 254, resource: {buffer: buffer33, offset: 0, size: 268}},
+    {binding: 62, resource: textureView7},
+  ],
+});
+let buffer63 = device0.createBuffer({
+  size: 6598,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder83 = device0.createCommandEncoder({});
+let sampler40 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.96,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup26, new Uint32Array(543), 150, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer8, 0, 2_297);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 22, height: 10, depthOrArrayLayers: 55}
+*/
+{
+  source: imageData4,
+  origin: { x: 7, y: 7 },
+  flipY: false,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup42 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView53}]});
+let textureView97 = texture3.createView({});
+let computePassEncoder65 = commandEncoder65.beginComputePass({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder65.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup9, new Uint32Array(4395), 446, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(5, 23, 0, 880_174_241);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer52, 196);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer0, 0, 6_383);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer29, 'uint16', 556, 1_331);
+} catch {}
+document.body.append(img0);
+let recycledExplicitBindGroupLayout3 = pipeline5.getBindGroupLayout(0);
+let texture71 = device0.createTexture({
+  size: {width: 180},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 26, 0, 135_633_785);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(4, 146, 5, 450_862_529, 204_120_250);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer54, 644);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer54, 16);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer7, 0, 238);
+} catch {}
+try {
+commandEncoder76.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1112 */
+  offset: 1112,
+  buffer: buffer49,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let canvas3 = document.createElement('canvas');
+let textureView98 = texture51.createView({dimension: 'cube', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder66 = commandEncoder83.beginComputePass();
+try {
+computePassEncoder52.setBindGroup(3, bindGroup3, new Uint32Array(1771), 557, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(2, 263, 0, 341_174_858);
+} catch {}
+try {
+computePassEncoder27.insertDebugMarker('\u0f98');
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 89, resource: {buffer: buffer27, offset: 1280, size: 2884}},
+    {binding: 61, resource: textureView13},
+  ],
+});
+let texture72 = device0.createTexture({
+  size: {width: 90, height: 40, depthOrArrayLayers: 45},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView99 = texture48.createView({});
+let computePassEncoder67 = commandEncoder82.beginComputePass({});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let sampler41 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup41, new Uint32Array(1755), 175, 0);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer56, 'uint32', 3_184, 1_587);
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 7},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1072 widthInBlocks: 134 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 744 */
+  offset: 744,
+  buffer: buffer33,
+}, {width: 134, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let buffer64 = device0.createBuffer({size: 4342, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture73 = device0.createTexture({
+  size: {width: 90, height: 40, depthOrArrayLayers: 4},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView100 = texture0.createView({dimension: '2d', format: 'astc-5x4-unorm', baseArrayLayer: 9});
+let sampler42 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder61.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup7, new Uint32Array(1434), 405, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer19, 'uint32', 1_624, 659);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let textureView101 = texture73.createView({arrayLayerCount: 1});
+let textureView102 = texture7.createView({aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 1});
+let computePassEncoder68 = commandEncoder84.beginComputePass();
+let renderPassEncoder16 = commandEncoder78.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  clearValue: { r: 406.4, g: -317.1, b: -293.1, a: 233.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder65.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup11, new Uint32Array(647), 33, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 60, 0, 235_869_617);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer58, 'uint32', 4_248, 214);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer53);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup7, new Uint32Array(378), 38, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(6, buffer32, 0);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 584 */
+  offset: 584,
+  bytesPerRow: 60160,
+  buffer: buffer47,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder44.pushDebugGroup('\u02c0');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 126, y: 11, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 21, depthOrArrayLayers: 0});
+} catch {}
+let canvas4 = document.createElement('canvas');
+let texture74 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView103 = texture64.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 5});
+let renderPassEncoder17 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{
+  view: textureView50,
+  clearValue: { r: -554.3, g: -11.13, b: -455.2, a: -997.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 345948540,
+});
+try {
+computePassEncoder68.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup28, new Uint32Array(1039), 67, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer0, 26_968);
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer29, 2988, buffer36, 460, 272);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 952 */
+  offset: 952,
+  buffer: buffer25,
+}, {
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 36, y: 0, z: 10},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup44 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 8, resource: externalTexture5}]});
+let commandEncoder85 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 183});
+let textureView104 = texture72.createView({format: 'rgba8uint'});
+let renderPassEncoder18 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{
+  view: textureView71,
+  clearValue: { r: 984.2, g: -133.9, b: -358.9, a: 160.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup5, new Uint32Array(1050), 337, 0);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 59, 0, 582_264_719);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer32, 1_548);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer56, 'uint32', 3_784, 593);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer19, 1_908);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup23, new Uint32Array(2348), 102, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(3, buffer46, 0, 25);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer48, 1272, buffer30, 456, 272);
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let textureView105 = texture74.createView({});
+let computePassEncoder69 = commandEncoder86.beginComputePass({});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'display-p3'});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup6, new Uint32Array(2965), 737, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(56, 191, 7, 715_936_075, 810_149_272);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup28, new Uint32Array(1700), 243, 0);
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout2]});
+let textureView106 = texture71.createView({});
+let textureView107 = texture57.createView({mipLevelCount: 1});
+let computePassEncoder70 = commandEncoder85.beginComputePass();
+try {
+computePassEncoder62.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(137);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer8, 'uint32', 172, 701);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup42, new Uint32Array(1504), 576, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer41, 'uint16', 94, 21);
+} catch {}
+let textureView108 = texture3.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup8, []);
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 225.3, g: -625.2, b: 237.3, a: -106.6, });
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer16, 344);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(4, buffer39);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 17},
+  aspect: 'all',
+}, new Uint8Array(100_855).fill(153), /* required buffer size: 100_855 */
+{offset: 195, bytesPerRow: 114, rowsPerImage: 63}, {width: 14, height: 1, depthOrArrayLayers: 15});
+} catch {}
+let imageData9 = new ImageData(16, 16);
+try {
+canvas4.getContext('webgl');
+} catch {}
+let texture75 = device0.createTexture({
+  size: {width: 180, height: 1, depthOrArrayLayers: 16},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder71 = commandEncoder36.beginComputePass({});
+let renderBundle14 = renderBundleEncoder14.finish({});
+let sampler43 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 95.23,
+});
+try {
+computePassEncoder67.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(8, 22, 84, -1_976_737_960, 417_776_386);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer26, 7_028);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let bindGroup45 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 282, resource: externalTexture7},
+    {binding: 37, resource: {buffer: buffer24, offset: 256, size: 388}},
+    {binding: 7, resource: textureView14},
+  ],
+});
+let textureView109 = texture6.createView({});
+let sampler44 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder37.setBindGroup(1, bindGroup41, new Uint32Array(435), 184, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup36, new Uint32Array(4215), 443, 0);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(10, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer51);
+} catch {}
+document.body.prepend(img0);
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpteSt4281', transfer: 'bt2020_12bit'} });
+let bindGroup46 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 578, resource: {buffer: buffer25, offset: 512, size: 3692}}],
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+let computePassEncoder72 = commandEncoder87.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 129}});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 1, 0, 60_991_517);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer16, 100);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(173).fill(7), /* required buffer size: 173 */
+{offset: 173, rowsPerImage: 1}, {width: 92, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0}});
+document.body.append(canvas1);
+let imageData10 = new ImageData(8, 60);
+let commandEncoder88 = device0.createCommandEncoder({});
+let textureView110 = texture73.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder73 = commandEncoder88.beginComputePass();
+let sampler45 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.43,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup41, new Uint32Array(1166), 666, 0);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup19, new Uint32Array(318), 91, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(59, 88, 31, 372_378_762, 1_111_060_869);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer39, 28);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer29, 632);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let commandEncoder89 = device0.createCommandEncoder({});
+let texture76 = device0.createTexture({
+  size: {width: 22, height: 10, depthOrArrayLayers: 4},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder74 = commandEncoder89.beginComputePass({});
+try {
+computePassEncoder59.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup0, new Uint32Array(203), 151, 0);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(26, 256, 9, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(81, 3, 0, 256_768_296, 859_433_731);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer61, 'uint16', 3_420, 1_327);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer32, 436, 1_733);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer50, 944, buffer44, 1092, 596);
+} catch {}
+let renderPassEncoder19 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 907.6, g: 70.46, b: -759.3, a: -377.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 43688920,
+});
+let sampler46 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 97.15});
+try {
+computePassEncoder63.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer32, 792);
+} catch {}
+let bindGroup47 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 6, resource: textureView27}]});
+let texture77 = device0.createTexture({
+  label: '\u3195\u4b1c\u42ab\u03f0\u{1f7c6}\u45f9\ue095\u0185\ud5a5\u0680',
+  size: [180, 80, 91],
+  dimension: '3d',
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture78 = device0.createTexture({
+  size: {width: 360, height: 1, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView111 = texture65.createView({baseArrayLayer: 0});
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 95.75,
+  compare: 'never',
+});
+try {
+renderPassEncoder7.setScissorRect(16, 0, 3, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 41, 0, 195_555_687);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer34, 708);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer35, 'uint32', 2_616, 848);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer39, 0, 42);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let pipeline11 = await promise12;
+let recycledExplicitBindGroupLayout4 = pipeline1.getBindGroupLayout(0);
+let bindGroup48 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 578, resource: {buffer: buffer26, offset: 1024}}],
+});
+let buffer65 = device0.createBuffer({size: 273, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let textureView112 = texture72.createView({mipLevelCount: 1});
+let textureView113 = texture40.createView({aspect: 'all', baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup21, new Uint32Array(3032), 169, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(85, 7, 48, 211_134_964, 461_921_618);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer39, 24);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer27, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder44.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 272, new Float32Array(10069), 6178, 1232);
+} catch {}
+try {
+externalTexture2.label = '\u7162\u{1f97c}\ue0fd\u1085\u5e88';
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 578, resource: {buffer: buffer63, offset: 1024, size: 3404}}],
+});
+let commandEncoder90 = device0.createCommandEncoder({});
+let renderPassEncoder20 = commandEncoder90.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 341,
+  clearValue: { r: -266.7, g: 210.7, b: 323.4, a: -384.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 65.93,
+  maxAnisotropy: 8,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroupsIndirect(buffer62, 272); };
+} catch {}
+try {
+renderPassEncoder9.draw(2, 71, 8, 1_814_235_494);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470m', transfer: 'smpteSt4281'} });
+let texture79 = device0.createTexture({
+  size: {width: 360, height: 1, depthOrArrayLayers: 818},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView114 = texture23.createView({dimension: '2d', format: 'rgba16uint', baseArrayLayer: 1});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 460, 0, 120_091_961);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(13, 556, 12, 561_264_646, 1_589_500_423);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer6, 260);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer16, 1_044);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer9, 'uint32', 288, 225);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker('\u03b7');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 83},
+  aspect: 'all',
+}, new Uint8Array(2_866_010).fill(221), /* required buffer size: 2_866_010 */
+{offset: 26, bytesPerRow: 276, rowsPerImage: 176}, {width: 25, height: 0, depthOrArrayLayers: 60});
+} catch {}
+let buffer66 = device0.createBuffer({size: 12229, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture80 = device0.createTexture({
+  label: '\udac8\u6115\u512b\u0ce2\u2d01\u09ff\u5dd7\u59b2\u{1fa8a}\u09f2\u6ec0',
+  size: [258],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], stencilReadOnly: true});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup31, new Uint32Array(1063), 631, 0);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(48);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer10, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer3, 'uint32', 11_376, 2_399);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 80},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 44, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas4);
+let commandEncoder91 = device0.createCommandEncoder({});
+let computePassEncoder75 = commandEncoder91.beginComputePass();
+try {
+computePassEncoder46.setBindGroup(0, bindGroup10, new Uint32Array(1386), 662, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup41, new Uint32Array(125), 2, 0);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(18, 102, 122, -1_508_695_862, 136_147_307);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer42, 'uint16', 104, 650);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(0, undefined, 259_999_440);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 3848, new BigUint64Array(1245));
+} catch {}
+let buffer67 = device0.createBuffer({
+  size: 18064,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView115 = texture71.createView({});
+let textureView116 = texture69.createView({mipLevelCount: 2});
+try {
+computePassEncoder74.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup37, new Uint32Array(40), 3, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 16, 0, 455_766_476);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer19, 'uint16', 28, 964);
+} catch {}
+try {
+commandEncoder5.copyBufferToBuffer(buffer35, 11580, buffer58, 1960, 1780);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 504 */
+  offset: 504,
+  buffer: buffer25,
+}, {
+  texture: texture30,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData11 = new ImageData(64, 48);
+let autogeneratedBindGroupLayout5 = pipeline8.getBindGroupLayout(0);
+let computePassEncoder76 = commandEncoder5.beginComputePass({});
+let sampler49 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 90.79});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup10, new Uint32Array(1701), 311, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroupsIndirect(buffer40, 964); };
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle6, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: -552.5, g: -159.1, b: -481.6, a: -545.8, });
+} catch {}
+try {
+renderPassEncoder16.setViewport(9.779028947576597, 0.3867687559122277, 22.811887668827193, 0.2378276509913158, 0.6416339444556813, 0.8233451268175345);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline5);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData12 = new ImageData(4, 160);
+try {
+globalThis.someLabel = externalTexture3.label;
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 578, resource: {buffer: buffer0, offset: 1536, size: 7804}},
+    {binding: 62, resource: textureView7},
+    {binding: 254, resource: {buffer: buffer24, offset: 256, size: 1784}},
+  ],
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder77 = commandEncoder92.beginComputePass();
+try {
+computePassEncoder50.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup29, new Uint32Array(1450), 383, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder9.draw(1, 190, 11, 2_512_225_053);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(4, buffer32, 11_920);
+} catch {}
+let sampler50 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 80.54,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroupsIndirect(buffer40, 1_240); };
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(1, 0, 41, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer62, 164);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(0, buffer63, 4_240, 719);
+} catch {}
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 47, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 267, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {
+      binding: 359,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let textureView117 = texture61.createView({});
+let sampler51 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.04,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup14, new Uint32Array(1203), 535, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroupsIndirect(buffer26, 7_856); };
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(53, 289, 13, -1_558_128_493, 741_259_237);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer32, 216);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer27, 1_448);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer0, 'uint32', 2_920, 48);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline2);
+} catch {}
+let promise14 = device0.createComputePipelineAsync({layout: pipelineLayout13, compute: {module: shaderModule0}});
+let pipeline12 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x2d4a8bb8},
+  fragment: {
+  module: shaderModule2,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 24,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 0, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+let texture81 = device0.createTexture({
+  size: [90, 1, 1],
+  sampleCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle15 = renderBundleEncoder15.finish({});
+let sampler52 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.55,
+  compare: 'equal',
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder9.draw(2, 90, 3, 242_313_760);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer34, 1_864);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer62, 'uint16', 56, 435);
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'unspecified', transfer: 'gamma28curve'} });
+let commandEncoder93 = device0.createCommandEncoder({});
+let textureView118 = texture74.createView({});
+let texture82 = device0.createTexture({
+  size: {width: 45, height: 1, depthOrArrayLayers: 4},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder78 = commandEncoder93.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup10, new Uint32Array(837), 37, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup2, new Uint32Array(2163), 126, 0);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer52, 76);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer54, 896);
+} catch {}
+let arrayBuffer1 = buffer37.getMappedRange(848, 52);
+let buffer68 = device0.createBuffer({
+  size: 15597,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+try {
+computePassEncoder47.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup46, new Uint32Array(1727), 237, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(31, 9, 66, 171_669_834, 1_080_811_326);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 5336, new Int16Array(2764), 509, 16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 11, height: 5, depthOrArrayLayers: 55}
+*/
+{
+  source: imageData10,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise13;
+} catch {}
+try {
+canvas5.getContext('webgpu');
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer8, 324);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer53, 2_680, 280);
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder({});
+let textureView119 = texture51.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 5});
+let computePassEncoder79 = commandEncoder94.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 41}});
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(3772);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer53, 828, 18);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 121},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(28).fill(63), /* required buffer size: 28 */
+{offset: 28, rowsPerImage: 37}, {width: 27, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let imageData13 = new ImageData(44, 48);
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder80 = commandEncoder95.beginComputePass({});
+try {
+computePassEncoder80.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer43, 12, new BigUint64Array(8338), 1402, 0);
+} catch {}
+let bindGroup51 = device0.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 6, resource: textureView43}]});
+let texture83 = device0.createTexture({
+  size: [360, 1, 75],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup20, new Uint32Array(2007), 123, 0);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0, renderBundle5, renderBundle1]);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+commandEncoder49.copyTextureToBuffer({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 512 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1024 */
+  offset: 1024,
+  buffer: buffer62,
+}, {width: 64, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 148, new Int16Array(9784), 4753, 108);
+} catch {}
+let veryExplicitBindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 328,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let bindGroup52 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 254, resource: {buffer: buffer26, offset: 3328}},
+    {binding: 62, resource: textureView9},
+    {binding: 578, resource: {buffer: buffer24, offset: 0, size: 3520}},
+  ],
+});
+let commandEncoder96 = device0.createCommandEncoder({});
+let textureView120 = texture76.createView({format: 'rgba16uint', arrayLayerCount: 1});
+try {
+computePassEncoder76.setPipeline(pipeline10);
+} catch {}
+let arrayBuffer2 = buffer37.getMappedRange(976, 168);
+try {
+commandEncoder49.copyBufferToTexture({
+  /* bytesInLastRow: 1296 widthInBlocks: 162 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 872 */
+  offset: 872,
+  bytesPerRow: 6912,
+  rowsPerImage: 703,
+  buffer: buffer50,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 162, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 62, resource: textureView9},
+    {binding: 254, resource: {buffer: buffer8, offset: 1536, size: 644}},
+    {binding: 578, resource: {buffer: buffer16, offset: 0, size: 3300}},
+  ],
+});
+let computePassEncoder81 = commandEncoder49.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 414, endOfPassWriteIndex: 147}});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer11, 0);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1312 */
+  offset: 1312,
+  bytesPerRow: 22528,
+  buffer: buffer3,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 16, y: 32, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let renderPassEncoder21 = commandEncoder96.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 97,
+  clearValue: { r: -496.0, g: -852.5, b: -299.9, a: 4.245, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup17, new Uint32Array(457), 4, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle11, renderBundle13, renderBundle13, renderBundle11, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer45, 'uint16', 134, 8_133);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup34, new Uint32Array(2295), 571, 0);
+} catch {}
+try {
+renderBundleEncoder16.insertDebugMarker('\u{1f7e3}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 1, y: 29, z: 1},
+  aspect: 'all',
+}, new Uint8Array(38_331).fill(12), /* required buffer size: 38_331 */
+{offset: 295, bytesPerRow: 332, rowsPerImage: 65}, {width: 94, height: 50, depthOrArrayLayers: 2});
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpteRp431', transfer: 'log'} });
+try {
+bindGroup0.label = '\u{1f6f1}\u22c3\u00a0\u{1fcaa}\ue334\u3b04\ua8c3\u095b\u3cbf\u0ef9';
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({});
+let textureView121 = texture38.createView({dimension: '2d', baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder82 = commandEncoder97.beginComputePass();
+let externalTexture12 = device0.importExternalTexture({source: videoFrame12, colorSpace: 'srgb'});
+try {
+computePassEncoder82.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer29, 'uint16', 564, 1_028);
+} catch {}
+let bindGroup54 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 6, resource: textureView27}]});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout2]});
+let buffer69 = device0.createBuffer({size: 1620, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView122 = texture13.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+let texture84 = device0.createTexture({
+  size: [45, 20, 146],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer62, 336); };
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer29, 'uint32', 848, 3_068);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer43, 4, 4);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(5, buffer27, 0);
+} catch {}
+let pipeline13 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule1}});
+let buffer70 = device0.createBuffer({
+  size: 45214,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder98 = device0.createCommandEncoder({});
+try {
+computePassEncoder75.setBindGroup(3, bindGroup31, new Uint32Array(1733), 728, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(3);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup50, new Uint32Array(35), 2, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer39, 0, 17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(81).fill(123), /* required buffer size: 81 */
+{offset: 81}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 62, resource: textureView18},
+    {binding: 254, resource: {buffer: buffer54, offset: 1024, size: 284}},
+    {binding: 578, resource: {buffer: buffer66, offset: 3072, size: 4004}},
+  ],
+});
+let renderPassEncoder22 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 334,
+  clearValue: { r: 338.8, g: -267.6, b: 872.2, a: 583.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet5},
+  maxDrawCount: 96000909,
+});
+let sampler53 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'repeat', lodMaxClamp: 98.51});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer54);
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 224 */
+  offset: 224,
+  buffer: buffer54,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 26},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageData13);
+let bindGroup56 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 20, resource: textureView91}, {binding: 483, resource: textureView45}],
+});
+let buffer71 = device0.createBuffer({
+  label: '\u0d8b\u{1fa82}',
+  size: 26869,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder99 = device0.createCommandEncoder();
+let commandBuffer3 = commandEncoder13.finish();
+let textureView123 = texture49.createView({});
+let sampler54 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 54.12});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup18, new Uint32Array(5314), 1_014, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer70, 'uint16', 9_750, 6_239);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer67, 'uint16', 844, 100);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup57 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 8, resource: externalTexture5}]});
+let buffer72 = device0.createBuffer({
+  size: 4314,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder83 = commandEncoder56.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 260, endOfPassWriteIndex: 146}});
+let renderPassEncoder23 = commandEncoder99.beginRenderPass({colorAttachments: [{view: textureView107, depthSlice: 117, loadOp: 'load', storeOp: 'store'}]});
+let sampler55 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 60.52,
+  maxAnisotropy: 13,
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'srgb'});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup55);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer7, 196, 473);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup31, new Uint32Array(3125), 362, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer54, 'uint16', 6, 608);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer49, 0, 1_201);
+} catch {}
+let promise15 = shaderModule3.getCompilationInfo();
+try {
+renderBundleEncoder16.insertDebugMarker('\u06fc');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 48, y: 15, z: 1},
+  aspect: 'all',
+}, new Uint8Array(83).fill(120), /* required buffer size: 83 */
+{offset: 83, bytesPerRow: 30, rowsPerImage: 107}, {width: 6, height: 5, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let bindGroup58 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 176, resource: textureView51}]});
+let sampler56 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 85.34});
+try {
+computePassEncoder83.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup17, []);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup7, new Uint32Array(2938), 72, 0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer8, 'uint16', 158, 34);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer31, 0, 311);
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+let computePassEncoder84 = commandEncoder100.beginComputePass({});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup35, new Uint32Array(5028), 61, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer65, 'uint32', 36, 98);
+} catch {}
+document.body.prepend(img0);
+let textureView124 = texture27.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let sampler57 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 92.07});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup56, new Uint32Array(1757), 102, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer58, 6_732, 1_667);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer45, 'uint32', 6_504, 945);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  label: '\u{1f64a}\u03e0\uabcf\u5aeb\u67b7\u8f36\uc95a',
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 6, resource: textureView43}],
+});
+let commandEncoder101 = device0.createCommandEncoder();
+let computePassEncoder85 = commandEncoder101.beginComputePass({label: '\uff89\u0388\u{1f88b}'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup50, new Uint32Array(5), 0, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer46, 0);
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker('\u8d52');
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({});
+let renderBundle16 = renderBundleEncoder16.finish();
+try {
+renderBundleEncoder17.setVertexBuffer(5, buffer9, 776);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 18, y: 18, z: 2},
+  aspect: 'all',
+}, new Uint8Array(27_093).fill(57), /* required buffer size: 27_093 */
+{offset: 445, bytesPerRow: 329, rowsPerImage: 17}, {width: 82, height: 13, depthOrArrayLayers: 5});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup60 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView8}]});
+let commandEncoder103 = device0.createCommandEncoder();
+let textureView125 = texture75.createView({dimension: '2d', format: 'rgba16float', baseArrayLayer: 1});
+let renderPassEncoder24 = commandEncoder103.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 31,
+  clearValue: { r: -789.3, g: -823.5, b: -86.78, a: -125.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 30},
+  maxDrawCount: 326277004,
+});
+try {
+renderBundleEncoder17.setIndexBuffer(buffer61, 'uint16', 4_668, 1_640);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer44, 0, 100);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let bindGroup61 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 483, resource: textureView53}, {binding: 20, resource: textureView90}],
+});
+let buffer73 = device0.createBuffer({size: 1458, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder104 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 276});
+let textureView126 = texture36.createView({dimension: '2d-array'});
+try {
+computePassEncoder85.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle11, renderBundle11, renderBundle13, renderBundle11, renderBundle13, renderBundle13, renderBundle13, renderBundle13, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer8, 'uint32', 432, 117);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer19);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 2380, new Float32Array(10081), 1362, 168);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 30, y: 39, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule1, targets: [{format: 'rgba16uint'}]},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 540,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 8, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder({});
+try {
+renderPassEncoder8.setViewport(31.563051150223217, 0.39734681755390844, 8.612264553893592, 0.46501640801701305, 0.4353479241868907, 0.842862508459725);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline5);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let bindGroup62 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 328, resource: textureView8}]});
+let commandEncoder106 = device0.createCommandEncoder({});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(1, bindGroup29, new Uint32Array(221), 8, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup61);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup15, new Uint32Array(1536), 1_177, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer54, 'uint32', 732, 206);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer74 = device0.createBuffer({
+  size: 2552,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder86 = commandEncoder102.beginComputePass({});
+let sampler58 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', mipmapFilter: 'nearest', lodMaxClamp: 99.26});
+try {
+computePassEncoder31.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder18.setViewport(40.262401558956185, 183.3232525289417, 204.13367230244708, 49.89174438943546, 0.8596863144656678, 0.990696630081272);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer48, 308);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST, colorSpace: 'srgb'});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline14 = await promise17;
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let texture85 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder87 = commandEncoder104.beginComputePass();
+let sampler59 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.18,
+});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup34, new Uint32Array(3043), 616, 0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, undefined, 0, 280_703_549);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup51, new Uint32Array(2241), 21, 0);
+} catch {}
+let imageData14 = new ImageData(64, 24);
+try {
+adapter0.label = '\uc2eb\ucf83\u{1f8d8}\u5b36';
+} catch {}
+let bindGroup63 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 127, resource: {buffer: buffer26, offset: 256}}, {binding: 8, resource: textureView6}],
+});
+let texture86 = device0.createTexture({
+  size: {width: 180},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder88 = commandEncoder106.beginComputePass({});
+let sampler60 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 97.62});
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup58);
+} catch {}
+let computePassEncoder89 = commandEncoder105.beginComputePass({});
+let renderBundle17 = renderBundleEncoder17.finish({});
+let sampler61 = device0.createSampler({addressModeU: 'repeat'});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup62, []);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer46, 0);
+} catch {}
+try {
+computePassEncoder83.pushDebugGroup('\u0124');
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline11.getBindGroupLayout(0);
+let commandEncoder107 = device0.createCommandEncoder({});
+try {
+computePassEncoder34.setBindGroup(1, bindGroup46, new Uint32Array(875), 105, 0);
+} catch {}
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer47, 1_212);
+} catch {}
+try {
+renderPassEncoder14.drawIndirect(buffer62, 272);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData6,
+  origin: { x: 3, y: 3 },
+  flipY: true,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 16, y: 22, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let bindGroup64 = device0.createBindGroup({layout: veryExplicitBindGroupLayout17, entries: [{binding: 328, resource: textureView68}]});
+let renderPassEncoder25 = commandEncoder107.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 525,
+  clearValue: { r: -248.6, g: -131.1, b: 489.2, a: 357.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 766, endOfPassWriteIndex: 568},
+});
+let sampler62 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 53.99,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder11.beginOcclusionQuery(61);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle11, renderBundle13, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(33, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder14.draw(853_275_355, 6, 71_341_468, 2_361_542_096);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder83.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let offscreenCanvas2 = new OffscreenCanvas(157, 37);
+let textureView127 = texture50.createView({format: 'rgba16uint'});
+try {
+renderPassEncoder14.drawIndexedIndirect(buffer39, 20);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer70, 'uint32', 3_748, 5_908);
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpteSt4281', transfer: 'log'} });
+let buffer75 = device0.createBuffer({size: 11660, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder108 = device0.createCommandEncoder({});
+try {
+computePassEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup60, new Uint32Array(2559), 892, 0);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(28, 54, 1, 64);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline12);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let buffer76 = device0.createBuffer({
+  size: 9834,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderPassEncoder26 = commandEncoder58.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 195,
+  clearValue: { r: 333.1, g: 81.81, b: 637.8, a: -742.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler63 = device0.createSampler({addressModeW: 'repeat', minFilter: 'linear', mipmapFilter: 'nearest'});
+try {
+buffer48.unmap();
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\u2ff4');
+} catch {}
+let bindGroup65 = device0.createBindGroup({layout: veryExplicitBindGroupLayout15, entries: [{binding: 3, resource: externalTexture8}]});
+let computePassEncoder90 = commandEncoder108.beginComputePass({});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup21, new Uint32Array(947), 288, 0);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup11, new Uint32Array(7416), 1_134, 0);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(56.93599816720424, 0.1506541852853549, 15.69715724823619, 0.33153328904309015, 0.3010819095450987, 0.3380238731504279);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer51, 'uint16', 7_760, 561);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(80).fill(120), /* required buffer size: 80 */
+{offset: 80, bytesPerRow: 190}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout6 = pipeline9.getBindGroupLayout(0);
+let sampler64 = device0.createSampler({addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 99.72});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup61, new Uint32Array(2860), 188, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup13, new Uint32Array(305), 81, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer43, 'uint16', 2, 8);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline11);
+} catch {}
+let recycledExplicitBindGroupLayout7 = pipeline4.getBindGroupLayout(0);
+let buffer77 = device0.createBuffer({
+  size: 2869,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder109 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  label: '\uf6fa\u8811\u0cb2',
+  size: {width: 90, height: 40, depthOrArrayLayers: 43},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder91 = commandEncoder109.beginComputePass({});
+try {
+computePassEncoder91.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer63, 'uint32', 608, 515);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder83.setBindGroup(0, bindGroup41, new Uint32Array(1377), 295, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup21, new Uint32Array(1082), 103, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer1, 'uint32', 52, 40);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer56, 1072, new DataView(new ArrayBuffer(2582)), 329, 124);
+} catch {}
+let texture88 = device0.createTexture({
+  size: [360, 1, 77],
+  mipLevelCount: 5,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder83); computePassEncoder83.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup8, new Uint32Array(1094), 131, 0);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u882a');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 1288, new Int16Array(2476));
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise18 = device0.createComputePipelineAsync({layout: pipelineLayout13, compute: {module: shaderModule2}});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture89 = device0.createTexture({
+  size: [90, 1, 78],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder27 = commandEncoder110.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 349,
+  clearValue: { r: 98.89, g: 730.4, b: 572.8, a: -254.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], sampleCount: 1, depthReadOnly: true});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup45);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer51, 'uint32', 2_376, 9_010);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer54, 4, 1_827);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup19, new Uint32Array(1139), 0, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer68, 'uint32', 1_348, 3_300);
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let computePassEncoder92 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup12, new Uint32Array(2005), 1_092, 0);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle6, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer19, 'uint32', 288, 1_784);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer43);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 168, new DataView(new ArrayBuffer(7112)), 1482, 812);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+document.body.append(img0);
+let commandEncoder112 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer72, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 948, new Int16Array(4140), 331, 324);
+} catch {}
+let texture90 = device0.createTexture({
+  size: {width: 45, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture91 = gpuCanvasContext1.getCurrentTexture();
+let textureView128 = texture28.createView({dimension: '3d', baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder93 = commandEncoder112.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 370, endOfPassWriteIndex: 223}});
+try {
+renderBundleEncoder18.setIndexBuffer(buffer70, 'uint16', 12_068, 8_681);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await promise15;
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 578, resource: {buffer: buffer8, offset: 0, size: 3292}},
+    {binding: 62, resource: textureView9},
+    {binding: 254, resource: {buffer: buffer32, offset: 2560, size: 180}},
+  ],
+});
+let buffer78 = device0.createBuffer({size: 8352, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder4.setVertexBuffer(0, undefined);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let imageData15 = new ImageData(12, 128);
+try {
+computePassEncoder19.setBindGroup(3, bindGroup19, new Uint32Array(1085), 13, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup34, new Uint32Array(716), 54, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer46);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup17, new Uint32Array(337), 33, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 2004, new Int16Array(27599), 3730, 1536);
+} catch {}
+let buffer79 = device0.createBuffer({
+  size: 2275,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView129 = texture60.createView({dimension: '2d', mipLevelCount: 1});
+let sampler65 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup35, new Uint32Array(1422), 158, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer35, 'uint32', 124, 2_178);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 3316, new Float32Array(8610), 772, 248);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'jedecP22Phosphors', transfer: 'hlg'} });
+let commandEncoder113 = device0.createCommandEncoder({});
+let textureView130 = texture15.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder94 = commandEncoder113.beginComputePass({});
+let sampler66 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 76.01});
+try {
+computePassEncoder94.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer74, 'uint16', 96, 137);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer54, 0, 715);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData8,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 81, y: 11, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup67 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 328, resource: textureView100}]});
+let commandEncoder114 = device0.createCommandEncoder({});
+let renderPassEncoder28 = commandEncoder114.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 614.9, g: 963.2, b: -798.8, a: 188.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet4},
+});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'srgb'});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup11, new Uint32Array(3308), 898, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer51, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(326).fill(186), /* required buffer size: 326 */
+{offset: 326, rowsPerImage: 225}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let buffer80 = device0.createBuffer({size: 5572, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let computePassEncoder95 = commandEncoder110.beginComputePass({});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup28, new Uint32Array(3130), 46, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(3, buffer66, 2_072, 2_214);
+} catch {}
+let texture92 = device0.createTexture({
+  size: [1035, 60, 11],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler67 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup2, new Uint32Array(1285), 106, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle10, renderBundle2, renderBundle15, renderBundle1, renderBundle10]);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer63);
+} catch {}
+let promise19 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x6d8c9b06},
+  fragment: {
+  module: shaderModule4,
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex4',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 312,
+        attributes: [
+          {format: 'sint8x2', offset: 10, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 20, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 14},
+          {format: 'uint32x2', offset: 24, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 144, attributes: [{format: 'sint8x2', offset: 20, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let commandEncoder115 = device0.createCommandEncoder();
+let texture93 = device0.createTexture({
+  size: [360, 1, 35],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture94 = device0.createTexture({
+  size: [360, 1, 154],
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder96 = commandEncoder115.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 304}});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup19, new Uint32Array(556), 11, 0);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder28.setStencilReference(97);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+buffer77.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img1);
+let commandEncoder116 = device0.createCommandEncoder({});
+let texture95 = device0.createTexture({
+  size: [45, 20, 22],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder97 = commandEncoder116.beginComputePass({});
+let sampler68 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 35.93,
+});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer74, 'uint16', 204, 543);
+} catch {}
+let veryExplicitBindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [{binding: 8, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let buffer81 = device0.createBuffer({
+  size: 4177,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView131 = texture95.createView({aspect: 'all', mipLevelCount: 1});
+let texture96 = device0.createTexture({
+  size: {width: 258, height: 15, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame15, colorSpace: 'srgb'});
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer7, 0);
+} catch {}
+try {
+renderBundleEncoder18.insertDebugMarker('\u{1ff24}');
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder();
+let texture97 = device0.createTexture({
+  size: [90, 1, 85],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder98 = commandEncoder117.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 451}});
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup14, new Uint32Array(1944), 86, 0);
+} catch {}
+try {
+renderPassEncoder28.setViewport(19.81482505097011, 8.890805613949821, 2.0186468978344334, 0.9739433606681159, 0.4718213608286993, 0.6147596227719461);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer40, 0);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(2, undefined, 0, 1_254_801_394);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6).fill(148), /* required buffer size: 6 */
+{offset: 6}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 31}
+*/
+{
+  source: imageData12,
+  origin: { x: 1, y: 20 },
+  flipY: false,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 59, y: 74, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let querySet8 = device0.createQuerySet({type: 'timestamp', count: 431});
+let textureView132 = texture93.createView({dimension: '2d', baseArrayLayer: 8});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup62, new Uint32Array(624), 170, 0);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(0, buffer47, 8, 560);
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'bt709'} });
+let bindGroup68 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 254, resource: {buffer: buffer52, offset: 0, size: 8}},
+    {binding: 62, resource: textureView18},
+    {binding: 578, resource: {buffer: buffer75, offset: 4352, size: 3344}},
+  ],
+});
+let commandEncoder118 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  size: [90, 40, 63],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture99 = device0.createTexture({
+  size: [22],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder16.setIndexBuffer(buffer41, 'uint16', 64, 138);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer34, 3_140, 2_530);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(0, buffer41);
+} catch {}
+try {
+renderPassEncoder18.pushDebugGroup('\u72be');
+} catch {}
+try {
+renderBundleEncoder19.insertDebugMarker('\u2e5a');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 22, height: 10, depthOrArrayLayers: 55}
+*/
+{
+  source: imageData15,
+  origin: { x: 0, y: 21 },
+  flipY: false,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = device0.createComputePipeline({layout: pipelineLayout15, compute: {module: shaderModule4}});
+let commandEncoder119 = device0.createCommandEncoder({});
+let textureView133 = texture98.createView({label: '\u{1f9d2}\u59dd\ud2d3\u07fb\u{1f8e3}\u{1fcdf}\uee4c', baseArrayLayer: 5, arrayLayerCount: 14});
+let computePassEncoder99 = commandEncoder118.beginComputePass({timestampWrites: {querySet: querySet1}});
+let renderPassEncoder29 = commandEncoder119.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 462,
+  clearValue: { r: -508.2, g: 51.72, b: 193.1, a: -895.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet8, endOfPassWriteIndex: 289},
+  maxDrawCount: 127172895,
+});
+let renderBundle19 = renderBundleEncoder19.finish({});
+let sampler69 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.86,
+  compare: 'never',
+  maxAnisotropy: 13,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder83); computePassEncoder83.dispatchWorkgroupsIndirect(buffer77, 176); };
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 2180, new BigUint64Array(6052), 1537, 12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 258, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 30, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup69 = device0.createBindGroup({layout: veryExplicitBindGroupLayout18, entries: [{binding: 8, resource: externalTexture8}]});
+let commandEncoder120 = device0.createCommandEncoder({});
+let textureView134 = texture95.createView({arrayLayerCount: 1});
+let computePassEncoder100 = commandEncoder120.beginComputePass({});
+try {
+computePassEncoder80.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer47);
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\uad27');
+} catch {}
+document.body.append(canvas3);
+let buffer82 = device0.createBuffer({size: 8801, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture100 = device0.createTexture({
+  size: [517, 30, 33],
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder61.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(0, bindGroup57, new Uint32Array(2902), 141, 0);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer53);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+let pipeline16 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(402);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer46, 'uint32', 4, 168);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer33, 628, 267);
+} catch {}
+let promise20 = device0.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule4, constants: {}}});
+let commandEncoder121 = device0.createCommandEncoder({});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup56, new Uint32Array(1223), 13, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer34, 952); };
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup36, new Uint32Array(942), 96, 0);
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override6 = 0.4949;
+
+struct T3 {
+  @align(32) @size(32) f0: T1,
+  @size(128) f1: atomic<i32>,
+  @size(1216) f2: array<array<array<T1, 1>, 2>>,
+}
+
+var<private> vp2: f16 = f16(864.9);
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+override override7: f32;
+
+struct T2 {
+  @align(64) @size(3264) f0: mat4x2h,
+}
+
+/* zero global variables used */
+fn fn2() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  var vf68: vec3h = radians(vec3h(unconst_f16(4003.4), unconst_f16(371.8), unconst_f16(2048.5)));
+  let vf69: vec2<bool> = (vec2f(unconst_f32(0.1736), unconst_f32(0.04485)) != vec2f(unconst_f32(-0.1279), unconst_f32(0.09416)));
+  let vf70: vec2h = exp(vec2h(unconst_f16(6544.5), unconst_f16(7548.4)));
+  let vf71: vec2<bool> = (vec2h(unconst_f16(11803.0), unconst_f16(29789.1)) >= vec2h(unconst_f16(7078.1), unconst_f16(5670.4)));
+  var vf72: bool = vf71[unconst_u32(522)];
+  vp2 -= asinh(vec3h(unconst_f16(469.6), unconst_f16(8460.8), unconst_f16(3521.9))).g;
+  return out;
+}
+
+/* used global variables: buffer84 */
+fn fn0(a0: ptr<storage, array<mat2x2f>, read>) -> VertexOutput5 {
+  var out: VertexOutput5;
+  let ptr62: ptr<storage, T2, read> = &buffer84;
+  out.f18 = bitcast<f32>((*ptr62).f0[unconst_i32(0)]);
+  var vf57: vec2h = (*&buffer84).f0[unconst_u32(378)];
+  let ptr63: ptr<storage, mat4x2h, read> = &(*ptr62).f0;
+  out.f17 = vec4f(f32(override5));
+  var vf58: vec2h = (*ptr62).f0[unconst_u32(23)];
+  return out;
+  _ = override5;
+  _ = buffer84;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T4 {
+  f0: f16,
+}
+
+struct T5 {
+  @align(64) @size(64) f0: T4,
+  @align(64) @size(3200) f1: T3,
+}
+
+@group(0) @binding(62) var tex5: texture_depth_2d;
+
+@group(0) @binding(578) var<storage, read> buffer84: T2;
+
+@id(15052) override override5: u32 = 407;
+
+@id(55222) override override4: i32;
+
+struct T0 {
+  f0: mat2x3h,
+  @size(4) f1: array<f16, 1>,
+  @size(144) f2: mat3x4h,
+}
+
+/* used global variables: buffer84 */
+@must_use 
+fn fn1(a0: array<VertexOutput5, 1>) -> T4 {
+  var out: T4;
+  let vf59: vec2f = inverseSqrt(vec2f(unconst_f32(0.1238), unconst_f32(0.4448)));
+  vp2 *= vec4h(a0[unconst_u32(290)].f17).b;
+  let vf60: vec4i = (vec4i(unconst_i32(20), unconst_i32(148), unconst_i32(38), unconst_i32(131)) ^ vec4i(unconst_i32(464), unconst_i32(149), unconst_i32(231), unconst_i32(220)));
+  var vf61: vec4h = radians(vec4h(f16(pack4x8unorm(vec4f(unconst_f32(0.5400), unconst_f32(0.2812), unconst_f32(0.1464), unconst_f32(1.000))))));
+  let vf62: vec2f = quantizeToF16(vec2f((unconst_i32(517) - vec2i(unconst_i32(16), unconst_i32(2)))));
+  for (var it4=u32(all((vec3i(unconst_i32(37), unconst_i32(-321), unconst_i32(157)) > vec3i(unconst_i32(-288), unconst_i32(76), unconst_i32(185))))); it4<u32(vf61[unconst_u32(119)]); it4++) {
+  let vf63: vec2h = sign(vec2h(unconst_f16(2966.3), unconst_f16(268.3)));
+  switch i32(pack2x16float(vec2f(unconst_f32(0.1532), unconst_f32(0.06690)))) { 
+  default {
+  let vf64: VertexOutput5 = a0[unconst_u32(64)];
+  out = T4(f16(floor(vec2f(unconst_f32(0.06608), unconst_f32(0.4171)))[1]));
+  let vf65: vec2h = (*&buffer84).f0[unconst_u32(77)];
+  break;
+  _ = buffer84;
+}
+  }
+  out.f0 = f16(a0[bitcast<u32>(a0[unconst_u32(115)].f18)].f17[1]);
+  let vf66: f32 = a0[unconst_u32(61)].f17[unconst_u32(262)];
+  vp2 = buffer84.f0[bitcast<u32>(override6)][1];
+  let vf67: array<VertexOutput5, 1> = a0;
+  _ = override6;
+  _ = buffer84;
+}
+  return out;
+  _ = override6;
+  _ = buffer84;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput5 {
+  @invariant @builtin(position) f17: vec4f,
+  @location(11) @interpolate(perspective, first) f18: f32,
+}
+
+struct T1 {
+  @align(8) @size(8) f0: array<array<array<array<array<f16, 2>, 1>, 1>, 1>, 1>,
+}
+
+struct FragmentOutput4 {
+  @location(2) @interpolate(flat) f0: vec2u,
+  @location(0) f1: vec4f,
+  @location(5) @interpolate(flat) f2: u32,
+  @builtin(sample_mask) f3: u32,
+}
+
+var<private> vp1: vec2h = vec2h(46183.2, 22737.1);
+
+/* used global variables: buffer84, tex5 */
+@vertex
+fn vertex6(@builtin(vertex_index) a0: u32, @location(7) @interpolate(flat) a1: u32, @location(0) @interpolate(flat) a2: vec2i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  _ = fn1(array<VertexOutput5, 1>(VertexOutput5(inverseSqrt(vec4f(f32(a0))), inverseSqrt(vec4f(f32(a0)))[2])));
+  let vf73: f32 = textureLoad(tex5, vec2i((unconst_f16(14060.2) * vec2h(unconst_f16(16408.0), unconst_f16(5319.0)))), unconst_i32(7));
+  out.f18 = select(vec2f(unconst_f32(0.06572), unconst_f32(0.04940)), vec2f(unconst_f32(-0.02053), unconst_f32(0.1155)), vec2<bool>(bool(a2[vec2u((vec2i(i32(vp1[unconst_u32(219)])) < vec2i(unconst_i32(4), unconst_i32(5))))[0]]))).x;
+  var vf74 = fn1(array<VertexOutput5, 1>(VertexOutput5(vec4f(vp1.xxxy), bitcast<f32>(vp1))));
+  vp2 += (*&buffer84).f0[unconst_i32(3)].g;
+  return out;
+  _ = override6;
+  _ = tex5;
+  _ = buffer84;
+}
+
+/* used global variables: buffer84 */
+@fragment
+fn fragment4() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  var vf75 = fn2();
+  _ = fn2();
+  var vf76: f16 = buffer84.f0[unconst_u32(55)][unconst_u32(74)];
+  var vf77 = fn2();
+  fn2();
+  {
+  var vf78 = fn2();
+}
+  vp1 *= vec2h(vf77.f0);
+  vf75.f0 = vec2u(bitcast<u32>( ~bitcast<i32>(buffer84.f0[unconst_u32(27)])));
+  var vf79 = fn2();
+  _ = fn2();
+  let ptr64: ptr<storage, mat4x2h, read> = &(*&buffer84).f0;
+  loop {
+  vp2 -= vec3h(trunc(vec3f(unconst_f32(0.08769), unconst_f32(0.3237), unconst_f32(0.4184))))[0];
+  out.f3 &= bitcast<u32>(abs(vec2h(unconst_f16(12797.7), unconst_f16(3632.1))));
+  _ = fn2();
+  var vf80 = fn2();
+  out = FragmentOutput4(bitcast<vec2u>(vf80.f1.bb), vf80.f1, u32(vf80.f1[1]), bitcast<u32>(vf80.f1.r));
+  break;
+}
+  var vf81 = fn2();
+  return out;
+  _ = buffer84;
+}`,
+});
+let recycledExplicitBindGroupLayout8 = pipeline4.getBindGroupLayout(0);
+let textureView135 = texture73.createView({label: '\u611f\u03d8\u3865\uf217\ufaf8', dimension: '2d'});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup68, new Uint32Array(2156), 435, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder83); computePassEncoder83.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder83); computePassEncoder83.dispatchWorkgroupsIndirect(buffer77, 104); };
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer54, 'uint16', 20, 1_575);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 1616, new Float32Array(2081), 1, 52);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 22, height: 10, depthOrArrayLayers: 55}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer85 = device0.createBuffer({size: 817, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandBuffer4 = commandEncoder121.finish();
+let texture101 = device0.createTexture({
+  size: [258],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler70 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder83.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer25, 'uint16', 1_140, 515);
+} catch {}
+let recycledExplicitBindGroupLayout9 = pipeline7.getBindGroupLayout(0);
+let bindGroup70 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 127, resource: {buffer: buffer7, offset: 0, size: 792}},
+    {binding: 8, resource: textureView14},
+  ],
+});
+let textureView136 = texture17.createView({});
+try {
+computePassEncoder87.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup55, new Uint32Array(3963), 5, 0);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder122 = device0.createCommandEncoder({});
+let textureView137 = texture47.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 10});
+let computePassEncoder101 = commandEncoder122.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder97.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer3, 'uint16', 2_266, 2_786);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline11);
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({});
+try {
+adapter1.label = '\u2d20\uaaa8\u47c7';
+} catch {}
+let texture102 = device0.createTexture({
+  size: [256, 256, 17],
+  sampleCount: 1,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView138 = texture8.createView({baseArrayLayer: 0});
+try {
+computePassEncoder95.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline7);
+} catch {}
+try {
+  await promise21;
+} catch {}
+let textureView139 = texture27.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder101.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup31, new Uint32Array(1227), 611, 0);
+} catch {}
+try {
+buffer80.unmap();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 578, resource: {buffer: buffer49, offset: 256}}],
+});
+let commandEncoder123 = device0.createCommandEncoder({});
+let textureView140 = texture31.createView({mipLevelCount: 1, arrayLayerCount: 4});
+let computePassEncoder102 = commandEncoder123.beginComputePass({});
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.51,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup47, new Uint32Array(2795), 101, 0);
+} catch {}
+try {
+computePassEncoder83.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup33, new Uint32Array(1208), 60, 0);
+} catch {}
+let arrayBuffer3 = buffer37.getMappedRange(1160, 148);
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1304 */
+  offset: 1304,
+  buffer: buffer9,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder56.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 52, y: 71, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise22 = adapter1.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'timestamp-query',
+  ],
+});
+try {
+externalTexture8.label = '\u{1ff2f}\u{1fc81}\u{1fbb9}\u{1f9a8}\u4780\u4db7\u7be3\u06e1';
+} catch {}
+let texture103 = device0.createTexture({
+  size: {width: 90, height: 40, depthOrArrayLayers: 45},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(2, bindGroup45, new Uint32Array(1938), 428, 0);
+} catch {}
+try {
+computePassEncoder82.end();
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 128 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4264 */
+  offset: 4264,
+  bytesPerRow: 7424,
+  rowsPerImage: 34,
+  buffer: buffer72,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 28, y: 58, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 25, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet8, 373, 10, buffer70, 13568);
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: [{binding: 176, resource: textureView75}]});
+let buffer86 = device0.createBuffer({size: 57157, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let renderPassEncoder30 = commandEncoder56.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 61,
+  clearValue: { r: -719.5, g: 636.7, b: 622.0, a: 591.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+});
+let sampler72 = device0.createSampler({
+  addressModeV: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.65,
+  lodMaxClamp: 98.84,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder68.setBindGroup(0, bindGroup19, new Uint32Array(1199), 179, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup60, new Uint32Array(38), 1, 0);
+} catch {}
+document.body.append(canvas5);
+let texture104 = device0.createTexture({
+  size: [258],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder103 = commandEncoder97.beginComputePass({});
+let sampler73 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', compare: 'less-equal', maxAnisotropy: 1});
+try {
+computePassEncoder103.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer71, 'uint16', 3_212, 3_746);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(7, buffer72);
+} catch {}
+let texture105 = device0.createTexture({
+  size: {width: 360},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView141 = texture43.createView({baseMipLevel: 0});
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(181).fill(121), /* required buffer size: 181 */
+{offset: 181}, {width: 96, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 256, height: 256, depthOrArrayLayers: 31}
+*/
+{
+  source: canvas4,
+  origin: { x: 7, y: 9 },
+  flipY: true,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 60, y: 19, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 29, height: 17, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpteSt4281', transfer: 'bt1361ExtendedColourGamut'} });
+let texture106 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder37.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline4);
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  layout: pipelineLayout14,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 16,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 0, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 10},
+          {format: 'sint16x2', offset: 0, shaderLocation: 14},
+          {format: 'uint32x2', offset: 4, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: false},
+});
+let querySet9 = device0.createQuerySet({type: 'timestamp', count: 548});
+try {
+computePassEncoder102.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder34.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(1, bindGroup58, new Uint32Array(2553), 115, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline7);
+} catch {}
+let arrayBuffer4 = buffer37.getMappedRange(904, 16);
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let imageData16 = new ImageData(20, 4);
+let bindGroup73 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 328, resource: textureView8}]});
+let buffer87 = device0.createBuffer({
+  size: 6568,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let sampler74 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 95.74});
+try {
+renderPassEncoder16.executeBundles([renderBundle5, renderBundle15]);
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 62, resource: textureView9},
+    {binding: 578, resource: {buffer: buffer25, offset: 0, size: 3652}},
+    {binding: 254, resource: {buffer: buffer87, offset: 256}},
+  ],
+});
+let commandEncoder124 = device0.createCommandEncoder({});
+let computePassEncoder104 = commandEncoder124.beginComputePass({timestampWrites: {querySet: querySet9, endOfPassWriteIndex: 457}});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup7, new Uint32Array(3), 0, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(0, buffer7, 1_796);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout10]});
+let commandEncoder125 = device0.createCommandEncoder({});
+let textureView142 = texture93.createView({dimension: '2d', baseArrayLayer: 4});
+let textureView143 = texture82.createView({dimension: '2d'});
+let computePassEncoder105 = commandEncoder125.beginComputePass({
+  timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 338, endOfPassWriteIndex: 4294967295},
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup15, new Uint32Array(2749), 945, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(46, 8, 2, 57_917_828, 36);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer62, 164);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup75 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 6, resource: textureView27}]});
+let commandEncoder126 = device0.createCommandEncoder({});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: false});
+let sampler75 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 25.00,
+});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup75, new Uint32Array(68), 12, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder17.draw(6, 22, 1_924_833_028, 3);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer72, 420);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer63, 'uint16', 90, 501);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, undefined);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup10, new Uint32Array(1383), 66, 0);
+} catch {}
+let buffer88 = device0.createBuffer({size: 17523, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let querySet10 = device0.createQuerySet({type: 'timestamp', count: 221});
+let texture107 = gpuCanvasContext2.getCurrentTexture();
+let textureView144 = texture104.createView({aspect: 'all'});
+let renderBundle20 = renderBundleEncoder20.finish();
+try {
+computePassEncoder42.setBindGroup(1, bindGroup62, new Uint32Array(1014), 421, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup56, new Uint32Array(1006), 18, 0);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer42, 'uint32', 224, 71);
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 578, resource: {buffer: buffer26, offset: 0}}],
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline18 = device0.createRenderPipeline({
+  layout: pipelineLayout13,
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba16uint'}]},
+  vertex: {
+    module: shaderModule4,
+    constants: {},
+    buffers: [{arrayStride: 168, attributes: [{format: 'float32x4', offset: 12, shaderLocation: 3}]}],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let recycledExplicitBindGroupLayout10 = pipeline18.getBindGroupLayout(0);
+let texture108 = device0.createTexture({
+  size: [90, 1, 1],
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder106 = commandEncoder126.beginComputePass();
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true});
+try {
+computePassEncoder98.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup53, new Uint32Array(361), 254, 0);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup23, new Uint32Array(4330), 79, 0);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 352 widthInBlocks: 88 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1636 */
+  offset: 1636,
+  bytesPerRow: 11520,
+  buffer: buffer16,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 29, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 88, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let buffer89 = device0.createBuffer({size: 10947, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let computePassEncoder107 = commandEncoder76.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup36, new Uint32Array(116), 35, 0);
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle5, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(151.12527476012806, 248.3580324486086, 67.36691231004855, 0.26984897361093796, 0.08339239491167116, 0.8532131388957873);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(30, 116, 186, 203_708_530, 226_720_303);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer76, 4_004);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer81, 36);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint16', 678, 3_300);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer9, 'uint16', 282, 4);
+} catch {}
+let pipeline19 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x79b6f0e},
+  fragment: {
+  module: shaderModule4,
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex1', buffers: []},
+  primitive: {cullMode: 'front'},
+});
+let imageData17 = new ImageData(28, 20);
+let texture109 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 17},
+  mipLevelCount: 5,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder107.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 201, 0, 39_886_225);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer8, 264);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer58, 92);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline19);
+} catch {}
+let promise23 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule5, targets: [{format: 'rgb10a2unorm'}]},
+  vertex: {
+    module: shaderModule4,
+    buffers: [
+      {
+        arrayStride: 332,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 80, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout5]});
+let commandEncoder127 = device0.createCommandEncoder({});
+let renderPassEncoder31 = commandEncoder127.beginRenderPass({
+  colorAttachments: [{view: textureView107, depthSlice: 91, loadOp: 'clear', storeOp: 'discard'}],
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 552},
+  maxDrawCount: 152323216,
+});
+let sampler76 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.73,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup75, new Uint32Array(3933), 98, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(0, buffer66, 0, 1_474);
+} catch {}
+try {
+buffer70.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 11, height: 5, depthOrArrayLayers: 55}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 21},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup77 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 282, resource: externalTexture5},
+    {binding: 7, resource: textureView14},
+    {binding: 37, resource: {buffer: buffer7, offset: 768, size: 428}},
+  ],
+});
+let buffer90 = device0.createBuffer({size: 11890, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView145 = texture38.createView({format: 'rgba16uint', baseArrayLayer: 1, arrayLayerCount: 3});
+let renderBundle21 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(3, bindGroup11, new Uint32Array(1458), 15, 0);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup50, new Uint32Array(4012), 24, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle13, renderBundle13, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(1_257, 435, 42, 525_792_657, 1_564_032_242);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer25, 664);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer70, 11_220);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(5, buffer47);
+} catch {}
+try {
+computePassEncoder23.pushDebugGroup('\u{1f8c3}');
+} catch {}
+try {
+computePassEncoder81.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder4.draw(0, 416, 0, 497_769_478);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(25, 245, 144, 392_570_477, 420_482_261);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer77, 636);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer25, 'uint16', 1_942, 256);
+} catch {}
+let bindGroup78 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 37, resource: {buffer: buffer79, offset: 0, size: 632}},
+    {binding: 282, resource: externalTexture1},
+    {binding: 7, resource: textureView79},
+  ],
+});
+let texture110 = device0.createTexture({size: [90, 1, 1], mipLevelCount: 2, format: 'rgba16float', usage: GPUTextureUsage.STORAGE_BINDING});
+let sampler77 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 30.09,
+});
+try {
+computePassEncoder105.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup49, new Uint32Array(560), 32, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 74, 0, 953_850_766);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(23, 436, 1, 547_389_026, 415_058_600);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer34, 5_036);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer81, 92);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer32, 0, 7_552);
+} catch {}
+let texture111 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 622},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView146 = texture71.createView({mipLevelCount: 1});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup50, new Uint32Array(982), 134, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(7, 0, 7, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer79, 204);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer76, 232);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer87, 'uint16', 364, 837);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let veryExplicitBindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 47, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 267, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {
+      binding: 359,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let textureView147 = texture104.createView({});
+let texture112 = device0.createTexture({
+  size: [90, 40, 51],
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView148 = texture44.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let sampler78 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 90.98});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(17, 22, 19, -1_611_285_040, 497_790_026);
+} catch {}
+let bindGroup79 = device0.createBindGroup({layout: veryExplicitBindGroupLayout18, entries: [{binding: 8, resource: externalTexture7}]});
+let buffer91 = device0.createBuffer({
+  size: 14355,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder128 = device0.createCommandEncoder({});
+let computePassEncoder108 = commandEncoder128.beginComputePass({});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame11});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup64, new Uint32Array(24), 2, 0);
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(11, 101, 19, -1_925_450_485, 617_232_517);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer73, 84);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 10, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 372, new Int16Array(1723), 101, 40);
+} catch {}
+let buffer92 = device0.createBuffer({
+  size: 2354,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer54, 508);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(3, bindGroup31, new Uint32Array(4465), 3_217, 0);
+} catch {}
+try {
+pipeline6.label = '\u0acf\u{1fbf5}\u{1f93d}\u0725\u6830\ufb2a\u08f3';
+} catch {}
+try {
+computePassEncoder104.setBindGroup(1, bindGroup6, new Uint32Array(1954), 162, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer25, 'uint32', 500, 730);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer31, 404);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(244).fill(30), /* required buffer size: 244 */
+{offset: 244, bytesPerRow: 552}, {width: 69, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 10, y: 9, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline20 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0x56fcd1d0},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment4',
+  targets: [{format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 856,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 132, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 5},
+          {format: 'sint32x2', offset: 24, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 204, shaderLocation: 14},
+          {format: 'sint32x4', offset: 24, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+await gc();
+let commandEncoder129 = device0.createCommandEncoder();
+let computePassEncoder109 = commandEncoder129.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup70, new Uint32Array(4027), 1_149, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(0, 107, 0, 553_446_841);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer55, 5_516);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer92, 'uint16', 734, 168);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1104 */
+  offset: 1104,
+  bytesPerRow: 2048,
+  buffer: buffer68,
+}, {
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let texture113 = device0.createTexture({size: [129, 7, 1155], dimension: '3d', format: 'rgba16uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let computePassEncoder110 = commandEncoder21.beginComputePass({});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup16, new Uint32Array(2628), 21, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroupsIndirect(buffer91, 2_456); };
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup39, new Uint32Array(2573), 796, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(38, 133, 20, 193_138_918, 487_369_544);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer8, 'uint32', 1_328, 751);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer8, 0, 314);
+} catch {}
+let arrayBuffer5 = buffer37.getMappedRange(1312, 12);
+document.body.prepend(img1);
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'log'} });
+let commandEncoder130 = device0.createCommandEncoder({});
+let texture114 = device0.createTexture({size: {width: 360}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder111 = commandEncoder130.beginComputePass({});
+try {
+computePassEncoder102.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup11, new Uint32Array(4547), 2_780, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer62, 20);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer41, 176, 477);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(5, buffer46);
+} catch {}
+let promise24 = shaderModule2.getCompilationInfo();
+try {
+computePassEncoder23.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 3640, new Int16Array(1190), 50, 236);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let videoFrame19 = new VideoFrame(videoFrame8, {timestamp: 0});
+let commandEncoder131 = device0.createCommandEncoder({});
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(28, 123, 2, 176_397_217, 1_008_543_925);
+} catch {}
+try {
+renderPassEncoder18.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder132 = device0.createCommandEncoder({});
+let computePassEncoder112 = commandEncoder131.beginComputePass({});
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer25, 440);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer34, 468);
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync({layout: pipelineLayout13, compute: {module: shaderModule1, entryPoint: 'compute1'}});
+let computePassEncoder113 = commandEncoder132.beginComputePass();
+let sampler79 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.64,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroupsIndirect(buffer26, 604); };
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup7, new Uint32Array(6653), 353, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer27, 1_164);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 90, height: 40, depthOrArrayLayers: 45}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 8, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline22 = device0.createComputePipeline({layout: pipelineLayout19, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+document.body.prepend(canvas5);
+let autogeneratedBindGroupLayout6 = pipeline20.getBindGroupLayout(0);
+let bindGroup80 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 8, resource: externalTexture12}]});
+let buffer93 = device0.createBuffer({
+  size: 9592,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView149 = texture47.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 11});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(442);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer26, 'uint32', 1_348, 880);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline20);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw24: f32;
+
+/* used global variables: buffer95 */
+fn fn1(a0: ptr<storage, vec2u, read_write>) -> mat2x2h {
+  var out: mat2x2h;
+  for (var it6=u32((*&buffer95)[unconst_u32(79)][5][0][0][unconst_u32(180)][unconst_u32(256)][unconst_u32(279)][16][unconst_u32(149)][0][unconst_u32(217)][0]); it6<u32((*&buffer95)[15][unconst_u32(164)][0][unconst_u32(79)][0][0][0][unconst_u32(468)][unconst_u32(69)][unconst_u32(218)][0][0]); it6++) {
+  vp3 = mat2x3h(buffer95[unconst_u32(307)][5][u32((*&buffer95)[15][5][0][unconst_u32(344)][0][unconst_u32(141)][0][16][0][0][0][0])][u32(buffer95[unconst_u32(1)][5][unconst_u32(33)][0][unconst_u32(193)][unconst_u32(35)][unconst_u32(144)][unconst_u32(133)][unconst_u32(394)][u32((*&buffer95)[15][unconst_u32(59)][0][unconst_u32(570)][unconst_u32(120)][unconst_u32(86)][u32((*&buffer95)[unconst_u32(128)][5][unconst_u32(285)][unconst_u32(137)][unconst_u32(43)][unconst_u32(88)][0][unconst_u32(3)][0][0][unconst_u32(294)][unconst_u32(187)])][unconst_u32(120)][u32(buffer95[15][5][unconst_u32(337)][0][0][unconst_u32(644)][unconst_u32(191)][unconst_u32(381)][0][unconst_u32(39)][0][0])][0][0][0])][0][0])][unconst_u32(222)][0][0][unconst_u32(428)][0][0][unconst_u32(483)][unconst_u32(302)], buffer95[unconst_u32(307)][5][u32((*&buffer95)[15][5][0][unconst_u32(344)][0][unconst_u32(141)][0][16][0][0][0][0])][u32(buffer95[unconst_u32(1)][5][unconst_u32(33)][0][unconst_u32(193)][unconst_u32(35)][unconst_u32(144)][unconst_u32(133)][unconst_u32(394)][u32((*&buffer95)[15][unconst_u32(59)][0][unconst_u32(570)][unconst_u32(120)][unconst_u32(86)][u32((*&buffer95)[unconst_u32(128)][5][unconst_u32(285)][unconst_u32(137)][unconst_u32(43)][unconst_u32(88)][0][unconst_u32(3)][0][0][unconst_u32(294)][unconst_u32(187)])][unconst_u32(120)][u32(buffer95[15][5][unconst_u32(337)][0][0][unconst_u32(644)][unconst_u32(191)][unconst_u32(381)][0][unconst_u32(39)][0][0])][0][0][0])][0][0])][unconst_u32(222)][0][0][unconst_u32(428)][0][0][unconst_u32(483)][unconst_u32(302)], buffer95[unconst_u32(307)][5][u32((*&buffer95)[15][5][0][unconst_u32(344)][0][unconst_u32(141)][0][16][0][0][0][0])][u32(buffer95[unconst_u32(1)][5][unconst_u32(33)][0][unconst_u32(193)][unconst_u32(35)][unconst_u32(144)][unconst_u32(133)][unconst_u32(394)][u32((*&buffer95)[15][unconst_u32(59)][0][unconst_u32(570)][unconst_u32(120)][unconst_u32(86)][u32((*&buffer95)[unconst_u32(128)][5][unconst_u32(285)][unconst_u32(137)][unconst_u32(43)][unconst_u32(88)][0][unconst_u32(3)][0][0][unconst_u32(294)][unconst_u32(187)])][unconst_u32(120)][u32(buffer95[15][5][unconst_u32(337)][0][0][unconst_u32(644)][unconst_u32(191)][unconst_u32(381)][0][unconst_u32(39)][0][0])][0][0][0])][0][0])][unconst_u32(222)][0][0][unconst_u32(428)][0][0][unconst_u32(483)][unconst_u32(302)], buffer95[unconst_u32(307)][5][u32((*&buffer95)[15][5][0][unconst_u32(344)][0][unconst_u32(141)][0][16][0][0][0][0])][u32(buffer95[unconst_u32(1)][5][unconst_u32(33)][0][unconst_u32(193)][unconst_u32(35)][unconst_u32(144)][unconst_u32(133)][unconst_u32(394)][u32((*&buffer95)[15][unconst_u32(59)][0][unconst_u32(570)][unconst_u32(120)][unconst_u32(86)][u32((*&buffer95)[unconst_u32(128)][5][unconst_u32(285)][unconst_u32(137)][unconst_u32(43)][unconst_u32(88)][0][unconst_u32(3)][0][0][unconst_u32(294)][unconst_u32(187)])][unconst_u32(120)][u32(buffer95[15][5][unconst_u32(337)][0][0][unconst_u32(644)][unconst_u32(191)][unconst_u32(381)][0][unconst_u32(39)][0][0])][0][0][0])][0][0])][unconst_u32(222)][0][0][unconst_u32(428)][0][0][unconst_u32(483)][unconst_u32(302)], buffer95[unconst_u32(307)][5][u32((*&buffer95)[15][5][0][unconst_u32(344)][0][unconst_u32(141)][0][16][0][0][0][0])][u32(buffer95[unconst_u32(1)][5][unconst_u32(33)][0][unconst_u32(193)][unconst_u32(35)][unconst_u32(144)][unconst_u32(133)][unconst_u32(394)][u32((*&buffer95)[15][unconst_u32(59)][0][unconst_u32(570)][unconst_u32(120)][unconst_u32(86)][u32((*&buffer95)[unconst_u32(128)][5][unconst_u32(285)][unconst_u32(137)][unconst_u32(43)][unconst_u32(88)][0][unconst_u32(3)][0][0][unconst_u32(294)][unconst_u32(187)])][unconst_u32(120)][u32(buffer95[15][5][unconst_u32(337)][0][0][unconst_u32(644)][unconst_u32(191)][unconst_u32(381)][0][unconst_u32(39)][0][0])][0][0][0])][0][0])][unconst_u32(222)][0][0][unconst_u32(428)][0][0][unconst_u32(483)][unconst_u32(302)], buffer95[unconst_u32(307)][5][u32((*&buffer95)[15][5][0][unconst_u32(344)][0][unconst_u32(141)][0][16][0][0][0][0])][u32(buffer95[unconst_u32(1)][5][unconst_u32(33)][0][unconst_u32(193)][unconst_u32(35)][unconst_u32(144)][unconst_u32(133)][unconst_u32(394)][u32((*&buffer95)[15][unconst_u32(59)][0][unconst_u32(570)][unconst_u32(120)][unconst_u32(86)][u32((*&buffer95)[unconst_u32(128)][5][unconst_u32(285)][unconst_u32(137)][unconst_u32(43)][unconst_u32(88)][0][unconst_u32(3)][0][0][unconst_u32(294)][unconst_u32(187)])][unconst_u32(120)][u32(buffer95[15][5][unconst_u32(337)][0][0][unconst_u32(644)][unconst_u32(191)][unconst_u32(381)][0][unconst_u32(39)][0][0])][0][0][0])][0][0])][unconst_u32(222)][0][0][unconst_u32(428)][0][0][unconst_u32(483)][unconst_u32(302)]);
+  vp3 += mat2x3h((*&buffer95)[15][5][unconst_u32(416)][0][0][unconst_u32(31)][unconst_u32(527)][unconst_u32(200)][unconst_u32(296)][unconst_u32(286)][0][0], (*&buffer95)[15][5][unconst_u32(416)][0][0][unconst_u32(31)][unconst_u32(527)][unconst_u32(200)][unconst_u32(296)][unconst_u32(286)][0][0], (*&buffer95)[15][5][unconst_u32(416)][0][0][unconst_u32(31)][unconst_u32(527)][unconst_u32(200)][unconst_u32(296)][unconst_u32(286)][0][0], (*&buffer95)[15][5][unconst_u32(416)][0][0][unconst_u32(31)][unconst_u32(527)][unconst_u32(200)][unconst_u32(296)][unconst_u32(286)][0][0], (*&buffer95)[15][5][unconst_u32(416)][0][0][unconst_u32(31)][unconst_u32(527)][unconst_u32(200)][unconst_u32(296)][unconst_u32(286)][0][0], (*&buffer95)[15][5][unconst_u32(416)][0][0][unconst_u32(31)][unconst_u32(527)][unconst_u32(200)][unconst_u32(296)][unconst_u32(286)][0][0]);
+  let ptr66: ptr<storage, f16, read> = &(*&buffer95)[unconst_u32(165)][5][unconst_u32(54)][unconst_u32(12)][0][0][0][16][u32((*&buffer95)[unconst_u32(9)][unconst_u32(164)][unconst_u32(89)][0][0][u32((*&buffer95)[15][unconst_u32(15)][0][unconst_u32(476)][0][0][unconst_u32(131)][unconst_u32(261)][0][0][0][0])][0][unconst_u32(33)][u32(buffer95[15][5][unconst_u32(49)][0][unconst_u32(235)][unconst_u32(127)][unconst_u32(62)][unconst_u32(615)][unconst_u32(217)][0][0][0])][0][0][0])][unconst_u32(155)][0][unconst_u32(129)];
+  _ = buffer95;
+}
+  switch i32(buffer95[unconst_u32(129)][5][u32((*&buffer95)[unconst_u32(115)][5][0][unconst_u32(113)][unconst_u32(40)][0][unconst_u32(0)][u32((*&buffer95)[15][5][0][0][unconst_u32(15)][unconst_u32(26)][unconst_u32(69)][16][unconst_u32(284)][0][unconst_u32(248)][0])][0][unconst_u32(45)][unconst_u32(167)][0])][0][0][0][unconst_u32(128)][16][0][unconst_u32(297)][unconst_u32(458)][0]) { 
+  default {
+  let ptr67: ptr<storage, f16, read> = &buffer95[15][5][0][unconst_u32(437)][0][u32(buffer95[u32((*&buffer95)[unconst_u32(59)][unconst_u32(448)][unconst_u32(222)][unconst_u32(169)][unconst_u32(52)][unconst_u32(416)][unconst_u32(85)][unconst_u32(25)][0][u32(buffer95[unconst_u32(39)][unconst_u32(139)][0][u32((*&buffer95)[15][5][0][unconst_u32(648)][unconst_u32(625)][unconst_u32(179)][0][16][unconst_u32(101)][0][0][0])][0][unconst_u32(24)][unconst_u32(293)][unconst_u32(85)][unconst_u32(7)][unconst_u32(107)][unconst_u32(76)][unconst_u32(148)])][0][unconst_u32(12)])][5][0][unconst_u32(101)][0][u32((*&buffer95)[unconst_u32(1)][unconst_u32(25)][unconst_u32(519)][unconst_u32(58)][0][unconst_u32(27)][unconst_u32(127)][16][0][0][0][0])][unconst_u32(22)][unconst_u32(116)][unconst_u32(25)][0][0][unconst_u32(200)])][0][unconst_u32(8)][0][unconst_u32(4)][unconst_u32(235)][unconst_u32(193)];
+  out = mat2x2h(buffer95[unconst_u32(22)][unconst_u32(407)][0][unconst_u32(176)][0][unconst_u32(137)][u32(buffer95[15][unconst_u32(269)][0][0][0][unconst_u32(112)][unconst_u32(11)][unconst_u32(253)][unconst_u32(32)][unconst_u32(122)][0][unconst_u32(250)])][16][0][0][unconst_u32(286)][0], buffer95[unconst_u32(22)][unconst_u32(407)][0][unconst_u32(176)][0][unconst_u32(137)][u32(buffer95[15][unconst_u32(269)][0][0][0][unconst_u32(112)][unconst_u32(11)][unconst_u32(253)][unconst_u32(32)][unconst_u32(122)][0][unconst_u32(250)])][16][0][0][unconst_u32(286)][0], buffer95[unconst_u32(22)][unconst_u32(407)][0][unconst_u32(176)][0][unconst_u32(137)][u32(buffer95[15][unconst_u32(269)][0][0][0][unconst_u32(112)][unconst_u32(11)][unconst_u32(253)][unconst_u32(32)][unconst_u32(122)][0][unconst_u32(250)])][16][0][0][unconst_u32(286)][0], buffer95[unconst_u32(22)][unconst_u32(407)][0][unconst_u32(176)][0][unconst_u32(137)][u32(buffer95[15][unconst_u32(269)][0][0][0][unconst_u32(112)][unconst_u32(11)][unconst_u32(253)][unconst_u32(32)][unconst_u32(122)][0][unconst_u32(250)])][16][0][0][unconst_u32(286)][0]);
+  vp3 = mat2x3h(buffer95[unconst_u32(116)][5][0][0][0][0][0][16][0][u32((*&buffer95)[unconst_u32(35)][5][0][unconst_u32(9)][0][0][0][unconst_u32(2)][0][0][0][0])][unconst_u32(321)][0], buffer95[unconst_u32(116)][5][0][0][0][0][0][16][0][u32((*&buffer95)[unconst_u32(35)][5][0][unconst_u32(9)][0][0][0][unconst_u32(2)][0][0][0][0])][unconst_u32(321)][0], buffer95[unconst_u32(116)][5][0][0][0][0][0][16][0][u32((*&buffer95)[unconst_u32(35)][5][0][unconst_u32(9)][0][0][0][unconst_u32(2)][0][0][0][0])][unconst_u32(321)][0], buffer95[unconst_u32(116)][5][0][0][0][0][0][16][0][u32((*&buffer95)[unconst_u32(35)][5][0][unconst_u32(9)][0][0][0][unconst_u32(2)][0][0][0][0])][unconst_u32(321)][0], buffer95[unconst_u32(116)][5][0][0][0][0][0][16][0][u32((*&buffer95)[unconst_u32(35)][5][0][unconst_u32(9)][0][0][0][unconst_u32(2)][0][0][0][0])][unconst_u32(321)][0], buffer95[unconst_u32(116)][5][0][0][0][0][0][16][0][u32((*&buffer95)[unconst_u32(35)][5][0][unconst_u32(9)][0][0][0][unconst_u32(2)][0][0][0][0])][unconst_u32(321)][0]);
+  let ptr68: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &buffer95[15][unconst_u32(242)][unconst_u32(80)][0][unconst_u32(183)][0][0][16][unconst_u32(263)];
+  break;
+  _ = buffer95;
+}
+  }
+  let ptr69: ptr<storage, f16, read> = &(*&buffer95)[15][unconst_u32(344)][0][unconst_u32(8)][0][0][0][16][unconst_u32(162)][u32((*&buffer95)[15][5][unconst_u32(310)][0][0][u32(buffer95[unconst_u32(174)][5][0][0][unconst_u32(17)][u32(buffer95[unconst_u32(117)][unconst_u32(27)][0][0][unconst_u32(342)][unconst_u32(106)][0][16][unconst_u32(886)][0][0][0])][0][unconst_u32(130)][unconst_u32(272)][u32((*&buffer95)[unconst_u32(25)][unconst_u32(23)][unconst_u32(13)][0][unconst_u32(4)][0][unconst_u32(272)][unconst_u32(309)][unconst_u32(263)][unconst_u32(239)][0][0])][0][u32(buffer95[15][5][0][0][0][0][0][unconst_u32(36)][0][0][0][unconst_u32(79)])])][0][unconst_u32(4)][0][0][0][0])][0][0];
+  let ptr70: ptr<storage, f16, read> = &(*&buffer95)[unconst_u32(29)][unconst_u32(126)][0][unconst_u32(11)][unconst_u32(146)][0][0][16][unconst_u32(131)][0][unconst_u32(97)][unconst_u32(267)];
+  loop {
+  let ptr71: ptr<storage, f16, read> = &(*&buffer95)[15][unconst_u32(611)][0][unconst_u32(74)][0][unconst_u32(162)][0][16][0][0][0][0];
+  let ptr72: ptr<storage, array<f16, 1>, read> = &buffer95[unconst_u32(327)][5][0][0][unconst_u32(236)][unconst_u32(146)][0][unconst_u32(31)][unconst_u32(321)][unconst_u32(95)][0];
+  vp3 = mat2x3h((*&buffer95)[15][unconst_u32(197)][0][unconst_u32(28)][unconst_u32(114)][0][0][unconst_u32(6)][unconst_u32(30)][0][0][0], (*&buffer95)[15][unconst_u32(197)][0][unconst_u32(28)][unconst_u32(114)][0][0][unconst_u32(6)][unconst_u32(30)][0][0][0], (*&buffer95)[15][unconst_u32(197)][0][unconst_u32(28)][unconst_u32(114)][0][0][unconst_u32(6)][unconst_u32(30)][0][0][0], (*&buffer95)[15][unconst_u32(197)][0][unconst_u32(28)][unconst_u32(114)][0][0][unconst_u32(6)][unconst_u32(30)][0][0][0], (*&buffer95)[15][unconst_u32(197)][0][unconst_u32(28)][unconst_u32(114)][0][0][unconst_u32(6)][unconst_u32(30)][0][0][0], (*&buffer95)[15][unconst_u32(197)][0][unconst_u32(28)][unconst_u32(114)][0][0][unconst_u32(6)][unconst_u32(30)][0][0][0]);
+  let ptr73: ptr<storage, f16, read> = &buffer95[unconst_u32(121)][5][unconst_u32(12)][0][0][0][0][unconst_u32(75)][0][0][unconst_u32(124)][0];
+  break;
+  _ = buffer95;
+}
+  let ptr74: ptr<storage, array<f16, 1>, read> = &(*&buffer95)[unconst_u32(267)][unconst_u32(397)][0][0][unconst_u32(8)][0][0][16][0][0][0];
+  let ptr75: ptr<storage, f16, read> = &buffer95[unconst_u32(138)][5][unconst_u32(45)][0][0][0][unconst_u32(150)][16][0][0][0][0];
+  let ptr76: ptr<storage, array<array<f16, 1>, 1>, read> = &(*&buffer95)[u32(buffer95[unconst_u32(187)][5][unconst_u32(24)][unconst_u32(515)][u32(buffer95[15][5][0][0][0][0][0][16][0][u32((*&buffer95)[unconst_u32(156)][5][0][unconst_u32(7)][0][0][unconst_u32(230)][16][unconst_u32(108)][0][unconst_u32(57)][unconst_u32(1)])][0][0])][0][0][unconst_u32(154)][0][0][0][unconst_u32(5)])][5][0][unconst_u32(76)][0][0][unconst_u32(446)][unconst_u32(38)][unconst_u32(165)][unconst_u32(577)];
+  let ptr77: ptr<storage, array<array<f16, 1>, 1>, read> = &(*&buffer95)[15][unconst_u32(146)][unconst_u32(266)][u32(buffer95[15][unconst_u32(6)][unconst_u32(202)][0][unconst_u32(5)][unconst_u32(65)][0][16][unconst_u32(312)][u32(buffer95[unconst_u32(168)][unconst_u32(39)][0][unconst_u32(166)][unconst_u32(113)][0][unconst_u32(279)][16][0][unconst_u32(49)][0][0])][0][0])][0][0][unconst_u32(115)][u32((*&buffer95)[unconst_u32(33)][unconst_u32(185)][0][0][unconst_u32(91)][0][0][16][0][0][u32((*&buffer95)[unconst_u32(13)][unconst_u32(324)][0][0][0][0][0][16][0][unconst_u32(260)][0][unconst_u32(201)])][unconst_u32(29)])][unconst_u32(524)][0];
+  out = mat2x2h(buffer95[unconst_u32(141)][5][unconst_u32(176)][0][u32(buffer95[unconst_u32(94)][5][0][0][unconst_u32(174)][0][0][16][0][unconst_u32(139)][0][0])][unconst_u32(266)][0][unconst_u32(21)][0][0][unconst_u32(230)][unconst_u32(112)], buffer95[unconst_u32(141)][5][unconst_u32(176)][0][u32(buffer95[unconst_u32(94)][5][0][0][unconst_u32(174)][0][0][16][0][unconst_u32(139)][0][0])][unconst_u32(266)][0][unconst_u32(21)][0][0][unconst_u32(230)][unconst_u32(112)], buffer95[unconst_u32(141)][5][unconst_u32(176)][0][u32(buffer95[unconst_u32(94)][5][0][0][unconst_u32(174)][0][0][16][0][unconst_u32(139)][0][0])][unconst_u32(266)][0][unconst_u32(21)][0][0][unconst_u32(230)][unconst_u32(112)], buffer95[unconst_u32(141)][5][unconst_u32(176)][0][u32(buffer95[unconst_u32(94)][5][0][0][unconst_u32(174)][0][0][16][0][unconst_u32(139)][0][0])][unconst_u32(266)][0][unconst_u32(21)][0][0][unconst_u32(230)][unconst_u32(112)]);
+  switch i32((*&buffer95)[unconst_u32(394)][unconst_u32(92)][0][unconst_u32(690)][u32(buffer95[unconst_u32(124)][5][unconst_u32(34)][0][unconst_u32(156)][0][unconst_u32(224)][16][0][unconst_u32(317)][0][0])][unconst_u32(116)][0][unconst_u32(89)][unconst_u32(69)][0][0][0]) { 
+  default {
+  out = mat2x2h((*&buffer95)[unconst_u32(39)][5][unconst_u32(53)][0][unconst_u32(263)][0][unconst_u32(136)][16][unconst_u32(108)][unconst_u32(150)][unconst_u32(454)][0], (*&buffer95)[unconst_u32(39)][5][unconst_u32(53)][0][unconst_u32(263)][0][unconst_u32(136)][16][unconst_u32(108)][unconst_u32(150)][unconst_u32(454)][0], (*&buffer95)[unconst_u32(39)][5][unconst_u32(53)][0][unconst_u32(263)][0][unconst_u32(136)][16][unconst_u32(108)][unconst_u32(150)][unconst_u32(454)][0], (*&buffer95)[unconst_u32(39)][5][unconst_u32(53)][0][unconst_u32(263)][0][unconst_u32(136)][16][unconst_u32(108)][unconst_u32(150)][unconst_u32(454)][0]);
+  _ = buffer95;
+}
+  }
+  let ptr78: ptr<storage, array<array<array<array<f16, 1>, 1>, 1>, 1>, read> = &(*&buffer95)[unconst_u32(259)][5][unconst_u32(60)][unconst_u32(533)][unconst_u32(226)][u32((*&buffer95)[15][unconst_u32(214)][unconst_u32(195)][unconst_u32(423)][unconst_u32(112)][unconst_u32(99)][unconst_u32(179)][unconst_u32(42)][unconst_u32(49)][0][0][0])][unconst_u32(382)][16];
+  let ptr79: ptr<storage, f16, read> = &(*&buffer95)[15][5][unconst_u32(4)][unconst_u32(30)][0][0][0][unconst_u32(93)][unconst_u32(21)][u32((*&buffer95)[15][5][0][unconst_u32(28)][0][unconst_u32(177)][unconst_u32(81)][unconst_u32(211)][0][0][unconst_u32(85)][0])][unconst_u32(44)][unconst_u32(31)];
+  return out;
+  _ = buffer95;
+}
+
+@group(0) @binding(578) var<storage, read> buffer95: array<array<array<array<array<array<array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 17>, 1>, 1>, 1>, 1>, 1>, 6>, 16>;
+
+var<workgroup> vw26: atomic<u32>;
+
+var<workgroup> vw25: vec4u;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp3: mat2x3h = mat2x3h();
+
+/* used global variables: buffer95 */
+fn fn3(a0: array<FragmentOutput5, 1>) -> mat4x3h {
+  var out: mat4x3h;
+  let ptr92: ptr<storage, array<array<f16, 1>, 1>, read> = &buffer95[15][unconst_u32(102)][unconst_u32(291)][u32((*&buffer95)[15][5][0][0][unconst_u32(90)][u32(buffer95[u32(buffer95[unconst_u32(207)][unconst_u32(561)][unconst_u32(90)][0][unconst_u32(242)][0][u32(buffer95[15][5][0][0][unconst_u32(78)][0][unconst_u32(150)][16][0][0][0][0])][unconst_u32(25)][0][0][unconst_u32(130)][0])][unconst_u32(171)][u32(buffer95[15][5][0][0][0][u32((*&buffer95)[unconst_u32(176)][5][0][unconst_u32(536)][0][0][0][16][unconst_u32(49)][0][0][0])][unconst_u32(29)][16][0][unconst_u32(153)][0][0])][unconst_u32(253)][0][0][unconst_u32(8)][unconst_u32(145)][0][unconst_u32(210)][unconst_u32(140)][0])][0][unconst_u32(355)][unconst_u32(54)][0][0][0])][unconst_u32(1)][unconst_u32(135)][u32(buffer95[unconst_u32(7)][unconst_u32(126)][0][0][0][0][0][16][u32(buffer95[15][unconst_u32(8)][0][0][0][unconst_u32(181)][unconst_u32(53)][16][0][0][0][0])][0][unconst_u32(58)][0])][u32(buffer95[unconst_u32(166)][unconst_u32(0)][0][unconst_u32(196)][0][0][0][unconst_u32(605)][unconst_u32(120)][unconst_u32(16)][0][0])][0][unconst_u32(3)];
+  return out;
+  _ = buffer95;
+}
+
+/* used global variables: buffer95 */
+@must_use 
+fn fn0() -> vec4h {
+  var out: vec4h;
+  for (var it5=u32(buffer95[unconst_u32(49)][5][0][unconst_u32(22)][unconst_u32(100)][0][0][unconst_u32(48)][0][0][0][0]); it5<u32((*&buffer95)[unconst_u32(243)][unconst_u32(231)][unconst_u32(220)][0][0][unconst_u32(78)][unconst_u32(121)][unconst_u32(20)][0][unconst_u32(81)][unconst_u32(501)][0]); it5++) {
+  vp3 = mat2x3h((*&buffer95)[15][unconst_u32(111)][0][0][0][0][unconst_u32(333)][unconst_u32(506)][0][unconst_u32(152)][u32((*&buffer95)[15][unconst_u32(67)][unconst_u32(92)][0][unconst_u32(562)][0][0][16][unconst_u32(489)][0][0][0])][0], (*&buffer95)[15][unconst_u32(111)][0][0][0][0][unconst_u32(333)][unconst_u32(506)][0][unconst_u32(152)][u32((*&buffer95)[15][unconst_u32(67)][unconst_u32(92)][0][unconst_u32(562)][0][0][16][unconst_u32(489)][0][0][0])][0], (*&buffer95)[15][unconst_u32(111)][0][0][0][0][unconst_u32(333)][unconst_u32(506)][0][unconst_u32(152)][u32((*&buffer95)[15][unconst_u32(67)][unconst_u32(92)][0][unconst_u32(562)][0][0][16][unconst_u32(489)][0][0][0])][0], (*&buffer95)[15][unconst_u32(111)][0][0][0][0][unconst_u32(333)][unconst_u32(506)][0][unconst_u32(152)][u32((*&buffer95)[15][unconst_u32(67)][unconst_u32(92)][0][unconst_u32(562)][0][0][16][unconst_u32(489)][0][0][0])][0], (*&buffer95)[15][unconst_u32(111)][0][0][0][0][unconst_u32(333)][unconst_u32(506)][0][unconst_u32(152)][u32((*&buffer95)[15][unconst_u32(67)][unconst_u32(92)][0][unconst_u32(562)][0][0][16][unconst_u32(489)][0][0][0])][0], (*&buffer95)[15][unconst_u32(111)][0][0][0][0][unconst_u32(333)][unconst_u32(506)][0][unconst_u32(152)][u32((*&buffer95)[15][unconst_u32(67)][unconst_u32(92)][0][unconst_u32(562)][0][0][16][unconst_u32(489)][0][0][0])][0]);
+  let ptr65: ptr<storage, array<f16, 1>, read> = &(*&buffer95)[unconst_u32(380)][5][unconst_u32(108)][unconst_u32(335)][unconst_u32(21)][unconst_u32(18)][unconst_u32(285)][16][0][unconst_u32(188)][unconst_u32(22)];
+  return out;
+  _ = buffer95;
+}
+  return out;
+  _ = buffer95;
+}
+
+var<workgroup> vw21: array<vec2f, 26>;
+
+@id(13179) override override8 = false;
+
+/* used global variables: buffer95 */
+fn fn4(a0: ptr<function, array<array<vec4u, 9>, 1>>) -> mat3x2f {
+  var out: mat3x2f;
+  {
+  (*a0)[unconst_u32(110)][unconst_u32(98)] -= vec4u(u32(buffer95[15][5][0][0][unconst_u32(495)][0][0][16][unconst_u32(204)][unconst_u32(459)][unconst_u32(37)][0]));
+  (*a0)[unconst_u32(452)][unconst_u32(53)] = vec4u(u32(buffer95[15][unconst_u32(13)][unconst_u32(27)][unconst_u32(32)][0][unconst_u32(66)][0][16][unconst_u32(31)][0][0][0]));
+  out = mat3x2f(f32(buffer95[15][unconst_u32(11)][0][unconst_u32(93)][0][unconst_u32(470)][0][16][unconst_u32(197)][unconst_u32(44)][0][unconst_u32(250)]), f32(buffer95[15][unconst_u32(11)][0][unconst_u32(93)][0][unconst_u32(470)][0][16][unconst_u32(197)][unconst_u32(44)][0][unconst_u32(250)]), f32(buffer95[15][unconst_u32(11)][0][unconst_u32(93)][0][unconst_u32(470)][0][16][unconst_u32(197)][unconst_u32(44)][0][unconst_u32(250)]), f32(buffer95[15][unconst_u32(11)][0][unconst_u32(93)][0][unconst_u32(470)][0][16][unconst_u32(197)][unconst_u32(44)][0][unconst_u32(250)]), f32(buffer95[15][unconst_u32(11)][0][unconst_u32(93)][0][unconst_u32(470)][0][16][unconst_u32(197)][unconst_u32(44)][0][unconst_u32(250)]), f32(buffer95[15][unconst_u32(11)][0][unconst_u32(93)][0][unconst_u32(470)][0][16][unconst_u32(197)][unconst_u32(44)][0][unconst_u32(250)]));
+  fn3(array<FragmentOutput5, 1>(FragmentOutput5(unpack4xU8(u32(buffer95[15][unconst_u32(132)][0][0][unconst_u32(168)][unconst_u32(67)][unconst_u32(237)][16][unconst_u32(12)][unconst_u32(447)][unconst_u32(35)][unconst_u32(57)])))));
+  fn3(array<FragmentOutput5, 1>(FragmentOutput5(vec4u(u32((*&buffer95)[15][u32((*&buffer95)[15][5][0][unconst_u32(386)][0][unconst_u32(570)][0][16][unconst_u32(160)][unconst_u32(63)][0][0])][0][0][unconst_u32(63)][unconst_u32(91)][unconst_u32(28)][16][unconst_u32(22)][unconst_u32(109)][0][0])))));
+  (*a0)[unconst_u32(118)][unconst_u32(342)] = vec4u(u32(buffer95[unconst_u32(49)][unconst_u32(5)][unconst_u32(211)][unconst_u32(729)][unconst_u32(335)][unconst_u32(450)][unconst_u32(2)][16][0][unconst_u32(372)][0][0]));
+  _ = buffer95;
+}
+  (*a0)[unconst_u32(61)][unconst_u32(343)] *= vec4u(u32((*&buffer95)[15][unconst_u32(686)][0][0][0][unconst_u32(95)][0][unconst_u32(187)][unconst_u32(203)][0][0][0]));
+  switch i32(buffer95[15][u32(buffer95[unconst_u32(648)][unconst_u32(121)][0][0][0][unconst_u32(16)][unconst_u32(360)][unconst_u32(170)][unconst_u32(23)][0][0][0])][0][0][0][0][unconst_u32(450)][unconst_u32(508)][unconst_u32(225)][0][0][unconst_u32(61)]) { 
+  default {
+  out = mat3x2f(f32((*&buffer95)[unconst_u32(328)][unconst_u32(489)][0][unconst_u32(357)][unconst_u32(546)][unconst_u32(152)][0][16][0][0][0][0]), f32((*&buffer95)[unconst_u32(328)][unconst_u32(489)][0][unconst_u32(357)][unconst_u32(546)][unconst_u32(152)][0][16][0][0][0][0]), f32((*&buffer95)[unconst_u32(328)][unconst_u32(489)][0][unconst_u32(357)][unconst_u32(546)][unconst_u32(152)][0][16][0][0][0][0]), f32((*&buffer95)[unconst_u32(328)][unconst_u32(489)][0][unconst_u32(357)][unconst_u32(546)][unconst_u32(152)][0][16][0][0][0][0]), f32((*&buffer95)[unconst_u32(328)][unconst_u32(489)][0][unconst_u32(357)][unconst_u32(546)][unconst_u32(152)][0][16][0][0][0][0]), f32((*&buffer95)[unconst_u32(328)][unconst_u32(489)][0][unconst_u32(357)][unconst_u32(546)][unconst_u32(152)][0][16][0][0][0][0]));
+  let ptr93: ptr<storage, array<array<array<array<f16, 1>, 1>, 1>, 1>, read> = &(*&buffer95)[15][5][unconst_u32(132)][unconst_u32(208)][0][0][unconst_u32(50)][unconst_u32(275)];
+  let ptr94: ptr<storage, array<f16, 1>, read> = &(*&buffer95)[u32(buffer95[u32((*&buffer95)[15][unconst_u32(368)][0][unconst_u32(17)][unconst_u32(599)][0][0][unconst_u32(7)][0][unconst_u32(138)][unconst_u32(132)][0])][unconst_u32(120)][unconst_u32(639)][0][unconst_u32(16)][unconst_u32(477)][0][16][unconst_u32(89)][0][unconst_u32(239)][u32(buffer95[15][5][unconst_u32(98)][unconst_u32(30)][unconst_u32(185)][unconst_u32(82)][unconst_u32(147)][16][0][unconst_u32(7)][0][0])])][unconst_u32(88)][u32((*&buffer95)[15][5][unconst_u32(113)][0][u32(buffer95[unconst_u32(223)][unconst_u32(204)][0][0][0][0][0][unconst_u32(113)][unconst_u32(276)][0][0][unconst_u32(53)])][unconst_u32(59)][0][unconst_u32(190)][0][unconst_u32(33)][0][unconst_u32(127)])][0][unconst_u32(44)][unconst_u32(36)][unconst_u32(110)][unconst_u32(129)][u32((*&buffer95)[15][5][0][unconst_u32(2)][0][0][0][unconst_u32(190)][0][0][0][0])][unconst_u32(32)][0];
+  break;
+  _ = buffer95;
+}
+  }
+  let ptr95: ptr<storage, f16, read> = &(*&buffer95)[15][5][unconst_u32(38)][0][0][unconst_u32(190)][unconst_u32(7)][u32(buffer95[15][5][unconst_u32(64)][unconst_u32(66)][unconst_u32(106)][unconst_u32(459)][unconst_u32(93)][unconst_u32(79)][unconst_u32(478)][unconst_u32(39)][0][0])][0][0][u32(buffer95[unconst_u32(180)][5][unconst_u32(359)][unconst_u32(237)][0][unconst_u32(288)][0][unconst_u32(13)][unconst_u32(22)][unconst_u32(42)][0][0])][0];
+  out = mat3x2f(f32((*&buffer95)[15][5][0][u32(buffer95[unconst_u32(106)][5][0][unconst_u32(179)][unconst_u32(70)][0][unconst_u32(103)][unconst_u32(353)][0][0][0][0])][0][unconst_u32(212)][0][unconst_u32(29)][0][0][unconst_u32(76)][0]), f32((*&buffer95)[15][5][0][u32(buffer95[unconst_u32(106)][5][0][unconst_u32(179)][unconst_u32(70)][0][unconst_u32(103)][unconst_u32(353)][0][0][0][0])][0][unconst_u32(212)][0][unconst_u32(29)][0][0][unconst_u32(76)][0]), f32((*&buffer95)[15][5][0][u32(buffer95[unconst_u32(106)][5][0][unconst_u32(179)][unconst_u32(70)][0][unconst_u32(103)][unconst_u32(353)][0][0][0][0])][0][unconst_u32(212)][0][unconst_u32(29)][0][0][unconst_u32(76)][0]), f32((*&buffer95)[15][5][0][u32(buffer95[unconst_u32(106)][5][0][unconst_u32(179)][unconst_u32(70)][0][unconst_u32(103)][unconst_u32(353)][0][0][0][0])][0][unconst_u32(212)][0][unconst_u32(29)][0][0][unconst_u32(76)][0]), f32((*&buffer95)[15][5][0][u32(buffer95[unconst_u32(106)][5][0][unconst_u32(179)][unconst_u32(70)][0][unconst_u32(103)][unconst_u32(353)][0][0][0][0])][0][unconst_u32(212)][0][unconst_u32(29)][0][0][unconst_u32(76)][0]), f32((*&buffer95)[15][5][0][u32(buffer95[unconst_u32(106)][5][0][unconst_u32(179)][unconst_u32(70)][0][unconst_u32(103)][unconst_u32(353)][0][0][0][0])][0][unconst_u32(212)][0][unconst_u32(29)][0][0][unconst_u32(76)][0]));
+  return out;
+  _ = buffer95;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T1 {
+  @align(32) @size(1984) f0: array<u32>,
+}
+
+var<workgroup> vw22: atomic<u32>;
+
+struct T2 {
+  f0: T0,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw20: array<array<atomic<u32>, 1>, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput5 {
+  @location(0) f0: vec4u,
+}
+
+/* used global variables: buffer95 */
+fn fn2(a0: mat3x3f) -> i32 {
+  var out: i32;
+  out = i32(buffer95[15][5][0][unconst_u32(595)][unconst_u32(168)][0][unconst_u32(624)][16][0][unconst_u32(165)][0][0]);
+  let ptr80: ptr<storage, f16, read> = &(*&buffer95)[15][unconst_u32(92)][unconst_u32(3)][0][unconst_u32(56)][unconst_u32(40)][unconst_u32(5)][unconst_u32(104)][unconst_u32(134)][unconst_u32(61)][unconst_u32(63)][0];
+  if bool((*&buffer95)[15][5][0][unconst_u32(96)][unconst_u32(204)][unconst_u32(45)][0][16][unconst_u32(22)][0][0][unconst_u32(365)]) {
+  while bool(buffer95[15][5][0][0][unconst_u32(143)][0][0][unconst_u32(78)][unconst_u32(181)][0][unconst_u32(143)][unconst_u32(74)]) {
+  out = i32(buffer95[unconst_u32(796)][unconst_u32(125)][unconst_u32(203)][0][0][0][unconst_u32(24)][16][u32(buffer95[unconst_u32(172)][5][0][unconst_u32(65)][0][unconst_u32(100)][0][unconst_u32(679)][0][0][0][0])][unconst_u32(76)][0][0]);
+  let ptr81: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &buffer95[15][5][0][unconst_u32(270)][unconst_u32(16)][0][0][16][0];
+  break;
+  _ = buffer95;
+}
+  let ptr82: ptr<storage, array<array<array<array<array<array<f16, 1>, 1>, 1>, 1>, 17>, 1>, read> = &(*&buffer95)[unconst_u32(116)][unconst_u32(11)][0][unconst_u32(168)][0][unconst_u32(27)];
+  _ = buffer95;
+}
+  let ptr83: ptr<storage, f16, read> = &(*&buffer95)[unconst_u32(169)][5][0][0][0][0][0][unconst_u32(323)][unconst_u32(32)][unconst_u32(377)][unconst_u32(37)][unconst_u32(112)];
+  let ptr84: ptr<storage, array<array<f16, 1>, 1>, read> = &(*&buffer95)[unconst_u32(110)][unconst_u32(863)][0][unconst_u32(224)][unconst_u32(402)][unconst_u32(3)][unconst_u32(186)][unconst_u32(276)][unconst_u32(417)][unconst_u32(85)];
+  vp3 = mat2x3h(buffer95[15][unconst_u32(236)][0][0][0][0][unconst_u32(73)][16][unconst_u32(152)][0][0][0], buffer95[15][unconst_u32(236)][0][0][0][0][unconst_u32(73)][16][unconst_u32(152)][0][0][0], buffer95[15][unconst_u32(236)][0][0][0][0][unconst_u32(73)][16][unconst_u32(152)][0][0][0], buffer95[15][unconst_u32(236)][0][0][0][0][unconst_u32(73)][16][unconst_u32(152)][0][0][0], buffer95[15][unconst_u32(236)][0][0][0][0][unconst_u32(73)][16][unconst_u32(152)][0][0][0], buffer95[15][unconst_u32(236)][0][0][0][0][unconst_u32(73)][16][unconst_u32(152)][0][0][0]);
+  let ptr85: ptr<storage, array<array<f16, 1>, 1>, read> = &buffer95[15][unconst_u32(18)][0][unconst_u32(12)][0][0][unconst_u32(115)][16][unconst_u32(120)][0];
+  if bool(buffer95[15][5][unconst_u32(536)][unconst_u32(12)][unconst_u32(173)][unconst_u32(107)][0][u32(buffer95[unconst_u32(130)][unconst_u32(1)][unconst_u32(558)][unconst_u32(739)][0][unconst_u32(236)][unconst_u32(712)][unconst_u32(76)][unconst_u32(19)][unconst_u32(42)][0][0])][0][unconst_u32(41)][0][0]) {
+  let ptr86: ptr<storage, array<f16, 1>, read> = &buffer95[15][5][unconst_u32(74)][0][0][unconst_u32(430)][unconst_u32(43)][unconst_u32(113)][0][0][u32(buffer95[unconst_u32(353)][5][unconst_u32(19)][0][0][0][0][unconst_u32(31)][0][unconst_u32(0)][0][0])];
+  vp3 += mat2x3h(buffer95[15][5][0][unconst_u32(271)][0][0][0][unconst_u32(55)][unconst_u32(275)][0][0][0], buffer95[15][5][0][unconst_u32(271)][0][0][0][unconst_u32(55)][unconst_u32(275)][0][0][0], buffer95[15][5][0][unconst_u32(271)][0][0][0][unconst_u32(55)][unconst_u32(275)][0][0][0], buffer95[15][5][0][unconst_u32(271)][0][0][0][unconst_u32(55)][unconst_u32(275)][0][0][0], buffer95[15][5][0][unconst_u32(271)][0][0][0][unconst_u32(55)][unconst_u32(275)][0][0][0], buffer95[15][5][0][unconst_u32(271)][0][0][0][unconst_u32(55)][unconst_u32(275)][0][0][0]);
+  loop {
+  let ptr87: ptr<storage, array<f16, 1>, read> = &buffer95[15][5][unconst_u32(15)][unconst_u32(482)][0][0][0][16][0][0][0];
+  out &= i32(buffer95[u32(buffer95[15][5][u32(buffer95[15][5][0][0][0][0][0][16][0][0][0][0])][unconst_u32(364)][0][0][0][unconst_u32(310)][unconst_u32(54)][0][0][0])][5][0][0][0][0][unconst_u32(97)][16][0][0][0][unconst_u32(169)]);
+  break;
+  _ = buffer95;
+}
+  if bool((*&buffer95)[15][5][0][unconst_u32(4)][0][unconst_u32(107)][u32((*&buffer95)[15][5][0][0][unconst_u32(51)][unconst_u32(324)][unconst_u32(13)][unconst_u32(4)][unconst_u32(65)][unconst_u32(356)][0][0])][unconst_u32(163)][unconst_u32(223)][unconst_u32(302)][0][0]) {
+  out |= i32((*&buffer95)[15][5][0][0][0][unconst_u32(339)][0][unconst_u32(74)][unconst_u32(26)][0][unconst_u32(1)][0]);
+  let ptr88: ptr<storage, array<f16, 1>, read> = &(*&buffer95)[15][5][0][0][0][0][0][unconst_u32(57)][unconst_u32(323)][0][0];
+  out -= i32((*&buffer95)[15][5][0][0][0][0][0][unconst_u32(113)][unconst_u32(274)][unconst_u32(36)][0][0]);
+  vp3 = mat2x3h((*&buffer95)[unconst_u32(701)][5][unconst_u32(81)][unconst_u32(9)][u32(buffer95[15][u32((*&buffer95)[15][unconst_u32(16)][u32((*&buffer95)[15][5][0][0][unconst_u32(238)][unconst_u32(33)][unconst_u32(54)][unconst_u32(82)][unconst_u32(28)][unconst_u32(5)][unconst_u32(90)][0])][0][unconst_u32(138)][0][0][16][unconst_u32(403)][0][unconst_u32(494)][unconst_u32(150)])][unconst_u32(227)][unconst_u32(106)][0][0][unconst_u32(44)][unconst_u32(199)][u32((*&buffer95)[15][5][0][unconst_u32(346)][u32(buffer95[15][5][unconst_u32(56)][unconst_u32(18)][unconst_u32(76)][unconst_u32(107)][0][16][unconst_u32(131)][0][0][0])][0][0][unconst_u32(27)][unconst_u32(6)][0][unconst_u32(413)][u32((*&buffer95)[unconst_u32(21)][5][unconst_u32(424)][unconst_u32(39)][0][0][unconst_u32(22)][16][0][unconst_u32(96)][0][unconst_u32(490)])])][0][0][0])][unconst_u32(34)][unconst_u32(181)][16][unconst_u32(37)][unconst_u32(181)][unconst_u32(202)][0], (*&buffer95)[unconst_u32(701)][5][unconst_u32(81)][unconst_u32(9)][u32(buffer95[15][u32((*&buffer95)[15][unconst_u32(16)][u32((*&buffer95)[15][5][0][0][unconst_u32(238)][unconst_u32(33)][unconst_u32(54)][unconst_u32(82)][unconst_u32(28)][unconst_u32(5)][unconst_u32(90)][0])][0][unconst_u32(138)][0][0][16][unconst_u32(403)][0][unconst_u32(494)][unconst_u32(150)])][unconst_u32(227)][unconst_u32(106)][0][0][unconst_u32(44)][unconst_u32(199)][u32((*&buffer95)[15][5][0][unconst_u32(346)][u32(buffer95[15][5][unconst_u32(56)][unconst_u32(18)][unconst_u32(76)][unconst_u32(107)][0][16][unconst_u32(131)][0][0][0])][0][0][unconst_u32(27)][unconst_u32(6)][0][unconst_u32(413)][u32((*&buffer95)[unconst_u32(21)][5][unconst_u32(424)][unconst_u32(39)][0][0][unconst_u32(22)][16][0][unconst_u32(96)][0][unconst_u32(490)])])][0][0][0])][unconst_u32(34)][unconst_u32(181)][16][unconst_u32(37)][unconst_u32(181)][unconst_u32(202)][0], (*&buffer95)[unconst_u32(701)][5][unconst_u32(81)][unconst_u32(9)][u32(buffer95[15][u32((*&buffer95)[15][unconst_u32(16)][u32((*&buffer95)[15][5][0][0][unconst_u32(238)][unconst_u32(33)][unconst_u32(54)][unconst_u32(82)][unconst_u32(28)][unconst_u32(5)][unconst_u32(90)][0])][0][unconst_u32(138)][0][0][16][unconst_u32(403)][0][unconst_u32(494)][unconst_u32(150)])][unconst_u32(227)][unconst_u32(106)][0][0][unconst_u32(44)][unconst_u32(199)][u32((*&buffer95)[15][5][0][unconst_u32(346)][u32(buffer95[15][5][unconst_u32(56)][unconst_u32(18)][unconst_u32(76)][unconst_u32(107)][0][16][unconst_u32(131)][0][0][0])][0][0][unconst_u32(27)][unconst_u32(6)][0][unconst_u32(413)][u32((*&buffer95)[unconst_u32(21)][5][unconst_u32(424)][unconst_u32(39)][0][0][unconst_u32(22)][16][0][unconst_u32(96)][0][unconst_u32(490)])])][0][0][0])][unconst_u32(34)][unconst_u32(181)][16][unconst_u32(37)][unconst_u32(181)][unconst_u32(202)][0], (*&buffer95)[unconst_u32(701)][5][unconst_u32(81)][unconst_u32(9)][u32(buffer95[15][u32((*&buffer95)[15][unconst_u32(16)][u32((*&buffer95)[15][5][0][0][unconst_u32(238)][unconst_u32(33)][unconst_u32(54)][unconst_u32(82)][unconst_u32(28)][unconst_u32(5)][unconst_u32(90)][0])][0][unconst_u32(138)][0][0][16][unconst_u32(403)][0][unconst_u32(494)][unconst_u32(150)])][unconst_u32(227)][unconst_u32(106)][0][0][unconst_u32(44)][unconst_u32(199)][u32((*&buffer95)[15][5][0][unconst_u32(346)][u32(buffer95[15][5][unconst_u32(56)][unconst_u32(18)][unconst_u32(76)][unconst_u32(107)][0][16][unconst_u32(131)][0][0][0])][0][0][unconst_u32(27)][unconst_u32(6)][0][unconst_u32(413)][u32((*&buffer95)[unconst_u32(21)][5][unconst_u32(424)][unconst_u32(39)][0][0][unconst_u32(22)][16][0][unconst_u32(96)][0][unconst_u32(490)])])][0][0][0])][unconst_u32(34)][unconst_u32(181)][16][unconst_u32(37)][unconst_u32(181)][unconst_u32(202)][0], (*&buffer95)[unconst_u32(701)][5][unconst_u32(81)][unconst_u32(9)][u32(buffer95[15][u32((*&buffer95)[15][unconst_u32(16)][u32((*&buffer95)[15][5][0][0][unconst_u32(238)][unconst_u32(33)][unconst_u32(54)][unconst_u32(82)][unconst_u32(28)][unconst_u32(5)][unconst_u32(90)][0])][0][unconst_u32(138)][0][0][16][unconst_u32(403)][0][unconst_u32(494)][unconst_u32(150)])][unconst_u32(227)][unconst_u32(106)][0][0][unconst_u32(44)][unconst_u32(199)][u32((*&buffer95)[15][5][0][unconst_u32(346)][u32(buffer95[15][5][unconst_u32(56)][unconst_u32(18)][unconst_u32(76)][unconst_u32(107)][0][16][unconst_u32(131)][0][0][0])][0][0][unconst_u32(27)][unconst_u32(6)][0][unconst_u32(413)][u32((*&buffer95)[unconst_u32(21)][5][unconst_u32(424)][unconst_u32(39)][0][0][unconst_u32(22)][16][0][unconst_u32(96)][0][unconst_u32(490)])])][0][0][0])][unconst_u32(34)][unconst_u32(181)][16][unconst_u32(37)][unconst_u32(181)][unconst_u32(202)][0], (*&buffer95)[unconst_u32(701)][5][unconst_u32(81)][unconst_u32(9)][u32(buffer95[15][u32((*&buffer95)[15][unconst_u32(16)][u32((*&buffer95)[15][5][0][0][unconst_u32(238)][unconst_u32(33)][unconst_u32(54)][unconst_u32(82)][unconst_u32(28)][unconst_u32(5)][unconst_u32(90)][0])][0][unconst_u32(138)][0][0][16][unconst_u32(403)][0][unconst_u32(494)][unconst_u32(150)])][unconst_u32(227)][unconst_u32(106)][0][0][unconst_u32(44)][unconst_u32(199)][u32((*&buffer95)[15][5][0][unconst_u32(346)][u32(buffer95[15][5][unconst_u32(56)][unconst_u32(18)][unconst_u32(76)][unconst_u32(107)][0][16][unconst_u32(131)][0][0][0])][0][0][unconst_u32(27)][unconst_u32(6)][0][unconst_u32(413)][u32((*&buffer95)[unconst_u32(21)][5][unconst_u32(424)][unconst_u32(39)][0][0][unconst_u32(22)][16][0][unconst_u32(96)][0][unconst_u32(490)])])][0][0][0])][unconst_u32(34)][unconst_u32(181)][16][unconst_u32(37)][unconst_u32(181)][unconst_u32(202)][0]);
+  _ = buffer95;
+}
+  out = i32(buffer95[unconst_u32(193)][unconst_u32(63)][0][unconst_u32(130)][unconst_u32(387)][unconst_u32(194)][0][unconst_u32(111)][0][0][unconst_u32(587)][0]);
+  out += i32(buffer95[unconst_u32(103)][u32((*&buffer95)[15][unconst_u32(21)][0][0][0][unconst_u32(176)][unconst_u32(56)][16][0][0][unconst_u32(64)][0])][0][0][unconst_u32(227)][unconst_u32(13)][0][16][0][0][0][0]);
+  let ptr89: ptr<storage, array<array<f16, 1>, 1>, read> = &(*&buffer95)[unconst_u32(170)][u32(buffer95[unconst_u32(264)][5][0][0][0][0][0][16][0][0][0][0])][unconst_u32(40)][unconst_u32(209)][unconst_u32(42)][unconst_u32(165)][0][unconst_u32(560)][0][0];
+  _ = buffer95;
+}
+  vp3 = mat2x3h((*&buffer95)[15][unconst_u32(87)][unconst_u32(328)][0][0][unconst_u32(57)][0][16][unconst_u32(20)][0][0][0], (*&buffer95)[15][unconst_u32(87)][unconst_u32(328)][0][0][unconst_u32(57)][0][16][unconst_u32(20)][0][0][0], (*&buffer95)[15][unconst_u32(87)][unconst_u32(328)][0][0][unconst_u32(57)][0][16][unconst_u32(20)][0][0][0], (*&buffer95)[15][unconst_u32(87)][unconst_u32(328)][0][0][unconst_u32(57)][0][16][unconst_u32(20)][0][0][0], (*&buffer95)[15][unconst_u32(87)][unconst_u32(328)][0][0][unconst_u32(57)][0][16][unconst_u32(20)][0][0][0], (*&buffer95)[15][unconst_u32(87)][unconst_u32(328)][0][0][unconst_u32(57)][0][16][unconst_u32(20)][0][0][0]);
+  let ptr90: ptr<storage, array<array<f16, 1>, 1>, read> = &(*&buffer95)[15][5][unconst_u32(38)][unconst_u32(315)][0][0][0][u32(buffer95[15][unconst_u32(5)][unconst_u32(72)][unconst_u32(61)][0][unconst_u32(156)][0][16][unconst_u32(150)][0][0][0])][0][0];
+  out += i32((*&buffer95)[unconst_u32(148)][unconst_u32(182)][0][unconst_u32(132)][0][0][unconst_u32(88)][16][unconst_u32(93)][0][0][0]);
+  let ptr91: ptr<storage, f16, read> = &(*&buffer95)[15][unconst_u32(27)][0][unconst_u32(182)][unconst_u32(131)][0][0][unconst_u32(153)][unconst_u32(78)][0][unconst_u32(205)][unconst_u32(101)];
+  return out;
+  _ = buffer95;
+}
+
+var<workgroup> vw23: array<FragmentOutput5, 1>;
+
+struct T0 {
+  f0: array<f16>,
+}
+
+/* used global variables: buffer95 */
+@fragment
+fn fragment5() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  var vf82 = fn2(mat3x3f(f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0]), f32((*&buffer95)[unconst_u32(30)][unconst_u32(37)][u32((*&buffer95)[unconst_u32(181)][unconst_u32(199)][unconst_u32(881)][unconst_u32(205)][0][unconst_u32(143)][0][unconst_u32(34)][unconst_u32(204)][unconst_u32(144)][unconst_u32(369)][0])][unconst_u32(142)][unconst_u32(26)][0][unconst_u32(506)][16][0][unconst_u32(76)][0][0])));
+  out.f0 = unpack4xU8(u32((*&buffer95)[15][5][0][0][0][unconst_u32(265)][0][16][unconst_u32(112)][0][0][0]));
+  vp3 -= mat2x3h((*&buffer95)[unconst_u32(87)][5][0][0][u32(buffer95[unconst_u32(335)][5][0][unconst_u32(138)][unconst_u32(168)][0][0][unconst_u32(175)][unconst_u32(13)][unconst_u32(61)][unconst_u32(110)][unconst_u32(158)])][u32(buffer95[unconst_u32(2)][5][0][0][u32(buffer95[unconst_u32(458)][5][0][0][unconst_u32(12)][unconst_u32(134)][unconst_u32(8)][unconst_u32(9)][0][0][0][0])][unconst_u32(133)][0][unconst_u32(108)][unconst_u32(263)][unconst_u32(38)][unconst_u32(678)][0])][0][16][0][unconst_u32(91)][0][0], (*&buffer95)[unconst_u32(87)][5][0][0][u32(buffer95[unconst_u32(335)][5][0][unconst_u32(138)][unconst_u32(168)][0][0][unconst_u32(175)][unconst_u32(13)][unconst_u32(61)][unconst_u32(110)][unconst_u32(158)])][u32(buffer95[unconst_u32(2)][5][0][0][u32(buffer95[unconst_u32(458)][5][0][0][unconst_u32(12)][unconst_u32(134)][unconst_u32(8)][unconst_u32(9)][0][0][0][0])][unconst_u32(133)][0][unconst_u32(108)][unconst_u32(263)][unconst_u32(38)][unconst_u32(678)][0])][0][16][0][unconst_u32(91)][0][0], (*&buffer95)[unconst_u32(87)][5][0][0][u32(buffer95[unconst_u32(335)][5][0][unconst_u32(138)][unconst_u32(168)][0][0][unconst_u32(175)][unconst_u32(13)][unconst_u32(61)][unconst_u32(110)][unconst_u32(158)])][u32(buffer95[unconst_u32(2)][5][0][0][u32(buffer95[unconst_u32(458)][5][0][0][unconst_u32(12)][unconst_u32(134)][unconst_u32(8)][unconst_u32(9)][0][0][0][0])][unconst_u32(133)][0][unconst_u32(108)][unconst_u32(263)][unconst_u32(38)][unconst_u32(678)][0])][0][16][0][unconst_u32(91)][0][0], (*&buffer95)[unconst_u32(87)][5][0][0][u32(buffer95[unconst_u32(335)][5][0][unconst_u32(138)][unconst_u32(168)][0][0][unconst_u32(175)][unconst_u32(13)][unconst_u32(61)][unconst_u32(110)][unconst_u32(158)])][u32(buffer95[unconst_u32(2)][5][0][0][u32(buffer95[unconst_u32(458)][5][0][0][unconst_u32(12)][unconst_u32(134)][unconst_u32(8)][unconst_u32(9)][0][0][0][0])][unconst_u32(133)][0][unconst_u32(108)][unconst_u32(263)][unconst_u32(38)][unconst_u32(678)][0])][0][16][0][unconst_u32(91)][0][0], (*&buffer95)[unconst_u32(87)][5][0][0][u32(buffer95[unconst_u32(335)][5][0][unconst_u32(138)][unconst_u32(168)][0][0][unconst_u32(175)][unconst_u32(13)][unconst_u32(61)][unconst_u32(110)][unconst_u32(158)])][u32(buffer95[unconst_u32(2)][5][0][0][u32(buffer95[unconst_u32(458)][5][0][0][unconst_u32(12)][unconst_u32(134)][unconst_u32(8)][unconst_u32(9)][0][0][0][0])][unconst_u32(133)][0][unconst_u32(108)][unconst_u32(263)][unconst_u32(38)][unconst_u32(678)][0])][0][16][0][unconst_u32(91)][0][0], (*&buffer95)[unconst_u32(87)][5][0][0][u32(buffer95[unconst_u32(335)][5][0][unconst_u32(138)][unconst_u32(168)][0][0][unconst_u32(175)][unconst_u32(13)][unconst_u32(61)][unconst_u32(110)][unconst_u32(158)])][u32(buffer95[unconst_u32(2)][5][0][0][u32(buffer95[unconst_u32(458)][5][0][0][unconst_u32(12)][unconst_u32(134)][unconst_u32(8)][unconst_u32(9)][0][0][0][0])][unconst_u32(133)][0][unconst_u32(108)][unconst_u32(263)][unconst_u32(38)][unconst_u32(678)][0])][0][16][0][unconst_u32(91)][0][0]);
+  let ptr96: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &(*&buffer95)[15][unconst_u32(33)][unconst_u32(5)][0][0][unconst_u32(180)][0][unconst_u32(115)][unconst_u32(320)];
+  let ptr97: ptr<storage, array<array<array<f16, 1>, 1>, 1>, read> = &buffer95[15][5][unconst_u32(292)][unconst_u32(1)][0][u32((*&buffer95)[15][5][unconst_u32(371)][0][unconst_u32(72)][0][0][16][0][0][0][0])][0][16][unconst_u32(296)];
+  out = FragmentOutput5(vec4u(u32(buffer95[unconst_u32(113)][unconst_u32(10)][0][unconst_u32(98)][0][u32((*&buffer95)[15][unconst_u32(8)][0][0][0][0][0][16][unconst_u32(95)][unconst_u32(110)][0][unconst_u32(52)])][unconst_u32(24)][16][unconst_u32(511)][unconst_u32(9)][unconst_u32(90)][0])));
+  let ptr98: ptr<storage, f16, read> = &(*&buffer95)[15][5][unconst_u32(115)][0][unconst_u32(179)][0][unconst_u32(26)][16][unconst_u32(217)][0][u32((*&buffer95)[unconst_u32(123)][unconst_u32(218)][unconst_u32(244)][unconst_u32(54)][0][unconst_u32(394)][0][unconst_u32(51)][unconst_u32(29)][unconst_u32(194)][unconst_u32(1)][0])][unconst_u32(311)];
+  vf82 &= i32((*&buffer95)[15][unconst_u32(26)][0][0][unconst_u32(125)][0][unconst_u32(25)][unconst_u32(794)][0][unconst_u32(92)][unconst_u32(53)][unconst_u32(38)]);
+  return out;
+  _ = buffer95;
+}
+
+/* used global variables: buffer95 */
+@compute @workgroup_size(1, 1, 1)
+fn compute5() {
+  atomicAdd(&vw26, unconst_u32(51));
+  let ptr99: ptr<storage, f16, read> = &(*&buffer95)[15][unconst_u32(325)][0][0][0][0][unconst_u32(0)][16][0][unconst_u32(77)][0][unconst_u32(126)];
+  let ptr100: ptr<storage, array<array<f16, 1>, 1>, read> = &buffer95[unconst_u32(23)][5][0][unconst_u32(113)][unconst_u32(364)][0][unconst_u32(9)][unconst_u32(35)][unconst_u32(209)][unconst_u32(96)];
+  atomicAnd(&vw20[unconst_u32(29)][unconst_u32(30)], unconst_u32(46));
+  {
+  vw25 += unpack4xU8(u32(buffer95[unconst_u32(226)][unconst_u32(177)][unconst_u32(26)][0][unconst_u32(745)][unconst_u32(110)][0][unconst_u32(102)][0][0][unconst_u32(76)][0]));
+  _ = buffer95;
+}
+  vw23[0] = FragmentOutput5(vec4u(u32((*&buffer95)[15][unconst_u32(26)][0][unconst_u32(37)][0][unconst_u32(39)][unconst_u32(8)][16][0][0][0][unconst_u32(402)])));
+  _ = fn0();
+  vw23[unconst_u32(206)] = FragmentOutput5(vec4u(u32(buffer95[unconst_u32(58)][unconst_u32(49)][0][unconst_u32(3)][unconst_u32(265)][unconst_u32(76)][unconst_u32(696)][16][unconst_u32(90)][0][unconst_u32(84)][unconst_u32(29)])));
+  var vf83 = fn0();
+  var vf84 = fn0();
+  _ = buffer95;
+}
+
+/* used global variables: buffer95 */
+@compute @workgroup_size(1, 1, 1)
+fn compute6() {
+  var vf85 = fn0();
+  vw24 = f32(buffer95[15][unconst_u32(242)][0][0][0][unconst_u32(435)][0][16][0][0][0][0]);
+  var vf86 = fn0();
+  _ = fn0();
+  var vf87 = fn0();
+  atomicCompareExchangeWeak(&vw20[0][unconst_u32(147)], unconst_u32(63), unconst_u32(226));
+  let ptr101: ptr<storage, array<f16, 1>, read> = &buffer95[15][unconst_u32(88)][0][unconst_u32(7)][0][unconst_u32(22)][0][unconst_u32(423)][0][0][unconst_u32(47)];
+  let ptr102: ptr<storage, f16, read> = &buffer95[unconst_u32(13)][unconst_u32(79)][0][0][unconst_u32(122)][0][0][unconst_u32(90)][unconst_u32(226)][unconst_u32(185)][0][0];
+  _ = fn0();
+  let ptr103: ptr<storage, array<f16, 1>, read> = &(*&buffer95)[15][unconst_u32(160)][0][0][unconst_u32(110)][0][0][16][0][0][0];
+  _ = buffer95;
+}
+
+/* used global variables: buffer95 */
+@compute @workgroup_size(3, 1, 1)
+fn compute7() {
+  storageBarrier();
+  let ptr104: ptr<storage, f16, read> = &(*&buffer95)[15][5][0][unconst_u32(176)][0][unconst_u32(806)][unconst_u32(306)][16][0][unconst_u32(15)][unconst_u32(62)][0];
+  let ptr105: ptr<storage, f16, read> = &(*&buffer95)[15][unconst_u32(29)][unconst_u32(480)][0][unconst_u32(47)][0][unconst_u32(5)][16][unconst_u32(186)][u32((*&buffer95)[unconst_u32(10)][5][unconst_u32(31)][0][unconst_u32(69)][0][0][unconst_u32(260)][unconst_u32(48)][unconst_u32(80)][0][0])][u32(buffer95[15][unconst_u32(105)][0][0][0][unconst_u32(61)][0][unconst_u32(23)][unconst_u32(255)][0][0][0])][0];
+  return;
+  _ = buffer95;
+}`,
+});
+let bindGroup81 = device0.createBindGroup({layout: veryExplicitBindGroupLayout17, entries: [{binding: 328, resource: textureView39}]});
+let buffer96 = device0.createBuffer({size: 3797, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let texture115 = device0.createTexture({
+  size: [45, 20, 1],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView150 = texture40.createView({baseArrayLayer: 0, arrayLayerCount: 2});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup4, new Uint32Array(277), 33, 0);
+} catch {}
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup62, new Uint32Array(3073), 45, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer34, 324);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer8, 688);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1408 */
+  offset: 1408,
+  bytesPerRow: 12288,
+  buffer: buffer7,
+}, {
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule2}});
+let textureView151 = texture98.createView({baseMipLevel: 0, baseArrayLayer: 14, arrayLayerCount: 5});
+try {
+computePassEncoder88.setBindGroup(0, bindGroup49, new Uint32Array(1461), 783, 0);
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer27, 192);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer61, 'uint16', 2_640, 1_030);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1064 */
+  offset: 1064,
+  rowsPerImage: 373,
+  buffer: buffer55,
+}, {
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let computePassEncoder114 = commandEncoder50.beginComputePass({});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup10, new Uint32Array(675), 276, 0);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder4.drawIndexed(4, 8, 21, 151_681_162, 1_027_734_515);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline12);
+} catch {}
+let promise25 = shaderModule1.getCompilationInfo();
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 284 */
+  offset: 284,
+  bytesPerRow: 2560,
+  buffer: buffer29,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 59, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder68.clearBuffer(buffer79, 820, 0);
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte432', transfer: 'bt709'} });
+let textureView152 = texture43.createView({});
+let renderPassEncoder32 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 398,
+  clearValue: { r: 255.5, g: 746.9, b: 276.2, a: 165.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet8, beginningOfPassWriteIndex: 194, endOfPassWriteIndex: 189},
+});
+try {
+computePassEncoder112.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder13.draw(1, 56, 1, 341_806_241);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer81, 2_368);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer55, 'uint32', 1_748, 1_740);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline20);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2920 */
+  offset: 2920,
+  bytesPerRow: 2048,
+  buffer: buffer2,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 15, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let querySet11 = device0.createQuerySet({type: 'timestamp', count: 1453});
+try {
+computePassEncoder109.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder13.draw(1, 93, 5, 93_217_530);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer5, 240);
+} catch {}
+try {
+renderPassEncoder13.drawIndirect(buffer52, 144);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(4, buffer47, 0, 171);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 988, new DataView(new ArrayBuffer(2122)), 78, 188);
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 560});
+let computePassEncoder115 = commandEncoder133.beginComputePass({timestampWrites: {querySet: querySet5, beginningOfPassWriteIndex: 34}});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+computePassEncoder101.setBindGroup(3, bindGroup58, new Uint32Array(4653), 427, 0);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer62, 188);
+} catch {}
+try {
+commandEncoder25.copyBufferToBuffer(buffer47, 572, buffer59, 544, 640);
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 152 */
+  offset: 152,
+  bytesPerRow: 21760,
+  buffer: buffer1,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder25.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 152 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7744 */
+  offset: 7744,
+  buffer: buffer51,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView153 = texture75.createView({arrayLayerCount: 1});
+let computePassEncoder116 = commandEncoder25.beginComputePass({});
+try {
+renderPassEncoder16.setVertexBuffer(1, buffer81, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer97 = device0.createBuffer({
+  size: 784,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture116 = device0.createTexture({size: [90, 40, 45], dimension: '3d', format: 'rgba16uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView154 = texture109.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 1});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup55, new Uint32Array(1125), 593, 0);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(0, 100, 0, -1_005_990_498, 2_139_906_241);
+} catch {}
+let buffer98 = device0.createBuffer({size: 965, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let texture117 = device0.createTexture({
+  size: [45, 20, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup49, new Uint32Array(2261), 82, 0);
+} catch {}
+try {
+renderPassEncoder13.draw(0, 101, 1, 333_014_566);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer9, 'uint32', 404, 88);
+} catch {}
+let imageData18 = new ImageData(16, 12);
+try {
+computePassEncoder115.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder13.draw(0, 63, 4, 865_488_611);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder({});
+let computePassEncoder117 = commandEncoder134.beginComputePass({timestampWrites: {querySet: querySet5}});
+try {
+computePassEncoder117.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer92, 480);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(27).fill(139), /* required buffer size: 27 */
+{offset: 27}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame21 = new VideoFrame(videoFrame0, {timestamp: 0});
+let bindGroup82 = device0.createBindGroup({
+  label: '\u4b36\u{1f708}\u{1f639}\u008c',
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 254, resource: {buffer: buffer16, offset: 256, size: 508}},
+    {binding: 578, resource: {buffer: buffer75, offset: 512}},
+    {binding: 62, resource: textureView9},
+  ],
+});
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout16]});
+let commandEncoder135 = device0.createCommandEncoder();
+try {
+computePassEncoder69.setBindGroup(0, bindGroup20, []);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup41, new Uint32Array(1077), 19, 0);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(2, 195, 0, 616_981_187, 131_102_559);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer97, 296);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(1, buffer32, 2_100);
+} catch {}
+try {
+commandEncoder135.copyBufferToTexture({
+  /* bytesInLastRow: 280 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 956 */
+  offset: 956,
+  bytesPerRow: 83456,
+  buffer: buffer56,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 70, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder({});
+let computePassEncoder118 = commandEncoder135.beginComputePass({});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup46, new Uint32Array(1689), 585, 0);
+} catch {}
+try {
+renderPassEncoder13.draw(5, 209, 0, 113_986_517);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(2, buffer32, 0, 2_475);
+} catch {}
+try {
+commandEncoder136.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1299 */
+  offset: 1299,
+  rowsPerImage: 429,
+  buffer: buffer29,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let promise27 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout14,
+  fragment: {
+  module: shaderModule6,
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex5',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 232,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 96, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+let commandEncoder137 = device0.createCommandEncoder({});
+let computePassEncoder119 = commandEncoder136.beginComputePass({});
+let renderPassEncoder33 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView114,
+  clearValue: { r: 497.2, g: 863.8, b: 461.6, a: 296.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+  timestampWrites: {querySet: querySet8, endOfPassWriteIndex: 364},
+  maxDrawCount: 252921138,
+});
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup40, new Uint32Array(222), 85, 0);
+} catch {}
+try {
+renderPassEncoder13.draw(1, 22, 6, 327_154_932);
+} catch {}
+try {
+renderPassEncoder13.drawIndexed(1, 161, 0, 347_321_148, 1_010_839_758);
+} catch {}
+try {
+renderPassEncoder13.drawIndexedIndirect(buffer54, 104);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer63, 'uint32', 3_796, 738);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 396, new Int16Array(2616), 106, 348);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+var<workgroup> vw30: array<T0, 1>;
+
+struct FragmentOutput7 {
+  @location(0) @interpolate(flat, first) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+}
+
+struct T5 {
+  f0: T0,
+}
+
+var<workgroup> vw28: array<T5, 1>;
+
+struct T1 {
+  f0: array<f16>,
+}
+
+/* zero global variables used */
+@must_use 
+fn fn5(a0: T3) -> T3 {
+  var out: T3;
+  var vf114 = fn4();
+  out = T3(array<f16, 1>(a0.f0[unconst_u32(8)]));
+  _ = fn4();
+  _ = fn4();
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+fn fn2(a0: ptr<storage, T4, read_write>) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  out.f0 = vec4u((vec3u(unconst_u32(337), unconst_u32(86), unconst_u32(52)) < vec3u(unconst_u32(258), unconst_u32(201), unconst_u32(308))).yzxx);
+  let vf106: f16 = step(unconst_f16(1732.2), unconst_f16(12487.9));
+  var vf107: bool = any(vec2<bool>(bool(step(unconst_f16(20343.8), unconst_f16(17227.9)))));
+  out.f0 -= vec4u(u32(step(unconst_f16(653.4), unconst_f16(1759.9))));
+  (*a0).f0 = (*a0).f0;
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T6 {
+  f0: f16,
+}
+
+struct T3 {
+  @align(4) @size(4) f0: array<f16, 1>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(254) var<storage, read> buffer99: array<array<f16, 1>, 1>;
+
+struct FragmentOutput6 {
+  @location(0) f0: vec4f,
+  @builtin(sample_mask) f1: u32,
+}
+
+struct T2 {
+  @size(128) f0: array<atomic<i32>, 1>,
+  @align(128) @size(1536) f1: T1,
+}
+
+struct T0 {
+  f0: f16,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(62) var tex7: texture_depth_2d;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* zero global variables used */
+fn fn4() -> T6 {
+  var out: T6;
+  out.f0 *= f16(pack4xI8(vec4i(unconst_i32(465), unconst_i32(-160), unconst_i32(19), unconst_i32(73))));
+  return out;
+}
+
+var<workgroup> vw29: FragmentOutput7;
+
+struct T4 {
+  f0: T1,
+}
+
+/* used global variables: tex7 */
+@must_use 
+fn fn1(a0: S1) -> T5 {
+  var out: T5;
+  var vf102 = fn0(T6(vw28[unconst_u32(186)].f0.f0));
+  var vf103: f32 = ceil(unconst_f32(0.02206));
+  let ptr107: ptr<workgroup, f16> = &(*&vw28)[unconst_u32(395)].f0.f0;
+  switch i32(acos(vec4h(unconst_f16(36267.2), unconst_f16(4412.2), unconst_f16(8332.9), unconst_f16(2513.5))).r) { 
+  default {
+  vw28[unconst_u32(54)].f0.f0 = (*&vw28)[0].f0.f0;
+  workgroupBarrier();
+  return out;
+}
+  }
+  var vf104: vec4h = cosh(vec4h(unconst_f16(7482.0), unconst_f16(57.89), unconst_f16(15538.5), unconst_f16(9263.5)));
+  vf103 += f32((*&vw28)[0].f0.f0);
+  for (var it8=u32(vw28[0].f0.f0); it8<textureNumLevels(tex7); it8++) {
+  var vf105 = fn0(T6(f16(textureDimensions(tex7, unconst_i32(14))[1])));
+  vw30[unconst_u32(70)] = T0((*&vw27).f0);
+  let ptr108: ptr<workgroup, u32> = &vw29.f1;
+  let ptr109: ptr<workgroup, T5> = &(*&vw28)[unconst_u32(34)];
+  _ = fn0(T6(vec4h((*&vw29).f0).z));
+  _ = tex7;
+}
+  out.f0.f0 = f16(pack4xI8Clamp(unpack4xI8(vw29.f0[unconst_u32(45)])));
+  vf102.f0[unconst_u32(491)] -= vw30[0].f0;
+  let ptr110: ptr<workgroup, T6> = &(*&vw27);
+  return out;
+  _ = tex7;
+}
+
+/* zero global variables used */
+fn fn6(a0: T6, a1: T0, a2: T3, a3: T5) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  _ = fn4();
+  _ = fn5(T3(array<f16, 1>((mat2x2h() * mat2x2h(unconst_f16(5548.0), unconst_f16(4020.5), unconst_f16(5210.8), unconst_f16(12887.6)))[unconst_i32(1)].r)));
+  var vf115: vec3h = sin(vec3h(unconst_f16(1786.0), unconst_f16(8945.1), unconst_f16(9576.5)));
+  for (var it10=u32(pow(f16(acosh(unconst_f32(0.1142))), unconst_f16(22315.3))); it10<pack4xU8Clamp(vec4u(unconst_u32(0), unconst_u32(134), unconst_u32(292), unconst_u32(56))); it10++) {
+  fn4();
+  break;
+}
+  vf115 -= vec3h(saturate(vec4f(unconst_f32(0.01676), unconst_f32(0.1211), unconst_f32(0.3204), unconst_f32(0.1354))).rgr);
+  var vf116: vec4f = quantizeToF16(bitcast<vec4f>(reverseBits(vec2u(unconst_u32(88), unconst_u32(30))).rggg));
+  var vf117 = fn4();
+  out.f0 = unpack4xU8(u32(a2.f0[0]));
+  var vf118 = fn5(T3(array<f16, 1>(a0.f0)));
+  return out;
+}
+
+/* zero global variables used */
+fn fn0(a0: T6) -> T3 {
+  var out: T3;
+  let vf88: vec2f = unpack2x16unorm(unconst_u32(314));
+  for (var it7=vec4u((vec2h(unconst_f16(3326.3), unconst_f16(9067.2)) * mat4x2h(unconst_f16(16223.4), unconst_f16(24110.6), unconst_f16(1978.1), unconst_f16(2546.6), unconst_f16(36282.9), unconst_f16(20171.1), unconst_f16(14407.9), unconst_f16(14783.5))))[2]; it7<vec3u(refract(vec3h(unconst_f16(3607.7), unconst_f16(22657.3), unconst_f16(2568.9)), vec3h(unconst_f16(1119.5), unconst_f16(9444.2), unconst_f16(2110.0)), unconst_f16(11408.0)))[0]; it7++) {
+  switch bitcast<i32>(pack4x8unorm(vec4f(unconst_f32(-0.1382), unconst_f32(0.1058), unconst_f32(0.06571), unconst_f32(0.2992)))) { 
+  default {
+  out = T3(array<f16, 1>(a0.f0));
+  {
+  var vf89: f16 = a0.f0;
+  vf89 = vec4h((vec4h(unconst_f16(7881.4), unconst_f16(7993.4), unconst_f16(13953.9), unconst_f16(7190.5)) < vec4h(unconst_f16(-613.1), unconst_f16(1509.4), unconst_f16(16365.9), unconst_f16(1228.7))))[2];
+}
+  var vf90: vec4h = faceForward(vec4h(unconst_f16(3355.9), unconst_f16(9314.3), unconst_f16(8494.2), unconst_f16(7743.2)), vec4h(unconst_f16(1241.2), unconst_f16(9710.4), unconst_f16(2745.7), unconst_f16(5663.7)), vec4h(unconst_f16(127.0), unconst_f16(11036.6), unconst_f16(21749.1), unconst_f16(14815.6)));
+  out.f0[unconst_u32(144)] = trunc(vec2h(unconst_f16(22404.9), unconst_f16(4264.0))).g;
+  if bool(clamp(vec2u(unconst_u32(505), unconst_u32(45)), vec2u(unconst_u32(18), unconst_u32(145)), vec2u(transpose(mat3x3f(unconst_f32(0.04676), unconst_f32(0.01855), unconst_f32(0.01663), unconst_f32(0.01101), unconst_f32(0.01628), unconst_f32(0.01841), unconst_f32(0.2386), unconst_f32(0.1374), unconst_f32(0.2007)))[unconst_i32(1)].rb))[1]) {
+  var vf91: u32 = pack4x8unorm(vec4f(unconst_f32(-0.05674), unconst_f32(0.5812), unconst_f32(0.2723), unconst_f32(0.2126)));
+  break;
+}
+}
+  }
+  var vf92: vec4f = ldexp(vec4f(unconst_f32(0.01027), unconst_f32(0.02446), unconst_f32(0.4391), unconst_f32(0.1536)), vec4i(unconst_i32(11), unconst_i32(-3), unconst_i32(-198), unconst_i32(256)));
+  let vf93: u32 = pack2x16float(vec2f(f32(floor(a0.f0))));
+  break;
+}
+  out.f0[unconst_u32(118)] = asin(vec3h(unconst_f16(-38435.5), unconst_f16(-10748.9), unconst_f16(30137.0))).z;
+  out.f0[0] += f16(ldexp(vec4f(unconst_f32(0.02636), unconst_f32(0.06685), unconst_f32(0.00171), unconst_f32(0.3277)), vec4i(unconst_i32(-27), unconst_i32(357), unconst_i32(16), unconst_i32(1)))[0]);
+  let vf94: vec3h = refract(vec3h(unconst_f16(22952.5), unconst_f16(517.9), unconst_f16(2872.7)), vec3h(unconst_f16(3630.8), unconst_f16(11494.4), unconst_f16(9432.0)), f16(abs(vec2u(unconst_u32(229), unconst_u32(248)))[0]));
+  var vf95: vec3h = asin(vec3h(unconst_f16(1005.8), unconst_f16(3627.0), unconst_f16(9050.6)));
+  let ptr106: ptr<function, vec3h> = &vf95;
+  var vf96: vec3h = refract(vec3h(unconst_f16(4340.8), unconst_f16(3851.1), unconst_f16(10305.6)), vec3h(unconst_f16(13360.2), unconst_f16(374.6), unconst_f16(23023.5)), unconst_f16(909.5));
+  var vf97: f16 = vf94[unconst_u32(91)];
+  let vf98: f16 = (*ptr106)[unconst_u32(34)];
+  let vf99: vec4h = tan(vec4h(unconst_f16(7482.4), unconst_f16(3940.2), unconst_f16(7879.8), unconst_f16(16235.7)));
+  let vf100: f16 = vf96[unconst_u32(108)];
+  var vf101: bool = (unconst_i32(247) != unconst_i32(452));
+  return out;
+}
+
+/* zero global variables used */
+fn fn7(a0: FragmentOutput6, a1: T6) {
+  let vf119: vec2<bool> = (vec2u(unconst_u32(29), unconst_u32(4)) >= vec2u(unconst_u32(90), unconst_u32(187)));
+  vw28[unconst_u32(115)] = T5(T0( -vec4h(unconst_f16(13430.3), unconst_f16(18988.5), unconst_f16(19335.0), unconst_f16(3678.1)).w));
+  vw28[unconst_u32(45)] = (*&vw28)[0];
+}
+
+/* used global variables: buffer99, tex7 */
+fn fn3(a0: array<T5, 1>, a1: T3) {
+  if bool((*&buffer99)[unconst_u32(29)][0]) {
+  let ptr111: ptr<storage, f16, read> = &buffer99[0][unconst_u32(75)];
+  _ = buffer99;
+}
+  var vf108: vec3<bool> = (vec3f(unconst_f32(-0.2690), unconst_f32(0.1338), unconst_f32(0.4830)) >= vec3f(unconst_f32(-0.1411), unconst_f32(0.3905), unconst_f32(0.2274)));
+  let ptr112: ptr<storage, f16, read> = &buffer99[unconst_u32(360)][unconst_u32(21)];
+  let vf109: f16 = a0[unconst_u32(324)].f0.f0;
+  let vf110: f16 = a0[0].f0.f0;
+  for (var it9=textureDimensions(tex7, bitcast<i32>(unpack4x8snorm(unconst_u32(110)).w))[1]; it9<vec3u(vf108)[0]; it9++) {
+  let ptr113: ptr<storage, array<f16, 1>, read> = &buffer99[unconst_u32(145)];
+  var vf111: f32 = determinant(mat4x4f(unconst_f32(0.3069), unconst_f32(0.1205), unconst_f32(0.08749), unconst_f32(0.1357), unconst_f32(0.1211), unconst_f32(0.3281), unconst_f32(0.2647), unconst_f32(0.2252), unconst_f32(0.08179), unconst_f32(0.03253), unconst_f32(0.1156), unconst_f32(0.01296), unconst_f32(0.06429), unconst_f32(0.3072), unconst_f32(0.3080), unconst_f32(0.03054)));
+  let ptr114: ptr<storage, f16, read> = &(*ptr113)[unconst_u32(280)];
+  let vf112: f32 = textureLoad(tex7, vec2i(i32((*ptr114))), unconst_i32(58));
+  let ptr115: ptr<storage, f16, read> = &buffer99[unconst_u32(72)][unconst_u32(136)];
+  break;
+  _ = tex7;
+  _ = buffer99;
+}
+  let vf113: vec2h = tan(vec2h((vec3f(unconst_f32(0.4246), unconst_f32(0.2031), unconst_f32(0.07234)) >= vec3f(unconst_f32(0.3750), unconst_f32(0.08733), unconst_f32(0.3224))).zy));
+  let ptr116: ptr<storage, f16, read> = &buffer99[unconst_u32(16)][unconst_u32(469)];
+  vf108 = vec3<bool>(bool((*&buffer99)[0][0]));
+  _ = tex7;
+  _ = buffer99;
+}
+
+struct S1 {
+  @location(10) f0: f16,
+  @location(7) @interpolate(linear) f1: f32,
+  @builtin(instance_index) f2: u32,
+}
+
+var<workgroup> vw27: T6;
+
+struct T7 {
+  @size(3264) f0: array<T5>,
+}
+
+/* used global variables: buffer99, tex7 */
+@vertex @must_use
+fn vertex7(@location(3) @interpolate(linear, centroid) a0: vec2h, a1: S1) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf120 = fn6(T6((*&buffer99)[unconst_u32(260)][0]), T0((*&buffer99)[unconst_u32(162)][0]), T3(array<f16, 1>(buffer99[0][0])), T5(T0(f16(pack2x16float(vec2f(unconst_f32(0.03410), unconst_f32(-0.1553)))))));
+  let vf121: vec2h = a0;
+  {
+  fn4();
+  out = vec4f(f32((*&buffer99)[0][firstTrailingBit(vec3u(unconst_u32(273), unconst_u32(48), unconst_u32(257))).x]));
+  let ptr117: ptr<storage, f16, read> = &(*&buffer99)[0][unconst_u32(27)];
+  _ = buffer99;
+}
+  let ptr118: ptr<storage, f16, read> = &(*&buffer99)[0][unconst_u32(114)];
+  out -= trunc(vec4f(unconst_f32(0.1577), unconst_f32(-0.3359), unconst_f32(0.6879), unconst_f32(0.04110)));
+  fn3(array<T5, 1>(T5(T0(buffer99[unconst_u32(45)][0]))), T3(array<f16, 1>(buffer99[unconst_u32(186)][unconst_u32(253)])));
+  out += vec4f((vec2<bool>(bool(buffer99[0][0])) | vec2<bool>(sqrt(vec2h(unconst_f16(900.5), unconst_f16(4214.2))))).xyxy);
+  vf120.f0 |= vec4u(u32(textureLoad(tex7, vec2i(unconst_i32(215), unconst_i32(267)), bitcast<i32>(radians(vec2h(unconst_f16(33764.9), unconst_f16(9691.2)))))));
+  vf120.f0 += unpack4xU8(u32((*&buffer99)[0][unconst_u32(55)]));
+  out = vec4f(a1.f1);
+  let ptr119: ptr<function, u32> = &vf120.f1;
+  fn3(array<T5, 1>(T5(T0(vec4h(exp(vec4f(unconst_f32(0.06940), unconst_f32(-0.08563), unconst_f32(0.1084), unconst_f32(0.3627))))[1]))), T3(array<f16, 1>((*&buffer99)[unconst_u32(56)][unconst_u32(52)])));
+  var vf122: vec2h = vf121;
+  return out;
+  _ = tex7;
+  _ = buffer99;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment6() -> @location(200) vec4f {
+  var out: vec4f;
+  _ = fn4();
+  let vf123: vec4<bool> = (vec4h(unconst_f16(711.0), unconst_f16(3442.5), unconst_f16(12414.6), unconst_f16(11878.8)) == vec4h(unconst_f16(20505.7), unconst_f16(14096.3), unconst_f16(5699.8), unconst_f16(4691.9)));
+  var vf124 = fn4();
+  var vf125 = fn0(T6(vec4h(unpack4x8snorm(unconst_u32(1))).b));
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment7() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  var vf126: u32 = pack2x16float(vec2f(unconst_f32(0.07928), unconst_f32(0.5949)));
+  out = FragmentOutput6(vec4f(ldexp(vec2h(unconst_f16(3177.8), unconst_f16(9563.8)), vec2i(unconst_i32(61), unconst_i32(-110))).yyyy), bitcast<u32>(ldexp(vec2h(unconst_f16(3177.8), unconst_f16(9563.8)), vec2i(unconst_i32(61), unconst_i32(-110)))));
+  vf126 = u32(determinant(mat2x2h(unconst_f16(14586.1), unconst_f16(306.0), unconst_f16(2237.3), unconst_f16(720.5))));
+  let ptr120: ptr<function, u32> = &vf126;
+  var vf127: u32 = pack4x8snorm(vec4f(unconst_f32(0.00695), unconst_f32(0.07667), unconst_f32(0.04411), unconst_f32(0.2119)));
+  var vf128 = fn5(T3(array<f16, 1>(f16(pack2x16float(vec2f(unconst_f32(0.2654), unconst_f32(0.1700)))))));
+  vf127 <<= u32(sqrt(sign(vec2h(unconst_f16(279.8), unconst_f16(35273.8))).rgg).g);
+  out.f1 |= vf126;
+  vf127 *= pack4x8snorm(vec4f(unconst_f32(0.3977), unconst_f32(0.00714), unconst_f32(0.1317), unconst_f32(0.1457)));
+  let vf129: vec2f = unpack2x16snorm(unconst_u32(82));
+  {
+  var vf130 = fn0(T6(f16(pack2x16snorm(vec2f(unconst_f32(0.4214), unconst_f32(0.05036))))));
+  out.f0 = unpack4x8unorm(pack4xI8(vec4i(unconst_i32(139), unconst_i32(360), unconst_i32(-27), unconst_i32(10))));
+  out.f1 = pack4x8snorm(vec4f(unconst_f32(0.1647), unconst_f32(0.01383), unconst_f32(0.04612), unconst_f32(0.05877)));
+  vf130.f0[unconst_u32(115)] = length(vec4h(unconst_f16(33374.1), unconst_f16(25504.9), unconst_f16(-2474.4), unconst_f16(564.9)));
+  let ptr121: ptr<function, array<f16, 1>> = &vf130.f0;
+  fn4();
+}
+  let vf131: u32 = dot4U8Packed(vf126, unconst_u32(128));
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment8() -> @location(200) vec4f {
+  var out: vec4f;
+  var vf132: u32 = pack4xU8Clamp(vec4u(unconst_u32(29), unconst_u32(8), unconst_u32(114), unconst_u32(377)));
+  vf132 = u32(cosh(vec3h(unconst_f16(2326.4), unconst_f16(7011.3), unconst_f16(16125.4))).x);
+  vf132 *= max(unconst_u32(128), unconst_u32(603));
+  var vf133: bool = any(unconst_bool(false));
+  _ = fn5(T3(array<f16, 1>(vec2h( -(unconst_f32(0.09999) * vec2f(unconst_f32(0.02269), unconst_f32(0.2862))))[1])));
+  let vf134: vec2i = (vec2i(unconst_i32(150), unconst_i32(90)) * vec2i(unconst_i32(-301), unconst_i32(297)));
+  switch abs(vec3i(unconst_i32(-249), unconst_i32(27), unconst_i32(35))).b { 
+  default {
+  _ = fn6(T6(f16(all( !vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(false))))), T0(vec4h(extractBits(vec4i(unconst_i32(27), unconst_i32(74), unconst_i32(-115), unconst_i32(323)), unconst_u32(491), vec3u(faceForward(vec3h(unconst_f16(1307.1), unconst_f16(-16352.4), unconst_f16(1504.6)), vec3h(f16((unconst_u32(442) / unconst_u32(881)))), vec3h(unconst_f16(1973.9), unconst_f16(394.5), unconst_f16(-130.9))))[0]))[0]), T3(array<f16, 1>(f16(asinh(vec4f(unconst_f32(0.3656), unconst_f32(0.1510), unconst_f32(0.09805), unconst_f32(0.1514))).w))), T5(T0(f16( ~vec2i(i32(max(unconst_f16(12085.0), unconst_f16(22920.7))))[0]))));
+  out *= vec4f(f32(acosh(unconst_f16(13395.1))));
+  out = vec4f(f32(length(unconst_f16(-31144.3))));
+  let vf135: vec2h = exp(vec2h(unconst_f16(10463.6), unconst_f16(25401.7)));
+  let vf136: f16 = vf135[unconst_u32(88)];
+  out = vec4f((vec2u(unconst_u32(7), unconst_u32(84)) > vec2u(unconst_u32(312), unconst_u32(29))).xxyx);
+  return out;
+}
+  }
+  fn4();
+  vf132 <<= bitcast<vec3u>(cross(vec3f( -vec2i(unconst_i32(39), unconst_i32(297)).rrr), vec3f(unconst_f32(0.1198), unconst_f32(0.03219), unconst_f32(0.1653))))[2];
+  var vf137 = fn5(T3(array<f16, 1>(ldexp(vec2h(unconst_f16(-1298.8), unconst_f16(7546.1)), vec2i(unconst_i32(230), unconst_i32(311))).r)));
+  var vf138: vec2h = ldexp(vec2h(unconst_f16(-4470.7), unconst_f16(33741.9)), vec2i(bitcast<i32>(vf132)));
+  let ptr122: ptr<function, f16> = &vf137.f0[unconst_u32(12)];
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment9(@invariant @builtin(position) a0: vec4f) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  var vf139 = fn5(T3(array<f16, 1>(f16(all(unconst_bool(true))))));
+  var vf140: vec2f = atan(vec2f(unconst_f32(0.03389), unconst_f32(-0.1955)));
+  discard;
+  out.f0 ^= vec4u(unpack2x16snorm(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(false)) == vec4<bool>(extractBits(vec4i(unconst_i32(125), unconst_i32(279), unconst_i32(324), unconst_i32(563)), u32(any(unconst_bool(true))), unconst_u32(810)))))[1]).yyxx);
+  vf140 *= vec2f(f32(all(vec3<bool>(inverseSqrt(vec3f(unconst_f32(0.6943), unconst_f32(0.00867), unconst_f32(0.03238)))))));
+  vf139 = T3(array<f16, 1>(vec3h( ~vec3i(unconst_i32(423), unconst_i32(128), unconst_i32(18)))[0]));
+  out = FragmentOutput7(vec4u(refract(vec3h(unconst_f16(30464.6), unconst_f16(987.0), unconst_f16(4533.5)), vec3h(f16(all(vec3<bool>(bool(vf140[unconst_u32(87)]))))), unconst_f16(-7122.4)).xyyx), vec3u(refract(vec3h(unconst_f16(30464.6), unconst_f16(987.0), unconst_f16(4533.5)), vec3h(f16(all(vec3<bool>(bool(vf140[unconst_u32(87)]))))), unconst_f16(-7122.4)))[1]);
+  return out;
+}
+
+/* used global variables: tex7 */
+@compute @workgroup_size(2, 1, 1)
+fn compute8() {
+  for (var it11=u32(vw27.f0); it11<u32(dot(vec4f(unconst_f32(0.2180), unconst_f32(0.02557), unconst_f32(0.2417), unconst_f32(0.01973)), vec4f(unconst_f32(0.3259), unconst_f32(0.1072), unconst_f32(0.2499), unconst_f32(0.1701)))); it11++) {
+  textureBarrier();
+  vw28[unconst_u32(96)] = T5(T0(vec2h(textureDimensions(tex7)).y));
+  let ptr123: ptr<workgroup, f16> = &(*&vw30)[0].f0;
+  var vf141: bool = (unconst_bool(true) || unconst_bool(false));
+  vf141 = bool(vw27.f0);
+  vf141 = bool((*&vw29).f1);
+  _ = tex7;
+}
+  var vf142 = fn1(S1(f16(workgroupUniformLoad(&vw29).f0[3]), bitcast<vec4f>(workgroupUniformLoad(&vw29).f0)[2], pack4xU8Clamp(workgroupUniformLoad(&vw29).f0)));
+  _ = fn5(T3(array<f16, 1>(vf142.f0.f0)));
+  vw27.f0 = f16(transpose(mat2x2f(unconst_f32(0.01628), unconst_f32(0.3985), unconst_f32(0.00027), unconst_f32(0.1005)))[unconst_i32(0)][1]);
+  var vf143 = fn4();
+  for (var it12=pack4xU8(unpack4xU8(unconst_u32(71))); it12<u32((*&vw30)[0].f0); it12++) {
+  let ptr124: ptr<workgroup, u32> = &(*&vw29).f1;
+  vw30[unconst_u32(33)] = T0((*&vw30)[unconst_u32(293)].f0);
+  workgroupBarrier();
+  break;
+}
+  var vf144: vec4h = mix(vec4h(f16((unconst_bool(true) || bool(reverseBits(vec4i(unconst_i32(233), unconst_i32(66), unconst_i32(65), unconst_i32(160)))[0])))), bitcast<vec4h>(textureDimensions(tex7, unconst_i32(-121))), unconst_f16(1925.4));
+  _ = fn5(T3(array<f16, 1>((*&vw30)[0].f0)));
+  var vf145: u32 = dot4U8Packed(unconst_u32(276), unconst_u32(116));
+  fn7(FragmentOutput6(vec4f(f32((*&vw28)[0].f0.f0)), u32((*&vw28)[0].f0.f0)), (*&vw27));
+  var vf146: array<T0, 1> = workgroupUniformLoad(&vw30);
+  _ = tex7;
+}`,
+});
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 16,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 5, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder138 = device0.createCommandEncoder({});
+let texture118 = gpuCanvasContext5.getCurrentTexture();
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle3, renderBundle7]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 6, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(5_206).fill(189), /* required buffer size: 5_206 */
+{offset: 400, bytesPerRow: 178, rowsPerImage: 27}, {width: 48, height: 0, depthOrArrayLayers: 2});
+} catch {}
+document.body.append(img1);
+let buffer100 = device0.createBuffer({size: 11096, usage: GPUBufferUsage.MAP_READ});
+let texture119 = device0.createTexture({
+  size: {width: 360, height: 1, depthOrArrayLayers: 50},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup49, new Uint32Array(73), 7, 0);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline20);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 14, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4_833).fill(26), /* required buffer size: 4_833 */
+{offset: 127, bytesPerRow: 81, rowsPerImage: 29}, {width: 2, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let texture120 = device0.createTexture({
+  size: [22],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView155 = texture109.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 6});
+let computePassEncoder120 = commandEncoder61.beginComputePass({});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup17, new Uint32Array(82), 37, 0);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle11, renderBundle13, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer93, 'uint32', 128, 1_990);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer27, 360, buffer86, 21752, 248);
+} catch {}
+try {
+commandEncoder138.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 56 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4640 */
+  offset: 4640,
+  rowsPerImage: 156,
+  buffer: buffer67,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline24 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule4, entryPoint: 'compute4', constants: {}}});
+try {
+  await promise25;
+} catch {}
+let commandEncoder139 = device0.createCommandEncoder({});
+let texture121 = device0.createTexture({
+  size: [129],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroups(2, 1, 1); };
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer56, 'uint16', 4_234, 825);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer91, 548, buffer10, 1532, 2356);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 0, new DataView(new ArrayBuffer(10425)), 358, 724);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 11, height: 5, depthOrArrayLayers: 55}
+*/
+{
+  source: img1,
+  origin: { x: 0, y: 5 },
+  flipY: false,
+}, {
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'bt470bg', transfer: 'bt2020_12bit'} });
+let commandEncoder140 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({
+  size: [45, 1, 25],
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder34 = commandEncoder140.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 88,
+  clearValue: { r: 321.1, g: 649.2, b: -935.6, a: -489.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup68, new Uint32Array(1668), 544, 0);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer9, 'uint32', 412, 239);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(3, buffer79, 0);
+} catch {}
+try {
+sampler60.label = '\ubf2c\ub90e\u8e7f\ue4a8';
+} catch {}
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {binding: 152, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 264,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup83 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [
+    {binding: 254, resource: {buffer: buffer75, offset: 5888}},
+    {binding: 578, resource: {buffer: buffer19, offset: 0, size: 3808}},
+    {binding: 62, resource: textureView9},
+  ],
+});
+let buffer101 = device0.createBuffer({size: 7667, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder141 = device0.createCommandEncoder({});
+let texture123 = device0.createTexture({size: {width: 256}, dimension: '1d', format: 'rg32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup36, new Uint32Array(75), 23, 0);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(6, 0, 5, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder141.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3096 */
+  offset: 3096,
+  buffer: buffer47,
+}, {
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 9, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({type: 'timestamp', count: 889});
+let textureView156 = texture25.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder119.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup73, new Uint32Array(3241), 225, 0);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 413.4, g: 17.07, b: 344.6, a: -171.0, });
+} catch {}
+let textureView157 = texture26.createView({
+  label: '\u06e9\u0386\u{1fa29}\uaae6\u35b6\uf9ae\u30b2\ud8af\u{1fd38}\u0091\u2033',
+  dimension: '2d-array',
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+computePassEncoder74.dispatchWorkgroups(1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer27, 2_108); };
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline17);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData6,
+  origin: { x: 1, y: 16 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 20, y: 25, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({});
+let computePassEncoder121 = commandEncoder143.beginComputePass({});
+let renderPassEncoder35 = commandEncoder142.beginRenderPass({
+  colorAttachments: [{
+  view: textureView70,
+  depthSlice: 27,
+  clearValue: { r: -78.63, g: 329.1, b: 593.8, a: 763.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup43, new Uint32Array(205), 30, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline20);
+} catch {}
+let arrayBuffer6 = buffer37.getMappedRange(920, 0);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(137_835).fill(155), /* required buffer size: 137_835 */
+{offset: 173, bytesPerRow: 134, rowsPerImage: 194}, {width: 22, height: 58, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await promise26;
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 62, resource: textureView7},
+    {binding: 254, resource: {buffer: buffer7, offset: 256, size: 948}},
+    {binding: 578, resource: {buffer: buffer19, offset: 0, size: 3840}},
+  ],
+});
+let textureView158 = texture73.createView({dimension: '2d', baseArrayLayer: 1});
+let textureView159 = texture3.createView({dimension: '2d-array', aspect: 'all', arrayLayerCount: 1});
+let renderPassEncoder36 = commandEncoder141.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 178,
+  clearValue: { r: 661.2, g: -352.1, b: -684.2, a: -834.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet13, endOfPassWriteIndex: 485},
+  maxDrawCount: 234049585,
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rg32float']});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer93, 2_096); };
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+commandEncoder138.copyBufferToTexture({
+  /* bytesInLastRow: 664 widthInBlocks: 83 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 72 */
+  offset: 72,
+  bytesPerRow: 9216,
+  buffer: buffer101,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 33, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 83, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let imageData19 = new ImageData(48, 80);
+let bindGroup85 = device0.createBindGroup({layout: veryExplicitBindGroupLayout17, entries: [{binding: 328, resource: textureView154}]});
+let commandEncoder144 = device0.createCommandEncoder();
+let texture124 = device0.createTexture({
+  size: [129, 7, 11],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture125 = device0.createTexture({
+  size: {width: 180, height: 80, depthOrArrayLayers: 91},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder122 = commandEncoder138.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 543}});
+try {
+computePassEncoder99.setBindGroup(0, bindGroup57, new Uint32Array(188), 5, 0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle18]);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(5, buffer92, 0, 186);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+  await buffer57.mapAsync(GPUMapMode.READ, 0, 712);
+} catch {}
+try {
+computePassEncoder54.pushDebugGroup('\u33ce');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 1080, new BigUint64Array(12981), 1043, 68);
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({});
+let textureView160 = texture60.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 4});
+let computePassEncoder123 = commandEncoder145.beginComputePass({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder123.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup61, new Uint32Array(547), 33, 0);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(2, buffer97, 0);
+} catch {}
+try {
+computePassEncoder54.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let autogeneratedBindGroupLayout7 = pipeline0.getBindGroupLayout(0);
+let commandEncoder146 = device0.createCommandEncoder();
+let texture126 = device0.createTexture({
+  size: {width: 180, height: 1, depthOrArrayLayers: 50},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView161 = texture70.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder124 = commandEncoder146.beginComputePass();
+try {
+computePassEncoder124.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup66, new Uint32Array(5), 4, 0);
+} catch {}
+try {
+  await promise24;
+} catch {}
+document.body.prepend(canvas4);
+let commandEncoder147 = device0.createCommandEncoder({});
+let texture127 = device0.createTexture({
+  label: '\u3dd8\u0f4a\uf555\u0220\uc3d6\u028a\uff06\u806a\uc884\u567c',
+  size: [180, 1, 26],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture128 = device0.createTexture({
+  size: [180],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer81, 'uint16', 474, 54);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(2, buffer45);
+} catch {}
+try {
+commandEncoder147.copyBufferToBuffer(buffer93, 1396, buffer4, 752, 252);
+} catch {}
+try {
+commandEncoder144.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 136 */
+  offset: 136,
+  rowsPerImage: 688,
+  buffer: buffer71,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt709', transfer: 'linear'} });
+let textureView162 = texture127.createView({});
+let computePassEncoder125 = commandEncoder147.beginComputePass({timestampWrites: {querySet: querySet10, endOfPassWriteIndex: 78}});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u0ffd\u0872\u{1fac4}\ue521\u60e3\u{1fd40}\u2e5a\u20ff\u462d\u5395',
+  colorFormats: ['rg32float'],
+  depthReadOnly: false,
+});
+let renderBundle24 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder125.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer56, 'uint32', 664, 3_330);
+} catch {}
+try {
+commandEncoder144.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 860 */
+  offset: 860,
+  bytesPerRow: 1536,
+  buffer: buffer3,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 25, y: 9, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 50}
+*/
+{
+  source: imageData18,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 23},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline25 = await promise18;
+document.body.append(img0);
+let textureView163 = texture126.createView({});
+let renderPassEncoder37 = commandEncoder144.beginRenderPass({
+  colorAttachments: [{view: textureView72, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet12,
+  timestampWrites: {querySet: querySet9, beginningOfPassWriteIndex: 474, endOfPassWriteIndex: 479},
+});
+let renderBundle25 = renderBundleEncoder24.finish({label: '\u{1f8fa}\u{1fa43}\u07ab\u{1faf4}\ud5ff\u0e4a\u{1fe5b}\u6bfa'});
+let sampler80 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 7,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer79, 204); };
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup10, new Uint32Array(4574), 556, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer19, 'uint32', 1_868, 3_901);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(0, buffer40);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 296, new DataView(new ArrayBuffer(13182)), 69, 308);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 45, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 27, y: 12 },
+  flipY: false,
+}, {
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas4);
+try {
+computePassEncoder77.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline26 = device0.createComputePipeline({layout: pipelineLayout14, compute: {module: shaderModule1}});
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout3]});
+let texture129 = device0.createTexture({
+  size: [180, 80, 1],
+  dimension: '2d',
+  format: 'astc-6x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView164 = texture56.createView({aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder38 = commandEncoder139.beginRenderPass({
+  colorAttachments: [{
+  view: textureView157,
+  clearValue: { r: 205.8, g: 123.8, b: -957.4, a: 353.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundle26 = renderBundleEncoder26.finish();
+try {
+renderPassEncoder6.setIndexBuffer(buffer61, 'uint32', 4_724, 805);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer0, 3_940, 5_289);
+} catch {}
+try {
+adapter1.label = '\u0075\u{1fd21}\u5aac';
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 254, resource: {buffer: buffer92, offset: 1024, size: 52}},
+    {binding: 62, resource: textureView9},
+    {binding: 578, resource: {buffer: buffer63, offset: 256, size: 3292}},
+  ],
+});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  lodMaxClamp: 52.00,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup44, new Uint32Array(3362), 75, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let bindGroup87 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [
+    {binding: 62, resource: textureView18},
+    {binding: 254, resource: {buffer: buffer54, offset: 0, size: 200}},
+    {binding: 578, resource: {buffer: buffer25, offset: 1024, size: 3432}},
+  ],
+});
+let texture130 = device0.createTexture({
+  size: [90],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(1, bindGroup49, new Uint32Array(2938), 138, 0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(2, buffer66, 0, 3_973);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder();
+let computePassEncoder126 = commandEncoder148.beginComputePass({});
+let sampler82 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.58,
+  compare: 'less',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder48.setBindGroup(2, bindGroup72, new Uint32Array(1215), 992, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup40, new Uint32Array(6049), 178, 0);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle11, renderBundle18, renderBundle11]);
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+let bindGroup88 = device0.createBindGroup({
+  label: '\u4768\u8623\u02e5\ua821\u4600\u8959\u{1fd3f}\ubf8b',
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 8, resource: externalTexture10}],
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let texture131 = device0.createTexture({
+  size: {width: 180, height: 80, depthOrArrayLayers: 91},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder127 = commandEncoder149.beginComputePass({});
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u6a73');
+} catch {}
+let querySet14 = device0.createQuerySet({type: 'timestamp', count: 1085});
+let computePassEncoder128 = commandEncoder89.beginComputePass({});
+let sampler83 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMinClamp: 3.595});
+try {
+{ clearResourceUsages(device0, computePassEncoder77); computePassEncoder77.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer88, 'uint16', 2_652, 2_989);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(3, buffer43);
+} catch {}
+let buffer102 = device0.createBuffer({
+  label: '\u575d\u05cb\u0eb5',
+  size: 7697,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView165 = texture126.createView({aspect: 'all', format: 'r32float', mipLevelCount: 1});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(0, bindGroup59, new Uint32Array(7406), 4_158, 0);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup9, new Uint32Array(365), 24, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer54, 224);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer52, 8);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer29, 'uint32', 2_124, 229);
+} catch {}
+try {
+buffer86.unmap();
+} catch {}
+let pipeline27 = device0.createComputePipeline({layout: pipelineLayout19, compute: {module: shaderModule7}});
+let buffer103 = device0.createBuffer({size: 34, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let texture132 = device0.createTexture({
+  size: {width: 129, height: 7, depthOrArrayLayers: 73},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let texture133 = gpuCanvasContext3.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer55, 1_440); };
+} catch {}
+try {
+renderPassEncoder10.draw(0, 34, 0, 44_601_094);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(34, 132, 3, 16_934_602, 76_533_836);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(121).fill(126), /* required buffer size: 121 */
+{offset: 121, bytesPerRow: 251}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline28 = await promise14;
+await gc();
+let veryExplicitBindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 7,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 37, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {binding: 282, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let buffer104 = device0.createBuffer({size: 1792, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let textureView166 = texture20.createView({arrayLayerCount: 1});
+try {
+computePassEncoder126.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder10.draw(0, 83, 0, 897_465_251);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(30, 70, 1, 165_403_647, 1_590_936_534);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer39, 8);
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+requires readonly_and_readwrite_storage_textures;
+
+var<workgroup> vw42: mat4x3f;
+
+var<workgroup> vw31: array<atomic<u32>, 1>;
+
+@id(57193) override override9: u32 = 339;
+
+/* zero global variables used */
+@must_use 
+fn fn4(a0: array<u32, 1>) -> VertexOutput6 {
+  var out: VertexOutput6;
+  out.f20 += unpack4x8unorm(a0[0]);
+  _ = fn2(mat4x2h(vec2h(transpose(mat3x4f())[unconst_i32(2)].yy), vec2h(transpose(mat3x4f())[unconst_i32(2)].zz), vec2h(transpose(mat3x4f())[unconst_i32(0)].xz), vec2h(transpose(mat3x4f())[unconst_i32(2)].bb)));
+  return out;
+  _ = override9;
+}
+
+var<workgroup> vw35: vec4i;
+
+/* zero global variables used */
+@must_use 
+fn fn2(a0: mat4x2h) -> VertexOutput6 {
+  var out: VertexOutput6;
+  switch bitcast<i32>(floor(vec3f(unconst_f32(0.07511), unconst_f32(0.01208), unconst_f32(0.1678))).b) { 
+  default {
+  let vf168: u32 = override9;
+  out.f19 = unpack4xU8(dot4U8Packed(unconst_u32(173), unconst_u32(64)));
+  let vf169: vec3h = normalize(vec3h(f16(vp5.f19[unconst_u32(185)])));
+  _ = override9;
+}
+  }
+  let ptr131: ptr<private, vec4u> = &vp5.f19;
+  return out;
+  _ = override9;
+}
+
+var<workgroup> vw40: mat4x2h;
+
+var<workgroup> vw33: vec4f;
+
+@group(0) @binding(152) var et0: texture_external;
+
+struct T0 {
+  @align(16) @size(1728) f0: array<u32>,
+}
+
+var<private> vp5: VertexOutput6 = VertexOutput6();
+
+@group(0) @binding(264) var<storage, read_write> buffer106: array<array<array<f16, 1>, 6>, 144>;
+
+/* zero global variables used */
+fn fn0() -> VertexOutput6 {
+  var out: VertexOutput6;
+  var vf147: vec3<bool> = (vec3h(unconst_f16(8283.6), unconst_f16(19695.4), unconst_f16(-1935.3)) <= vec3h(countLeadingZeros(vec4u(unconst_u32(182), unconst_u32(0), unconst_u32(11), unconst_u32(22))).xyy));
+  let vf148: mat2x3h = transpose(mat3x2h(unconst_f16(1848.5), unconst_f16(10668.2), unconst_f16(2197.3), unconst_f16(-4272.8), unconst_f16(4282.6), unconst_f16(3594.9)));
+  var vf149: vec4u = countLeadingZeros(vec4u(unconst_u32(352), unconst_u32(55), unconst_u32(50), unconst_u32(2)));
+  let vf150: u32 = pack4x8snorm(vec4f(unconst_f32(0.1095), unconst_f32(0.06567), unconst_f32(0.03142), unconst_f32(0.2086)));
+  out.f20 -= bitcast<vec4f>( ~vec4u(unconst_u32(44), unconst_u32(128), unconst_u32(139), unconst_u32(201)));
+  {
+  let vf151: f16 = inverseSqrt(unconst_f16(233.3));
+  let vf152: f32 = vp4.f0[unconst_u32(229)];
+  var vf153: u32 = (bitcast<u32>(tan(vec3f(unconst_f32(0.3291), unconst_f32(0.04020), unconst_f32(0.04869)))[1]) ^ pack4xU8Clamp(firstLeadingBit(vec4u(unconst_u32(145), unconst_u32(180), unconst_u32(459), unconst_u32(225)))));
+  var vf154: bool = (unconst_bool(false) && unconst_bool(false));
+  var vf155: vec3h = floor(vec3h(unconst_f16(19105.2), unconst_f16(8753.6), unconst_f16(4375.5)));
+  vf153 = u32((unconst_bool(true) && unconst_bool(true)));
+}
+  switch bitcast<i32>(vf150) { 
+  default {
+  switch bitcast<i32>(vp5.f20[3]) { 
+  default {
+  let vf156: u32 = pack4x8unorm(vec4f(unconst_f32(0.06431), unconst_f32(0.03866), unconst_f32(0.3251), unconst_f32(0.1101)));
+  var vf157: f32 = ceil(unconst_f32(0.2840));
+}
+  }
+  vp5.f19 = bitcast<vec4u>(unpack2x16unorm(bitcast<u32>(round(vec2h(unconst_f16(9610.6), unconst_f16(60000.0))))).xxyx);
+  vp5 = VertexOutput6(firstLeadingBit(vp5.f19), vec4f(firstLeadingBit(vp5.f19)));
+  let vf158: vec4u = firstLeadingBit(vec4u(unconst_u32(0), unconst_u32(91), unconst_u32(223), unconst_u32(21)));
+  let vf159: vec2f = degrees(vec2f(unconst_f32(0.04293), unconst_f32(0.5262)));
+  let ptr125: ptr<private, vec4u> = &vp5.f19;
+  let vf160: vec2f = vf159;
+  break;
+}
+  }
+  let ptr126: ptr<private, vec4f> = &vp4.f0;
+  let ptr127: ptr<private, vec4u> = &vp5.f19;
+  var vf161: u32 = (*ptr127)[unconst_u32(50)];
+  {
+  let vf162: vec3h = faceForward(vec3h(unconst_f16(-13000.7), unconst_f16(-11703.8), unconst_f16(7546.7)), vec3h(unconst_f16(9456.7), unconst_f16(10430.5), unconst_f16(-10676.9)), vec3h(unconst_f16(-4964.1), unconst_f16(2254.9), unconst_f16(1532.9)));
+  var vf163: f16 = abs(unconst_f16(3633.9));
+  let ptr128: ptr<private, vec4f> = &vp5.f20;
+}
+  let ptr129: ptr<private, vec4u> = &(*ptr127);
+  let vf164: f32 = vp5.f20[pack4x8snorm(vec4f((vec4i(unconst_i32(174), unconst_i32(158), unconst_i32(759), unconst_i32(50)) <= unpack4xI8(unconst_u32(93)))))];
+  var vf165: vec4u =  ~vec4u(unconst_u32(63), unconst_u32(122), unconst_u32(294), unconst_u32(180));
+  return out;
+}
+
+/* zero global variables used */
+fn fn1(a0: VertexOutput6) -> VertexOutput6 {
+  var out: VertexOutput6;
+  vp5.f20 = vec4f(a0.f19);
+  var vf166: vec4f = a0.f20;
+  let ptr130: ptr<function, vec4f> = &vf166;
+  vf166 *= vec4f(f32(vp5.f19[unconst_u32(298)]));
+  var vf167 = fn0();
+  _ = fn0();
+  return out;
+}
+
+var<workgroup> vw39: array<vec2h, 1>;
+
+struct T1 {
+  @align(8) @size(8) f0: array<i32>,
+}
+
+/* zero global variables used */
+fn fn5(a0: ptr<function, vec2i>) {
+  _ = fn0();
+  _ = fn2(mat4x2h(vec2h(unpack4xU8(unconst_u32(11)).ww), vec2h(unpack4xU8(unconst_u32(11)).ga), vec2h(unpack4xU8(unconst_u32(11)).zz), vec2h(unpack4xU8(unconst_u32(11)).ra)));
+  var vf174 = fn0();
+  vp5 = VertexOutput6(vec4u( ~vec3i(unconst_i32(232), unconst_i32(641), unconst_i32(40)).brgb), vec4f( ~vec3i(unconst_i32(232), unconst_i32(641), unconst_i32(40)).rgrg));
+  let ptr133: ptr<private, vec4f> = &vp5.f20;
+  _ = override9;
+}
+
+var<workgroup> vw41: FragmentOutput8;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* used global variables: buffer106 */
+fn fn3(a0: VertexOutput6, a1: array<VertexOutput6, 1>, a2: ptr<uniform, array<array<FragmentOutput8, 1>, 3>>) -> VertexOutput6 {
+  var out: VertexOutput6;
+  var vf170: u32 = vw34.f19[unconst_u32(486)];
+  var vf171 = fn2(mat4x2h((*&buffer106)[143][5][0], (*&buffer106)[143][5][0], (*&buffer106)[143][5][0], (*&buffer106)[143][5][0], (*&buffer106)[143][5][0], (*&buffer106)[143][5][0], (*&buffer106)[143][5][0], (*&buffer106)[143][5][0]));
+  vw42 = mat4x3f(vec3f((*&vw34).f19.ywx), vec3f((*&vw34).f19.raa), bitcast<vec3f>((*&vw34).f19.www), vec3f((*&vw34).f19.agr));
+  _ = fn2(mat4x2h(f16(a0.f20[unconst_u32(370)]), f16(a0.f20[unconst_u32(370)]), f16(a0.f20[unconst_u32(370)]), f16(a0.f20[unconst_u32(370)]), f16(a0.f20[unconst_u32(370)]), f16(a0.f20[unconst_u32(370)]), f16(a0.f20[unconst_u32(370)]), f16(a0.f20[unconst_u32(370)])));
+  var vf172 = fn2(mat4x2h(f16((*&vw33)[unconst_u32(0)]), f16((*&vw33)[unconst_u32(0)]), f16((*&vw33)[unconst_u32(0)]), f16((*&vw33)[unconst_u32(0)]), f16((*&vw33)[unconst_u32(0)]), f16((*&vw33)[unconst_u32(0)]), f16((*&vw33)[unconst_u32(0)]), f16((*&vw33)[unconst_u32(0)])));
+  loop {
+  if bool(ldexp(vec2h(unconst_f16(2619.6), unconst_f16(20285.4)), vec2i(unconst_i32(231), unconst_i32(304))).r) {
+  break;
+}
+  buffer106[bitcast<u32>((*&vw35).a)][unconst_u32(41)][unconst_u32(101)] = (*&buffer106)[143][unconst_u32(63)][unconst_u32(47)];
+  break;
+  _ = buffer106;
+}
+  let vf173: f32 = vf171.f20[unconst_u32(115)];
+  out.f20 -= vw34.f20;
+  vp5.f19 ^= vf171.f19;
+  let ptr132: ptr<uniform, FragmentOutput8> = &(*a2)[unconst_u32(37)][0];
+  return out;
+  _ = override9;
+  _ = buffer106;
+}
+
+var<workgroup> vw43: VertexOutput6;
+
+var<workgroup> vw37: array<f16, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw36: atomic<i32>;
+
+var<workgroup> vw38: atomic<i32>;
+
+var<private> vp4: FragmentOutput8 = FragmentOutput8();
+
+struct FragmentOutput8 {
+  @location(0) @interpolate(linear, either) f0: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+var<workgroup> vw34: VertexOutput6;
+
+var<workgroup> vw32: atomic<i32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput6 {
+  @location(7) @interpolate(flat, sample) f19: vec4u,
+  @builtin(position) f20: vec4f,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex8(@location(13) @interpolate(flat) a0: u32) -> VertexOutput6 {
+  var out: VertexOutput6;
+  {
+  {
+  _ = fn1(VertexOutput6(bitcast<vec4u>(vp4.f0), vp4.f0));
+}
+  out.f19 = unpack4xU8(u32(vp5.f20[unconst_u32(8)]));
+}
+  _ = fn2(mat4x2h(vec2h(unpack4x8snorm(unconst_u32(164)).gg), vec2h(unpack4x8snorm(unconst_u32(164)).yy), vec2h(unpack4x8snorm(unconst_u32(164)).rr), vec2h(unpack4x8snorm(unconst_u32(164)).ab)));
+  let vf175: vec2i = (vec2i(unconst_i32(148), unconst_i32(-183)) | vec2i(unconst_i32(63), unconst_i32(214)));
+  var vf176 = fn1(VertexOutput6(bitcast<vec4u>(vp4.f0), vp4.f0));
+  let ptr134: ptr<private, vec4u> = &vp5.f19;
+  vf176 = VertexOutput6(vec4u(override9), vec4f(f32(override9)));
+  vf176.f20 = vec4f(f32((*ptr134)[unconst_u32(157)]));
+  var vf177: f32 = vp4.f0[unconst_u32(343)];
+  var vf178 = fn1(VertexOutput6(vec4u(vp4.f0), vp4.f0));
+  return out;
+  _ = override9;
+}
+
+/* used global variables: et0 */
+@fragment
+fn fragment10(@location(5) a0: vec4f, @location(15) @interpolate(linear, sample) a1: f16) -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  vp5.f19 = unpack4xU8(pack4xI8Clamp(vec4i(unconst_i32(565), unconst_i32(21), unconst_i32(44), unconst_i32(319))));
+  let ptr135: ptr<private, vec4f> = &vp4.f0;
+  vp5 = VertexOutput6(vec4u(vp5.f19[unconst_u32(54)]), unpack4x8unorm(vp5.f19[unconst_u32(54)]));
+  out.f0 = textureLoad(et0, countTrailingZeros(vec2u(unconst_u32(106), unconst_u32(192))));
+  let vf179: vec2u = countLeadingZeros(vec2u(pack4xI8Clamp(vec4i(vp4.f0))));
+  out = FragmentOutput8(bitcast<vec4f>((vec2u(smoothstep(vec4f(unconst_f32(0.09916), unconst_f32(0.2664), unconst_f32(0.09424), unconst_f32(0.00909)), bitcast<vec4f>(min(vec3i(unconst_i32(69), unconst_i32(131), unconst_i32(280)), vec3i(unconst_i32(55), unconst_i32(-111), unconst_i32(47))).rggr), vec4f(unconst_f32(0.1572), unconst_f32(0.01595), unconst_f32(0.09762), unconst_f32(0.1593))).yz) + vec2u(unconst_u32(65), unconst_u32(46))).rggg));
+  while bool(vp5.f20[1]) {
+  var vf180: u32 = vp5.f19[u32(vp4.f0.w)];
+}
+  out.f0 = vp4.f0;
+  out = FragmentOutput8(bitcast<vec4f>(clamp(vec4i(unconst_i32(221), unconst_i32(397), unconst_i32(28), unconst_i32(232)), vec4i(unconst_i32(-20), unconst_i32(24), unconst_i32(2), unconst_i32(77)), vec4i((vec3h(unconst_f16(4432.4), unconst_f16(2594.8), unconst_f16(13509.5)) != vec3h(f16(pack4xI8Clamp(vec4i(unconst_i32(113), unconst_i32(214), unconst_i32(347), unconst_i32(-687)))))).bbgb))));
+  out.f0 = vec4f(f32(a1));
+  vp4 = FragmentOutput8(unpack4x8unorm(pack4xI8Clamp(vec4i(unconst_i32(47), unconst_i32(17), unconst_i32(78), unconst_i32(314)))));
+  var vf181: u32 = pack4x8unorm(vec4f(unconst_f32(0.1838), unconst_f32(0.1260), unconst_f32(0.2239), unconst_f32(0.5769)));
+  if bool(clamp(vec4i(unconst_i32(10), unconst_i32(510), unconst_i32(121), unconst_i32(85)), vec4i(unconst_i32(133), unconst_i32(117), unconst_i32(4), unconst_i32(-28)), vec4i(unconst_i32(36), unconst_i32(385), unconst_i32(37), unconst_i32(205)))[0]) {
+  _ = fn4(array<u32, 1>(pack4xU8Clamp(vp5.f19)));
+  let vf182: f32 = degrees(a0[unconst_u32(115)]);
+  let vf183: vec2f = radians(vec2f(f32(a1)));
+  return out;
+  _ = override9;
+}
+  out = FragmentOutput8(vec4f(f32(vp5.f19[unconst_u32(77)])));
+  return out;
+  _ = override9;
+  _ = et0;
+}`,
+});
+let texture134 = device0.createTexture({
+  size: [258, 15, 538],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint'], depthReadOnly: true});
+let renderBundle27 = renderBundleEncoder27.finish({});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup81);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup62, new Uint32Array(1573), 203, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(0, 7, 0, 937_080_212);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer40, 3_728);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer26, 'uint32', 2_452, 3_518);
+} catch {}
+let imageBitmap4 = await createImageBitmap(canvas1);
+try {
+computePassEncoder108.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer91, 876);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer29, 412);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer25, 'uint16', 3_410, 434);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer79, 80, 646);
+} catch {}
+try {
+adapter1.label = '\ua8b0\u2b88\u2d89';
+} catch {}
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout21]});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame7});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpteSt4281', transfer: 'smpteSt4281'} });
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+/* used global variables: tex8 */
+@must_use 
+fn fn7(a0: vec2h, a1: mat2x3h) -> array<vec2h, 1> {
+  var out: array<vec2h, 1>;
+  var vf214 = fn0();
+  _ = fn3();
+  while bool(vp6[0][48][0]) {
+  var vf215 = fn0();
+  break;
+  _ = override11;
+}
+  fn3();
+  return out;
+  _ = override11;
+  _ = tex8;
+}
+
+@group(0) @binding(176) var tex8: texture_2d<i32>;
+
+/* used global variables: tex8 */
+fn fn4(a0: mat2x2f) -> array<f16, 32> {
+  var out: array<f16, 32>;
+  let vf209: vec4u = firstLeadingBit(vec4u(unconst_u32(382), unconst_u32(197), unconst_u32(350), unconst_u32(2)));
+  var vf210: vec3f = cosh(vec3f(unconst_f32(0.06808), unconst_f32(0.05692), unconst_f32(0.3178)));
+  fn2();
+  let ptr160: ptr<private, array<array<i32, 1>, 49>> = &vp6[unconst_u32(366)];
+  vf210 += bitcast<vec3f>(firstLeadingBit(vec4u(unconst_u32(17), unconst_u32(14), unconst_u32(117), unconst_u32(147))).zxy);
+  fn0();
+  fn1(unpack4xI8(textureNumLevels(tex8)));
+  vp8 += bitcast<vec4f>(vf209);
+  vf210 = vec3f(f32(vp6[0][unconst_u32(428)][0]));
+  var vf211: vec2u = textureDimensions(tex8, unconst_i32(56));
+  var vf212 = fn1((vec2i(unconst_i32(303), unconst_i32(56)) / vec2i(unconst_i32(40), unconst_i32(17))).rrrr);
+  vp8 = vec4f(bitcast<f32>(vp6[unconst_u32(210)][48][0]));
+  let vf213: f16 = vf212[unconst_u32(209)][unconst_u32(81)][0][3][0][0][unconst_u32(17)];
+  return out;
+  _ = override11;
+  _ = override10;
+  _ = tex8;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* zero global variables used */
+fn fn1(a0: vec4i) -> array<array<array<array<array<array<vec4h, 1>, 1>, 4>, 1>, 1>, 1> {
+  var out: array<array<array<array<array<array<vec4h, 1>, 1>, 4>, 1>, 1>, 1>;
+  out[0][unconst_u32(39)][unconst_u32(28)][unconst_u32(238)][unconst_u32(50)][unconst_u32(136)] = sin(vec3h(unconst_f16(525.9), unconst_f16(2037.3), unconst_f16(18289.3))).rrbr;
+  var vf192 = fn0();
+  var vf193: u32 = pack2x16unorm(vec2f(unconst_f32(0.2643), unconst_f32(-0.1685)));
+  _ = fn0();
+  let ptr145: ptr<private, i32> = &vp6[0][48][0];
+  vf193 = bitcast<u32>(vp6[unconst_u32(56)][48][0]);
+  for (var it13=u32(vp6[0][48][0]); it13<bitcast<vec3u>(cosh(vec3f(unconst_f32(0.00113), unconst_f32(0.2978), unconst_f32(0.03256)))).x; it13++) {
+  vp7 = mat2x2h(f16(vp6[unconst_u32(1000)][48][0]), f16(vp6[unconst_u32(1000)][48][0]), f16(vp6[unconst_u32(1000)][48][0]), f16(vp6[unconst_u32(1000)][48][0]));
+  let ptr146: ptr<private, array<array<array<i32, 1>, 49>, 1>> = &vp6;
+  {
+  vp7 = mat2x2h(f16(dot(vec4f(unconst_f32(0.2029), unconst_f32(0.2386), unconst_f32(0.1543), unconst_f32(0.1208)), vec4f(unconst_f32(0.5899), unconst_f32(0.2254), unconst_f32(0.4442), unconst_f32(1.000)))), f16(dot(vec4f(unconst_f32(0.2029), unconst_f32(0.2386), unconst_f32(0.1543), unconst_f32(0.1208)), vec4f(unconst_f32(0.5899), unconst_f32(0.2254), unconst_f32(0.4442), unconst_f32(1.000)))), f16(dot(vec4f(unconst_f32(0.2029), unconst_f32(0.2386), unconst_f32(0.1543), unconst_f32(0.1208)), vec4f(unconst_f32(0.5899), unconst_f32(0.2254), unconst_f32(0.4442), unconst_f32(1.000)))), f16(dot(vec4f(unconst_f32(0.2029), unconst_f32(0.2386), unconst_f32(0.1543), unconst_f32(0.1208)), vec4f(unconst_f32(0.5899), unconst_f32(0.2254), unconst_f32(0.4442), unconst_f32(1.000)))));
+}
+  break;
+}
+  let ptr147: ptr<function, f16> = &vf192[unconst_u32(32)];
+  let vf194: vec2f = reflect(vec2f(unconst_f32(0.2499), unconst_f32(0.00674)), vec2f(unconst_f32(0.01701), unconst_f32(0.1775)));
+  return out;
+  _ = override11;
+}
+
+/* zero global variables used */
+fn fn2() -> array<array<array<f32, 1>, 1>, 40> {
+  var out: array<array<array<f32, 1>, 1>, 40>;
+  vp7 -= mat2x2h(f16(vp6[unconst_u32(11)][unconst_u32(103)][0]), f16(vp6[unconst_u32(11)][unconst_u32(103)][0]), f16(vp6[unconst_u32(11)][unconst_u32(103)][0]), f16(vp6[unconst_u32(11)][unconst_u32(103)][0]));
+  let ptr148: ptr<private, array<i32, 1>> = &vp6[unconst_u32(231)][48];
+  let vf195: vec2h = vp7[unconst_u32(155)];
+  vp7 += mat2x2h(f16((*ptr148)[0]), f16((*ptr148)[0]), f16((*ptr148)[0]), f16((*ptr148)[0]));
+  _ = fn1(vec4i(vp6[unconst_u32(112)][unconst_u32(352)][unconst_u32(47)]));
+  loop {
+  var vf196: vec2<bool> = (vec2f(unconst_f32(0.1326), unconst_f32(0.06572)) != vec2f(unconst_f32(-0.1907), unconst_f32(0.00193)));
+  break;
+}
+  vp6[unconst_u32(242)][unconst_u32(49)][0] += i32(vp7[unconst_u32(113)][unconst_u32(48)]);
+  loop {
+  _ = fn1(vec4i(cross(vec3h(f16(override10)), vec3h(unconst_f16(2598.4), unconst_f16(13517.1), unconst_f16(205.9))).brgg));
+  fn0();
+  vp7 = mat2x2h(f16(vp6[unconst_u32(936)][48][0]), f16(vp6[unconst_u32(936)][48][0]), f16(vp6[unconst_u32(936)][48][0]), f16(vp6[unconst_u32(936)][48][0]));
+  break;
+  _ = override10;
+  _ = override11;
+}
+  out[unconst_u32(25)][0][0] = bitcast<f32>(vp7[unconst_i32(0)]);
+  out[unconst_u32(45)][unconst_u32(274)][unconst_u32(57)] = quantizeToF16(vec2f(unconst_f32(0.01853), unconst_f32(0.00396)))[0];
+  {
+  fn1(vec4i(vp6[unconst_u32(617)][48][0]));
+  let ptr149: ptr<private, i32> = &vp6[unconst_u32(307)][unconst_u32(46)][0];
+  let ptr150: ptr<private, i32> = &vp6[0][(vec3u(unconst_u32(207), unconst_u32(48), unconst_u32(176)) << (bitcast<u32>(vp6[unconst_u32(33)][48][unconst_u32(80)]) % vec2u(unconst_u32(137), unconst_u32(123))).yxx)[2]][unconst_u32(103)];
+  vp6[unconst_u32(114)][unconst_u32(7)][unconst_u32(123)] *= i32(any((vec3u(unconst_u32(254), unconst_u32(15), unconst_u32(69)) != vec3u(unconst_u32(107), unconst_u32(56), unconst_u32(175)))));
+  let ptr151: ptr<private, vec4f> = &vp8;
+  var vf197: vec4h = reflect(vec4h(unconst_f16(27389.2), unconst_f16(4182.9), unconst_f16(14350.2), unconst_f16(26576.8)), vec4h(unconst_f16(7183.1), unconst_f16(846.0), unconst_f16(15612.3), unconst_f16(2263.5)));
+  _ = override11;
+}
+  {
+  let ptr152: ptr<private, i32> = &vp6[unconst_u32(95)][48][0];
+  vp7 = mat2x2h(f16(vp6[0][48][unconst_u32(250)]), f16(vp6[0][48][unconst_u32(250)]), f16(vp6[0][48][unconst_u32(250)]), f16(vp6[0][48][unconst_u32(250)]));
+  let vf198: vec3h = cosh(vec3h(unconst_f16(9035.1), unconst_f16(15453.1), unconst_f16(-1815.4)));
+  loop {
+  let ptr153: ptr<private, array<i32, 1>> = &vp6[unconst_u32(12)][48];
+  var vf199 = fn1(vec4i(i32((unconst_f16(869.3) - unconst_f16(7529.0)))));
+  let ptr154: ptr<function, vec4h> = &vf199[0][unconst_u32(115)][0][3][0][0];
+  var vf200 = fn1(vec4i(vf199[0][unconst_u32(41)][vec4u(vf199[unconst_u32(166)][0][unconst_u32(119)][unconst_u32(38)][0][0]).b][u32(vf199[unconst_u32(10)][0][0][3][0][pack2x16float(vec2f(unconst_f32(0.1270), unconst_f32(0.09040)))][bitcast<u32>(vp7[unconst_u32(38)])])][unconst_u32(1)][0]));
+  break;
+  _ = override11;
+}
+  out[unconst_u32(390)][unconst_u32(209)][unconst_u32(187)] += vp8[unconst_u32(511)];
+  vp7 -= mat2x2h(f16(select(unconst_u32(124), unconst_u32(87), unconst_bool(false))), f16(select(unconst_u32(124), unconst_u32(87), unconst_bool(false))), f16(select(unconst_u32(124), unconst_u32(87), unconst_bool(false))), f16(select(unconst_u32(124), unconst_u32(87), unconst_bool(false))));
+  _ = override11;
+}
+  return out;
+  _ = override10;
+  _ = override11;
+}
+
+struct T0 {
+  @align(8) @size(40) f0: array<u32>,
+}
+
+struct T1 {
+  @size(3040) f0: array<array<array<array<atomic<u32>, 1>, 1>, 1>>,
+}
+
+var<private> vp6: array<array<array<i32, 1>, 49>, 1> = array<array<array<i32, 1>, 49>, 1>();
+
+@id(63796) override override10: i32;
+
+var<private> vp8: vec4f = vec4f(0.2517, 0.09246, 0.05628, 0.2851);
+
+var<workgroup> vw46: mat3x2h;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw45: array<mat2x4h, 1>;
+
+/* zero global variables used */
+fn fn6(a0: array<array<vec2i, 1>, 1>, a1: array<vec2h, 1>) -> array<i32, 1> {
+  var out: array<i32, 1>;
+  let ptr162: ptr<private, i32> = &vp6[0][unconst_u32(44)][unconst_u32(114)];
+  vp6[unconst_u32(567)][48][unconst_u32(625)] = bitcast<i32>(quantizeToF16(unconst_f32(0.1132)));
+  out[unconst_u32(183)] = a0[unconst_u32(7)][0][unconst_u32(650)];
+  return out;
+}
+
+var<workgroup> vw44: u32;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+fn fn0() -> array<f16, 32> {
+  var out: array<f16, 32>;
+  let vf184: vec2h = smoothstep(vec2h(unconst_f16(-10820.7), unconst_f16(12449.8)), vec2h(unconst_f16(-6312.3), unconst_f16(1046.3)), vec2h(unconst_f16(15821.2), unconst_f16(3210.5)));
+  out[31] = vp7[unconst_u32(267)].g;
+  out[pack4xU8Clamp(vec4u(transpose(mat4x3h())[unconst_i32(0)]))] -= f16(vp6[unconst_u32(515)][48][unconst_u32(109)]);
+  let ptr136: ptr<private, array<i32, 1>> = &vp6[unconst_u32(10)][unconst_u32(72)];
+  switch i32(reverseBits(vec4u(unconst_u32(417), unconst_u32(44), unconst_u32(185), unconst_u32(642))).w) { 
+  default {
+  let vf185: bool = all(vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false), unconst_bool(true)));
+  let ptr137: ptr<private, i32> = &vp6[unconst_u32(104)][48][unconst_u32(26)];
+  var vf186: f32 = fract(unconst_f32(0.05134));
+  let vf187: vec3f = log(vec3f(unconst_f32(0.08066), unconst_f32(0.1490), unconst_f32(-0.07331)));
+  let vf188: vec2h = ldexp(vec2h(unconst_f16(16925.6), unconst_f16(954.4)), vec2i(unconst_i32(568), unconst_i32(411)));
+  let vf189: u32 = pack2x16float(radians(vec3f(unconst_f32(0.09113), unconst_f32(0.02322), unconst_f32(0.05006))).rb);
+  break;
+}
+  }
+  vp6[unconst_u32(163)][unconst_u32(3)][unconst_u32(45)] = vp6[unconst_u32(664)][48][0];
+  let ptr138: ptr<private, array<i32, 1>> = &vp6[unconst_u32(124)][unconst_u32(2)];
+  let vf190: u32 = pack4x8snorm(vec4f(unconst_f32(0.00130), unconst_f32(0.06602), unconst_f32(0.3089), unconst_f32(0.3544)));
+  out[unconst_u32(181)] = f16((mat2x2f(unconst_f32(0.1437), unconst_f32(0.4011), unconst_f32(0.00970), unconst_f32(0.09912)) * unconst_f32(-0.00124))[unconst_i32(0)].g);
+  let ptr139: ptr<private, i32> = &(*ptr138)[unconst_u32(79)];
+  while bool(vp6[0][u32(cos(vec3h(unconst_f16(16547.0), unconst_f16(8950.9), unconst_f16(5265.3)))[0])][0]) {
+  let ptr140: ptr<private, array<i32, 1>> = &vp6[0][48];
+  vp8 = unpack4x8unorm(override11);
+  break;
+  _ = override11;
+}
+  loop {
+  let ptr141: ptr<private, i32> = &vp6[unconst_u32(281)][unconst_u32(14)][unconst_u32(11)];
+  let vf191: bool = all(unconst_bool(true));
+  vp7 = mat2x2h(f16(vp6[0][unconst_u32(363)][0]), f16(vp6[0][unconst_u32(363)][0]), f16(vp6[0][unconst_u32(363)][0]), f16(vp6[0][unconst_u32(363)][0]));
+  break;
+}
+  let ptr142: ptr<private, i32> = &vp6[unconst_u32(110)][unconst_u32(169)][unconst_u32(603)];
+  let ptr143: ptr<private, array<array<i32, 1>, 49>> = &vp6[unconst_u32(356)];
+  let ptr144: ptr<private, i32> = &(*ptr143)[unconst_u32(62)][unconst_u32(44)];
+  return out;
+  _ = override11;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* used global variables: tex8 */
+fn fn3() -> vec2h {
+  var out: vec2h;
+  var vf201 = fn0();
+  vf201[bitcast<u32>(vp6[unconst_u32(210)][unconst_u32(55)][unconst_u32(56)])] = f16(vp6[unconst_u32(156)][48][0]);
+  var vf202 = fn0();
+  vp7 = mat2x2h(f16(vp6[unconst_u32(248)][48][0]), f16(vp6[unconst_u32(248)][48][0]), f16(vp6[unconst_u32(248)][48][0]), f16(vp6[unconst_u32(248)][48][0]));
+  out = bitcast<vec2h>(vp6[bitcast<u32>(vp6[0][48][unconst_u32(244)])][unconst_u32(62)][unconst_u32(197)]);
+  let ptr155: ptr<function, f16> = &vf202[unconst_u32(141)];
+  {
+  let ptr156: ptr<private, i32> = &vp6[0][48][unconst_u32(35)];
+  fn0();
+  var vf203 = fn0();
+  var vf204: vec4i = textureLoad(tex8, vec2i(unconst_i32(-144), unconst_i32(1000)), unconst_i32(268));
+  _ = override11;
+  _ = tex8;
+}
+  let ptr157: ptr<function, f16> = &(*ptr155);
+  {
+  while bool(textureDimensions(tex8, unconst_i32(286)).y) {
+  vp7 = mat2x2h(f16(pack2x16float(vec2f(unconst_f32(0.04584), unconst_f32(0.2067)))), f16(pack2x16float(vec2f(unconst_f32(0.04584), unconst_f32(0.2067)))), f16(pack2x16float(vec2f(unconst_f32(0.04584), unconst_f32(0.2067)))), f16(pack2x16float(vec2f(unconst_f32(0.04584), unconst_f32(0.2067)))));
+  var vf205 = fn0();
+  break;
+  _ = override11;
+}
+  {
+  let ptr158: ptr<private, array<i32, 1>> = &vp6[unconst_u32(106)][unconst_u32(202)];
+  var vf206 = fn0();
+  vp6[unconst_u32(557)][unconst_u32(344)][unconst_u32(271)] &= (*ptr158)[0];
+  let vf207: bool = (unconst_bool(true) || unconst_bool(true));
+  _ = override11;
+}
+  let ptr159: ptr<private, i32> = &vp6[unconst_u32(112)][unconst_u32(210)][0];
+  _ = override11;
+  _ = tex8;
+}
+  var vf208 = fn0();
+  return out;
+  _ = override11;
+  _ = tex8;
+}
+
+/* zero global variables used */
+fn fn5(a0: ptr<private, mat3x3f>, a1: array<vec4<bool>, 1>) -> array<array<mat2x3f, 2>, 1> {
+  var out: array<array<mat2x3f, 2>, 1>;
+  let ptr161: ptr<private, i32> = &vp6[0][48][0];
+  fn0();
+  _ = fn0();
+  fn0();
+  (*a0) += mat3x3f(bitcast<f32>(vp6[0][48][0]), bitcast<f32>(vp6[0][48][0]), bitcast<f32>(vp6[0][48][0]), bitcast<f32>(vp6[0][48][0]), f32(vp6[0][48][0]), f32(vp6[0][48][0]), f32(vp6[0][48][0]), f32(vp6[0][48][0]), f32(vp6[0][48][0]));
+  return out;
+  _ = override11;
+}
+
+@id(26995) override override11: u32;
+
+var<private> vp7: mat2x2h = mat2x2h(1598.5, 3080.3, 6306.1, 18528.4);
+
+/* zero global variables used */
+@fragment
+fn fragment11() -> @location(200) @interpolate(flat, either) vec4f {
+  var out: vec4f;
+  let ptr163: ptr<private, array<array<i32, 1>, 49>> = &vp6[unconst_u32(276)];
+  let ptr164: ptr<private, i32> = &vp6[unconst_u32(68)][48][unconst_u32(186)];
+  fn0();
+  fn1(firstLeadingBit(vec2i(vp6[unconst_u32(476)][unconst_u32(202)][0])).xxxx);
+  var vf216 = fn0();
+  vp6[unconst_u32(154)][unconst_u32(100)][unconst_u32(58)] |= vp6[unconst_u32(15)][48][0];
+  out += vec4f((vec3i(i32(vf216[31])) >> vec3u(unconst_u32(261), unconst_u32(98), unconst_u32(99))).rbbg);
+  return out;
+  _ = override11;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(2, 1, 1)
+fn compute9() {
+  _ = fn2();
+  vp8 *= vec4f((*&vw46)[unconst_i32(2)].rrgg);
+  let ptr165: ptr<workgroup, mat2x4h> = &(*&vw45)[0];
+  _ = override11;
+  _ = override10;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute10() {
+  let vf217: f16 = vw46[unconst_u32(29)][unconst_u32(217)];
+  var vf218: vec3i = countTrailingZeros(vec3i(unconst_i32(350), unconst_i32(317), unconst_i32(1)));
+  var vf219: u32 = pack2x16snorm(vec2f(unconst_f32(-0.2115), unconst_f32(0.1491)));
+  fn2();
+  vw46 += mat3x2h(ldexp(vec2h(unconst_f16(4548.9), unconst_f16(21581.4)), vec2i(unconst_i32(460), unconst_i32(43))), ldexp(vec2h(unconst_f16(4548.9), unconst_f16(21581.4)), vec2i(unconst_i32(460), unconst_i32(43))), ldexp(vec2h(unconst_f16(4548.9), unconst_f16(21581.4)), vec2i(unconst_i32(460), unconst_i32(43))));
+  for (var it14=bitcast<u32>(vp6[unconst_u32(40)][unconst_u32(13)][0]); it14<u32(vw45[0][unconst_u32(305)][unconst_u32(12)]); it14++) {
+  let ptr166: ptr<workgroup, mat2x4h> = &(*&vw45)[unconst_u32(73)];
+  var vf220 = fn0();
+  let ptr167: ptr<private, i32> = &vp6[0][48][0];
+  let ptr168: ptr<private, i32> = &vp6[unconst_u32(66)][48][0];
+  _ = override11;
+}
+  _ = override11;
+  _ = override10;
+}`,
+});
+let buffer107 = device0.createBuffer({
+  size: 10003,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture135 = device0.createTexture({
+  size: [258, 15, 11],
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup13, new Uint32Array(5617), 699, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer54, 984);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer71, 10_192);
+} catch {}
+try {
+computePassEncoder84.insertDebugMarker('\u0c1a');
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder();
+let texture136 = device0.createTexture({
+  size: {width: 22, height: 10, depthOrArrayLayers: 9},
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+let textureView167 = texture110.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder11.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer62, 420);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer10, 'uint16', 7_220, 66);
+} catch {}
+let texture137 = device0.createTexture({
+  size: [180, 80, 91],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder129 = commandEncoder150.beginComputePass({});
+try {
+computePassEncoder127.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup11, new Uint32Array(1944), 1_280, 0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle4, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder10.draw(0, 103, 0, 388_259_449);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer40, 444);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer47);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let veryExplicitBindGroupLayout23 = device0.createBindGroupLayout({entries: [{binding: 3, visibility: GPUShaderStage.VERTEX, externalTexture: {}}]});
+let textureView168 = texture137.createView({baseArrayLayer: 0});
+let texture138 = device0.createTexture({
+  size: {width: 180, height: 80, depthOrArrayLayers: 16},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder129.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup40, new Uint32Array(461), 39, 0);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 376.9, g: -996.9, b: 516.8, a: -520.0, });
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer6, 2_136);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer16, 732);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer82, 'uint16', 2_268, 2_180);
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder({});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(0, bindGroup78, new Uint32Array(5406), 115, 0);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {binding: 152, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 264,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup89 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 169, resource: {buffer: buffer19, offset: 3584, size: 123}},
+    {binding: 359, resource: sampler70},
+    {binding: 267, resource: {buffer: buffer11, offset: 256, size: 352}},
+    {binding: 47, resource: externalTexture1},
+    {binding: 192, resource: {buffer: buffer8, offset: 256, size: 2644}},
+  ],
+});
+let commandEncoder152 = device0.createCommandEncoder();
+let texture139 = gpuCanvasContext1.getCurrentTexture();
+let textureView169 = texture102.createView({dimension: '2d-array', baseArrayLayer: 4, arrayLayerCount: 8});
+let renderPassEncoder39 = commandEncoder152.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 442,
+  clearValue: { r: 753.9, g: -343.0, b: -702.6, a: -386.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet5},
+});
+let sampler84 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint16', 1_014, 17);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet2, 14, 75, buffer11, 3840);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 40, new Float32Array(13111), 3222, 692);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline29 = device0.createRenderPipeline({
+  layout: pipelineLayout13,
+  fragment: {module: shaderModule5, constants: {}, targets: [{format: 'rgb10a2unorm'}]},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex6',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 224,
+        attributes: [
+          {format: 'sint32x2', offset: 4, shaderLocation: 0},
+          {format: 'uint32x2', offset: 76, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', cullMode: 'front', unclippedDepth: false},
+});
+let commandEncoder153 = device0.createCommandEncoder({});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer43, 'uint16', 2, 12);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 612, new Int16Array(1104), 4, 172);
+} catch {}
+document.body.append(img1);
+let imageData20 = new ImageData(188, 24);
+try {
+adapter1.label = '\u9c87\u{1ffe2}\uf86e\ue414\u0eb3';
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 169, resource: {buffer: buffer32, offset: 5120, size: 403}},
+    {binding: 267, resource: {buffer: buffer87, offset: 512}},
+    {binding: 47, resource: externalTexture11},
+    {binding: 192, resource: {buffer: buffer49, offset: 3328}},
+    {binding: 359, resource: sampler37},
+  ],
+});
+let commandBuffer5 = commandEncoder10.finish();
+let textureView170 = texture109.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer87, 'uint32', 372, 620);
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer92, 152, buffer57, 356, 56);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 32, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(50, 359);
+try {
+adapter0.label = '\u06af\u{1faaf}\u0720\u2ef9\u43c9\u0380\u{1f8f7}\u0ab6\u532e\u{1fa59}\u9bba';
+} catch {}
+let autogeneratedBindGroupLayout8 = pipeline14.getBindGroupLayout(0);
+let bindGroup91 = device0.createBindGroup({layout: veryExplicitBindGroupLayout23, entries: [{binding: 3, resource: externalTexture6}]});
+let buffer108 = device0.createBuffer({size: 10499, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT, mappedAtCreation: false});
+let sampler85 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup33, []);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 0, y: 42 },
+  flipY: true,
+}, {
+  texture: texture108,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 133});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer103, 0); };
+} catch {}
+let arrayBuffer7 = buffer57.getMappedRange(8, 44);
+try {
+buffer92.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+await gc();
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte432', transfer: 'iec61966-2-1'} });
+let computePassEncoder130 = commandEncoder153.beginComputePass({});
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup29);
+} catch {}
+let sampler86 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 92.37,
+});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup9, new Uint32Array(5993), 1_441, 0);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer88, 'uint32', 648, 665);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 5, y: 23, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer30, 336, new BigUint64Array(5168), 59, 12);
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({});
+let texture140 = device0.createTexture({
+  size: {width: 45, height: 20, depthOrArrayLayers: 39},
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder40 = commandEncoder151.beginRenderPass({colorAttachments: [{view: textureView107, depthSlice: 62, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder124.setBindGroup(3, bindGroup51, new Uint32Array(161), 16, 0);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(378);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder154.copyTextureToTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 83, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer78, 1180, new BigUint64Array(6132), 3539, 40);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas3.getContext('webgpu');
+let commandEncoder155 = device0.createCommandEncoder();
+let texture141 = gpuCanvasContext2.getCurrentTexture();
+let textureView171 = texture56.createView({mipLevelCount: 1});
+let computePassEncoder131 = commandEncoder154.beginComputePass();
+let sampler87 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 84.28});
+try {
+computePassEncoder115.setBindGroup(2, bindGroup88);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup23, new Uint32Array(3077), 1_427, 0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer71, 'uint16', 1_754, 8_225);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer49);
+} catch {}
+let computePassEncoder132 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup75, new Uint32Array(1912), 386, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle5, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer32, 'uint32', 528, 430);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline20);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 244, new BigUint64Array(1126), 83, 20);
+} catch {}
+let buffer109 = device0.createBuffer({
+  size: 11085,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder156 = device0.createCommandEncoder();
+let texture142 = device0.createTexture({
+  size: {width: 45, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder133 = commandEncoder156.beginComputePass({timestampWrites: {querySet: querySet11, beginningOfPassWriteIndex: 617, endOfPassWriteIndex: 810}});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer71, 2_396); };
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer43, 'uint16', 10, 7);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer104, 0, 716);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup84);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer87, 'uint32', 996, 198);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1, buffer34, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer58, 1548, new Float32Array(1522));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 108, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(344_361).fill(53), /* required buffer size: 344_361 */
+{offset: 17, bytesPerRow: 1204, rowsPerImage: 22}, {width: 150, height: 0, depthOrArrayLayers: 14});
+} catch {}
+try {
+globalThis.someLabel = externalTexture9.label;
+} catch {}
+let externalTexture19 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder67.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup59, new Uint32Array(1008), 183, 0);
+} catch {}
+try {
+renderPassEncoder33.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle24, renderBundle18]);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(6, buffer7);
+} catch {}
+try {
+buffer73.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 1268, new Int16Array(2780), 193, 192);
+} catch {}
+let texture143 = device0.createTexture({
+  size: {width: 258},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup64, new Uint32Array(251), 17, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder103); computePassEncoder103.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer41, 'uint16', 446, 94);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer74, 'uint32', 156, 227);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 3260, new Int16Array(848));
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let commandEncoder157 = device0.createCommandEncoder();
+let computePassEncoder134 = commandEncoder157.beginComputePass();
+try {
+computePassEncoder75.setBindGroup(1, bindGroup66, new Uint32Array(508), 68, 0);
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer46, 'uint16', 184, 43);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer74, 'uint16', 670, 184);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(6, undefined);
+} catch {}
+let imageData21 = new ImageData(16, 160);
+let texture144 = device0.createTexture({
+  size: [258, 15, 44],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle28 = renderBundleEncoder28.finish({});
+let sampler88 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup69, new Uint32Array(1003), 49, 0);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(2, bindGroup69, new Uint32Array(1171), 70, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline8);
+} catch {}
+let promise30 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule6,
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 260,
+        attributes: [
+          {format: 'unorm16x2', offset: 40, shaderLocation: 14},
+          {format: 'sint32', offset: 28, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 28, shaderLocation: 5},
+          {format: 'sint32x3', offset: 64, shaderLocation: 13},
+          {format: 'uint8x4', offset: 80, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let commandEncoder158 = device0.createCommandEncoder({});
+let texture145 = device0.createTexture({
+  size: [45, 20, 22],
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture146 = device0.createTexture({
+  size: {width: 129, height: 7, depthOrArrayLayers: 11},
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder33.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer74, 'uint32', 120, 201);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let imageData22 = new ImageData(112, 100);
+let buffer110 = device0.createBuffer({
+  size: 13282,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let texture147 = device0.createTexture({
+  size: [90, 1, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let textureView172 = texture52.createView({});
+let renderBundle29 = renderBundleEncoder29.finish({});
+let sampler89 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame21});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer16, 172); };
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 32, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(187).fill(229), /* required buffer size: 187 */
+{offset: 187}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise29;
+} catch {}
+let autogeneratedBindGroupLayout9 = pipeline8.getBindGroupLayout(0);
+try {
+computePassEncoder125.setBindGroup(2, bindGroup73, new Uint32Array(1974), 110, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder103); computePassEncoder103.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer11, 'uint32', 4_312, 9_491);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer92, 528, 33);
+} catch {}
+try {
+  await shaderModule7.getCompilationInfo();
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 80, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 38, y: 49, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = device0.createRenderPipeline({
+  layout: pipelineLayout21,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment7',
+  constants: {},
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule8,
+    constants: {},
+    buffers: [{arrayStride: 492, attributes: [{format: 'uint16x4', offset: 244, shaderLocation: 13}]}],
+  },
+});
+let commandEncoder159 = device0.createCommandEncoder({});
+let texture148 = device0.createTexture({
+  size: [256],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder41 = commandEncoder158.beginRenderPass({
+  colorAttachments: [{
+  view: textureView128,
+  depthSlice: 14,
+  clearValue: { r: -842.0, g: 448.6, b: -648.5, a: 336.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder124.setBindGroup(3, bindGroup28, new Uint32Array(2194), 956, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+commandEncoder159.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1216 */
+  offset: 1216,
+  bytesPerRow: 4608,
+  buffer: buffer69,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 1, y: 17, z: 2},
+  aspect: 'all',
+}, {width: 10, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder30.insertDebugMarker('\u0b99');
+} catch {}
+let commandEncoder160 = device0.createCommandEncoder({});
+let renderPassEncoder42 = commandEncoder160.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  depthSlice: 378,
+  clearValue: { r: -185.8, g: -430.2, b: 100.5, a: -711.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder18.setVertexBuffer(0, buffer8, 304, 1_863);
+} catch {}
+try {
+commandEncoder159.clearBuffer(buffer75);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 22, height: 10, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData17,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout11 = pipeline29.getBindGroupLayout(0);
+let bindGroup92 = device0.createBindGroup({layout: veryExplicitBindGroupLayout23, entries: [{binding: 3, resource: externalTexture13}]});
+let buffer111 = device0.createBuffer({
+  size: 9873,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder135 = commandEncoder159.beginComputePass({timestampWrites: {querySet: querySet9, endOfPassWriteIndex: 302}});
+try {
+{ clearResourceUsages(device0, computePassEncoder77); computePassEncoder77.dispatchWorkgroupsIndirect(buffer97, 4); };
+} catch {}
+try {
+computePassEncoder77.end();
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup59, new Uint32Array(3356), 174, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(1, buffer44, 588, 50);
+} catch {}
+let bindGroup93 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 328, resource: textureView15}]});
+let buffer112 = device0.createBuffer({
+  size: 1736,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView173 = texture115.createView({aspect: 'all', baseArrayLayer: 0});
+let computePassEncoder136 = commandEncoder92.beginComputePass();
+try {
+computePassEncoder56.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(0, bindGroup69, new Uint32Array(1934), 84, 0);
+} catch {}
+try {
+computePassEncoder136.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: -954.4, g: -561.3, b: 853.0, a: -676.9, });
+} catch {}
+let promise31 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 180, height: 1, depthOrArrayLayers: 50}
+*/
+{
+  source: imageData4,
+  origin: { x: 4, y: 9 },
+  flipY: false,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup94 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 578, resource: {buffer: buffer26, offset: 256}}],
+});
+let commandEncoder161 = device0.createCommandEncoder({});
+let computePassEncoder137 = commandEncoder161.beginComputePass({});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup53, new Uint32Array(576), 1, 0);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle27, renderBundle4, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer81, 'uint32', 840, 2_520);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline29);
+} catch {}
+try {
+  await promise31;
+} catch {}
+let videoFrame26 = videoFrame4.clone();
+let commandEncoder162 = device0.createCommandEncoder({label: '\u83ac\u{1ff39}\u0965\udc3a\u{1f819}\ubf23\u{1fc38}\ub420\u{1f6c7}\u7a10'});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup78, new Uint32Array(156), 9, 0);
+} catch {}
+try {
+commandEncoder162.clearBuffer(buffer109, 2728, 256);
+} catch {}
+let texture149 = device0.createTexture({
+  size: [22, 10, 11],
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder138 = commandEncoder162.beginComputePass();
+try {
+computePassEncoder4.setBindGroup(0, bindGroup6, new Uint32Array(657), 33, 0);
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline22);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 94 */
+  offset: 94,
+  bytesPerRow: 10752,
+  buffer: buffer75,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup95 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [{binding: 16, resource: {buffer: buffer8, offset: 512, size: 1512}}],
+});
+let commandEncoder163 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder52.finish();
+let texture150 = device0.createTexture({
+  size: [90, 1, 27],
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder139 = commandEncoder163.beginComputePass({});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup80);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder118); computePassEncoder118.dispatchWorkgroupsIndirect(buffer68, 9_868); };
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup54, new Uint32Array(3411), 189, 0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline20);
+} catch {}
+try {
+computePassEncoder75.insertDebugMarker('\u{1fd4c}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture108,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView174 = texture74.createView({});
+let texture151 = device0.createTexture({
+  size: [517, 30, 11],
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder29.setIndexBuffer(buffer10, 'uint32', 9_948, 2_826);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer27, 0, 811);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 47, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 169,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 192,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 267, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {
+      binding: 359,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let textureView175 = texture148.createView({});
+let sampler90 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.82,
+  compare: 'greater-equal',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder137.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup44, new Uint32Array(8115), 102, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, undefined);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+document.body.append(img0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData23 = new ImageData(12, 16);
+let texture152 = device0.createTexture({
+  size: {width: 517, height: 30, depthOrArrayLayers: 11},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame18, colorSpace: 'srgb'});
+try {
+computePassEncoder118.end();
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup53, new Uint32Array(1911), 33, 0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(5, buffer51, 96);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 10, y: 48, z: 10},
+  aspect: 'all',
+}, new Uint8Array(6_650).fill(151), /* required buffer size: 6_650 */
+{offset: 286, bytesPerRow: 225, rowsPerImage: 26}, {width: 20, height: 12, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(canvas2);
+let bindGroup96 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [{binding: 16, resource: {buffer: buffer25, offset: 0, size: 2748}}],
+});
+let texture153 = device0.createTexture({
+  size: [180, 1, 10],
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderPassEncoder43 = commandEncoder135.beginRenderPass({colorAttachments: [{view: textureView157, loadOp: 'load', storeOp: 'discard'}]});
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(5, buffer45, 4_048);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'premultiplied'});
+} catch {}
+try {
+  await promise28;
+} catch {}
+document.body.append(img0);
+let bindGroup97 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 254, resource: {buffer: buffer74, offset: 0, size: 28}},
+    {binding: 62, resource: textureView18},
+    {binding: 578, resource: {buffer: buffer0, offset: 0, size: 4108}},
+  ],
+});
+let buffer113 = device0.createBuffer({
+  size: 5067,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder164 = device0.createCommandEncoder({});
+let textureView176 = texture70.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 2});
+let computePassEncoder140 = commandEncoder164.beginComputePass();
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint'], depthReadOnly: true});
+let renderBundle30 = renderBundleEncoder30.finish({});
+try {
+computePassEncoder103.end();
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer2, 1024, buffer72, 948, 8);
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 268, new Float32Array(823), 46, 40);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder165 = device0.createCommandEncoder({});
+let sampler91 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder140.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup77);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer65, 'uint32', 8, 7);
+} catch {}
+try {
+commandEncoder165.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture122,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise32 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x332099f7},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment7',
+  targets: [{format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 340,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 24, shaderLocation: 14}, {format: 'uint8x4', offset: 0, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 40, shaderLocation: 10},
+          {format: 'uint8x4', offset: 136, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(16, 245, 60, 434_712_509, 1_296_859_674);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer16, 44);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer111, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let recycledExplicitBindGroupLayout12 = pipeline5.getBindGroupLayout(0);
+let texture154 = device0.createTexture({size: {width: 45}, dimension: '1d', format: 'rgba8unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderPassEncoder44 = commandEncoder165.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: -330.8, g: -865.6, b: 826.8, a: -750.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 106347549,
+});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rgba16uint']});
+let sampler92 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 97.92});
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer87, 92);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer102, 'uint32', 3_680, 347);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer39, 0);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder97.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 64, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder({});
+let texture155 = device0.createTexture({
+  size: [1035, 60, 11],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler93 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup64, new Uint32Array(2084), 539, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.draw(30, 325, 2, 19_902_114);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer62, 516);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer109);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup58);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline11);
+} catch {}
+let buffer114 = device0.createBuffer({size: 205, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let textureView177 = texture64.createView({dimension: 'cube', mipLevelCount: 1, baseArrayLayer: 5});
+try {
+computePassEncoder137.setBindGroup(2, bindGroup59, new Uint32Array(3522), 1_448, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup51, new Uint32Array(3549), 289, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(10, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer29, 'uint16', 1_854, 2_262);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder97.copyBufferToTexture({
+  /* bytesInLastRow: 216 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1068 */
+  offset: 1068,
+  bytesPerRow: 3328,
+  buffer: buffer108,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 15, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 54, height: 54, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture2.label = '\ucd67\u9583\u{1f609}\ue4de\u{1fa42}\ub411\u0dce\ue0c5\udd57\ud715\u9b5b';
+} catch {}
+let texture156 = device0.createTexture({
+  size: [360, 1, 690],
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder45 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: 297.5, g: -964.6, b: -386.2, a: -238.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder96.setBindGroup(2, bindGroup35);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup59, new Uint32Array(4326), 553, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer35, 'uint16', 1_632, 882);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+videoFrame0.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -50,6 +50,8 @@ CommandBuffer::CommandBuffer(Device& device)
 CommandBuffer::~CommandBuffer()
 {
     m_device->protectedQueue()->removeMTLCommandBuffer(m_commandBuffer);
+    m_commandBuffer = nil;
+    m_cachedCommandBuffer = nil;
 }
 
 void CommandBuffer::setLabel(String&& label)
@@ -65,6 +67,7 @@ void CommandBuffer::makeInvalid(NSString* lastError)
     m_lastErrorString = lastError;
     m_device->protectedQueue()->removeMTLCommandBuffer(m_commandBuffer);
     m_commandBuffer = nil;
+    m_cachedCommandBuffer = nil;
     m_commandEncoder = nullptr;
 }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -115,6 +115,7 @@ public:
     bool encoderIsCurrent(id<MTLCommandEncoder>) const;
     bool submitWillBeInvalid() const { return m_makeSubmitInvalid; }
     void addBuffer(id<MTLBuffer>);
+    void addBuffer(id<MTLCounterSampleBuffer>);
     void addICB(id<MTLIndirectCommandBuffer>);
     void addTexture(id<MTLTexture>);
     void addTexture(const Texture&);
@@ -170,6 +171,7 @@ private:
     NSMutableSet<id<MTLTexture>> *m_retainedTextures { nil };
     NSMutableSet<id<MTLBuffer>> *m_retainedBuffers { nil };
     HashSet<RefPtr<const Sampler>> m_retainedSamplers;
+    NSMutableSet<id<MTLCounterSampleBuffer>> *m_retainedTimestampBuffers { nil };
     id<MTLSharedEvent> m_sharedEvent { nil };
     uint64_t m_sharedEventSignalValue { 0 };
 private PUBLIC_IN_WEBGPU_SWIFT:

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -136,6 +136,7 @@ void QuerySet::setCommandEncoder(CommandEncoder& commandEncoder) const
 {
     CommandEncoder::trackEncoder(commandEncoder, m_commandEncoders);
     commandEncoder.addBuffer(m_visibilityBuffer);
+    commandEncoder.addBuffer(m_timestampBuffer);
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();
 }

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -44,6 +44,7 @@ namespace WebGPU {
 
 class Buffer;
 class CommandBuffer;
+class CommandEncoder;
 class Device;
 class Texture;
 class TextureView;
@@ -93,6 +94,8 @@ public:
 
     // This can be called on a background thread.
     void scheduleWork(Instance::WorkItem&&);
+    uint32_t WARN_UNUSED_RETURN retainEncoder(CommandEncoder&);
+    void releaseEncoder(uint32_t);
 private:
     Queue(id<MTLCommandQueue>, Adapter&, Device&);
     Queue(Adapter&, Device&);
@@ -120,6 +123,7 @@ private:
     HashMap<uint64_t, OnSubmittedWorkScheduledCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkScheduledCallbacks;
     using OnSubmittedWorkDoneCallbacks = Vector<WTF::Function<void(WGPUQueueWorkDoneStatus)>>;
     HashMap<uint64_t, OnSubmittedWorkDoneCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkDoneCallbacks;
+    HashMap<uint32_t, RefPtr<CommandEncoder>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_retainedEncoders;
     NSMutableOrderedSet<id<MTLCommandBuffer>> *m_createdNotCommittedBuffers { nil };
     NSMapTable<id<MTLCommandBuffer>, id<MTLCommandEncoder>> *m_openCommandEncoders;
     const ThreadSafeWeakPtr<Instance> m_instance;


### PR DESCRIPTION
#### c28e06df6892d9222e4d75c59f24c9933362dcd6
<pre>
[WebGPU] optional counter sample indices are not respected
<a href="https://bugs.webkit.org/show_bug.cgi?id=286689">https://bugs.webkit.org/show_bug.cgi?id=286689</a>
<a href="https://rdar.apple.com/143805885">rdar://143805885</a>

(Reland with ASAN crash regression fixed)

Reviewed by Dan Glastonbury.

The specification says a sample index which is not specified should
be treated as &apos;don&apos;t sample&apos; instead of sampling the counter.

* LayoutTests/fast/webgpu/nocrash/fuzz-286689-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-286689.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::timestampWriteIndex):
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):
Don&apos;t sample non-specified counter values and ensure counter sample
buffers are retained for the lifetime of the command buffer.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseFeatures):
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::retainEncoder):
(WebGPU::Queue::releaseEncoder):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::checkForIndirectDrawDeviceLost):
(WebGPU::RenderPassEncoder::executeBundles):
We need to manually retain the CommandEncoder until the completion handler
completes, otherwise a sample counter buffer may be released resulting
in a retain on a release pointer. Tracked by <a href="https://rdar.apple.com/143905417">rdar://143905417</a>

Canonical link: <a href="https://commits.webkit.org/289644@main">https://commits.webkit.org/289644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f25479e735b6b56f2f72bd821a0fd67347f0946e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41975 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15278 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/92459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90596 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79264 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33658 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94345 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14762 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/10824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15016 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18620 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7713 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14778 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->