### PR TITLE
Reduce use of strcmp() in the code base

### DIFF
--- a/Source/WTF/wtf/ObjCRuntimeExtras.h
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.h
@@ -24,9 +24,12 @@
 
 #pragma once
 
+#import <Foundation/Foundation.h>
 #import <objc/message.h>
 #import <wtf/MallocSpan.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/SystemMalloc.h>
+#import <wtf/text/StringCommon.h>
 
 #ifdef __cplusplus
 
@@ -52,12 +55,26 @@ WTF_EXPORT_PRIVATE MallocSpan<objc_method_description, SystemMalloc> protocol_co
 WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> protocol_copyPropertyListSpan(Protocol *);
 WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> protocol_copyProtocolListSpan(Protocol *);
 
+template<typename Type>
+std::span<const char> objcEncode()
+{
+    return unsafeSpan(@encode(Type));
+}
+
+template<typename Type>
+bool nsValueHasObjCType(NSValue *value)
+{
+    return equalSpans(unsafeSpan([value objCType]), objcEncode<Type>());
+}
+
 } // namespace WTF
 
 using WTF::class_copyIvarListSpan;
 using WTF::class_copyMethodListSpan;
 using WTF::class_copyPropertyListSpan;
 using WTF::class_copyProtocolListSpan;
+using WTF::nsValueHasObjCType;
+using WTF::objcEncode;
 using WTF::protocol_copyMethodDescriptionListSpan;
 using WTF::protocol_copyPropertyListSpan;
 using WTF::protocol_copyProtocolListSpan;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -59,6 +59,7 @@
 #import "TextIterator.h"
 #import "VisibleUnits.h"
 #import <Accessibility/Accessibility.h>
+#import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <pal/cocoa/AccessibilitySoftLink.h>
 
@@ -910,10 +911,9 @@ AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(AXCore
     if ([startElement isKindOfClass:[WebAccessibilityObjectWrapperBase class]])
         criteria.startObject = startElement.axBackingObject;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if ([startRange isKindOfClass:[NSValue class]] && !strcmp([(NSValue *)startRange objCType], @encode(NSRange)))
+    if ([startRange isKindOfClass:[NSValue class]] && nsValueHasObjCType<NSRange>((NSValue *)startRange))
         criteria.startRange = [(NSValue *)startRange rangeValue];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 #if PLATFORM(MAC)
     else if (startRange && CFGetTypeID((__bridge CFTypeRef)startRange) == AXTextMarkerRangeGetTypeID()) {
         AXTextMarkerRange markerRange { (AXTextMarkerRangeRef)startRange };

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -81,6 +81,7 @@
 #import "VisibleUnits.h"
 #import "WebCoreFrameView.h"
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
+#import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -2390,10 +2391,8 @@ id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>& backingObje
         markerRef = (AXTextMarkerRef)parameter;
     else if (AXObjectIsTextMarkerRange(parameter))
         markerRangeRef = (AXTextMarkerRangeRef)parameter;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    else if ([parameter isKindOfClass:[NSValue class]] && !strcmp([(NSValue *)parameter objCType], @encode(NSRange)))
+    else if ([parameter isKindOfClass:[NSValue class]] && nsValueHasObjCType<NSRange>((NSValue *)parameter))
         nsRange = [(NSValue*)parameter rangeValue];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     else
         return nil;
 
@@ -3311,8 +3310,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     bool rangeSet = false;
     NSRect rect = NSZeroRect;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
     // common parameter type check/casting.  Nil checks in handlers catch wrong type case.
     // NOTE: This assumes nil is not a valid parameter, because it is indistinguishable from
     // a parameter of the wrong type.
@@ -3332,20 +3329,18 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         array = parameter;
     else if ([parameter isKindOfClass:[NSDictionary class]])
         dictionary = parameter;
-    else if ([parameter isKindOfClass:[NSValue class]] && !strcmp([(NSValue*)parameter objCType], @encode(NSPoint))) {
+    else if ([parameter isKindOfClass:[NSValue class]] && nsValueHasObjCType<NSPoint>((NSValue*)parameter)) {
         pointSet = true;
         point = [(NSValue*)parameter pointValue];
-    } else if ([parameter isKindOfClass:[NSValue class]] && !strcmp([(NSValue*)parameter objCType], @encode(NSRange))) {
+    } else if ([parameter isKindOfClass:[NSValue class]] && nsValueHasObjCType<NSRange>((NSValue*)parameter)) {
         rangeSet = true;
         range = [(NSValue*)parameter rangeValue];
-    } else if ([parameter isKindOfClass:[NSValue class]] && !strcmp([(NSValue*)parameter objCType], @encode(NSRect)))
+    } else if ([parameter isKindOfClass:[NSValue class]] && nsValueHasObjCType<NSRect>((NSValue*)parameter))
         rect = [(NSValue*)parameter rectValue];
     else {
         // Attribute type is not supported. Allow super to handle.
         return [super accessibilityAttributeValue:attribute forParameter:parameter];
     }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // dispatch
     if ([attribute isEqualToString:NSAccessibilitySelectTextWithCriteriaParameterizedAttribute]) {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm
@@ -28,6 +28,7 @@
 
 #import "CoreIPCNSCFObject.h"
 #import "CoreIPCTypes.h"
+#import <wtf/ObjCRuntimeExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <WebCore/WAKAppKitStubs.h>
@@ -46,13 +47,11 @@ CoreIPCNSValue::CoreIPCNSValue(Value&& value)
 
 auto CoreIPCNSValue::valueFromNSValue(NSValue *nsValue) -> Value
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (!strcmp(nsValue.objCType, @encode(NSRange)))
+    if (nsValueHasObjCType<NSRange>(nsValue))
         return nsValue.rangeValue;
 
-    if (!strcmp(nsValue.objCType, @encode(CGRect)))
+    if (nsValueHasObjCType<CGRect>(nsValue))
         return nsValue.rectValue;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return makeUniqueRef<CoreIPCNSCFObject>(nsValue);
 }

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatatypeTraits.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatatypeTraits.h
@@ -26,6 +26,7 @@
 #import "_WKWebExtensionSQLiteDatabase.h"
 #import <sqlite3.h>
 #import <tuple>
+#import <wtf/ObjCRuntimeExtras.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -161,12 +162,8 @@ public:
         if (!value)
             return sqlite3_bind_null(statement, index);
 
-        const char* objCType = [value objCType];
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (!strcmp(objCType, @encode(double)) || !strcmp(objCType, @encode(float)))
+        if (nsValueHasObjCType<double>(value) || nsValueHasObjCType<float>(value))
             return sqlite3_bind_double(statement, index, value.doubleValue);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         return sqlite3_bind_int64(statement, index, value.longLongValue);
     }

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -47,6 +47,7 @@
 #import <WebCore/Scrollbar.h>
 #import <WebCore/WebAccessibilityObjectWrapperMac.h>
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
+#import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace ax = WebCore::Accessibility;
@@ -311,9 +312,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     WebCore::FloatPoint pageOverlayPoint;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if ([parameter isKindOfClass:[NSValue class]] && !strcmp([(NSValue *)parameter objCType], @encode(NSPoint)))
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    if ([parameter isKindOfClass:[NSValue class]] && nsValueHasObjCType<NSPoint>((NSValue *)parameter))
         pageOverlayPoint = [self convertScreenPointToRootView:[(NSValue *)parameter pointValue]];
     else
         return nil;

--- a/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
@@ -39,6 +39,7 @@
 #import <WebCore/Settings.h>
 #import <WebCore/WebBackgroundTaskController.h>
 #import <WebCore/WebCoreThreadSystemInterface.h>
+#import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/spi/darwin/dyldSPI.h>
 
 using namespace WebCore;
@@ -135,13 +136,11 @@ CGPathRef WebKitCreatePathWithShrinkWrappedRects(NSArray* cgRects, CGFloat radiu
     Vector<FloatRect> rects;
     rects.reserveInitialCapacity([cgRects count]);
 
-    const char* cgRectEncodedString = @encode(CGRect);
-
     for (NSValue *rectValue in cgRects) {
         CGRect cgRect;
         [rectValue getValue:&cgRect];
 
-        if (strcmp(cgRectEncodedString, rectValue.objCType))
+        if (!nsValueHasObjCType<CGRect>(rectValue))
             return nullptr;
         rects.append(cgRect);
     }

--- a/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
@@ -38,6 +38,7 @@
 #import <JavaScriptCore/JSStringRefCF.h>
 #import <WebKit/WebFrame.h>
 #import <objc/runtime.h>
+#import <wtf/ObjCRuntimeExtras.h>
 
 @interface NSObject (WebAccessibilityObjectWrapperAdditions)
 + (void)accessibilitySetShouldRepostNotifications:(BOOL)repost;
@@ -106,7 +107,7 @@ static JSValueRef makeValueRefForValue(JSContextRef context, id value)
     if ([value isKindOfClass:[NSString class]])
         return JSValueMakeString(context, [value createJSStringRef].get());
     if ([value isKindOfClass:[NSNumber class]]) {
-        if (!strcmp([value objCType], @encode(BOOL)) || !strcmp([value objCType], "c"))
+        if (nsValueHasObjCType<BOOL>((NSValue *)value) || nsValueHasObjCType<char>((NSValue *)value))
             return JSValueMakeBoolean(context, [value boolValue]);
         return JSValueMakeNumber(context, [value doubleValue]);
     }

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -36,6 +36,7 @@
 #import "StringFunctions.h"
 #import <JavaScriptCore/JSStringRefCF.h>
 #import <objc/runtime.h>
+#import <wtf/ObjCRuntimeExtras.h>
 
 @implementation NSString (JSStringRefAdditions)
 
@@ -89,7 +90,7 @@ JSValueRef makeValueRefForValue(JSContextRef context, id value)
     if ([value isKindOfClass:[NSString class]])
         return JSValueMakeString(context, [value createJSStringRef].get());
     if ([value isKindOfClass:[NSNumber class]]) {
-        if (!strcmp([value objCType], @encode(BOOL)) || !strcmp([value objCType], "c"))
+        if (nsValueHasObjCType<BOOL>((NSValue *)value) || nsValueHasObjCType<char>((NSValue *)value))
             return JSValueMakeBoolean(context, [value boolValue]);
         return JSValueMakeNumber(context, [value doubleValue]);
     }


### PR DESCRIPTION
#### 194cb17b4307483f10ee7ebafad162dacb7f3692
<pre>
Reduce use of strcmp() in the code base
<a href="https://bugs.webkit.org/show_bug.cgi?id=286854">https://bugs.webkit.org/show_bug.cgi?id=286854</a>

Reviewed by Timothy Hatcher.

Reduce use of strcmp() in the code base as it is considered unsafe.

* Source/WTF/wtf/ObjCRuntimeExtras.h:
(WTF::objcEncode):
(WTF::nsValueHasObjCType):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(accessibilitySearchCriteriaForSearchPredicate):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(parameterizedAttributeValueForTesting):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(encodeInvocationArguments):
(decodeInvocationArguments):
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm:
(WebKit::CoreIPCNSValue::valueFromNSValue):
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatatypeTraits.h:
(WebKit::_WKWebExtensionSQLiteDatatypeTraits&lt;NSNumber::bind):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:forParameter:]):
* Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm:
(WebKitCreatePathWithShrinkWrappedRects):
* Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm:
(makeValueRefForValue):
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::makeValueRefForValue):

Canonical link: <a href="https://commits.webkit.org/289673@main">https://commits.webkit.org/289673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4df49f4203ffe1248200b05799eaac5e3acb3b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67696 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33741 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37539 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80480 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94433 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86457 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14850 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10887 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75781 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7802 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13663 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14866 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20168 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/108951 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14610 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26201 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->