### PR TITLE
[scroll-animations] Scroll padding should be used if view-timeline-inset is explicitly set to auto

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
@@ -7,21 +7,21 @@ PASS view-timeline-inset with negative values
 FAIL view-timeline-inset with horizontal scroller assert_equals: expected "50" but got "30"
 PASS view-timeline-inset with block scroller
 FAIL view-timeline-inset with inline scroller assert_equals: expected "50" but got "30"
-FAIL view-timeline-inset:auto, block assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, block, vertical-lr assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, block, vertical-rl assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, inline assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, inline, vertical-rl assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, inline, vertical-lr assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, inline, rtl assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, inline, vertical-rl, rtl assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, inline, vertical-lr, rtl assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, y assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, y, vertical-rl assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, y, vertical-rl, rtl assert_equals: expected "-1" but got "0"
-FAIL view-timeline-inset:auto, x assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, x, rtl assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, x, vertical-lr assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, x, vertical-rl assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, mix assert_equals: expected "-1" but got "0"
+PASS view-timeline-inset:auto, block
+PASS view-timeline-inset:auto, block, vertical-lr
+PASS view-timeline-inset:auto, block, vertical-rl
+FAIL view-timeline-inset:auto, inline assert_equals: expected "50" but got "30"
+FAIL view-timeline-inset:auto, inline, vertical-rl assert_equals: expected "50" but got "25"
+FAIL view-timeline-inset:auto, inline, vertical-lr assert_equals: expected "50" but got "25"
+FAIL view-timeline-inset:auto, inline, rtl assert_equals: expected "50" but got "30"
+FAIL view-timeline-inset:auto, inline, vertical-rl, rtl assert_equals: expected "50" but got "25"
+FAIL view-timeline-inset:auto, inline, vertical-lr, rtl assert_equals: expected "50" but got "25"
+PASS view-timeline-inset:auto, y
+FAIL view-timeline-inset:auto, y, vertical-rl assert_equals: expected "50" but got "25"
+FAIL view-timeline-inset:auto, y, vertical-rl, rtl assert_equals: expected "50" but got "25"
+FAIL view-timeline-inset:auto, x assert_equals: expected "50" but got "30"
+FAIL view-timeline-inset:auto, x, rtl assert_equals: expected "50" but got "30"
+PASS view-timeline-inset:auto, x, vertical-lr
+PASS view-timeline-inset:auto, x, vertical-rl
+PASS view-timeline-inset:auto, mix
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Default ViewTimeline is not affected by scroll-padding
+FAIL Default ViewTimeline is not affected by scroll-padding assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got -12.5
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -270,9 +270,11 @@ void ViewTimeline::cacheCurrentTime()
             return scrollDirection->isVertical ? style.scrollPaddingBottom() : style.scrollPaddingRight();
         };
 
-        auto hasAutoStartInset = !m_insets.start;
+        auto hasAutoStartInset = !m_insets.start || m_insets.start->isAuto();
         auto insetStartLength = hasAutoStartInset ? scrollPadding(PaddingEdge::Start) : *m_insets.start;
         auto insetEndLength = m_insets.end.value_or(hasAutoStartInset ? scrollPadding(PaddingEdge::End) : insetStartLength);
+        if (insetEndLength.isAuto())
+            insetEndLength = scrollPadding(PaddingEdge::End);
         auto insetStart = floatValueForOffset(insetStartLength, scrollContainerSize);
         auto insetEnd = floatValueForOffset(insetEndLength, scrollContainerSize);
 


### PR DESCRIPTION
#### 8c5177f6ae2c32d35f47af1ede61b01a374e2643
<pre>
[scroll-animations] Scroll padding should be used if view-timeline-inset is explicitly set to auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=286842">https://bugs.webkit.org/show_bug.cgi?id=286842</a>
<a href="https://rdar.apple.com/143990760">rdar://143990760</a>

Reviewed by Antoine Quint.

Scroll padding should be used if view-timeline-inset is explicitly set to auto. Most of the tests in
css/view-timeline-inset-animation.html still fail due to scrollTop/scrollLeft getting clamped for
some unknown reason. Needs investigation. view-timelines/view-timeline-snapport.html is failing after
this patch due to <a href="https://github.com/w3c/csswg-drafts/issues/11644.">https://github.com/w3c/csswg-drafts/issues/11644.</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):

Canonical link: <a href="https://commits.webkit.org/289803@main">https://commits.webkit.org/289803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2381766f80cb64c5cbd9d3ee43aea12f248ecdb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25651 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48280 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34012 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37838 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94755 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76765 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76003 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20395 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18817 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8153 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13738 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20468 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->