### PR TITLE
AX: Implement off-main thread versions of NextWordEnd, PreviousWordStart, LeftWord, and RightWord APIs

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -338,6 +338,9 @@ media/deactivate-audio-session.html [ Skip ]
 # To be removed after AccessibilityThreadTextApisEnabled is enabled by default.
 accessibility/ax-thread-text-apis [ Skip ]
 
+# Skip isolated-tree specific tests.
+accessibility/isolated-tree [ Skip ]
+
 # ApplePay is only available on iOS (greater than iOS 10) and macOS (greater than macOS 10.12) and only for WebKit2.
 fast/css/appearance-apple-pay-button.html [ Skip ]
 fast/css/appearance-apple-pay-button-div.html [ Skip ]

--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -39,3 +39,6 @@ accessibility/datetime/input-date-field-labels-and-value-changes.html [ Pass Tim
 
 # When ENABLE(AX_THREAD_TEXT_APIS) is on by default, un-comment this.
 # accessibility/ax-thread-text-apis [ Pass ]
+
+# Un-skip all isolated-tree specific tests (when AX_THREAD_TEXT_APIS is enabled, un-comment this)
+# accessibility/isolated-tree [ Pass ]

--- a/LayoutTests/accessibility/isolated-tree/editable-word-navigation-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/editable-word-navigation-expected.txt
@@ -1,0 +1,26 @@
+This tests that word navigation in editable contexts is working correctly (testing previous word start, next word end, left word, and right word).
+Current character is: E
+Left word is: Edit
+Right word is: Edit
+Pre word start to next word end: Edit
+
+Current character is: t
+Left word is: Edit
+Right word is:
+Pre word start to next word end: Edit me
+
+Current character is:
+Left word is:
+Right word is: me
+Pre word start to next word end: Edit me
+
+Current character is: e
+Left word is: me
+Right word is: me
+Pre word start to next word end: me
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/editable-word-navigation.html
+++ b/LayoutTests/accessibility/isolated-tree/editable-word-navigation.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<title>Editable Word Navigation</title>
+<meta charset="utf-8">
+</head>
+<body>
+
+<textarea id="textarea">Edit me</textarea>
+
+<script>
+var output = "This tests that word navigation in editable contexts is working correctly (testing previous word start, next word end, left word, and right word).\n";
+
+if (window.accessibilityController) {
+    var textarea = accessibilityController.accessibleElementById("textarea");
+    textMarkerRange = textarea.textMarkerRangeForElement(textarea)
+    var currentMarker = textarea.startTextMarkerForTextMarkerRange(textMarkerRange);
+
+    currentMarker = advanceAndVerify(currentMarker, 1, textarea);
+    currentMarker = advanceAndVerify(currentMarker, 3, textarea);
+    currentMarker = advanceAndVerify(currentMarker, 1, textarea);
+    currentMarker = advanceAndVerify(currentMarker, 2, textarea);
+
+    debug(output);
+}
+
+function advanceAndVerify(currentMarker, offset, obj) {
+    var previousMarker = currentMarker;
+    for (var i = 0; i < offset; i++) {
+        previousMarker = currentMarker;
+        currentMarker = obj.nextTextMarker(previousMarker);
+    }
+    verifyWordRangeForTextMarker(previousMarker, currentMarker, obj);
+    return currentMarker;
+}
+
+function verifyWordRangeForTextMarker(preMarker, textMarker, obj) {
+    var markerRange = obj.textMarkerRangeForMarkers(preMarker, textMarker);
+    var currentCharacter = obj.stringForTextMarkerRange(markerRange);
+    output += `Current character is: ${currentCharacter}\n`;
+
+    var previousWordRange = obj.leftWordTextMarkerRangeForTextMarker(textMarker);
+    var nextWordRange = obj.rightWordTextMarkerRangeForTextMarker(textMarker);
+    var preWord = obj.stringForTextMarkerRange(previousWordRange);
+    var nextWord = obj.stringForTextMarkerRange(nextWordRange);
+    output += `Left word is: ${preWord}\n`;
+    output += `Right word is: ${nextWord}\n`;
+
+    var preWordStart = obj.previousWordStartTextMarkerForTextMarker(textMarker);
+    var nextWordEnd = obj.nextWordEndTextMarkerForTextMarker(textMarker);
+    var preAndNextWordRange = obj.textMarkerRangeForMarkers(preWordStart, nextWordEnd);
+    var preAndNextWord = obj.stringForTextMarkerRange(preAndNextWordRange);
+    output += `Pre word start to next word end: ${preAndNextWord}\n`;
+    output += `\n`;
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt
@@ -1,0 +1,52 @@
+This tests that basic word navigation is working correctly (testing previous word start, next word end, left word, and right word).
+Current character is: T
+Left word is: This
+Right word is: This
+Pre word start to next word end: This
+
+Current character is: s
+Left word is: This
+Right word is:
+Pre word start to next word end: This is
+
+Current character is:
+Left word is:
+Right word is: is
+Pre word start to next word end: This is
+
+Current character is: s
+Left word is: is
+Right word is:
+Pre word start to next word end: is some
+
+Current character is:
+Left word is:
+Right word is: some
+Pre word start to next word end: is some
+
+Current character is: e
+Left word is: some
+Right word is:
+Pre word start to next word end: some text
+
+Current character is:
+Left word is:
+Right word is: text
+Pre word start to next word end: some text
+
+Current character is: t
+Left word is: text
+Right word is: text
+Pre word start to next word end: text
+
+Current character is: I
+Left word is: I'm
+Right word is: I'm
+Pre word start to next word end: I'm
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is some text
+I'm a paragraph.

--- a/LayoutTests/accessibility/isolated-tree/simple-word-navigation.html
+++ b/LayoutTests/accessibility/isolated-tree/simple-word-navigation.html
@@ -1,0 +1,80 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<title>Simple Word Navigation</title>
+<meta charset="utf-8">
+</head>
+<body>
+
+<div id="content">
+This is some text
+</div>
+
+<p>
+I'm a paragraph.
+</p>
+
+<script>
+var output = "This tests that basic word navigation is working correctly (testing previous word start, next word end, left word, and right word).\n";
+
+if (window.accessibilityController) {
+    var text = accessibilityController.accessibleElementById("content");
+    
+    // Get the actual text node.
+    text = text.childAtIndex(0);
+    
+    var textMarkerRange = text.textMarkerRangeForElement(text);
+    var startMarker = text.startTextMarkerForTextMarkerRange(textMarkerRange);
+    var currentMarker = advanceAndVerify(startMarker, 1, text);
+
+    currentMarker = advanceAndVerify(currentMarker, 3, text);
+    currentMarker = advanceAndVerify(currentMarker, 1, text);
+    currentMarker = advanceAndVerify(currentMarker, 2, text);
+    currentMarker = advanceAndVerify(currentMarker, 1, text);
+    currentMarker = advanceAndVerify(currentMarker, 4, text);
+    currentMarker = advanceAndVerify(currentMarker, 1, text);
+
+    // Right word should't move beyond object boundaries.
+    currentMarker = advanceAndVerify(currentMarker, 4, text);
+    
+    // Verify we can move into another text block;
+    currentMarker = advanceAndVerify(currentMarker, 1, text);
+
+    debug(output);
+}
+
+function advanceAndVerify(currentMarker, offset, obj) {
+    var previousMarker = currentMarker;
+    for (var i = 0; i < offset; i++) {
+        previousMarker = currentMarker;
+        currentMarker = obj.nextTextMarker(previousMarker);
+    }
+    verifyWordRangeForTextMarker(previousMarker, currentMarker, obj);
+    return currentMarker;
+}
+
+function verifyWordRangeForTextMarker(preMarker, textMarker, obj) {
+    var markerRange = obj.textMarkerRangeForMarkers(preMarker, textMarker);
+    var currentCharacter = obj.stringForTextMarkerRange(markerRange);
+    output += `Current character is: ${currentCharacter}\n`;
+
+    var previousWordRange = obj.leftWordTextMarkerRangeForTextMarker(textMarker);
+    var nextWordRange = obj.rightWordTextMarkerRangeForTextMarker(textMarker);
+    var preWord = obj.stringForTextMarkerRange(previousWordRange);
+    var nextWord = obj.stringForTextMarkerRange(nextWordRange);
+    output += `Left word is: ${preWord}\n`;
+    output += `Right word is: ${nextWord}\n`;
+
+    var preWordStart = obj.previousWordStartTextMarkerForTextMarker(textMarker);
+    var nextWordEnd = obj.nextWordEndTextMarkerForTextMarker(textMarker);
+    var preAndNextWordRange = obj.textMarkerRangeForMarkers(preWordStart, nextWordEnd);
+    var preAndNextWord = obj.stringForTextMarkerRange(preAndNextWordRange);
+    output += `Pre word start to next word end: ${preAndNextWord}\n`;
+    output += `\n`;
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -280,7 +280,13 @@ public:
     AXTextMarker nextLineEnd(std::optional<AXID> stopAtID = std::nullopt) const { return findLine(AXDirection::Next, AXTextUnitBoundary::End, stopAtID); }
     AXTextMarker nextLineEnd(IncludeTrailingLineBreak includeTrailingLineBreak, std::optional<AXID> stopAtID = std::nullopt) const { return findLine(AXDirection::Next, AXTextUnitBoundary::End, includeTrailingLineBreak, stopAtID); }
     AXTextMarker nextWordStart() const { return findWord(AXDirection::Next, AXTextUnitBoundary::Start); }
+    // The next end word boundary, not including the current position
+    // Exception: unless the current text marker is at the end of a containing block, which
+    // would return the current position.
     AXTextMarker nextWordEnd() const { return findWord(AXDirection::Next, AXTextUnitBoundary::End); }
+    // The previous start word boundary, not including the current position
+    // Exception: unless the current text marker is at the start of a containing block, which
+    // would return the current position.
     AXTextMarker previousWordStart() const { return findWord(AXDirection::Previous, AXTextUnitBoundary::Start); }
     AXTextMarker previousWordEnd() const { return findWord(AXDirection::Previous, AXTextUnitBoundary::End); }
     AXTextMarker previousSentenceStart() const { return findSentence(AXDirection::Previous, AXTextUnitBoundary::Start); }
@@ -290,7 +296,8 @@ public:
 
     // Creates a range for the line this marker points to.
     AXTextMarkerRange lineRange(LineRangeType, IncludeTrailingLineBreak = IncludeTrailingLineBreak::No) const;
-    // Creates a range for the word specified by the line range type.
+    // This returns the full word range *immediately* to the right/left of a text marker. If the
+    // text marker is in a word, this is that word range.
     AXTextMarkerRange wordRange(WordRangeType) const;
     // Creates a range for the sentence specified by the sentence range type;
     AXTextMarkerRange sentenceRange(SentenceRangeType) const;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3090,8 +3090,8 @@ enum class TextUnit {
         case TextUnit::Paragraph:
             return inputMarker.paragraphRange().platformData().autorelease();
         default:
-            // TODO: Not implemented!
-            break;
+            ASSERT_NOT_REACHED();
+            return nil;
         }
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
@@ -3190,6 +3190,10 @@ enum class TextUnit {
             return inputMarker.nextParagraphEnd().platformData().autorelease();
         case TextUnit::PreviousParagraphStart:
             return inputMarker.previousParagraphStart().platformData().autorelease();
+        case TextUnit::NextWordEnd:
+            return inputMarker.nextWordEnd().platformData().autorelease();
+        case TextUnit::PreviousWordStart:
+            return inputMarker.previousWordStart().platformData().autorelease();
         default:
             // TODO: Not implemented!
             break;


### PR DESCRIPTION
#### b2047fa58d86cb7ebdad3454fd27f998c837b096
<pre>
AX: Implement off-main thread versions of NextWordEnd, PreviousWordStart, LeftWord, and RightWord APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=286832">https://bugs.webkit.org/show_bug.cgi?id=286832</a>
<a href="https://rdar.apple.com/143986260">rdar://143986260</a>

Reviewed by Tyler Wilcock.

This PR re-implements the LeftWord and RightWord APIs off the main thread, as well as simplifies
our word navigation (previousWordStart, nextWordEnd) APIs.

Our previous go at doing LeftWord and RightWord made it challenging to implement
PreviousWordStart and NextWordEnd, since the former APIs are in essence a subset of the latter.

This new implemenation creates a new baseline expectation for what these APIs should return,
illustrated in the new simple-word-navigation.html and editable-word-navigation tests.

- Previous word start: the previous start word boundary, not including the current position
(unless at the start of a containing block, which would return the current position).
- Next word end: the next end word boundary, not including the current position
(unless at the end of a containing block, which would return the current position).
- Right/Left word: The full word *immediately* to the right/left of a text marker. If you are
in a word, this is that word range.

* LayoutTests/TestExpectations:
* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/isolated-tree/editable-word-navigation-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/editable-word-navigation.html: Added.
* LayoutTests/accessibility/isolated-tree/simple-word-navigation-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/simple-word-navigation.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::findWordOrSentence const):
(WebCore::AXTextMarker::wordRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper textMarkerRangeAtTextMarker:forUnit:]):
(-[WebAccessibilityObjectWrapper textMarkerForTextMarker:atUnit:]):

Canonical link: <a href="https://commits.webkit.org/289758@main">https://commits.webkit.org/289758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3be954c24bf1b3f2139911d63123bad523435fe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67846 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25589 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5737 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15046 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11078 "Found 1 new test failure: ipc/decode-object-array-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76693 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75930 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20318 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8050 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20365 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14806 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->