### PR TITLE
Remove current layout engine's unbreakable images quirk

### DIFF
--- a/LayoutTests/fast/table/unbreakable-images-quirk.html
+++ b/LayoutTests/fast/table/unbreakable-images-quirk.html
@@ -1,5 +1,5 @@
 <style>
-    img { background-color: lightblue; width: 20px; height: 50px; }
+    img { background-color: lightblue; width: 20px; height: 40px; }
     table {width: 15px; background: silver; }
 </style>
 No line break
@@ -20,7 +20,7 @@ No line break
     </TR>
 </TABLE>
 <hr>
-Line break after the "a".
+Line break after "loremipsum".
 <TABLE>
     <TR> 
         <TD>
@@ -29,7 +29,7 @@ Line break after the "a".
     </TR>
 </TABLE>
 <hr>
-Line break after the "a".
+Line break after the "loremipsum".
 <TABLE>
     <TR> 
         <TD>
@@ -38,7 +38,7 @@ Line break after the "a".
     </TR>
 </TABLE>
 <hr>
-Line break after "wideword".
+Line break after the first image.
 <TABLE>
     <TR> 
         <TD>

--- a/LayoutTests/platform/mac/fast/table/unbreakable-images-quirk-expected.txt
+++ b/LayoutTests/platform/mac/fast/table/unbreakable-images-quirk-expected.txt
@@ -6,70 +6,70 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,0) size 784x18
         RenderText {#text} at (0,0) size 88x18
           text run at (0,0) width 88: "No line break"
-      RenderTable {TABLE} at (0,18) size 123x60 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 123x60
-          RenderTableRow {TR} at (0,2) size 123x56
-            RenderTableCell {TD} at (2,2) size 119x56 [r=0 c=0 rs=1 cs=1]
-              RenderImage {IMG} at (1,1) size 20x50 [bgcolor=#ADD8E6]
-              RenderText {#text} at (21,37) size 77x18
-                text run at (21,37) width 77: "loremipsum"
-              RenderImage {IMG} at (97,1) size 21x50 [bgcolor=#ADD8E6]
+      RenderTable {TABLE} at (0,18) size 123x50 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 123x50
+          RenderTableRow {TR} at (0,2) size 123x46
+            RenderTableCell {TD} at (2,2) size 119x46 [r=0 c=0 rs=1 cs=1]
+              RenderImage {IMG} at (1,1) size 20x40 [bgcolor=#ADD8E6]
+              RenderText {#text} at (21,27) size 77x18
+                text run at (21,27) width 77: "loremipsum"
+              RenderImage {IMG} at (97,1) size 21x40 [bgcolor=#ADD8E6]
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,96) size 784x18
+      RenderBlock (anonymous) at (0,86) size 784x18
         RenderText {#text} at (0,0) size 88x18
           text run at (0,0) width 88: "No line break"
-      RenderTable {TABLE} at (0,114) size 103x60 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 103x60
-          RenderTableRow {TR} at (0,2) size 103x56
-            RenderTableCell {TD} at (2,2) size 99x56 [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,37) size 77x18
-                text run at (1,37) width 77: "loremipsum"
-              RenderImage {IMG} at (77,1) size 21x50 [bgcolor=#ADD8E6]
+      RenderTable {TABLE} at (0,104) size 103x50 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 103x50
+          RenderTableRow {TR} at (0,2) size 103x46
+            RenderTableCell {TD} at (2,2) size 99x46 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,27) size 77x18
+                text run at (1,27) width 77: "loremipsum"
+              RenderImage {IMG} at (77,1) size 21x40 [bgcolor=#ADD8E6]
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,192) size 784x18
-        RenderText {#text} at (0,0) size 154x18
-          text run at (0,0) width 154: "Line break after the \"a\"."
-      RenderTable {TABLE} at (0,210) size 103x74 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 103x74
-          RenderTableRow {TR} at (0,2) size 103x70
-            RenderTableCell {TD} at (2,2) size 99x70 [r=0 c=0 rs=1 cs=1]
+      RenderBlock (anonymous) at (0,172) size 784x18
+        RenderText {#text} at (0,0) size 200x18
+          text run at (0,0) width 200: "Line break after \"loremipsum\"."
+      RenderTable {TABLE} at (0,190) size 103x64 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 103x64
+          RenderTableRow {TR} at (0,2) size 103x60
+            RenderTableCell {TD} at (2,2) size 99x60 [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 88x18
                 text run at (1,1) width 88: "a loremipsum"
-              RenderImage {IMG} at (1,19) size 20x50 [bgcolor=#ADD8E6]
+              RenderImage {IMG} at (1,19) size 20x40 [bgcolor=#ADD8E6]
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,302) size 784x18
-        RenderText {#text} at (0,0) size 154x18
-          text run at (0,0) width 154: "Line break after the \"a\"."
-      RenderTable {TABLE} at (0,320) size 123x110 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 123x110
-          RenderTableRow {TR} at (0,2) size 123x106
-            RenderTableCell {TD} at (2,2) size 119x106 [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,37) size 12x18
-                text run at (1,37) width 12: "a "
-              RenderImage {IMG} at (12,1) size 21x50 [bgcolor=#ADD8E6]
-              RenderText {#text} at (32,37) size 77x18
-                text run at (32,37) width 77: "loremipsum"
-              RenderImage {IMG} at (1,55) size 20x50 [bgcolor=#ADD8E6]
+      RenderBlock (anonymous) at (0,272) size 784x18
+        RenderText {#text} at (0,0) size 224x18
+          text run at (0,0) width 224: "Line break after the \"loremipsum\"."
+      RenderTable {TABLE} at (0,290) size 123x90 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 123x90
+          RenderTableRow {TR} at (0,2) size 123x86
+            RenderTableCell {TD} at (2,2) size 119x86 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,27) size 12x18
+                text run at (1,27) width 12: "a "
+              RenderImage {IMG} at (12,1) size 21x40 [bgcolor=#ADD8E6]
+              RenderText {#text} at (32,27) size 77x18
+                text run at (32,27) width 77: "loremipsum"
+              RenderImage {IMG} at (1,45) size 20x40 [bgcolor=#ADD8E6]
               RenderText {#text} at (0,0) size 0x0
-      RenderBlock (anonymous) at (0,448) size 784x18
-        RenderText {#text} at (0,0) size 188x18
-          text run at (0,0) width 188: "Line break after \"wideword\"."
-      RenderTable {TABLE} at (0,466) size 123x114 [bgcolor=#C0C0C0]
-        RenderTableSection {TBODY} at (0,0) size 123x114
-          RenderTableRow {TR} at (0,2) size 123x110
-            RenderTableCell {TD} at (2,2) size 119x110 [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (1,37) size 68x18
-                text run at (1,37) width 68: "wideword "
-              RenderImage {IMG} at (68,1) size 21x50 [bgcolor=#ADD8E6]
-              RenderText {#text} at (1,91) size 77x18
-                text run at (1,91) width 77: "loremipsum"
-              RenderImage {IMG} at (77,55) size 21x50 [bgcolor=#ADD8E6]
+      RenderBlock (anonymous) at (0,398) size 784x18
+        RenderText {#text} at (0,0) size 202x18
+          text run at (0,0) width 202: "Line break after the first image."
+      RenderTable {TABLE} at (0,416) size 123x94 [bgcolor=#C0C0C0]
+        RenderTableSection {TBODY} at (0,0) size 123x94
+          RenderTableRow {TR} at (0,2) size 123x90
+            RenderTableCell {TD} at (2,2) size 119x90 [r=0 c=0 rs=1 cs=1]
+              RenderText {#text} at (1,27) size 68x18
+                text run at (1,27) width 68: "wideword "
+              RenderImage {IMG} at (68,1) size 21x40 [bgcolor=#ADD8E6]
+              RenderText {#text} at (1,71) size 77x18
+                text run at (1,71) width 77: "loremipsum"
+              RenderImage {IMG} at (77,45) size 21x40 [bgcolor=#ADD8E6]
               RenderText {#text} at (0,0) size 0x0
-layer at (8,94) size 784x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,86) size 784x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,190) size 784x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,182) size 784x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,300) size 784x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,292) size 784x2 [color=#808080] [border: (1px inset #808080)]
-layer at (8,446) size 784x2 clip at (0,0) size 0x0
-  RenderBlock {HR} at (0,438) size 784x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,84) size 784x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,76) size 784x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,170) size 784x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,162) size 784x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,270) size 784x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,262) size 784x2 [color=#808080] [border: (1px inset #808080)]
+layer at (8,396) size 784x2 clip at (0,0) size 0x0
+  RenderBlock {HR} at (0,388) size 784x2 [color=#808080] [border: (1px inset #808080)]

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -76,7 +76,6 @@ public:
         , m_autoWrap(false)
         , m_autoWrapWasEverTrueOnLine(false)
         , m_collapseWhiteSpace(false)
-        , m_allowImagesToBreak(!block.document().inQuirksMode() || !block.isRenderTableCell() || !m_blockStyle.logicalWidth().isIntrinsicOrAuto())
         , m_atEnd(false)
         , m_hadUncommittedWidthBeforeCurrent(false)
         , m_lineWhitespaceCollapsingState(resolver.whitespaceCollapsingState())
@@ -169,7 +168,6 @@ private:
     bool m_autoWrap;
     bool m_autoWrapWasEverTrueOnLine;
     bool m_collapseWhiteSpace;
-    bool m_allowImagesToBreak;
     bool m_atEnd;
     bool m_hadUncommittedWidthBeforeCurrent;
     
@@ -739,7 +737,7 @@ inline void BreakingContext::commitAndUpdateLineBreakIfNeeded()
 
     if (!m_current.renderer()->isFloatingOrOutOfFlowPositioned()) {
         m_lastObject = m_current.renderer();
-        if (m_lastObject->isReplacedOrAtomicInline() && m_autoWrap && (!m_lastObject->isImage() || m_allowImagesToBreak)) {
+        if (m_lastObject->isReplacedOrAtomicInline() && m_autoWrap) {
             auto* renderListMarker = dynamicDowncast<RenderListMarker>(*m_lastObject);
             if (!renderListMarker || renderListMarker->isInside()) {
                 if (m_nextObject)


### PR DESCRIPTION
#### b166313546c7ab9cc7179ba6fbf4c6b63801e423
<pre>
Remove current layout engine&apos;s unbreakable images quirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=286861">https://bugs.webkit.org/show_bug.cgi?id=286861</a>
<a href="https://rdar.apple.com/144018888">rdar://144018888</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/88f301874fe22403ea3526f695cbe2cbab47f93a">https://source.chromium.org/chromium/chromium/src/+/88f301874fe22403ea3526f695cbe2cbab47f93a</a>

This removes the unbreakable images quirk (where there is no break
opportunity between an image and a word), during the layout phase of
the current layout system.

* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::BreakingContext):
(WebCore::BreakingContext::commitAndUpdateLineBreakIfNeeded):
* LayoutTests/fast/table/unbreakable-images-quirk.html:
* LayoutTests/platform/mac/fast/table/unbreakable-images-quirk-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b166313546c7ab9cc7179ba6fbf4c6b63801e423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38436 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15377 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67701 "Found 1 new test failure: fast/table/unbreakable-images-quirk.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90692 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5786 "Found 1 new test failure: fast/table/unbreakable-images-quirk.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48073 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5573 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94441 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14858 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10899 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76549 "Found 1 new test failure: fast/table/unbreakable-images-quirk.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75784 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20150 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7818 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20176 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14618 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->