### PR TITLE
[WKTR] Remove workaround for kUTTypePNG in TestInvocationCG.cpp

### DIFF
--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunner.xcconfig
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunner.xcconfig
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2010-2015 Apple Inc. All rights reserved.
+// Copyright (C) 2010-2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ LD_RUNPATH_SEARCH_PATHS = "@loader_path";
 PRODUCT_NAME = WebKitTestRunner;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebKitTestRunner;
 GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -lWebKitTestRunner -framework Carbon -framework Cocoa -framework JavaScriptCore -framework WebKit;
+OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -lWebKitTestRunner -framework Carbon -framework Cocoa -framework JavaScriptCore -framework UniformTypeIdentifiers -framework WebKit;
 STRIP_STYLE = debugging;
 SKIP_INSTALL[sdk=embedded*] = YES;
 

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2010-2015 Apple Inc. All rights reserved.
+// Copyright (C) 2010-2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ PRODUCT_BUNDLE_IDENTIFIER = org.webkit.$(PRODUCT_NAME:rfc1034identifier);
 
 GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 
-OTHER_LDFLAGS = $(inherited) -lWebKitTestRunner -lPAL -lWebCoreTestSupport -framework JavaScriptCore -framework CoreGraphics -framework QuartzCore -framework ImageIO -framework IOKit -framework UIKit -framework WebKit -framework Foundation -framework GraphicsServices;
+OTHER_LDFLAGS = $(inherited) -lWebKitTestRunner -lPAL -lWebCoreTestSupport -framework CoreGraphics -framework Foundation -framework GraphicsServices -framework ImageIO -framework IOKit -framework JavaScriptCore -framework QuartzCore -framework UIKit -framework UniformTypeIdentifiers -framework WebKit;
 OTHER_LDFLAGS[sdk=watch*] = $(OTHER_LDFLAGS) -framework PepperUICore
 
 STRIP_STYLE = debugging;

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 		A185103A1B9AE0DA00744AEB /* CrashReporterInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB90A31905BC6A000FDBF3 /* CrashReporterInfo.mm */; };
 		A185103B1B9AE0E200744AEB /* TestControllerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DCE2CD11B84524500C7F832 /* TestControllerCocoa.mm */; };
 		A185103C1B9AE0FE00744AEB /* Options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 841CC00D181185BF0042E9B6 /* Options.cpp */; };
-		A185103D1B9AE10600744AEB /* TestInvocationCG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC9192041333E4F8003011DC /* TestInvocationCG.cpp */; };
+		A185103D1B9AE10600744AEB /* TestInvocationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC9192041333E4F8003011DC /* TestInvocationCocoa.mm */; };
 		A185103E1B9AE12200744AEB /* CyclicRedundancyCheck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5322FB4113FDA0CD0041ABCC /* CyclicRedundancyCheck.cpp */; };
 		A185103F1B9AE12900744AEB /* GeolocationProviderMock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 26D758E5160BECDC00268472 /* GeolocationProviderMock.cpp */; };
 		A18510401B9AE13100744AEB /* PixelDumpSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5322FB4413FDA0EA0041ABCC /* PixelDumpSupport.cpp */; };
@@ -466,7 +466,7 @@
 		BC8FD8CB120E52B000F3E71A /* EventSendingController.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EventSendingController.idl; sourceTree = "<group>"; };
 		BC8FD8D0120E545B00F3E71A /* JSEventSendingController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSEventSendingController.cpp; sourceTree = "<group>"; };
 		BC8FD8D1120E545B00F3E71A /* JSEventSendingController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSEventSendingController.h; sourceTree = "<group>"; };
-		BC9192041333E4F8003011DC /* TestInvocationCG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TestInvocationCG.cpp; path = cg/TestInvocationCG.cpp; sourceTree = "<group>"; };
+		BC9192041333E4F8003011DC /* TestInvocationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TestInvocationCocoa.mm; sourceTree = "<group>"; };
 		BC952EC511F3C10F003398B4 /* DerivedSources.make */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DerivedSources.make; sourceTree = "<group>"; };
 		BC952ED211F3C29F003398B4 /* TestRunner.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestRunner.idl; sourceTree = "<group>"; };
 		BC952ED311F3C318003398B4 /* CodeGeneratorTestRunner.pm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.perl; path = CodeGeneratorTestRunner.pm; sourceTree = "<group>"; };
@@ -591,7 +591,6 @@
 		08FB7795FE84155DC02AAC07 /* TestRunner */ = {
 			isa = PBXGroup;
 			children = (
-				BC9192021333E4CD003011DC /* cg */,
 				0FEB90A11905BC4A000FDBF3 /* cocoa */,
 				7CAA0E7525353BC500C519E5 /* Derived Sources */,
 				2EE52D121890A9FB0010ED21 /* ios */,
@@ -720,6 +719,7 @@
 				0FEB90A31905BC6A000FDBF3 /* CrashReporterInfo.mm */,
 				2904FA1D265CC5D900A7EBC9 /* StringFunctionsCocoa.h */,
 				2DCE2CD11B84524500C7F832 /* TestControllerCocoa.mm */,
+				BC9192041333E4F8003011DC /* TestInvocationCocoa.mm */,
 				0F87B6141BACC4B9004EC572 /* TestRunnerWKWebView.h */,
 				0F87B6151BACC4B9004EC572 /* TestRunnerWKWebView.mm */,
 				41C5378C21F1333C008B1FAD /* TestWebsiteDataStoreDelegate.h */,
@@ -979,14 +979,6 @@
 				BC251A1811D16795002EBC01 /* WebKitTestRunnerLibrary.xcconfig */,
 			);
 			path = Configurations;
-			sourceTree = "<group>";
-		};
-		BC9192021333E4CD003011DC /* cg */ = {
-			isa = PBXGroup;
-			children = (
-				BC9192041333E4F8003011DC /* TestInvocationCG.cpp */,
-			);
-			name = cg;
 			sourceTree = "<group>";
 		};
 		BC952C0A11F3B939003398B4 /* Bindings */ = {
@@ -1399,7 +1391,7 @@
 				A185103B1B9AE0E200744AEB /* TestControllerCocoa.mm in Sources */,
 				7CFF9BCA2534AF1D0008009F /* TestFeatures.cpp in Sources */,
 				A18510421B9AE13E00744AEB /* TestInvocation.cpp in Sources */,
-				A185103D1B9AE10600744AEB /* TestInvocationCG.cpp in Sources */,
+				A185103D1B9AE10600744AEB /* TestInvocationCocoa.mm in Sources */,
 				0F622CE91BBB3A1A00838AD3 /* TestOptions.cpp in Sources */,
 				0F87B6171BACC4C0004EC572 /* TestRunnerWKWebView.mm in Sources */,
 				41C5378E21F13414008B1FAD /* TestWebsiteDataStoreDelegate.mm in Sources */,


### PR DESCRIPTION
#### 4b865d87ca3ee75c43f0dbf6fb5904d719983cdf
<pre>
[WKTR] Remove workaround for kUTTypePNG in TestInvocationCG.cpp
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=286846">https://bugs.webkit.org/show_bug.cgi?id=286846</a>&gt;
&lt;<a href="https://rdar.apple.com/143993362">rdar://143993362</a>&gt;

Reviewed by Sam Weinig.

* Tools/WebKitTestRunner/Configurations/WebKitTestRunner.xcconfig:
- Link to UniformTypeIdentifiers.framework.
* Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig:
- Ditto.
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
- Rename TestInvocationCG.cpp to TestInvocationCocoa.mm to use
  Objective-C UTTypePNG class.
* Tools/WebKitTestRunner/cocoa/TestInvocationCocoa.mm: Renamed from Tools/WebKitTestRunner/cg/TestInvocationCG.cpp.
- Replace use of kUTTypePNG with undeprecated UTTypePNG.identifier.

Canonical link: <a href="https://commits.webkit.org/289672@main">https://commits.webkit.org/289672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/674aab2285c9fa111dad9c4007c3f97883209e2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87664 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92529 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38408 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67684 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25430 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37521 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14832 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10875 "Found 3 new test failures: fast/dom/gc-dom-tree-async-node-deletion-queue-limit.html fast/text/font-face-set-cssom.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76534 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75763 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7783 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13662 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14848 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->