### PR TITLE
Adopt span for data member in StylePropertyShorthand.h

### DIFF
--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -32,8 +32,7 @@ public:
     StylePropertyShorthand() = default;
 
     template<std::size_t numProperties> StylePropertyShorthand(CSSPropertyID id, std::span<const CSSPropertyID, numProperties> properties)
-        : m_properties(properties.data())
-        , m_length(properties.size())
+        : m_properties(properties)
         , m_shorthandID(id)
     {
         static_assert(numProperties != std::dynamic_extent);
@@ -42,14 +41,13 @@ public:
     const CSSPropertyID* begin() const { return std::to_address(properties().begin()); }
     const CSSPropertyID* end() const { return std::to_address(properties().end()); }
 
-    size_t length() const { return m_length; }
+    size_t length() const { return m_properties.size(); }
     CSSPropertyID id() const { return m_shorthandID; }
 
-    std::span<const CSSPropertyID> properties() const { return unsafeMakeSpan(m_properties, m_length); }
+    std::span<const CSSPropertyID> properties() const { return m_properties; }
 
 private:
-    const CSSPropertyID* m_properties { nullptr };
-    unsigned m_length { 0 };
+    std::span<const CSSPropertyID> m_properties;
     CSSPropertyID m_shorthandID { CSSPropertyInvalid };
 };
 


### PR DESCRIPTION
#### 512f8aeacc802c1a207fa570e74c9c9285769ac1
<pre>
Adopt span for data member in StylePropertyShorthand.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=286855">https://bugs.webkit.org/show_bug.cgi?id=286855</a>

Reviewed by Geoffrey Garen.

This tested as neutral on Membuster and Speedometer.

* Source/WebCore/css/StylePropertyShorthand.h:
(WebCore::StylePropertyShorthand::StylePropertyShorthand):
(WebCore::StylePropertyShorthand::length const):
(WebCore::StylePropertyShorthand::properties const):

Canonical link: <a href="https://commits.webkit.org/289669@main">https://commits.webkit.org/289669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/344bb3fb826084ab012fab3776a4cc97bdb87856

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67695 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5565 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33736 "Found 3 new test failures: editing/undo/redo-reapply-edit-command-crash.html http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94428 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14845 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10885 "Found 1 new test failure: swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76544 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75774 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7796 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13660 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20162 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14605 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->