### PR TITLE
www.webkit.org webkit_surveys plugin errors in PHP-FPM 8.1

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
+++ b/Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php
@@ -26,12 +26,12 @@ class WebKit_Survey {
         add_shortcode('survey', ['WebKit_Survey', 'survey_shortcode']);
     }
     
-    public function process_survey($post_id, $post_after, $post_before) {
+    public static function process_survey($post_id, $post_after, $post_before) {
         self::$post_update = true;
         do_shortcode($post_after->post_content);
     }
     
-    public function survey_shortcode($atts, $content) {
+    public static function survey_shortcode($atts, $content) {
         $json_string = str_replace(array('“','”'), '"', html_entity_decode(strip_tags($content)));
         $Survey = json_decode($json_string);
 
@@ -57,7 +57,7 @@ class WebKit_Survey {
         return ob_get_clean();
     }
 
-    public function add_survey_boxes() {
+    public static function add_survey_boxes() {
         $post_id = get_the_ID();
         $settings = get_post_meta($post_id, 'webkit_survey_settings');
         if (!$settings)
@@ -74,7 +74,7 @@ class WebKit_Survey {
         }
     }
     
-    public function admin_box() {
+    public static function admin_box() {
         $post_id = get_the_ID();
         $settings = get_post_meta($post_id, 'webkit_survey_settings');
         ?>
@@ -89,7 +89,7 @@ class WebKit_Survey {
         echo '<strong>' . number_format($total) . '</strong> Total Votes';
     }
 
-    public function process_vote() {
+    public static function process_vote() {
         if (self::responded()) {
             self::$responded = true;
             return;


### PR DESCRIPTION
#### df6132558a464cb836d160f46940e11994af861a
<pre>
www.webkit.org webkit_surveys plugin errors in PHP-FPM 8.1
<a href="https://bugs.webkit.org/show_bug.cgi?id=286829">https://bugs.webkit.org/show_bug.cgi?id=286829</a>
<a href="https://rdar.apple.com/143981711">rdar://143981711</a>

Reviewed by Alexey Proskuryakov.

These changes will fix the error in PHP-FPM 8.1:
non-static method WebKit_Survey::process_vote() cannot be called statically

* Websites/webkit.org/wp-content/plugins/webkit-survey/plugin.php:

Canonical link: <a href="https://commits.webkit.org/290121@main">https://commits.webkit.org/290121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0358ee5bbefba696bb8bd551b8dda4419dc54812

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68176 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25595 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5749 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94661 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75943 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18923 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8068 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15082 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14824 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->