### PR TITLE
An infinite loop happens when drawing wavy underline for small text at a very large x-position

### DIFF
--- a/LayoutTests/fast/text/text-large-x-small-size-wavy-style-expected.txt
+++ b/LayoutTests/fast/text/text-large-x-small-size-wavy-style-expected.txt
@@ -1,0 +1,1 @@
+Passes if it does not crash.

--- a/LayoutTests/fast/text/text-large-x-small-size-wavy-style.html
+++ b/LayoutTests/fast/text/text-large-x-small-size-wavy-style.html
@@ -1,0 +1,20 @@
+<style>
+    .container {
+        position: absolute;
+        left: 10000000px;
+    }
+    p {
+        text-decoration-style: wavy;
+        text-decoration-line: underline;
+        font-size: 1px;
+    }
+</style>
+<body>
+    <div class="container">
+        <p>Passes if it does not crash.</p>
+    </div>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+</body>

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -99,7 +99,7 @@ static void strokeWavyTextDecoration(GraphicsContext& context, const FloatRect& 
     FloatPoint controlPoint1(0, yAxis + wavyStrokeParameters.controlPointDistance);
     FloatPoint controlPoint2(0, yAxis - wavyStrokeParameters.controlPointDistance);
 
-    for (float x = x1; x + 2 * wavyStrokeParameters.step <= x2;) {
+    for (double x = x1; x + 2 * wavyStrokeParameters.step <= x2;) {
         controlPoint1.setX(x + wavyStrokeParameters.step);
         controlPoint2.setX(x + wavyStrokeParameters.step);
         x += 2 * wavyStrokeParameters.step;


### PR DESCRIPTION
#### 8cf800b33c662574f43084f92d26ca705e39a8c2
<pre>
An infinite loop happens when drawing wavy underline for small text at a very large x-position
<a href="https://bugs.webkit.org/show_bug.cgi?id=286831">https://bugs.webkit.org/show_bug.cgi?id=286831</a>
<a href="https://rdar.apple.com/141022987">rdar://141022987</a>

Reviewed by Simon Fraser.

If the text is displayed at x which is larger than 2^23 and the wavy step is less
than 0.5, the for-loop in strokeWavyTextDecoration() will not terminate. We will
keep adding PathSegements to the Path till WebKit jetsams.

The fix is to use `double` for for-loop control variable so it can add the small
step and we eventually exit the for-loop.

* LayoutTests/fast/text/text-large-x-small-size-wavy-style-expected.txt: Added.
* LayoutTests/fast/text/text-large-x-small-size-wavy-style.html: Added.
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::strokeWavyTextDecoration):

Canonical link: <a href="https://commits.webkit.org/289659@main">https://commits.webkit.org/289659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe52434950c447f4ec2ebb09156d72b9e4f3577

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67659 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25402 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14781 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10840 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html svg/custom/use-image-in-g.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76505 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18628 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18531 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7732 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->