### PR TITLE
[visionOS] Context menu is automatically dismissed when previewing an image or attachment for the first time

### DIFF
--- a/LayoutTests/fast/events/ios/dragstart-hang-does-not-dismiss-context-menu-expected.txt
+++ b/LayoutTests/fast/events/ios/dragstart-hang-does-not-dismiss-context-menu-expected.txt
@@ -1,0 +1,13 @@
+
+This test requires WebKitTestRunner. To manually test, load the page in a configuration where drag and drop is enabled by default; long press the image to show the context menu, and verify that the context menu remains visible
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS startedDrag became true
+PASS previewBounds.width is >= 0
+PASS previewBounds.height is >= 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/ios/dragstart-hang-does-not-dismiss-context-menu.html
+++ b/LayoutTests/fast/events/ios/dragstart-hang-does-not-dismiss-context-menu.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ dragInteractionPolicy=always-enable useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body, html {
+    margin: 0;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test requires WebKitTestRunner. To manually test, load the page in a configuration where drag and drop is enabled by default; long press the image to show the context menu, and verify that the context menu remains visible");
+
+    startedDrag = false;
+
+    let image = document.querySelector("img");
+    image.addEventListener("dragstart", () => {
+        const startTime = Date.now();
+        while (true) {
+            if (Date.now() - startTime > 2500)
+                break;
+        }
+        getSelection().setPosition(document.body, 1);
+        startedDrag = true;
+    });
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.longPressElement(image);
+    await UIHelper.waitForContextMenuToShow();
+    await shouldBecomeEqual("startedDrag", "true");
+    await UIHelper.delayFor(1000);
+
+    previewBounds = await UIHelper.contextMenuPreviewRect();
+    shouldBeGreaterThanOrEqual("previewBounds.width", "0");
+    shouldBeGreaterThanOrEqual("previewBounds.height", "0");
+
+    await UIHelper.activateAt(1, 1);
+    await UIHelper.waitForContextMenuToHide();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <img src="../resources/abe.png">
+    <p id="description"></p>
+    <p id="console"></p>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -62,6 +62,14 @@
 @property (nonatomic, readonly) BOOL _wk_isInFullscreenPresentation;
 @end
 
+#if USE(UICONTEXTMENU)
+
+@interface UIContextMenuInteraction (WebKitInternal)
+@property (nonatomic, readonly) BOOL _wk_isMenuVisible;
+@end
+
+#endif
+
 namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message);

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -287,6 +287,24 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
 @end
 
+#if USE(UICONTEXTMENU)
+
+@implementation UIContextMenuInteraction (WebKitInternal)
+
+- (BOOL)_wk_isMenuVisible
+{
+    bool contextMenuIsVisible = false;
+    [self updateVisibleMenuWithBlock:makeBlockPtr([&contextMenuIsVisible](UIMenu *menu) {
+        contextMenuIsVisible = true;
+        return menu;
+    }).get()];
+    return contextMenuIsVisible;
+}
+
+@end
+
+#endif // USE(UICONTEXTMENU)
+
 namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -385,7 +385,7 @@ WKSelectionDrawingInfo::WKSelectionDrawingInfo()
 
 WKSelectionDrawingInfo::WKSelectionDrawingInfo(const EditorState& editorState)
 {
-    if (editorState.selectionIsNone) {
+    if (editorState.selectionIsNone || (!editorState.selectionIsRange && !editorState.isContentEditable)) {
         type = SelectionType::None;
         return;
     }

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -31,6 +31,7 @@
 
 #import "RemoteLayerTreeNode.h"
 #import "RemoteLayerTreeViews.h"
+#import "UIKitUtilities.h"
 #import "WKContentViewInteraction.h"
 #import <WebCore/TileController.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -295,6 +296,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HideEditMenuScope);
 {
     if (_hideEditMenuScope)
         return;
+
+#if USE(UICONTEXTMENU)
+    if (self.contextMenuInteraction._wk_isMenuVisible)
+        return;
+#endif
 
     _hideEditMenuScope = WTF::makeUnique<WebKit::HideEditMenuScope>(self, WebKit::DeactivateSelection::Yes);
 }


### PR DESCRIPTION
#### 7a2c656fafcd92b9c26c31136ed5c32ca1206111
<pre>
[visionOS] Context menu is automatically dismissed when previewing an image or attachment for the first time
<a href="https://bugs.webkit.org/show_bug.cgi?id=286825">https://bugs.webkit.org/show_bug.cgi?id=286825</a>
<a href="https://rdar.apple.com/143333992">rdar://143333992</a>

Reviewed by Abrar Rahman Protyasha.

On visionOS, long pressing an image or attachment for the first time on a webpage causes the
resulting context menu to automatically dismiss after a few seconds. This happens because the first
time we initiate a drag in a web process, we end up spending a large amount of time underneath
`+[UIScreen initialize]` within the web process, while trying to render the drag image using the
helpers in `DragImageIOS.mm` (which instantiate `UIGraphicsImageRenderer`). This, in turn, causes
the IPC response message `WebPageProxy::DidHandleDragStartRequest` to be delayed by a few seconds,
such that the IPC message to start a UI-side drag session arrives *after* the context menu
presentation animation is already complete.

Consequently, we attempt to hide the selection highlight and edit menu while a drag session is
active, which goes through the (somewhat-poorly-named) method `-willStartScrollingOverflow`, which
ends up dismissing the context menu from within UIKit code.

I&apos;m using <a href="https://webkit.org/b/286819">https://webkit.org/b/286819</a> to track refactoring the iOS `DragImage` helper functions to
avoid instantiating the main `UIScreen`; to fix this bug, I&apos;m making adjustments to prevent drag
initiation from (indirectly) dismissing an open context menu, in the event that starting a drag in
the web process takes longer than the context menu presentation animation.

* LayoutTests/fast/events/ios/dragstart-hang-does-not-dismiss-context-menu-expected.txt: Added.
* LayoutTests/fast/events/ios/dragstart-hang-does-not-dismiss-context-menu.html: Added.

Add a layout test to excercise this change, by intentionally hanging inside of a `dragstart` for
long enough, that it effective triggers the same bug that&apos;s originally observed on visionOS.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIContextMenuInteraction _wk_isMenuVisible]):

Add a helper method to return whether or not the context menu is currently visible.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(WebKit::WKSelectionDrawingInfo::WKSelectionDrawingInfo):

Make another small adjustment here, to treat the case where the selection is a non-editable caret
in the same way as if the selection were null (`None`), only for the purposes of painting the UIKit
selection. While this is already taken care of by `-[WKContentView selectedTextRange]`, it means
we&apos;ll still call into `-selectionChanged` unnecessarily in the case where a selection changes from
being `None` → (non-editable) `Caret` or vice versa.

Importantly, in the context of this bug, this extra call to `-selectionChanged` also causes the
active context menu to dismiss after starting a drag.

* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper willBeginDragLift]):

Check if the context menu is visible when beginning a drag lift, and avoid hiding the selection.

Canonical link: <a href="https://commits.webkit.org/289662@main">https://commits.webkit.org/289662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d5840e739afd124c3b8c3fd141acc545ebb849e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38372 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67666 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25410 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48029 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5532 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37485 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94379 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14796 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10849 "Found 7 new test failures: fast/table/table-section-split2.html fast/text/font-face-set-cssom.html imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative.html ipc/create-media-source-with-invalid-constraints-crash.html js/exception-with-handler-inside-eval-with-dynamic-scope.html media/media-session/actionHandler-no-document-leak.html svg/custom/use-image-in-g.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76513 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75736 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20110 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7747 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14812 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20113 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->