### PR TITLE
Optimize comparing various RenderStyle properties

### DIFF
--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -198,8 +198,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
             view().frameView().removeViewportConstrainedObject(*this);
     }
 
-    const RenderStyle& newStyle = style();
-    if (oldStyle && oldStyle->scrollPadding() != newStyle.scrollPadding()) {
+    if (oldStyle && !oldStyle->scrollPaddingEqual(style())) {
         if (isDocumentElementRenderer()) {
             LocalFrameView& frameView = view().frameView();
             frameView.updateScrollbarSteps();
@@ -207,10 +206,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
             renderLayer->updateScrollbarSteps();
     }
 
-    bool scrollMarginChanged = oldStyle && oldStyle->scrollMargin() != newStyle.scrollMargin();
-    bool scrollAlignChanged = oldStyle && oldStyle->scrollSnapAlign() != newStyle.scrollSnapAlign();
-    bool scrollSnapStopChanged = oldStyle && oldStyle->scrollSnapStop() != newStyle.scrollSnapStop();
-    if (scrollMarginChanged || scrollAlignChanged || scrollSnapStopChanged) {
+    if (oldStyle && !oldStyle->scrollSnapDataEquivalent(style())) {
         if (auto* scrollSnapBox = enclosingScrollableContainer())
             scrollSnapBox->setNeedsLayout();
     }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -294,6 +294,7 @@ struct Color;
 struct ColorScheme;
 struct ScopedName;
 
+enum class Change : uint8_t;
 enum class PositionTryOrder : uint8_t;
 }
 
@@ -771,6 +772,7 @@ public:
     inline bool containsLayoutOrPaint() const;
     inline ContainerType containerType() const;
     inline const Vector<Style::ScopedName>& containerNames() const;
+    inline bool containerTypeAndNamesEqual(const RenderStyle&) const;
 
     inline ContentVisibility contentVisibility() const;
 
@@ -912,6 +914,7 @@ public:
     inline unsigned short columnRuleWidth() const;
     inline bool columnRuleIsTransparent() const;
     inline ColumnSpan columnSpan() const;
+    inline bool columnSpanEqual(const RenderStyle&) const;
 
     inline const TransformOperations& transform() const;
     inline bool hasTransform() const;
@@ -1073,11 +1076,13 @@ public:
     const Length& scrollPaddingBottom() const;
     const Length& scrollPaddingLeft() const;
     const Length& scrollPaddingRight() const;
+    inline bool scrollPaddingEqual(const RenderStyle&) const;
 
     bool hasSnapPosition() const;
     ScrollSnapType scrollSnapType() const;
     const ScrollSnapAlign& scrollSnapAlign() const;
     ScrollSnapStop scrollSnapStop() const;
+    bool scrollSnapDataEquivalent(const RenderStyle&) const;
 
     Color usedScrollbarThumbColor() const;
     Color usedScrollbarTrackColor() const;
@@ -1794,7 +1799,7 @@ public:
     inline bool hasContent() const;
     inline const ContentData* contentData() const;
     void setContent(std::unique_ptr<ContentData>, bool add);
-    inline bool contentDataEquivalent(const RenderStyle*) const;
+    inline bool contentDataEquivalent(const RenderStyle&) const;
     void clearContent();
     inline void setHasContentNone(bool);
     void setContent(const String&, bool add = false);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -128,7 +128,6 @@ inline const LengthBox& RenderStyle::borderImageSlices() const { return border()
 inline StyleImage* RenderStyle::borderImageSource() const { return border().image().image(); }
 inline NinePieceImageRule RenderStyle::borderImageVerticalRule() const { return border().image().verticalRule(); }
 inline const LengthBox& RenderStyle::borderImageWidth() const { return border().image().borderSlices(); }
-inline bool RenderStyle::borderIsEquivalentForPainting(const RenderStyle& otherStyle) const { return border().isEquivalentForPainting(otherStyle.border(), color() != otherStyle.color()); }
 inline const BorderValue& RenderStyle::borderLeft() const { return border().left(); }
 inline const Style::Color& RenderStyle::borderLeftColor() const { return border().left().color(); }
 inline bool RenderStyle::borderLeftIsTransparent() const { return border().left().isTransparent(); }
@@ -208,7 +207,6 @@ inline bool RenderStyle::containsSizeOrInlineSize() const { return usedContain()
 inline bool RenderStyle::containsStyle() const { return usedContain().contains(Containment::Style); }
 constexpr OptionSet<Containment> RenderStyle::contentContainment() { return { Containment::Layout, Containment::Paint, Containment::Style }; }
 inline const ContentData* RenderStyle::contentData() const { return m_nonInheritedData->miscData->content.get(); }
-inline bool RenderStyle::contentDataEquivalent(const RenderStyle* otherStyle) const { return m_nonInheritedData->miscData->contentDataEquivalent(*otherStyle->m_nonInheritedData->miscData); }
 inline ContentVisibility RenderStyle::contentVisibility() const { return static_cast<ContentVisibility>(m_nonInheritedData->rareData->contentVisibility); }
 inline CursorList* RenderStyle::cursors() const { return m_rareInheritedData->cursorData.get(); }
 inline StyleAppearance RenderStyle::usedAppearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->usedAppearance); }
@@ -1070,6 +1068,56 @@ inline bool RenderStyle::isInterCharacterRubyPosition() const
 {
     auto rubyPosition = this->rubyPosition();
     return rubyPosition == RubyPosition::InterCharacter || rubyPosition == RubyPosition::LegacyInterCharacter;
+}
+
+inline bool RenderStyle::columnSpanEqual(const RenderStyle& other) const
+{
+    if (m_nonInheritedData.ptr() == other.m_nonInheritedData.ptr()
+        || m_nonInheritedData->miscData.ptr() == other.m_nonInheritedData->miscData.ptr()
+        || m_nonInheritedData->miscData->multiCol.ptr() == other.m_nonInheritedData->miscData->multiCol.ptr())
+        return true;
+
+    return m_nonInheritedData->miscData->multiCol->columnSpan == other.m_nonInheritedData->miscData->multiCol->columnSpan;
+}
+
+inline bool RenderStyle::borderIsEquivalentForPainting(const RenderStyle& other) const
+{
+    bool colorDiffers = color() != other.color();
+
+    if (!colorDiffers
+        && (m_nonInheritedData.ptr() == other.m_nonInheritedData.ptr()
+        || m_nonInheritedData->surroundData.ptr() == other.m_nonInheritedData->surroundData.ptr()
+        || m_nonInheritedData->surroundData->border == other.m_nonInheritedData->surroundData->border))
+        return true;
+
+    return border().isEquivalentForPainting(other.border(), colorDiffers);
+}
+
+inline bool RenderStyle::contentDataEquivalent(const RenderStyle& other) const
+{
+    if (m_nonInheritedData.ptr() == other.m_nonInheritedData.ptr()
+        || m_nonInheritedData->miscData.ptr() == other.m_nonInheritedData->miscData.ptr())
+        return true;
+
+    return m_nonInheritedData->miscData->contentDataEquivalent(other.m_nonInheritedData->miscData);
+}
+
+inline bool RenderStyle::containerTypeAndNamesEqual(const RenderStyle& other) const
+{
+    if (m_nonInheritedData.ptr() == other.m_nonInheritedData.ptr()
+        || m_nonInheritedData->rareData.ptr() == other.m_nonInheritedData->rareData.ptr())
+        return true;
+
+    return containerType() == other.containerType() && containerNames() == other.containerNames();
+}
+
+inline bool RenderStyle::scrollPaddingEqual(const RenderStyle& other) const
+{
+    if (m_nonInheritedData.ptr() == other.m_nonInheritedData.ptr()
+        || m_nonInheritedData->rareData.ptr() == other.m_nonInheritedData->rareData.ptr())
+        return true;
+
+    return m_nonInheritedData->rareData->scrollPadding == other.m_nonInheritedData->rareData->scrollPadding;
 }
 
 inline bool generatesBox(const RenderStyle& style)

--- a/Source/WebCore/rendering/style/StyleSurroundData.h
+++ b/Source/WebCore/rendering/style/StyleSurroundData.h
@@ -41,7 +41,7 @@ class StyleSurroundData : public RefCounted<StyleSurroundData> {
 public:
     static Ref<StyleSurroundData> create() { return adoptRef(*new StyleSurroundData); }
     Ref<StyleSurroundData> copy() const;
-    
+
     bool operator==(const StyleSurroundData&) const;
 
 #if !LOG_DISABLED

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -37,30 +37,35 @@ Change determineChange(const RenderStyle& s1, const RenderStyle& s2)
 {
     if (s1.display() != s2.display())
         return Change::Renderer;
+
     if (s1.hasPseudoStyle(PseudoId::FirstLetter) != s2.hasPseudoStyle(PseudoId::FirstLetter))
         return Change::Renderer;
+
     // We just detach if a renderer acquires or loses a column-span, since spanning elements
     // typically won't contain much content.
     auto columnSpanNeedsNewRenderer = [&] {
-        if (s1.columnSpan() != s2.columnSpan())
+        if (!s1.columnSpanEqual(s2))
             return true;
         if (s1.columnSpan() != ColumnSpan::All)
             return false;
         // Spanning in ignored for floating and out-of-flow boxes.
         return s1.isFloating() != s2.isFloating() || s1.hasOutOfFlowPosition() != s2.hasOutOfFlowPosition();
     }();
+
     if (columnSpanNeedsNewRenderer)
         return Change::Renderer;
-    if (!s1.contentDataEquivalent(&s2))
-        return Change::Renderer;
+
     // When text-combine property has been changed, we need to prepare a separate renderer object.
     // When text-combine is on, we use RenderCombineText, otherwise RenderText.
     // https://bugs.webkit.org/show_bug.cgi?id=55069
     if (s1.hasTextCombine() != s2.hasTextCombine())
         return Change::Renderer;
 
+    if (!s1.contentDataEquivalent(s2))
+        return Change::Renderer;
+
     // Query container changes affect descendant style.
-    if (s1.containerType() != s2.containerType() || s1.containerNames() != s2.containerNames())
+    if (!s1.containerTypeAndNamesEqual(s2))
         return Change::Descendants;
 
     if (!s1.descendantAffectingNonInheritedPropertiesEqual(s2))
@@ -79,5 +84,20 @@ Change determineChange(const RenderStyle& s1, const RenderStyle& s2)
     return Change::None;
 }
 
+TextStream& operator<<(TextStream& ts, Change change)
+{
+    switch (change) {
+    case Change::None: ts << "None"; break;
+    case Change::NonInherited: ts << "NonInherited"; break;
+    case Change::FastPathInherited: ts << "FastPathInherited"; break;
+    case Change::NonInheritedAndFastPathInherited: ts << "NonInheritedAndFastPathInherited"; break;
+    case Change::Inherited: ts << "Inherited"; break;
+    case Change::Descendants: ts << "Descendants"; break;
+    case Change::Renderer: ts << "Renderer"; break;
+    }
+    return ts;
 }
-}
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/StyleChange.h
+++ b/Source/WebCore/style/StyleChange.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 class RenderStyle;
@@ -43,5 +47,8 @@ enum class Change : uint8_t {
 
 WEBCORE_EXPORT Change determineChange(const RenderStyle&, const RenderStyle&);
 
+WTF::TextStream& operator<<(WTF::TextStream&, Change);
+
 }
+
 }


### PR DESCRIPTION
#### 21fec260eb85e4c360106111b32ac8c42e18f862
<pre>
Optimize comparing various RenderStyle properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=286868">https://bugs.webkit.org/show_bug.cgi?id=286868</a>
<a href="https://rdar.apple.com/144024685">rdar://144024685</a>

Reviewed by Sam Weinig.

We can optimize comparisons of things like column span, border colors, content data etc
by first comparing the pointers (`m_nonInheritedData` etc) before then comparing
the values. This is done by adding some helper functions on RenderStyle.

Also optimize `RenderStyle::changeAffectsVisualOverflow()` by grouping and reordering
comparisons.

* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::styleDidChange):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeAffectsVisualOverflow const):
(WebCore::RenderStyle::scrollSnapDataEquivalent const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::borderImageWidth const):
(WebCore::RenderStyle::contentData const):
(WebCore::RenderStyle::columnSpanEqual const):
(WebCore::RenderStyle::borderIsEquivalentForPainting const):
(WebCore::RenderStyle::contentDataEquivalent const):
(WebCore::RenderStyle::containerTypeAndNamesEqual const):
(WebCore::RenderStyle::scrollPaddingEqual const):
* Source/WebCore/rendering/style/StyleSurroundData.h:
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChange):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/StyleChange.h:

Canonical link: <a href="https://commits.webkit.org/289700@main">https://commits.webkit.org/289700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b02d368d73d4eadb6a44046e8003ca604306f5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67724 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48095 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33772 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14888 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10925 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76577 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18645 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20175 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7855 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20206 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14648 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->