### PR TITLE
Convert scroll-padding/scroll-margin types to strongly typed Style values

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -202,6 +202,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/images"
     "${WEBCORE_DIR}/style/values/motion"
     "${WEBCORE_DIR}/style/values/primitives"
+    "${WEBCORE_DIR}/style/values/scroll-snap"
     "${WEBCORE_DIR}/style/values/shapes"
     "${WEBCORE_DIR}/style/values/text-decoration"
     "${WEBCORE_DIR}/svg"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2682,6 +2682,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StylePrimitiveNumericTypes.h
     style/values/primitives/StyleUnevaluatedCalculation.h
 
+    style/values/scroll-snap/StyleScrollMargin.h
+    style/values/scroll-snap/StyleScrollPadding.h
+
     style/values/shapes/StyleBasicShape.h
     style/values/shapes/StyleCircleFunction.h
     style/values/shapes/StyleEllipseFunction.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3171,6 +3171,8 @@ style/values/primitives/StyleLengthResolution.cpp
 style/values/primitives/StylePosition.cpp
 style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
 style/values/primitives/StyleUnevaluatedCalculation.cpp
+style/values/scroll-snap/StyleScrollMargin.cpp
+style/values/scroll-snap/StyleScrollPadding.cpp
 style/values/shapes/StyleBasicShape.cpp
 style/values/shapes/StyleCircleFunction.cpp
 style/values/shapes/StyleEllipseFunction.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8930,7 +8930,7 @@
         "scroll-margin-bottom": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-bottom"
                 ],
@@ -8948,7 +8948,7 @@
         "scroll-margin-left": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-left"
                 ],
@@ -8966,7 +8966,7 @@
         "scroll-margin-right": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-right"
                 ],
@@ -8984,7 +8984,7 @@
         "scroll-margin-top": {
             "codegen-properties": {
                 "initial": "initialScrollMargin",
-                "converter": "Length",
+                "converter": "ScrollMarginEdge",
                 "aliases": [
                     "scroll-snap-margin-top"
                 ],
@@ -9096,7 +9096,7 @@
         "scroll-padding-bottom": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "bottom"
@@ -9111,7 +9111,7 @@
         "scroll-padding-left": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "left"
@@ -9126,7 +9126,7 @@
         "scroll-padding-right": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "right"
@@ -9141,7 +9141,7 @@
         "scroll-padding-top": {
             "codegen-properties": {
                 "initial": "initialScrollPadding",
-                "converter": "LengthOrAuto",
+                "converter": "ScrollPaddingEdge",
                 "logical-property-group": {
                     "name": "scroll-padding",
                     "resolver": "top"

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -97,6 +97,8 @@
 #include "StyleReflection.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include "StyleScrollMargin.h"
+#include "StyleScrollPadding.h"
 #include "StyleTextShadow.h"
 #include "Styleable.h"
 #include "TimelineRange.h"
@@ -4709,13 +4711,13 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyScrollMargin:
         return getCSSPropertyValuesFor4SidesShorthand(scrollMarginShorthand());
     case CSSPropertyScrollMarginBottom:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginBottom(), style);
+        return style.scrollMarginBottom().toCSS(style);
     case CSSPropertyScrollMarginTop:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginTop(), style);
+        return style.scrollMarginTop().toCSS(style);
     case CSSPropertyScrollMarginRight:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginRight(), style);
+        return style.scrollMarginRight().toCSS(style);
     case CSSPropertyScrollMarginLeft:
-        return zoomAdjustedPixelValueForLength(style.scrollMarginLeft(), style);
+        return style.scrollMarginLeft().toCSS(style);
     case CSSPropertyScrollMarginBlock:
         return getCSSPropertyValuesFor2SidesShorthand(scrollMarginBlockShorthand());
     case CSSPropertyScrollMarginInline:
@@ -4723,13 +4725,13 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyScrollPadding:
         return getCSSPropertyValuesFor4SidesShorthand(scrollPaddingShorthand());
     case CSSPropertyScrollPaddingBottom:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingBottom(), style);
+        return style.scrollPaddingBottom().toCSS(style);
     case CSSPropertyScrollPaddingTop:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingTop(), style);
+        return style.scrollPaddingTop().toCSS(style);
     case CSSPropertyScrollPaddingRight:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingRight(), style);
+        return style.scrollPaddingRight().toCSS(style);
     case CSSPropertyScrollPaddingLeft:
-        return zoomAdjustedPixelValueForLength(style.scrollPaddingLeft(), style);
+        return style.scrollPaddingLeft().toCSS(style);
     case CSSPropertyScrollPaddingBlock:
         return getCSSPropertyValuesFor2SidesShorthand(scrollPaddingBlockShorthand());
     case CSSPropertyScrollPaddingInline:

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -490,17 +490,17 @@ template<typename T> struct SpaceSeparatedRectEdges {
     {
     }
 
-    const T& top() const { return value.top(); }
-    const T& right() const { return value.right(); }
-    const T& bottom() const { return value.bottom(); }
-    const T& left() const { return value.left(); }
-
-    T& top() { return value.top(); }
-    T& right() { return value.right(); }
-    T& bottom() { return value.bottom(); }
-    T& left() { return value.left(); }
-
     constexpr bool operator==(const SpaceSeparatedRectEdges<T>&) const = default;
+
+    const T& top() const    { return value.top(); }
+    const T& right() const  { return value.right(); }
+    const T& bottom() const { return value.bottom(); }
+    const T& left() const   { return value.left(); }
+
+    T& top()                { return value.top(); }
+    T& right()              { return value.right(); }
+    T& bottom()             { return value.bottom(); }
+    T& left()               { return value.left(); }
 
     RectEdges<T> value;
 };
@@ -534,6 +534,11 @@ template<typename T> inline constexpr auto SerializationSeparator<SpaceSeparated
 template<typename T> struct MinimallySerializingSpaceSeparatedRectEdges {
     using value_type = T;
 
+    constexpr MinimallySerializingSpaceSeparatedRectEdges(T value)
+        : value { value, value, value, value }
+    {
+    }
+
     constexpr MinimallySerializingSpaceSeparatedRectEdges(T top, T right, T bottom, T left)
         : value { WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left) }
     {
@@ -544,17 +549,17 @@ template<typename T> struct MinimallySerializingSpaceSeparatedRectEdges {
     {
     }
 
+    constexpr bool operator==(const MinimallySerializingSpaceSeparatedRectEdges<T>&) const = default;
+
     const T& top() const    { return value.top(); }
     const T& right() const  { return value.right(); }
     const T& bottom() const { return value.bottom(); }
     const T& left() const   { return value.left(); }
 
-    T& top() { return value.top(); }
-    T& right() { return value.right(); }
-    T& bottom() { return value.bottom(); }
-    T& left() { return value.left(); }
-
-    constexpr bool operator==(const MinimallySerializingSpaceSeparatedRectEdges<T>&) const = default;
+    T& top()                { return value.top(); }
+    T& right()              { return value.right(); }
+    T& bottom()             { return value.bottom(); }
+    T& left()               { return value.left(); }
 
     RectEdges<T> value;
 };

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5816,12 +5816,7 @@ LayoutUnit RenderBox::offsetFromLogicalTopOfFirstPage() const
 
 LayoutBoxExtent RenderBox::scrollPaddingForViewportRect(const LayoutRect& viewportRect)
 {
-    // We are using minimumValueForLength here, because scroll-padding values might be "auto". WebKit currently
-    // interprets "auto" as 0. See: https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding
-    const auto& padding = style().scrollPadding();
-    return LayoutBoxExtent(
-        minimumValueForLength(padding.top(), viewportRect.height()), minimumValueForLength(padding.right(), viewportRect.width()),
-        minimumValueForLength(padding.bottom(), viewportRect.height()), minimumValueForLength(padding.left(), viewportRect.width()));
+    return Style::extentForRect(style().scrollPadding(), viewportRect);
 }
 
 LayoutUnit synthesizedBaseline(const RenderBox& box, const RenderStyle& parentStyle, LineDirectionMode direction, BaselineSynthesisEdge edge)

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2018,22 +2018,18 @@ LayoutRect RenderElement::absoluteAnchorRect(bool* insideFixed) const
 
 MarginRect RenderElement::absoluteAnchorRectWithScrollMargin(bool* insideFixed) const
 {
-    LayoutRect anchorRect = absoluteAnchorRect(insideFixed);
-    const LengthBox& scrollMargin = style().scrollMargin();
-    if (scrollMargin.isZero())
+    auto anchorRect = absoluteAnchorRect(insideFixed);
+
+    const auto& scrollMargin = style().scrollMargin();
+    if (Style::isZero(scrollMargin))
         return { anchorRect, anchorRect };
 
     // The scroll snap specification says that the scroll-margin should be applied in the
     // coordinate system of the scroll container and applied to the rectangular bounding
     // box of the transformed border box of the target element.
     // See https://www.w3.org/TR/css-scroll-snap-1/#scroll-margin.
-    const LayoutBoxExtent margin(
-        valueForLength(scrollMargin.top(), anchorRect.height()),
-        valueForLength(scrollMargin.right(), anchorRect.width()),
-        valueForLength(scrollMargin.bottom(), anchorRect.height()),
-        valueForLength(scrollMargin.left(), anchorRect.width()));
     auto marginRect = anchorRect;
-    marginRect.expand(margin);
+    marginRect.expand(Style::extentForRect(scrollMargin, anchorRect));
     return { marginRect, anchorRect };
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3587,94 +3587,94 @@ bool RenderStyle::customPropertiesEqual(const RenderStyle& other) const
         && m_rareInheritedData->customProperties == other.m_rareInheritedData->customProperties;
 }
 
-const LengthBox& RenderStyle::scrollMargin() const
+const Style::ScrollMargin& RenderStyle::scrollMargin() const
 {
     return m_nonInheritedData->rareData->scrollMargin;
 }
 
-const Length& RenderStyle::scrollMarginTop() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginTop() const
 {
     return scrollMargin().top();
 }
 
-const Length& RenderStyle::scrollMarginBottom() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginBottom() const
 {
     return scrollMargin().bottom();
 }
 
-const Length& RenderStyle::scrollMarginLeft() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginLeft() const
 {
     return scrollMargin().left();
 }
 
-const Length& RenderStyle::scrollMarginRight() const
+const Style::ScrollMarginEdge& RenderStyle::scrollMarginRight() const
 {
     return scrollMargin().right();
 }
 
-void RenderStyle::setScrollMarginTop(Length&& length)
+void RenderStyle::setScrollMarginTop(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.top(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.top(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollMarginBottom(Length&& length)
+void RenderStyle::setScrollMarginBottom(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.bottom(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.bottom(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollMarginLeft(Length&& length)
+void RenderStyle::setScrollMarginLeft(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.left(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.left(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollMarginRight(Length&& length)
+void RenderStyle::setScrollMarginRight(Style::ScrollMarginEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.right(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollMargin.right(), WTFMove(edge));
 }
 
-const LengthBox& RenderStyle::scrollPadding() const
+const Style::ScrollPadding& RenderStyle::scrollPadding() const
 {
     return m_nonInheritedData->rareData->scrollPadding;
 }
 
-const Length& RenderStyle::scrollPaddingTop() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingTop() const
 {
     return scrollPadding().top();
 }
 
-const Length& RenderStyle::scrollPaddingBottom() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingBottom() const
 {
     return scrollPadding().bottom();
 }
 
-const Length& RenderStyle::scrollPaddingLeft() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingLeft() const
 {
     return scrollPadding().left();
 }
 
-const Length& RenderStyle::scrollPaddingRight() const
+const Style::ScrollPaddingEdge& RenderStyle::scrollPaddingRight() const
 {
     return scrollPadding().right();
 }
 
-void RenderStyle::setScrollPaddingTop(Length&& length)
+void RenderStyle::setScrollPaddingTop(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.top(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.top(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollPaddingBottom(Length&& length)
+void RenderStyle::setScrollPaddingBottom(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.bottom(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.bottom(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollPaddingLeft(Length&& length)
+void RenderStyle::setScrollPaddingLeft(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.left(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.left(), WTFMove(edge));
 }
 
-void RenderStyle::setScrollPaddingRight(Length&& length)
+void RenderStyle::setScrollPaddingRight(Style::ScrollPaddingEdge&& edge)
 {
-    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.right(), WTFMove(length));
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollPadding.right(), WTFMove(edge));
 }
 
 ScrollSnapType RenderStyle::initialScrollSnapType()

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -293,6 +293,10 @@ class ViewTransitionName;
 struct Color;
 struct ColorScheme;
 struct ScopedName;
+struct ScrollMargin;
+struct ScrollMarginEdge;
+struct ScrollPadding;
+struct ScrollPaddingEdge;
 
 enum class Change : uint8_t;
 enum class PositionTryOrder : uint8_t;
@@ -1065,17 +1069,17 @@ public:
 
     inline bool effectiveInert() const;
 
-    const LengthBox& scrollMargin() const;
-    const Length& scrollMarginTop() const;
-    const Length& scrollMarginBottom() const;
-    const Length& scrollMarginLeft() const;
-    const Length& scrollMarginRight() const;
+    const Style::ScrollMargin& scrollMargin() const;
+    const Style::ScrollMarginEdge& scrollMarginTop() const;
+    const Style::ScrollMarginEdge& scrollMarginBottom() const;
+    const Style::ScrollMarginEdge& scrollMarginLeft() const;
+    const Style::ScrollMarginEdge& scrollMarginRight() const;
 
-    const LengthBox& scrollPadding() const;
-    const Length& scrollPaddingTop() const;
-    const Length& scrollPaddingBottom() const;
-    const Length& scrollPaddingLeft() const;
-    const Length& scrollPaddingRight() const;
+    const Style::ScrollPadding& scrollPadding() const;
+    const Style::ScrollPaddingEdge& scrollPaddingTop() const;
+    const Style::ScrollPaddingEdge& scrollPaddingBottom() const;
+    const Style::ScrollPaddingEdge& scrollPaddingLeft() const;
+    const Style::ScrollPaddingEdge& scrollPaddingRight() const;
     inline bool scrollPaddingEqual(const RenderStyle&) const;
 
     bool hasSnapPosition() const;
@@ -1625,15 +1629,15 @@ public:
 
     inline void setEffectiveInert(bool);
 
-    void setScrollMarginTop(Length&&);
-    void setScrollMarginBottom(Length&&);
-    void setScrollMarginLeft(Length&&);
-    void setScrollMarginRight(Length&&);
+    void setScrollMarginTop(Style::ScrollMarginEdge&&);
+    void setScrollMarginBottom(Style::ScrollMarginEdge&&);
+    void setScrollMarginLeft(Style::ScrollMarginEdge&&);
+    void setScrollMarginRight(Style::ScrollMarginEdge&&);
 
-    void setScrollPaddingTop(Length&&);
-    void setScrollPaddingBottom(Length&&);
-    void setScrollPaddingLeft(Length&&);
-    void setScrollPaddingRight(Length&&);
+    void setScrollPaddingTop(Style::ScrollPaddingEdge&&);
+    void setScrollPaddingBottom(Style::ScrollPaddingEdge&&);
+    void setScrollPaddingLeft(Style::ScrollPaddingEdge&&);
+    void setScrollPaddingRight(Style::ScrollPaddingEdge&&);
 
     void setScrollSnapType(ScrollSnapType);
     void setScrollSnapAlign(const ScrollSnapAlign&);
@@ -2102,8 +2106,8 @@ public:
 
     static constexpr FieldSizing initialFieldSizing();
 
-    static inline Length initialScrollMargin();
-    static inline Length initialScrollPadding();
+    static inline Style::ScrollMarginEdge initialScrollMargin();
+    static inline Style::ScrollPaddingEdge initialScrollPadding();
 
     static ScrollSnapType initialScrollSnapType();
     static ScrollSnapAlign initialScrollSnapAlign();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -70,6 +70,8 @@
 
 namespace WebCore {
 
+using namespace CSS::Literals;
+
 inline const Style::Color& RenderStyle::accentColor() const { return m_rareInheritedData->accentColor; }
 inline bool RenderStyle::affectsTransform() const { return hasTransform() || offsetPath() || rotate() || scale() || translate(); }
 inline const StyleContentAlignmentData& RenderStyle::alignContent() const { return m_nonInheritedData->miscData->alignContent; }
@@ -478,8 +480,8 @@ inline GapLength RenderStyle::initialRowGap() { return { }; }
 constexpr RubyPosition RenderStyle::initialRubyPosition() { return RubyPosition::Over; }
 constexpr RubyAlign RenderStyle::initialRubyAlign() { return RubyAlign::SpaceAround; }
 constexpr RubyOverhang RenderStyle::initialRubyOverhang() { return RubyOverhang::Auto; }
-inline Length RenderStyle::initialScrollMargin() { return zeroLength(); }
-inline Length RenderStyle::initialScrollPadding() { return { }; }
+inline Style::ScrollMarginEdge RenderStyle::initialScrollMargin() { return 0_css_px; }
+inline Style::ScrollPaddingEdge RenderStyle::initialScrollPadding() { return CSS::Keyword::Auto { }; }
 inline std::optional<ScrollbarColor> RenderStyle::initialScrollbarColor() { return std::nullopt; }
 constexpr ScrollbarWidth RenderStyle::initialScrollbarWidth() { return ScrollbarWidth::Auto; }
 constexpr StyleSelfAlignmentData RenderStyle::initialSelfAlignment() { return { ItemPosition::Auto, OverflowAlignment::Default }; }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -44,6 +44,9 @@
 #include "ShapeValue.h"
 #include "StyleColor.h"
 #include "StyleContentAlignmentData.h"
+#include "StylePrimitiveNumericTypes.h"
+#include "StyleScrollMargin.h"
+#include "StyleScrollPadding.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleSelfAlignmentData.h"
 #include "StyleTextEdge.h"
@@ -66,6 +69,8 @@ class TextStream;
 }
 
 namespace WebCore {
+
+using namespace CSS::Literals;
 
 class AnimationList;
 class ContentData;
@@ -144,9 +149,11 @@ public:
     DataRef<StyleGridData> grid;
     DataRef<StyleGridItemData> gridItem;
 
+    // Only meaningful when `hasClip` is true.
     LengthBox clip;
-    LengthBox scrollMargin { 0, 0, 0, 0 };
-    LengthBox scrollPadding { Length(LengthType::Auto), Length(LengthType::Auto), Length(LengthType::Auto), Length(LengthType::Auto) };
+
+    Style::ScrollMargin scrollMargin { 0_css_px };
+    Style::ScrollPadding scrollPadding { CSS::Keyword::Auto { } };
 
     CounterDirectiveMap counterDirectives;
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -83,6 +83,8 @@
 #include "StyleRayFunction.h"
 #include "StyleReflection.h"
 #include "StyleResolveForFont.h"
+#include "StyleScrollMargin.h"
+#include "StyleScrollPadding.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleTextEdge.h"
 #include "TabSize.h"
@@ -252,6 +254,9 @@ public:
 
     static SingleTimelineRange convertAnimationRangeStart(BuilderState&, const CSSValue&);
     static SingleTimelineRange convertAnimationRangeEnd(BuilderState&, const CSSValue&);
+
+    static Style::ScrollPaddingEdge convertScrollPaddingEdge(BuilderState&, const CSSValue&);
+    static Style::ScrollMarginEdge convertScrollMarginEdge(BuilderState&, const CSSValue&);
 
     static Vector<PositionTryFallback> convertPositionTryFallbacks(BuilderState&, const CSSValue&);
 
@@ -2451,6 +2456,16 @@ inline Vector<PositionTryFallback> BuilderConverter::convertPositionTryFallbacks
         auto fallback = fallbackForValueList(*itemList);
         return fallback ? *fallback : PositionTryFallback { };
     });
+}
+
+inline Style::ScrollPaddingEdge BuilderConverter::convertScrollPaddingEdge(BuilderState& builderState, const CSSValue& value)
+{
+    return Style::scrollPaddingEdgeFromCSSValue(value, builderState);
+}
+
+inline Style::ScrollMarginEdge BuilderConverter::convertScrollMarginEdge(BuilderState& builderState, const CSSValue& value)
+{
+    return Style::scrollMarginEdgeFromCSSValue(value, builderState);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -77,6 +77,8 @@ inline LengthBox forwardInheritedValue(const LengthBox& value) { auto copy = val
 inline GapLength forwardInheritedValue(const GapLength& value) { auto copy = value; return copy; }
 inline FilterOperations forwardInheritedValue(const FilterOperations& value) { auto copy = value; return copy; }
 inline TransformOperations forwardInheritedValue(const TransformOperations& value) { auto copy = value; return copy; }
+inline ScrollMarginEdge forwardInheritedValue(const ScrollMarginEdge& value) { auto copy = value; return copy; }
+inline ScrollPaddingEdge forwardInheritedValue(const ScrollPaddingEdge& value) { auto copy = value; return copy; }
 
 // Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleScrollMargin.h"
+
+#include "ComputedStyleExtractor.h"
+#include "LayoutRect.h"
+#include "StyleBuilderConverter.h"
+#include "StyleBuilderState.h"
+
+namespace WebCore {
+namespace Style {
+
+LayoutUnit ScrollMarginEdge::evaluate(LayoutUnit referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return LayoutUnit(m_value.value());
+
+    case LengthType::Percent:
+        return LayoutUnit(static_cast<float>(referenceLength * m_value.percent() / 100.0f));
+
+    case LengthType::Calculated:
+        return LayoutUnit(m_value.nonNanCalculatedValue(referenceLength));
+
+    case LengthType::FillAvailable:
+    case LengthType::Auto:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0_lu;
+}
+
+float ScrollMarginEdge::evaluate(float referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return m_value.value();
+
+    case LengthType::Percent:
+        return referenceLength * m_value.percent() / 100.0f;
+
+    case LengthType::Calculated:
+        return m_value.nonNanCalculatedValue(referenceLength);
+
+    case LengthType::FillAvailable:
+    case LengthType::Auto:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0.0f;
+}
+
+Ref<CSSValue> ScrollMarginEdge::toCSS(const RenderStyle& style) const
+{
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(m_value, style);
+}
+
+ScrollMarginEdge scrollMarginEdgeFromCSSValue(const CSSValue& value, BuilderState& state)
+{
+    return ScrollMarginEdge { BuilderConverter::convertLength(state, value) };
+}
+
+LayoutBoxExtent extentForRect(const ScrollMargin& margin, const LayoutRect& rect)
+{
+    return LayoutBoxExtent {
+        Style::evaluate(margin.top(), rect.height()),
+        Style::evaluate(margin.right(), rect.width()),
+        Style::evaluate(margin.bottom(), rect.height()),
+        Style::evaluate(margin.left(), rect.width()),
+    };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Length.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+
+class CSSValue;
+class LayoutRect;
+class LayoutUnit;
+class RenderStyle;
+using LayoutBoxExtent = RectEdges<LayoutUnit>;
+
+namespace Style {
+
+class BuilderState;
+
+// <'scroll-margin-*'> = <length>
+// https://drafts.csswg.org/css-scroll-snap-1/#margin-longhands-physical
+struct ScrollMarginEdge {
+    ScrollMarginEdge(WebCore::Length&& value)
+        : m_value { WTFMove(value) }
+    {
+        RELEASE_ASSERT(m_value.isSpecified());
+    }
+
+    ScrollMarginEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> pixels)
+        : m_value { pixels.value, WebCore::LengthType::Fixed }
+    {
+    }
+
+    ScrollMarginEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> percentage)
+        : m_value { percentage.value, WebCore::LengthType::Percent }
+    {
+    }
+
+    LayoutUnit evaluate(LayoutUnit referenceLength) const;
+    float evaluate(float referenceLength) const;
+
+    Ref<CSSValue> toCSS(const RenderStyle&) const;
+
+    bool isZero() const { return m_value.isZero(); }
+
+    bool operator==(const ScrollMarginEdge&) const = default;
+
+private:
+    WebCore::Length m_value;
+};
+
+// <'scroll-margin'> = <length>{1,4}
+// https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin
+struct ScrollMargin : SpaceSeparatedRectEdges<ScrollMarginEdge> {
+    using Wrapped = SpaceSeparatedRectEdges<ScrollMarginEdge>;
+    using Wrapped::Wrapped;
+    using Wrapped::operator=;
+
+    template<size_t I> friend const auto& get(const ScrollMargin& self)
+    {
+        return get<I>(static_cast<const Wrapped&>(self));
+    }
+
+    bool operator==(const ScrollMargin&) const = default;
+};
+
+// MARK: - Conversion
+
+ScrollMarginEdge scrollMarginEdgeFromCSSValue(const CSSValue&, BuilderState&);
+
+// MARK: - Evaluation
+
+template<> struct Evaluation<ScrollMarginEdge> {
+    template<typename T> auto operator()(const ScrollMarginEdge& edge, T referenceLength) -> T
+    {
+        return edge.evaluate(referenceLength);
+    }
+};
+
+// MARK: - Extent
+
+LayoutBoxExtent extentForRect(const ScrollMargin&, const LayoutRect&);
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ScrollMargin, 4)

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleScrollPadding.h"
+
+#include "ComputedStyleExtractor.h"
+#include "LayoutRect.h"
+#include "StyleBuilderConverter.h"
+#include "StyleBuilderState.h"
+
+namespace WebCore {
+namespace Style {
+
+LayoutUnit ScrollPaddingEdge::evaluate(LayoutUnit referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return LayoutUnit(m_value.value());
+
+    case LengthType::Percent:
+        return LayoutUnit(static_cast<float>(referenceLength * m_value.percent() / 100.0f));
+
+    case LengthType::Calculated:
+        return LayoutUnit(m_value.nonNanCalculatedValue(referenceLength));
+
+    case LengthType::Auto:
+            return 0_lu;
+
+    case LengthType::FillAvailable:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0_lu;
+}
+
+float ScrollPaddingEdge::evaluate(float referenceLength) const
+{
+    switch (m_value.type()) {
+    case LengthType::Fixed:
+        return m_value.value();
+
+    case LengthType::Percent:
+        return referenceLength * m_value.percent() / 100.0f;
+
+    case LengthType::Calculated:
+        return m_value.nonNanCalculatedValue(referenceLength);
+
+    case LengthType::Auto:
+            return 0;
+
+    case LengthType::FillAvailable:
+    case LengthType::Normal:
+    case LengthType::Content:
+    case LengthType::Relative:
+    case LengthType::Intrinsic:
+    case LengthType::MinIntrinsic:
+    case LengthType::MinContent:
+    case LengthType::MaxContent:
+    case LengthType::FitContent:
+    case LengthType::Undefined:
+        break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0;
+}
+
+Ref<CSSValue> ScrollPaddingEdge::toCSS(const RenderStyle& style) const
+{
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(m_value, style);
+}
+
+ScrollPaddingEdge scrollPaddingEdgeFromCSSValue(const CSSValue& value, BuilderState& state)
+{
+    if (value.valueID() == CSSValueAuto)
+        return ScrollPaddingEdge { CSS::Keyword::Auto { } };
+    return ScrollPaddingEdge { BuilderConverter::convertLength(state, value) };
+}
+
+LayoutBoxExtent extentForRect(const ScrollPadding& padding, const LayoutRect& rect)
+{
+    return LayoutBoxExtent {
+        Style::evaluate(padding.top(), rect.height()),
+        Style::evaluate(padding.right(), rect.width()),
+        Style::evaluate(padding.bottom(), rect.height()),
+        Style::evaluate(padding.left(), rect.width()),
+    };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Length.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+
+class CSSValue;
+class LayoutRect;
+class LayoutUnit;
+class RenderStyle;
+using LayoutBoxExtent = RectEdges<LayoutUnit>;
+
+namespace Style {
+
+class BuilderState;
+
+// <'scroll-padding-*'> = auto | <length-percentage [0,∞]>
+// https://drafts.csswg.org/css-scroll-snap-1/#padding-longhands-physical
+struct ScrollPaddingEdge {
+    ScrollPaddingEdge(WebCore::Length&& value)
+        : m_value { WTFMove(value) }
+    {
+        RELEASE_ASSERT(m_value.isSpecified());
+    }
+
+    ScrollPaddingEdge(CSS::Keyword::Auto)
+        : m_value { WebCore::LengthType::Auto }
+    {
+    }
+
+    ScrollPaddingEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> pixels)
+        : m_value { pixels.value, WebCore::LengthType::Fixed }
+    {
+    }
+
+    ScrollPaddingEdge(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> percentage)
+        : m_value { percentage.value, WebCore::LengthType::Percent }
+    {
+    }
+
+    LayoutUnit evaluate(LayoutUnit referenceLength) const;
+    float evaluate(float referenceLength) const;
+
+    Ref<CSSValue> toCSS(const RenderStyle&) const;
+
+    bool isZero() const { return m_value.isZero(); }
+
+    bool operator==(const ScrollPaddingEdge&) const = default;
+
+private:
+    WebCore::Length m_value;
+};
+
+// <'scroll-padding'> = [ auto | <length-percentage [0,∞]> ]{1,4}
+// https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding
+struct ScrollPadding : SpaceSeparatedRectEdges<ScrollPaddingEdge> {
+    using Wrapped = SpaceSeparatedRectEdges<ScrollPaddingEdge>;
+    using Wrapped::Wrapped;
+    using Wrapped::operator=;
+
+    template<size_t I> friend const auto& get(const ScrollPadding& self)
+    {
+        return get<I>(static_cast<const Wrapped&>(self));
+    }
+
+    bool operator==(const ScrollPadding&) const = default;
+};
+
+// MARK: - Conversion
+
+ScrollPaddingEdge scrollPaddingEdgeFromCSSValue(const CSSValue&, BuilderState&);
+
+// MARK: - Evaluation
+
+template<> struct Evaluation<ScrollPaddingEdge> {
+    template<typename T> auto operator()(const ScrollPaddingEdge& edge, T referenceLength) -> T
+    {
+        return edge.evaluate(referenceLength);
+    }
+};
+
+// MARK: - Extent
+
+LayoutBoxExtent extentForRect(const ScrollPadding&, const LayoutRect&);
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ScrollPadding, 4)


### PR DESCRIPTION
#### aeae68feccffa4d8156c4bb28abd04e2d967f43f
<pre>
Convert scroll-padding/scroll-margin types to strongly typed Style values
<a href="https://bugs.webkit.org/show_bug.cgi?id=286867">https://bugs.webkit.org/show_bug.cgi?id=286867</a>

Reviewed by Antti Koivisto.

Partially re-applies a simplified version of 288829@main.

This version wraps WebCore::Length values rather than trying to
to build these new value types on top of CompactVariant. With this
in place, we can work on updating the implementation with much more
targeted changes.

This change also only updates the Style type, leaving the CSS
type alone for now.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h: Added.

Canonical link: <a href="https://commits.webkit.org/289829@main">https://commits.webkit.org/289829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21ad5ef319d62c59726f95a5ce731e7bdf015202

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88128 "") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15822 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79715 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48372 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34129 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37986 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94924 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15296 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75571 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76110 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18714 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20501 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15314 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18501 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->