### PR TITLE
[Flex] president.mn: Images in header display squished (vert-lr).

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-vert-lr-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-vert-lr-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-vert-lr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-vert-lr.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-main-item">
+<meta name="assert" content="Flex item should compute its main size from its definite cros size and aspect ratio.">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<style>
+.flexbox {
+  position: relative;
+  display: flex;
+  writing-mode: vertical-lr;
+  width: 100px;
+  align-items: start;
+}
+.flex-item{
+  width: 40px
+}
+.abspos {
+  width: 60px;
+  height: 100px; background-color: green;
+  position: absolute;
+  left: 40px;
+}
+</style>
+</head>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="flexbox">
+    <img class="flex-item" src="support/20x50-green.png">
+    <div class="abspos"></div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -236,8 +236,11 @@ private:
     LayoutUnit crossAxisScrollbarExtent() const;
     LayoutUnit crossAxisScrollbarExtentForFlexItem(const RenderBox& flexItem) const;
     LayoutPoint flowAwareLocationForFlexItem(const RenderBox& flexItem) const;
+
+    double preferredAspectRatioForFlexItem(const RenderBox&) const;
     bool flexItemHasComputableAspectRatio(const RenderBox&) const;
     bool flexItemHasComputableAspectRatioAndCrossSizeIsConsideredDefinite(const RenderBox&);
+
     bool crossAxisIsLogicalWidth() const;
     bool flexItemCrossSizeShouldUseContainerCrossSize(const RenderBox& flexItem) const;
     LayoutUnit computeCrossSizeForFlexItemUsingContainerCrossSize(const RenderBox& flexItem) const;


### PR DESCRIPTION
#### daff5d72c1049582a91f4aae31c5c36ccdd4b8bc
<pre>
[Flex] president.mn: Images in header display squished (vert-lr).
<a href="https://rdar.apple.com/119196407">rdar://119196407</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270959">https://bugs.webkit.org/show_bug.cgi?id=270959</a>

Reviewed by Alan Baradlay.

RenderFlexibleBox::computeMainSizeFromAspectRatioUsing is used to
compute the main size of a flex item according to section 9.2.3B of flex
layout. Basically, we are supposed to compute the main size from the flex
item&apos;s definite cross size and its preferred aspect ratio.
Unfortunately, this can fail in vertical-lr (and probably other) writing
modes.

This seems to be because the code to compute the main size after
we have resolved the cross size and preferred aspect ratio seems to
expect the value to be in physical dimensions as is checks
isHorizontalFlow(). However, the code to resolve the preferred aspect
ratio is a bit all over the place since in some cases the aspect ratio
may be in physical dimensions (i.e. physical width / physical height) and
sometimes, when referring to computeIntrinsicAspectRatio(), may be
logical in terms of the flex item&apos;s writing mode (inline size / block
size). This can result in us computing an incorrect main size.

To fix this, we do two main things in this patch:

1.) Switch all of the code related to resolving the preferred aspect
ratio to be in logical dimensions with respect to Flex Layout
(i.e. main size / cross size). This is basically the same as using the
logical dimensions with respect to the flex item&apos;s writing mode but
computing the inverse if the flexbox&apos;s main axis != flex item&apos;s main
axis.

2.) Factor out this code into a dedicated helper function. This is
mostly to reduce clutter in the function it was in before, but this
should also hopefully make it a bit more clear which type of dimensions
we are dealing with when getting the flex item&apos;s aspect ratio.

Canonical link: <a href="https://commits.webkit.org/295214@main">https://commits.webkit.org/295214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56d1ceac556acc7c43ad259731815a1c21e5ed51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78914 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11743 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53891 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88135 "Found 1 new API test failure: TestWebKitAPI.CARingBufferTest.FetchTimeBoundsConsistent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111443 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87567 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22408 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32457 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10182 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25385 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30948 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36258 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->