### PR TITLE
Implement revamped scoped custom element registry

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+PASS A constructor with only a scoped custom element registry definition should fail upon construction
+PASS A constructor uses the global registry to create an element
+PASS A constructor creating an element from another registry before or after super call should work
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+test(() => {
+    class ABElement extends HTMLElement { };
+    const scopedRegistry = new CustomElementRegistry;
+    scopedRegistry.define('a-b', ABElement);
+    assert_throws_js(TypeError, () => new ABElement);
+}, 'A constructor with only a scoped custom element registry definition should fail upon construction');
+
+test(() => {
+    class CElement extends HTMLElement { };
+    const scopedRegistry = new CustomElementRegistry;
+    scopedRegistry.define('scoped-c', CElement);
+    customElements.define('global-c', CElement);
+    const cElement = new CElement;
+    assert_equals(cElement.localName, 'global-c');
+}, 'A constructor uses the global registry to create an element');
+
+test(() => {
+    let fgElement;
+    let hiElement;
+    class DEElement extends HTMLElement {
+        constructor() {
+            fgElement = document.createElement('f-g', {customElements: scopedRegistry2});
+            super();
+            hiElement = document.createElement('h-i', {customElements: scopedRegistry2});
+        }
+    };
+    class FGElement extends HTMLElement { }
+    class HIElement extends HTMLElement { }
+    const scopedRegistry1 = new CustomElementRegistry;
+    scopedRegistry1.define('d-e', DEElement);
+    const scopedRegistry2 = new CustomElementRegistry;
+    scopedRegistry2.define('f-g', FGElement);
+    scopedRegistry2.define('h-i', HIElement);
+
+    const deElement = document.createElement('d-e', {customElements: scopedRegistry1});
+    assert_true(deElement instanceof DEElement);
+    assert_equals(deElement.customElements, scopedRegistry1);
+    assert_true(fgElement instanceof FGElement);
+    assert_equals(fgElement.customElements, scopedRegistry2);
+    assert_true(hiElement instanceof HIElement);
+    assert_equals(hiElement.customElements, scopedRegistry2);
+}, 'A constructor creating an element from another registry before or after super call should work');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Create a CustomElementRegistry not identically equal to window.customElements
+PASS Defining an element in the global registry does not add a definition to a scoped CustomElementRegistry
+PASS Defining an element in a scoped global registry does not add a definition to the global registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(() => {
+    let registry = new CustomElementRegistry();
+    assert_not_equals(registry, window.customElements);
+}, 'Create a CustomElementRegistry not identically equal to window.customElements');
+
+test(() => {
+    let registry = new CustomElementRegistry();
+    window.customElements.define('a-b', class extends HTMLElement {});
+    assert_equals(registry.get('a-b'), undefined);
+}, 'Defining an element in the global registry does not add a definition to a scoped CustomElementRegistry');
+
+test(() => {
+    let registry = new CustomElementRegistry();
+    registry.define('b-c', class extends HTMLElement {});
+    assert_equals(window.customElements.get('b-c'), undefined);
+}, 'Defining an element in a scoped global registry does not add a definition to the global registry');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative-expected.txt
@@ -1,0 +1,9 @@
+
+PASS initialize is a function on both global and scoped CustomElementRegistry
+PASS initialize sets element.customElements to the global registry
+PASS initialize does not set the registry of nested shadow tree to the global registry
+PASS initialize sets element.customElements to a scoped registry
+PASS initialize does not set the registry of nested shadow tree to a scoped registry
+PASS initialize sets element.customElements permantently
+PASS initialize is no-op on a subtree with a non-null registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="host">
+    <template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelements>
+        <a-b>
+            <template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelements>
+                <c-d/><c-d>
+            </template>
+        </a-b>
+        <ef></ef>
+    </template>
+</div>
+<div id="host-with-registry">
+    <template shadowrootmode="open" shadowrootclonable="true">
+        <a-b></a-b>
+        <ef></ef>
+    </template>
+</div>
+<script>
+
+test(() => {
+    assert_equals(typeof(window.customElements.initialize), 'function');
+    assert_equals(typeof((new CustomElementRegistry).initialize), 'function');
+}, 'initialize is a function on both global and scoped CustomElementRegistry');
+
+test(() => {
+    const clone = host.cloneNode(true);
+    const shadowRoot = clone.shadowRoot;
+    assert_equals(shadowRoot.customElements, null);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, null);
+    assert_equals(shadowRoot.querySelector('ef').customElements, null);
+    window.customElements.initialize(shadowRoot);
+    assert_equals(shadowRoot.customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('ef').customElements, window.customElements);
+}, 'initialize sets element.customElements to the global registry');
+
+test(() => {
+    const clone = host.cloneNode(true);
+    const shadowRoot = clone.shadowRoot;
+    assert_equals(shadowRoot.customElements, null);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, null);
+    assert_equals(shadowRoot.querySelector('ef').customElements, null);
+    window.customElements.initialize(shadowRoot);
+    assert_equals(shadowRoot.customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('ef').customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('a-b').shadowRoot.customElements, null);
+    assert_equals(shadowRoot.querySelector('a-b').shadowRoot.querySelector('c-d').customElements, null);
+}, 'initialize does not set the registry of nested shadow tree to the global registry');
+
+
+test(() => {
+    const clone = host.cloneNode(true);
+    const shadowRoot = clone.shadowRoot;
+    assert_equals(shadowRoot.customElements, null);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, null);
+    assert_equals(shadowRoot.querySelector('ef').customElements, null);
+    const registry = new CustomElementRegistry;
+    registry.initialize(shadowRoot);
+    assert_equals(shadowRoot.customElements, registry);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, registry);
+    assert_equals(shadowRoot.querySelector('ef').customElements, registry);
+}, 'initialize sets element.customElements to a scoped registry');
+
+test(() => {
+    const clone = host.cloneNode(true);
+    const shadowRoot = clone.shadowRoot;
+    assert_equals(shadowRoot.customElements, null);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, null);
+    assert_equals(shadowRoot.querySelector('ef').customElements, null);
+    const registry = new CustomElementRegistry;
+    registry.initialize(shadowRoot);
+    assert_equals(shadowRoot.customElements, registry);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, registry);
+    assert_equals(shadowRoot.querySelector('ef').customElements, registry);
+    assert_equals(shadowRoot.querySelector('a-b').shadowRoot.customElements, null);
+    assert_equals(shadowRoot.querySelector('a-b').shadowRoot.querySelector('c-d').customElements, null);
+}, 'initialize does not set the registry of nested shadow tree to a scoped registry');
+
+test(() => {
+    const clone = host.cloneNode(true);
+    const shadowRoot = clone.shadowRoot;
+    assert_equals(shadowRoot.customElements, null);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, null);
+    assert_equals(shadowRoot.querySelector('ef').customElements, null);
+    const registry = new CustomElementRegistry;
+    registry.initialize(shadowRoot);
+    assert_equals(shadowRoot.customElements, registry);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, registry);
+    assert_equals(shadowRoot.querySelector('ef').customElements, registry);
+    document.body.appendChild(clone);
+    assert_equals(shadowRoot.customElements, registry);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, registry);
+    assert_equals(shadowRoot.querySelector('ef').customElements, registry);
+}, 'initialize sets element.customElements permantently');
+
+test(() => {
+    const clone = document.getElementById('host-with-registry').cloneNode(true);
+    const shadowRoot = clone.shadowRoot;
+    assert_equals(shadowRoot.customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('ef').customElements, window.customElements);
+    const registry = new CustomElementRegistry;
+    registry.initialize(shadowRoot);
+    assert_equals(shadowRoot.customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('a-b').customElements, window.customElements);
+    assert_equals(shadowRoot.querySelector('ef').customElements, window.customElements);
+}, 'initialize is no-op on a subtree with a non-null registry');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+PASS upgrade is a function on both global and scoped CustomElementRegistry
+PASS upgrade is a no-op when called on a shadow root with no association
+PASS upgrade should upgrade a candidate element when called on a shadow root with an association
+PASS upgrade should not upgrade a candidate element not associated with the registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<some-host id="host">
+    <template shadowrootmode="closed" shadowrootclonable="true" shadowrootcustomelements>
+        <a-b>
+            <template shadowrootmode="closed" shadowrootclonable="true" shadowrootcustomelements>
+                <c-d/>
+                    <template shadowrootmode="closed" shadowrootclonable="true">
+                        <a-b></a-b>
+                    </template>
+                <c-d>
+            </template>
+        </a-b>
+    </template>
+</some-host>
+<script>
+
+customElements.define('some-host', class SomeHost extends HTMLElement {
+    internals;
+
+    constructor() {
+        super();
+        this.internals = this.attachInternals();
+    }
+});
+customElements.define('a-b', class GlobalABElement extends HTMLElement { });
+customElements.define('c-d', class GlobalCDElement extends HTMLElement { });
+
+test(() => {
+    assert_equals(typeof(window.customElements.upgrade), 'function');
+    assert_equals(typeof((new CustomElementRegistry).upgrade), 'function');
+}, 'upgrade is a function on both global and scoped CustomElementRegistry');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    registry.define('a-b', class ABElement extends HTMLElement { });
+
+    const clone = host.cloneNode(true);
+    registry.upgrade(clone.internals.shadowRoot);
+    assert_equals(clone.internals.shadowRoot.querySelector('a-b').__proto__.constructor.name, 'HTMLElement');
+}, 'upgrade is a no-op when called on a shadow root with no association');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    registry.define('a-b', class ABElement extends HTMLElement {
+        internals;
+
+        constructor() {
+            super();
+            this.internals = this.attachInternals();
+        }
+    });
+
+    const clone = host.cloneNode(true);
+    registry.initialize(clone.internals.shadowRoot);
+    registry.upgrade(clone.internals.shadowRoot);
+    const abElement = clone.internals.shadowRoot.querySelector('a-b');
+    assert_equals(abElement.__proto__.constructor.name, 'ABElement');
+    assert_equals(abElement.internals.shadowRoot.customElements, null);
+    const cdElement = abElement.internals.shadowRoot.querySelector('c-d');
+    assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
+    assert_equals(cdElement.customElements, null);
+}, 'upgrade should upgrade a candidate element when called on a shadow root with an association');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    registry.define('a-b', class ScopedABElement extends HTMLElement {
+        internals;
+
+        constructor() {
+            super();
+            this.internals = this.attachInternals();
+        }
+    });
+
+    const clone = host.cloneNode(true);
+    registry.initialize(clone.internals.shadowRoot);
+    registry.upgrade(clone.internals.shadowRoot);
+    const abElement = clone.internals.shadowRoot.querySelector('a-b');
+    assert_equals(abElement.__proto__.constructor.name, 'ScopedABElement');
+    registry.initialize(abElement.internals.shadowRoot);
+    assert_equals(abElement.internals.shadowRoot.customElements, registry);
+    const cdElement = abElement.internals.shadowRoot.querySelector('c-d');
+    assert_equals(cdElement.customElements, registry);
+
+    registry.define('c-d', class ScopedCDElement extends HTMLElement {
+        internals;
+
+        constructor() {
+            super();
+            this.internals = this.attachInternals();
+        }
+    });
+    assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
+    registry.upgrade(abElement.internals.shadowRoot);
+    assert_equals(cdElement.__proto__.constructor.name, 'ScopedCDElement');
+    assert_equals(cdElement.customElements, registry);
+
+    assert_equals(cdElement.internals.shadowRoot.customElements, window.customElements);
+    const innerAB = cdElement.internals.shadowRoot.querySelector('a-b');
+    assert_equals(innerAB.customElements, window.customElements);
+    assert_equals(innerAB.__proto__.constructor.name, 'HTMLElement');
+}, 'upgrade should not upgrade a candidate element not associated with the registry');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative-expected.txt
@@ -1,0 +1,8 @@
+
+PASS createElement should use the global registry by default
+PASS createElement should use the specified scoped registry
+PASS createElement should create a builtin element regardles of a custom element registry specified
+PASS createElement should use the specified global registry
+PASS createElement should create an upgrade candidate when there is no matching definition in the specified registry
+PASS createElement should create an upgrade candidate and the candidate should be upgraded when the element is defined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+const scopedRegistry = new CustomElementRegistry();
+const otherScopedRegistry = new CustomElementRegistry();
+class GlobalABElement extends HTMLElement {};
+class ScopedABElement extends HTMLElement {};
+customElements.define('a-b', GlobalABElement);
+scopedRegistry.define('a-b', ScopedABElement);
+
+test(() => {
+    assert_true(document.createElement('a-b') instanceof GlobalABElement);
+}, 'createElement should use the global registry by default');
+
+test(() => {
+    assert_true(document.createElement('a-b', {customElements: scopedRegistry}) instanceof ScopedABElement);
+}, 'createElement should use the specified scoped registry');
+
+test(() => {
+    const elements = {
+        div: HTMLDivElement,
+        form: HTMLFormElement,
+        span: HTMLSpanElement,
+        table: HTMLTableElement,
+    };
+    for (const localName in elements)
+        assert_true(document.createElement(localName, {customElements: scopedRegistry}) instanceof elements[localName], localName);
+    for (const localName in elements)
+        assert_true(document.createElement(localName, {customElements: window.customElements}) instanceof elements[localName], localName);
+}, 'createElement should create a builtin element regardles of a custom element registry specified');
+
+test(() => {
+    assert_true(document.createElement('a-b', {customElements: window.customElements}) instanceof GlobalABElement);
+}, 'createElement should use the specified global registry');
+
+test(() => {
+    const element = document.createElement('a-b', {customElements: otherScopedRegistry});
+    assert_equals(element.__proto__.constructor.name, 'HTMLElement');
+}, 'createElement should create an upgrade candidate when there is no matching definition in the specified registry');
+
+test(() => {
+    class CDElement extends HTMLElement { }
+    const registry = new CustomElementRegistry;
+    const cdElement = document.createElement('c-d', {customElements: registry});
+    assert_false(cdElement instanceof CDElement);
+    assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
+    registry.define('c-d', CDElement);
+    assert_false(cdElement instanceof CDElement); // Not yet upgraded since it's disconnected.
+    assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
+    document.body.appendChild(cdElement);
+    assert_true(cdElement instanceof CDElement);
+}, 'createElement should create an upgrade candidate and the candidate should be upgraded when the element is defined');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative-expected.txt
@@ -1,0 +1,11 @@
+
+PASS importNode should clone using the global regsitry by default
+PASS importNode should clone using the specified scoped regsitry
+PASS importNode should preserve null-ness of custom element registry
+PASS importNode should clone a shadow host with a declarative shadow DOM using the global registry by default
+PASS importNode should clone a shadow host with a declarative shadow DOM using a specified scoped registry
+PASS importNode should clone an element originating from a scoped registry using another scoped registry
+PASS importNode should clone a template content using the global registry by default
+PASS importNode should clone a template content using a specified scoped registry
+PASS importNode should clone a template content with a nested template element using a scoped registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="host">
+    <template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelements>
+        <div>
+            <some-element></some-element>
+            <other-element></other-element>
+        </div>
+    </template>
+</div>
+<template id="template">
+    <some-element>
+        <template shadowrootmode="closed" shadowrootclonable="true" shadowrootcustomelements>
+            <div>
+                <some-element></some-element>
+                <other-element></other-element>
+            </div>
+        </template>
+    </some-element>
+</template>
+<script>
+
+const scopedRegistry = new CustomElementRegistry();
+const emptyRegistry = new CustomElementRegistry();
+class GlobalSomeElement extends HTMLElement {
+    internals;
+
+    constructor() {
+        super();
+        this.internals = this.attachInternals();
+        if (this.internals.shadowRoot)
+            scopedRegistry.initialize(this.internals.shadowRoot);
+    }
+};
+class GlobalOtherElement extends HTMLElement {};
+class ScopedSomeElement extends HTMLElement {};
+customElements.define('some-element', GlobalSomeElement);
+customElements.define('other-element', GlobalOtherElement);
+scopedRegistry.define('some-element', ScopedSomeElement);
+
+test(() => {
+    assert_true(document.importNode(document.createElement('some-element')) instanceof GlobalSomeElement);
+}, 'importNode should clone using the global regsitry by default');
+
+test(() => {
+    assert_true(document.importNode(document.createElement('some-element'), {customElements: scopedRegistry}) instanceof ScopedSomeElement);
+}, 'importNode should clone using the specified scoped regsitry');
+
+test(() => {
+    const clone = document.importNode(host, {deep: true, customElements: scopedRegistry});
+    assert_equals(clone.shadowRoot.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
+    assert_false(clone.shadowRoot.querySelector('some-element') instanceof GlobalSomeElement);
+    assert_false(clone.shadowRoot.querySelector('some-element') instanceof ScopedSomeElement);
+    assert_true(clone.shadowRoot.querySelector('other-element') instanceof HTMLElement);
+    assert_false(clone.shadowRoot.querySelector('other-element') instanceof GlobalOtherElement);
+}, 'importNode should preserve null-ness of custom element registry');
+
+test(() => {
+    const clone = document.importNode(host.shadowRoot.querySelector('div'), {deep: true});
+    assert_equals(clone.customElements, window.customElements);
+    assert_true(clone.querySelector('some-element') instanceof GlobalSomeElement);
+    assert_true(clone.querySelector('other-element') instanceof GlobalOtherElement);
+}, 'importNode should clone a shadow host with a declarative shadow DOM using the global registry by default');
+
+test(() => {
+    const clone = document.importNode(host.shadowRoot.querySelector('div'), {deep: true, customElements: scopedRegistry});
+    assert_equals(clone.customElements, scopedRegistry);
+    assert_true(clone.querySelector('some-element') instanceof ScopedSomeElement);
+    assert_false(clone.querySelector('other-element') instanceof GlobalOtherElement);
+}, 'importNode should clone a shadow host with a declarative shadow DOM using a specified scoped registry');
+
+test(() => {
+    const element = document.createElement('div', {customElements: emptyRegistry});
+    element.innerHTML = '<some-element></some-element><other-element></other-element>';
+    const clone = document.importNode(element, {deep: true, customElements: scopedRegistry});
+    assert_equals(clone.customElements, scopedRegistry);
+    assert_true(clone.querySelector('some-element') instanceof ScopedSomeElement);
+    assert_false(clone.querySelector('other-element') instanceof GlobalOtherElement);
+}, 'importNode should clone an element originating from a scoped registry using another scoped registry');
+
+test(() => {
+    const template = document.createElement('template');
+    template.innerHTML = '<div><some-element>hello</some-element><other-element>world</other-element></div>';
+    assert_equals(template.content.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
+    assert_equals(template.content.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
+    const clone = document.importNode(template.content, {deep: true});
+    assert_equals(clone.querySelector('some-element').customElements, window.customElements);
+    assert_equals(clone.querySelector('some-element').__proto__.constructor.name, 'GlobalSomeElement');
+    assert_equals(clone.querySelector('other-element').__proto__.constructor.name, 'GlobalOtherElement');
+}, 'importNode should clone a template content using the global registry by default');
+
+test(() => {
+    const template = document.createElement('template');
+    template.innerHTML = '<div><some-element>hello</some-element><other-element>world</other-element></div>';
+    assert_equals(template.content.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
+    assert_equals(template.content.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
+    const clone = document.importNode(template.content, {deep: true, customElements: scopedRegistry});
+    assert_equals(clone.querySelector('some-element').customElements, scopedRegistry);
+    assert_equals(clone.querySelector('some-element').__proto__.constructor.name, 'ScopedSomeElement');
+    assert_equals(clone.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
+}, 'importNode should clone a template content using a specified scoped registry');
+
+test(() => {
+    const template = document.createElement('template');
+    template.innerHTML = `
+<div>
+    <some-element>
+        <template>
+            <other-element>
+                hello
+            </other-element>
+        </template>
+    </some-element>
+    <other-element>
+        world
+    </other-element>
+</div>`;
+    assert_equals(template.content.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
+    assert_equals(template.content.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
+    const clone = document.importNode(template.content, {deep: true});
+    assert_equals(clone.querySelector('some-element').customElements, window.customElements);
+    assert_equals(clone.querySelector('some-element').__proto__.constructor.name, 'GlobalSomeElement');
+    const otherElementInTemplate = clone.querySelector('template').content.querySelector('other-element');
+    assert_equals(otherElementInTemplate.__proto__.constructor.name, 'HTMLElement');
+    assert_equals(clone.querySelector('other-element').__proto__.constructor.name, 'GlobalOtherElement');
+}, 'importNode should clone a template content with a nested template element using a scoped registry');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative-expected.txt
@@ -1,0 +1,17 @@
+CONSOLE MESSAGE: function TypeError() {
+    [native code]
+}
+CONSOLE MESSAGE: NotSupportedError: A newly constructed custom element has incorrect local name
+CONSOLE MESSAGE: function TypeError() {
+    [native code]
+}
+CONSOLE MESSAGE: TypeError: Custom element constructor returned a wrong element
+CONSOLE MESSAGE: function TypeError() {
+    [native code]
+}
+CONSOLE MESSAGE: NotSupportedError: A newly constructed custom element has incorrect local name
+
+PASS customElements on a failed custom element created by calling createElement on CustomElementRegistry should return the registry
+PASS customElements on a failed custom element created by setting innerHTML should return the associated scoped registry
+PASS customElements on a failed custom element created by parser should return the specified custom regsitry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="host-window"><template shadowrootmode="open"><a-b></a-b></template></div>
+<div id="host-null"><template shadowrootmode="open" shadowrootcustomelements=""><a-b></a-b></template></div>
+<script>
+
+setup({allow_uncaught_exception : true});
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    registry.define('constructor-throws-exception', class extends HTMLElement { constructor() { super(); throw TypeError; } });
+    registry.define('constructor-returns-different-element', class extends HTMLElement { constructor() { super(); return document.createElement('span'); } });
+    assert_equals(document.createElement('constructor-throws-exception', {customElements: registry}).customElements, registry);
+    assert_equals(document.createElement('constructor-returns-different-element', {customElements: registry}).customElements, registry);
+}, 'customElements on a failed custom element created by calling createElement on CustomElementRegistry should return the registry');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    registry.define('constructor-throws-exception', class extends HTMLElement { constructor() { super(); throw TypeError; } });
+    registry.define('constructor-returns-different-element', class extends HTMLElement { constructor() { super(); return document.createElement('span'); } });
+    const container = document.createElement('div', {customElements: registry});
+    container.innerHTML = '<constructor-throws-exception></constructor-throws-exception><constructor-returns-different-element></constructor-returns-different-element>';
+    assert_equals(container.querySelector('constructor-throws-exception').customElements, registry);
+    assert_equals(container.querySelector('constructor-returns-different-element').customElements, registry);
+}, 'customElements on a failed custom element created by setting innerHTML should return the associated scoped registry');
+
+function insideDeclarativeShadowTreeWithNullRegistry(test, script, markup, check) {
+    const frame = document.body.appendChild(document.createElement('iframe'));
+    test.add_cleanup(() => frame.remove());
+
+    frame.contentDocument.open();
+    frame.contentDocument.write(`<!DOCTYPE html><html><body><div id="host"><template shadowrootmode="open" shadowrootcustomelements><script>`
+        + script + `</` + 'script>' + markup + '</template></div></body></html>');
+    frame.contentDocument.close();
+    check(frame.contentDocument, frame.contentWindow);
+}
+
+test((t) => {
+    insideDeclarativeShadowTreeWithNullRegistry(t, `
+        window.registry = new CustomElementRegistry;
+        registry.initialize(host.shadowRoot);
+        registry.define('constructor-throws-exception', class extends HTMLElement { constructor() { super(); throw TypeError; } });
+        registry.define('constructor-returns-different-element', class extends HTMLElement { constructor() { super(); return document.createElement('span'); } });`,
+        '<constructor-throws-exception></constructor-throws-exception><constructor-returns-different-element></constructor-returns-different-element>',
+        (doc, win) => {
+            assert_equals(win.host.shadowRoot.querySelector('constructor-throws-exception').customElements, win.registry);
+            assert_equals(win.host.shadowRoot.querySelector('constructor-returns-different-element').customElements, win.registry);
+        });
+}, 'customElements on a failed custom element created by parser should return the specified custom regsitry');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative-expected.txt
@@ -1,0 +1,12 @@
+
+PASS customElements on a newly constrcuted element should return window.customElements by default
+PASS customElements on an element inside a declarative shadow DOM should return window.customElements by default
+PASS customElements on an element inside a declarative shadow DOM with shadowrootcustomelements should return null
+PASS customElements on a clone of a declarative shadow tree with shadowrootcustomelements should return null
+PASS customElements on a clone of a declarative shadow tree with shadowrootcustomelements should return the global registry after getting inserted into a document
+PASS customElements on an element inside a declarative shadow DOM with shadowrootcustomelements should return the scoped registry after calling initialize
+PASS customElements on a builtin element created by calling createElement on CustomElementRegistry should return the registry
+PASS customElements on an upgarde candidate created by calling createElement on CustomElementRegistry should return the registry
+PASS customElements on an unknown element created by calling createElement on CustomElementRegistry should return the registry
+PASS customElements on a defined custom element created by calling createElement on CustomElementRegistry should return the registry
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="host-window"><template shadowrootmode="open" shadowrootclonable="true"><a-b></a-b></template></div>
+<div id="host-null"><template shadowrootmode="open" shadowrootclonable="true" shadowrootcustomelements=""><a-b></a-b></template></div>
+<script>
+
+test(() => {
+    assert_equals(document.createElement('div').customElements, window.customElements);
+}, 'customElements on a newly constrcuted element should return window.customElements by default');
+
+test(() => {
+    const sr = document.getElementById('host-window').shadowRoot;
+    const ab = sr.querySelector('a-b');
+    assert_equals(sr.customElements, window.customElements);
+    assert_equals(ab.customElements, window.customElements);
+}, 'customElements on an element inside a declarative shadow DOM should return window.customElements by default');
+
+test(() => {
+    const sr = document.getElementById('host-null').shadowRoot;
+    const ab = sr.querySelector('a-b');
+    assert_equals(sr.customElements, null);
+    assert_equals(ab.customElements, null);
+}, 'customElements on an element inside a declarative shadow DOM with shadowrootcustomelements should return null');
+
+test(() => {
+    const clone = document.getElementById('host-null').cloneNode(true);
+    const sr = clone.shadowRoot;
+    const ab = sr.querySelector('a-b');
+    assert_equals(sr.customElements, null);
+    assert_equals(ab.customElements, null);
+}, 'customElements on a clone of a declarative shadow tree with shadowrootcustomelements should return null');
+
+test((t) => {
+    const clone = document.getElementById('host-null').cloneNode(true);
+    const ab = clone.shadowRoot.querySelector('a-b');
+    document.body.appendChild(ab);
+    assert_equals(ab.customElements, window.customElements);
+
+    const frame = document.createElement('iframe');
+    t.add_cleanup(() => frame.remove());
+    document.body.appendChild(frame);
+    frame.contentDocument.body.append(ab);
+    assert_equals(ab.customElements, frame.contentWindow.customElements);
+
+}, 'customElements on a clone of a declarative shadow tree with shadowrootcustomelements should return the global registry after getting inserted into a document');
+
+test(() => {
+    const sr = document.getElementById('host-null').shadowRoot;
+    const ab = sr.querySelector('a-b');
+    const registry = new CustomElementRegistry;
+    registry.initialize(sr);
+    assert_equals(sr.customElements, registry);
+    assert_equals(ab.customElements, registry);
+}, 'customElements on an element inside a declarative shadow DOM with shadowrootcustomelements should return the scoped registry after calling initialize');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    element = document.createElement('div', {customElements: registry});
+    assert_equals(element.customElements, registry);
+}, 'customElements on a builtin element created by calling createElement on CustomElementRegistry should return the registry');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    element = document.createElement('non-existent', {customElements: registry});
+    assert_equals(element.customElements, registry);
+}, 'customElements on an upgarde candidate created by calling createElement on CustomElementRegistry should return the registry');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    element = document.createElement('nonexistent', {customElements: registry});
+    assert_equals(element.customElements, registry);
+}, 'customElements on an unknown element created by calling createElement on CustomElementRegistry should return the registry');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    registry.define('custom-element', class extends HTMLElement { })
+    element = document.createElement('custom-element', {customElements: registry});
+    assert_equals(element.customElements, registry);
+}, 'customElements on a defined custom element created by calling createElement on CustomElementRegistry should return the registry');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS innerHTML on a disconnected element should use the scoped registry it was created with
+PASS innerHTML on an inserted element should continue to use the scoped registry it was created with
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+function createConnectedShadowTree(test, customElements) {
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElements});
+    document.body.appendChild(host);
+    test.add_cleanup(() => host.remove());
+    return shadowRoot;
+}
+
+class GlobalSomeElement extends HTMLElement { };
+customElements.define('some-element', GlobalSomeElement);
+
+class GlobalOtherElement extends HTMLElement { };
+customElements.define('other-element', GlobalOtherElement);
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+
+    class ScopedSomeElement extends HTMLElement { };
+    registry.define('some-element', ScopedSomeElement);
+
+    class ScopedOtherElement extends HTMLElement { };
+    registry.define('other-element', ScopedOtherElement);
+
+    const shadowRoot = createConnectedShadowTree(test, registry);
+    const someElement = document.createElement('some-element', {customElements: registry});
+    assert_true(someElement instanceof ScopedSomeElement);
+    someElement.innerHTML = '<other-element></other-element>';
+    assert_true(someElement.querySelector('other-element') instanceof ScopedOtherElement);
+}, 'innerHTML on a disconnected element should use the scoped registry it was created with');
+
+test((test) => {
+    const registry1 = new CustomElementRegistry;
+    const registry2 = new CustomElementRegistry;
+
+    class ScopedSomeElement extends HTMLElement { };
+    registry1.define('some-element', ScopedSomeElement);
+
+    class ScopedOtherElement1 extends HTMLElement { };
+    registry1.define('other-element', ScopedOtherElement1);
+    class ScopedOtherElement2 extends HTMLElement { };
+    registry2.define('other-element', ScopedOtherElement2);
+
+    const shadowRoot1 = createConnectedShadowTree(test, registry1);
+    const shadowRoot2 = createConnectedShadowTree(test, registry2);
+    const someElement = document.createElement('some-element', {customElements: registry1});
+    someElement.innerHTML = '<other-element></other-element>';
+    assert_true(someElement.querySelector('other-element') instanceof ScopedOtherElement1);
+    shadowRoot2.appendChild(someElement);
+    someElement.innerHTML = '<other-element></other-element>';
+    assert_true(someElement.querySelector('other-element') instanceof ScopedOtherElement1);
+    someElement.remove();
+    someElement.innerHTML = '<other-element></other-element>';
+    assert_true(someElement.querySelector('other-element') instanceof ScopedOtherElement1);
+}, 'innerHTML on an inserted element should continue to use the scoped registry it was created with');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+PASS A newly attached disconnected ShadowRoot should use the global registry by default
+PASS A newly attached connected ShadowRoot should use the global registry by default
+PASS A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
+PASS A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+test(() => {
+    const shadowRoot = document.createElement('div').attachShadow({mode: 'closed'});
+    assert_equals(shadowRoot.customElements, window.customElements);
+}, 'A newly attached disconnected ShadowRoot should use the global registry by default');
+
+test(() => {
+    const host = document.body.appendChild(document.createElement('div'));
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    assert_equals(shadowRoot.customElements, window.customElements);
+}, 'A newly attached connected ShadowRoot should use the global registry by default');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    const shadowRoot = document.createElement('div').attachShadow({mode: 'closed', customElements: registry});
+    assert_equals(shadowRoot.customElements, registry);
+}, 'A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow');
+
+test(() => {
+    const registry = new CustomElementRegistry;
+    const host = document.body.appendChild(document.createElement('div'));
+    const shadowRoot = host.attachShadow({mode: 'closed', customElements: registry});
+    assert_equals(shadowRoot.customElements, registry);
+}, 'A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+PASS innerHTML on a shadow root should use the scoped registry
+PASS innerHTML on a connected shadow root should use the associated scoped registry
+PASS innerHTML on a connected shadow root should not upgrade a custom element inside a template element
+PASS innerHTML on a connected shadow root should be able to create an unknown element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://github.com/whatwg/html/issues/10854">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+function createConnectedShadowTree(test, customElements) {
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed', customElements});
+    document.body.appendChild(host);
+    test.add_cleanup(() => host.remove());
+    return shadowRoot;
+}
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+
+    class SomeElement extends HTMLElement { };
+    registry.define('some-element', SomeElement);
+
+    class OtherElement extends HTMLElement { };
+    registry.define('other-element', OtherElement);
+
+    const shadowRoot = createConnectedShadowTree(test, registry);
+    assert_true(document.createElement('some-element', {customElements: registry}) instanceof SomeElement);
+    assert_true(document.createElement('other-element', {customElements: registry}) instanceof OtherElement);
+    shadowRoot.innerHTML = '<some-element></some-element><other-element></other-element>';
+
+    assert_true(shadowRoot.querySelector('some-element') instanceof SomeElement);
+    assert_equals(shadowRoot.querySelector('some-element').customElements, registry);
+    assert_true(shadowRoot.querySelector('other-element') instanceof OtherElement);
+    assert_equals(shadowRoot.querySelector('other-element').customElements, registry);
+}, 'innerHTML on a shadow root should use the scoped registry');
+
+test((test) => {
+    class SomeElement1 extends HTMLElement { };
+    customElements.define('some-element', SomeElement1);
+
+    const registry = new CustomElementRegistry;
+    class SomeElement2 extends HTMLElement { };
+    registry.define('some-element', SomeElement2);
+
+    const shadowRoot = createConnectedShadowTree(test, registry);
+    shadowRoot.innerHTML = '<some-element></some-element>';
+    assert_true(shadowRoot.querySelector('some-element') instanceof SomeElement2);
+    assert_equals(shadowRoot.querySelector('some-element').customElements, registry);
+}, 'innerHTML on a connected shadow root should use the associated scoped registry');
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+    class SomeElement extends HTMLElement { };
+    registry.define('some-element', SomeElement);
+    const shadowRoot = createConnectedShadowTree(test, registry);
+
+    shadowRoot.innerHTML = '<some-element></some-element><template><some-element></some-element></template>';
+    assert_equals(shadowRoot.querySelector('some-element').__proto__.constructor.name, 'SomeElement');
+    assert_equals(shadowRoot.querySelector('some-element').customElements, registry);
+    assert_equals(shadowRoot.querySelector('template').content.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
+    assert_equals(shadowRoot.querySelector('template').content.querySelector('some-element').customElements, null);
+}, 'innerHTML on a connected shadow root should not upgrade a custom element inside a template element');
+
+test((test) => {
+    const registry = new CustomElementRegistry;
+    const shadowRoot = createConnectedShadowTree(test, registry);
+    shadowRoot.innerHTML = '<someelement></someelement>';
+    assert_equals(shadowRoot.querySelector('someelement').__proto__.constructor.name, 'HTMLUnknownElement');
+    assert_equals(shadowRoot.querySelector('someelement').customElements, registry);
+}, 'innerHTML on a connected shadow root should be able to create an unknown element');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-createElement.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-createElement.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-PASS ShadowRoot.createElement() for autonomous custom element
-PASS ShadowRoot.createElementNS() for autonomous custom element
-FAIL ShadowRoot.createElement() for customized built-in element assert_true: expected true got false
-FAIL ShadowRoot.createElementNS() for customized built-in element assert_true: expected true got false
+FAIL ShadowRoot.createElement() for autonomous custom element shadow.createElement is not a function. (In 'shadow.createElement('test-element')', 'shadow.createElement' is undefined)
+FAIL ShadowRoot.createElementNS() for autonomous custom element shadow.createElementNS is not a function. (In 'shadow.createElementNS(html, 'test-element')', 'shadow.createElementNS' is undefined)
+FAIL ShadowRoot.createElement() for customized built-in element shadow.createElement is not a function. (In 'shadow.createElement('p', {is: 'test-element'})', 'shadow.createElement' is undefined)
+FAIL ShadowRoot.createElementNS() for customized built-in element shadow.createElementNS is not a function. (In 'shadow.createElementNS(html, 'p', {is: 'test-element'})', 'shadow.createElementNS' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-importNode.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-importNode.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-PASS ShadowRoot.importNode: an upgrade candidate from document
-PASS ShadowRoot.importNode: a custom element from another shadow tree
-PASS ShadowRoot.importNode: a template content from document
+FAIL ShadowRoot.importNode: an upgrade candidate from document shadowRoot.createElement is not a function. (In 'shadowRoot.createElement('some-element')', 'shadowRoot.createElement' is undefined)
+FAIL ShadowRoot.importNode: a custom element from another shadow tree shadowRoot1.createElement is not a function. (In 'shadowRoot1.createElement('some-element')', 'shadowRoot1.createElement' is undefined)
+FAIL ShadowRoot.importNode: a template content from document shadowRoot.importNode is not a function. (In 'shadowRoot.importNode(template.content, /* deep */ true)', 'shadowRoot.importNode' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-init-registry.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-init-registry.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-PASS ShadowRoot.registry is null if not explicitly specified
-PASS Attach the global registry to a shadow root
-PASS Attach a non-global registry to a shadow root
-PASS Attach the same registry to multiple shadow roots
-PASS Attaching registry to shadow root can only be done during initialization
+FAIL ShadowRoot.registry is null if not explicitly specified assert_equals: expected (object) null but got (undefined) undefined
+FAIL Attach the global registry to a shadow root assert_equals: expected (object) object "[object CustomElementRegistry]" but got (undefined) undefined
+FAIL Attach a non-global registry to a shadow root assert_equals: expected (object) object "[object CustomElementRegistry]" but got (undefined) undefined
+FAIL Attach the same registry to multiple shadow roots assert_equals: expected (object) object "[object CustomElementRegistry]" but got (undefined) undefined
+FAIL Attaching registry to shadow root can only be done during initialization assert_equals: expected null but got object "[object CustomElementRegistry]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-PASS Upgrade into autonomous custom element when inserted via innerHTML
-PASS Upgrade into autonomous custom element when definition is added
+FAIL Upgrade into autonomous custom element when inserted via innerHTML assert_true: target tree scope expected true got false
+FAIL Upgrade into autonomous custom element when definition is added assert_true: target tree scope expected true got false
 FAIL Upgrade into customized built-in element when inserted via innerHTML assert_true: target tree scope expected true got false
 FAIL Upgrade into customized built-in element when definition is added assert_true: target tree scope expected true got false
-PASS Upgrade into autonomous custom element should not inherit from global registry for missing values
+FAIL Upgrade into autonomous custom element should not inherit from global registry for missing values assert_false: is not GloballyScoped expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-PASS innerHTML on a shadow root should use scoped custom element registry
-PASS innerHTML on a disconnected element should use the associated scoped custom element registry
-PASS innerHTML on a connected shadow root should use its scoped custom element
-PASS innerHTML on an inserted element should use the scoped custom element of the ancestor shadow root
-PASS innerHTML should not upgrade a custom element inside a template element
+FAIL innerHTML on a shadow root should use scoped custom element registry shadowRoot.createElement is not a function. (In 'shadowRoot.createElement('some-element')', 'shadowRoot.createElement' is undefined)
+FAIL innerHTML on a disconnected element should use the associated scoped custom element registry shadowRoot.createElement is not a function. (In 'shadowRoot.createElement('some-element')', 'shadowRoot.createElement' is undefined)
+FAIL innerHTML on a connected shadow root should use its scoped custom element assert_true: expected true got false
+FAIL innerHTML on an inserted element should use the scoped custom element of the ancestor shadow root shadowRoot1.createElement is not a function. (In 'shadowRoot1.createElement('some-element')', 'shadowRoot1.createElement' is undefined)
+FAIL innerHTML should not upgrade a custom element inside a template element assert_equals: expected "SomeElement" but got "SomeElement1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-reentry-with-different-definition.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-reentry-with-different-definition.tentative-expected.txt
@@ -1,8 +1,6 @@
-CONSOLE MESSAGE: TypeError: Cannot instantiate a custom element inside its own constructor during upgrades
-CONSOLE MESSAGE: TypeError: Cannot instantiate a custom element inside its own constructor during upgrades
 
-PASS Re-entry via upgrade before calling super()
-PASS Re-entry via upgrade after calling super()
-PASS Re-entry via direct constructor call before calling super()
-PASS Re-entry via direct constructor call after calling super()
+FAIL Re-entry via upgrade before calling super() assert_true: expected true got false
+FAIL Re-entry via upgrade after calling super() assert_true: expected true got false
+FAIL Re-entry via direct constructor call before calling super() assert_true: expected true got false
+FAIL Re-entry via direct constructor call after calling super() assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-criteria.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-criteria.tentative-expected.txt
@@ -1,13 +1,13 @@
 
-PASS Adding definition to global registry should not affect shadow roots using scoped registry
+FAIL Adding definition to global registry should not affect shadow roots using scoped registry assert_false: expected false got true
 PASS Adding definition to global registry should affect shadow roots also using global registry
-PASS Adding definition to scoped registry should affect all associated shadow roots
-PASS Adding definition to scoped registry should not affect document tree scope
-PASS Adding definition to scoped registry should not affect shadow roots using other registries
-PASS Adding definition to global registry should not upgrade nodes no longer using the registry
+FAIL Adding definition to scoped registry should affect all associated shadow roots assert_true: expected true got false
+FAIL Adding definition to scoped registry should not affect document tree scope assert_true: expected true got false
+FAIL Adding definition to scoped registry should not affect shadow roots using other registries assert_true: expected true got false
+FAIL Adding definition to global registry should not upgrade nodes no longer using the registry assert_false: expected false got true
 PASS Adding definition to scoped registry should not upgrade nodes no longer using the registry
-PASS Adding definition to scoped registry affects associated shadow roots in all iframes
-PASS Adding definition to scoped registry affects associated shadow roots in other frame trees
+FAIL Adding definition to scoped registry affects associated shadow roots in all iframes assert_true: expected true got false
+FAIL Adding definition to scoped registry affects associated shadow roots in other frame trees assert_true: expected true got false
 PASS Adding definition to scoped registry should not upgrade disconnected elements
 PASS Adding definition to scoped registry should not upgrade nodes in constructed documents
 PASS Adding definition to scoped registry should not upgrade nodes in detached frames

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-order.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-order.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-PASS Upgrade in tree order in the same tree scope
-PASS Upgrade in shadow-including tree order across tree scopes
-PASS Upgrade order does not depend on shadow root attach order
-PASS Upgrade in association order across documents, then tree order in each document
-PASS Upgrade order is not affected by DOM order between child frames
-PASS Upgrade order is affected by shadow tree adoption across documents
-PASS Elements in the "owner" window of a scoped registry are not always upgraded first
+FAIL Upgrade in tree order in the same tree scope assert_array_equals: lengths differ, expected array ["a", "b", "c"] length 3, got [] length 0
+FAIL Upgrade in shadow-including tree order across tree scopes assert_array_equals: lengths differ, expected array ["a", "b", "c"] length 3, got [] length 0
+FAIL Upgrade order does not depend on shadow root attach order assert_array_equals: lengths differ, expected array ["a", "c", "b"] length 3, got [] length 0
+FAIL Upgrade in association order across documents, then tree order in each document assert_array_equals: lengths differ, expected array ["a", "b", "c"] length 3, got [] length 0
+FAIL Upgrade order is not affected by DOM order between child frames assert_array_equals: lengths differ, expected array ["a", "b"] length 2, got [] length 0
+FAIL Upgrade order is affected by shadow tree adoption across documents assert_array_equals: lengths differ, expected array ["b", "a"] length 2, got [] length 0
+FAIL Elements in the "owner" window of a scoped registry are not always upgraded first assert_array_equals: lengths differ, expected array ["a", "b"] length 2, got [] length 0
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1135,6 +1135,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/Element+PointerLock.idl
     dom/Element.idl
     dom/ElementContentEditable.idl
+    dom/ElementCreationOptions.idl
     dom/ElementInternals.idl
     dom/ErrorEvent.idl
     dom/Event.idl
@@ -1154,6 +1155,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/IdleDeadline.idl
     dom/IdleRequestCallback.idl
     dom/IdleRequestOptions.idl
+    dom/ImportNodeOptions.idl
     dom/InnerHTML.idl
     dom/InputEvent.idl
     dom/KeyboardEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1443,6 +1443,7 @@ $(PROJECT_DIR)/dom/Element+PointerEvents.idl
 $(PROJECT_DIR)/dom/Element+PointerLock.idl
 $(PROJECT_DIR)/dom/Element.idl
 $(PROJECT_DIR)/dom/ElementContentEditable.idl
+$(PROJECT_DIR)/dom/ElementCreationOptions.idl
 $(PROJECT_DIR)/dom/ElementInternals.idl
 $(PROJECT_DIR)/dom/ErrorEvent.idl
 $(PROJECT_DIR)/dom/Event.idl
@@ -1466,6 +1467,7 @@ $(PROJECT_DIR)/dom/HashChangeEvent.idl
 $(PROJECT_DIR)/dom/IdleDeadline.idl
 $(PROJECT_DIR)/dom/IdleRequestCallback.idl
 $(PROJECT_DIR)/dom/IdleRequestOptions.idl
+$(PROJECT_DIR)/dom/ImportNodeOptions.idl
 $(PROJECT_DIR)/dom/InnerHTML.idl
 $(PROJECT_DIR)/dom/InputEvent.idl
 $(PROJECT_DIR)/dom/KeyboardEvent.idl
@@ -1680,7 +1682,6 @@ $(PROJECT_DIR)/html/VideoFrameMetadata.idl
 $(PROJECT_DIR)/html/VideoFrameRequestCallback.idl
 $(PROJECT_DIR)/html/VoidCallback.idl
 $(PROJECT_DIR)/html/WebKitMediaKeyError.idl
-$(PROJECT_DIR)/html/closewatcher/CloseWatcher.idl
 $(PROJECT_DIR)/html/canvas/ANGLEInstancedArrays.idl
 $(PROJECT_DIR)/html/canvas/CanvasCompositing.idl
 $(PROJECT_DIR)/html/canvas/CanvasDirection.idl
@@ -1791,6 +1792,7 @@ $(PROJECT_DIR)/html/canvas/WebGLTransformFeedback.idl
 $(PROJECT_DIR)/html/canvas/WebGLUniformLocation.idl
 $(PROJECT_DIR)/html/canvas/WebGLVertexArrayObject.idl
 $(PROJECT_DIR)/html/canvas/WebGLVertexArrayObjectOES.idl
+$(PROJECT_DIR)/html/closewatcher/CloseWatcher.idl
 $(PROJECT_DIR)/html/parser/HTMLEntityNames.in
 $(PROJECT_DIR)/html/parser/create-html-entity-table
 $(PROJECT_DIR)/html/shadow/attachmentElementShadow.css

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1001,6 +1001,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementCSSInlineStyle.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementCSSInlineStyle.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementContentEditable.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementContentEditable.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementCreationOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementCreationOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementInternals.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSElementInternals.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEndingType.cpp
@@ -1721,6 +1723,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageResource.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageResource.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageSmoothingQuality.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImageSmoothingQuality.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImportNodeOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSImportNodeOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInnerHTML.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInnerHTML.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInputDeviceInfo.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1142,6 +1142,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/Element+PointerLock.idl \
     $(WebCore)/dom/Element.idl \
     $(WebCore)/dom/ElementContentEditable.idl \
+    $(WebCore)/dom/ElementCreationOptions.idl \
     $(WebCore)/dom/ElementInternals.idl \
     $(WebCore)/dom/ErrorEvent.idl \
     $(WebCore)/dom/Event.idl \
@@ -1162,6 +1163,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/IdleDeadline.idl \
     $(WebCore)/dom/IdleRequestCallback.idl \
     $(WebCore)/dom/IdleRequestOptions.idl \
+    $(WebCore)/dom/ImportNodeOptions.idl \
     $(WebCore)/dom/InnerHTML.idl \
     $(WebCore)/dom/InputEvent.idl \
     $(WebCore)/dom/KeyboardEvent.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1110,6 +1110,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/GCReachableRef.h
     dom/GetHTMLOptions.h
     dom/ImageOverlay.h
+    dom/ImportNodeOptions.h
     dom/InlineStyleSheetOwner.h
     dom/KeyboardEvent.h
     dom/LiveNodeList.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3792,6 +3792,7 @@ JSEcdsaParams.cpp
 JSEffectTiming.cpp
 JSElement.cpp
 JSElementCSSInlineStyle.cpp
+JSElementCreationOptions.cpp
 JSElementInternals.cpp
 JSEndingType.cpp
 JSErrorCallback.cpp
@@ -4122,6 +4123,7 @@ JSImageData.cpp
 JSImageDataSettings.cpp
 JSImageDataStorageFormat.cpp
 JSImageSmoothingQuality.cpp
+JSImportNodeOptions.cpp
 JSInputDeviceInfo.cpp
 JSInputEvent.cpp
 JSInspectorAuditAccessibilityObject.cpp

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -109,9 +109,9 @@ ExceptionOr<void> Attr::setNodeValue(const String& value)
     return setValue(value.isNull() ? emptyAtom() : AtomString(value));
 }
 
-Ref<Node> Attr::cloneNodeInternal(TreeScope& treeScope, CloningOperation)
+Ref<Node> Attr::cloneNodeInternal(Document& document, CloningOperation, CustomElementRegistry*)
 {
-    return adoptRef(*new Attr(treeScope.documentScope(), qualifiedName(), value()));
+    return adoptRef(*new Attr(document, qualifiedName(), value()));
 }
 
 CSSStyleDeclaration* Attr::style()

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -70,7 +70,7 @@ private:
 
     ExceptionOr<void> setPrefix(const AtomString&) final;
 
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) final;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) final;
 
     bool isAttributeNode() const final { return true; }
 

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -45,9 +45,8 @@ String CDATASection::nodeName() const
     return "#cdata-section"_s;
 }
 
-Ref<Node> CDATASection::cloneNodeInternal(TreeScope& treeScope, CloningOperation)
+Ref<Node> CDATASection::cloneNodeInternal(Document& document, CloningOperation, CustomElementRegistry*)
 {
-    Ref document = treeScope.documentScope();
     return create(document, String { data() });
 }
 

--- a/Source/WebCore/dom/CDATASection.h
+++ b/Source/WebCore/dom/CDATASection.h
@@ -36,7 +36,7 @@ private:
     CDATASection(Document&, String&&);
 
     String nodeName() const override;
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
     Ref<Text> virtualCreate(String&&) override;
 };
 

--- a/Source/WebCore/dom/Comment.cpp
+++ b/Source/WebCore/dom/Comment.cpp
@@ -44,9 +44,8 @@ String Comment::nodeName() const
     return "#comment"_s;
 }
 
-Ref<Node> Comment::cloneNodeInternal(TreeScope& treeScope, CloningOperation)
+Ref<Node> Comment::cloneNodeInternal(Document& document, CloningOperation, CustomElementRegistry*)
 {
-    Ref document = treeScope.documentScope();
     return create(document, String { data() });
 }
 

--- a/Source/WebCore/dom/Comment.h
+++ b/Source/WebCore/dom/Comment.h
@@ -36,7 +36,7 @@ private:
     Comment(Document&, String&&);
 
     String nodeName() const override;
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1026,17 +1026,17 @@ void ContainerNode::childrenChanged(const ChildChange& change)
     }
 }
 
-void ContainerNode::cloneChildNodes(TreeScope& treeScope, ContainerNode& clone)
+void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* registry, ContainerNode& clone)
 {
     NodeVector postInsertionNotificationTargets;
     bool hadElement = false;
     for (RefPtr child = firstChild(); child; child = child->nextSibling()) {
-        Ref clonedChild = child->cloneNodeInternal(treeScope, CloningOperation::SelfWithTemplateContent);
+        Ref clonedChild = child->cloneNodeInternal(document, CloningOperation::SelfWithTemplateContent, registry);
         {
             WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
             ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
-            clonedChild->setTreeScopeRecursively(treeScope);
+            clonedChild->setTreeScopeRecursively(clone.treeScope());
 
             clone.appendChildCommon(clonedChild);
             notifyChildNodeInserted(clone, clonedChild, postInsertionNotificationTargets);
@@ -1044,7 +1044,7 @@ void ContainerNode::cloneChildNodes(TreeScope& treeScope, ContainerNode& clone)
             hadElement = hadElement || is<Element>(clonedChild);
         }
         if (RefPtr childAsContainerNode = dynamicDowncast<ContainerNode>(*child))
-            childAsContainerNode->cloneChildNodes(treeScope, downcast<ContainerNode>(clonedChild));
+            childAsContainerNode->cloneChildNodes(document, registry, downcast<ContainerNode>(clonedChild));
     }
     clone.childrenChanged(makeChildChangeForCloneInsertion(hadElement ? ClonedChildIncludesElements::Yes : ClonedChildIncludesElements::No));
 

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -77,7 +77,7 @@ public:
 
     void takeAllChildrenFrom(ContainerNode*);
 
-    void cloneChildNodes(TreeScope&, ContainerNode& clone);
+    void cloneChildNodes(Document&, CustomElementRegistry*, ContainerNode& clone);
 
     enum class CanDelayNodeDeletion : uint8_t { No, Yes, Unknown };
     struct ChildChange {

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -147,7 +147,7 @@ void CustomElementReactionQueue::tryToUpgradeElement(Element& element)
 {
     ASSERT(CustomElementReactionDisallowedScope::isReactionAllowed());
     ASSERT(element.isCustomElementUpgradeCandidate());
-    RefPtr registry = element.treeScope().customElementRegistry();
+    RefPtr registry = CustomElementRegistry::registryForElement(element);
     if (!registry)
         return;
 

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -69,6 +69,8 @@ public:
 
     static CustomElementRegistry* registryForElement(const Element& element)
     {
+        if (element.usesNullCustomElementRegistry())
+            return nullptr;
         if (UNLIKELY(element.usesScopedCustomElementRegistryMap()))
             return scopedCustomElementRegistryMap().get(element);
         return element.treeScope().customElementRegistry();
@@ -76,6 +78,10 @@ public:
 
     static CustomElementRegistry* registryForNodeOrTreeScope(const Node& node, const TreeScope& treeScope)
     {
+        if (node.usesNullCustomElementRegistry()) {
+            ASSERT(is<Element>(node));
+            return nullptr;
+        }
         if (auto* element = dynamicDowncast<Element>(node); UNLIKELY(element && element->usesScopedCustomElementRegistryMap()))
             return scopedCustomElementRegistryMap().get(*element);
         return treeScope.customElementRegistry();
@@ -99,6 +105,7 @@ public:
     JSC::JSValue get(const AtomString&);
     String getName(JSC::JSValue);
     void upgrade(Node& root);
+    void initialize(Node& root);
 
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>>& promiseMap() { return m_promiseMap; }
     bool isShadowDisabled(const AtomString& name) const { return m_disabledShadowSet.contains(name); }

--- a/Source/WebCore/dom/CustomElementRegistry.idl
+++ b/Source/WebCore/dom/CustomElementRegistry.idl
@@ -38,4 +38,5 @@
 
     [Custom, ReturnsOwnPromise] Promise<undefined> whenDefined(DOMString name);
     [CEReactions=Needed] undefined upgrade(Node root);
+    [CEReactions=Needed] undefined initialize(Node root);
 };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -283,7 +283,9 @@ struct BoundaryPoint;
 struct CSSParserContext;
 struct CaretPositionFromPointOptions;
 struct ClientOrigin;
+struct ElementCreationOptions;
 struct FocusOptions;
+struct ImportNodeOptions;
 struct IntersectionObserverData;
 struct OwnerPermissionsPolicyData;
 struct QuerySelectorAllResults;
@@ -503,6 +505,8 @@ public:
     WEBCORE_EXPORT bool hasFocus() const;
     void whenVisible(Function<void()>&&);
 
+    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName);
+    ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName, const ElementCreationOptions&);
     WEBCORE_EXPORT Ref<DocumentFragment> createDocumentFragment();
     WEBCORE_EXPORT Ref<Text> createTextNode(String&& data);
     WEBCORE_EXPORT Ref<Comment> createComment(String&& data);
@@ -510,6 +514,10 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<ProcessingInstruction>> createProcessingInstruction(String&& target, String&& data);
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttribute(const AtomString& name);
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, bool shouldIgnoreNamespaceChecks = false);
+    WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, std::optional<std::variant<bool, ImportNodeOptions>>&&);
+    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
+
+    WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser, CustomElementRegistry* = nullptr);
 
     static CustomElementNameValidationStatus validateCustomElementName(const AtomString&);
     void setActiveCustomElementRegistry(CustomElementRegistry*);
@@ -622,7 +630,6 @@ public:
 
     bool isSrcdocDocument() const { return m_isSrcdocDocument; }
 
-    void setSawElementsInKnownNamespaces() { m_sawElementsInKnownNamespaces = true; }
     bool sawElementsInKnownNamespaces() const { return m_sawElementsInKnownNamespaces; }
     bool wasRemovedLastRefCalled() const { return m_wasRemovedLastRefCalled; }
 
@@ -2034,7 +2041,7 @@ private:
 
     String nodeName() const final;
     bool childTypeAllowed(NodeType) const final;
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) final;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) final;
     void cloneDataFromDocument(const Document&);
 
     Seconds minimumDOMTimerInterval() const final;

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -56,7 +56,7 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     readonly attribute DocumentType? doctype;
     [DOMJIT=Getter] readonly attribute Element? documentElement;
 
-    [NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName);
+    [NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName, optional ElementCreationOptions options = { });
     [NewObject] Element createElementNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName);
     HTMLCollection getElementsByTagName([AtomString] DOMString qualifiedName);
     HTMLCollection getElementsByTagNameNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);
@@ -68,7 +68,7 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     [NewObject] Comment createComment(DOMString data);
     [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
 
-    [CEReactions=Needed, NewObject] Node importNode(Node node, optional boolean deep = false);
+    [CEReactions=Needed, NewObject] Node importNode(Node node, optional (boolean or ImportNodeOptions) options);
     [CEReactions=Needed] Node adoptNode(Node node);
 
     [NewObject] Attr createAttribute([AtomString] DOMString localName);

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -75,15 +75,15 @@ bool DocumentFragment::childTypeAllowed(NodeType type) const
     }
 }
 
-Ref<Node> DocumentFragment::cloneNodeInternal(TreeScope& treeScope, CloningOperation type)
+Ref<Node> DocumentFragment::cloneNodeInternal(Document& document, CloningOperation type, CustomElementRegistry* registry)
 {
-    Ref clone = create(treeScope.documentScope());
+    Ref clone = create(document);
     switch (type) {
     case CloningOperation::OnlySelf:
     case CloningOperation::SelfWithTemplateContent:
         break;
     case CloningOperation::Everything:
-        cloneChildNodes(treeScope, clone);
+        cloneChildNodes(document, registry, clone);
         break;
     }
     return clone;

--- a/Source/WebCore/dom/DocumentFragment.h
+++ b/Source/WebCore/dom/DocumentFragment.h
@@ -49,7 +49,7 @@ protected:
     String nodeName() const final;
 
 private:
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
     bool childTypeAllowed(NodeType) const override;
 };
 

--- a/Source/WebCore/dom/DocumentType.cpp
+++ b/Source/WebCore/dom/DocumentType.cpp
@@ -45,9 +45,8 @@ String DocumentType::nodeName() const
     return name();
 }
 
-Ref<Node> DocumentType::cloneNodeInternal(TreeScope& treeScope, CloningOperation)
+Ref<Node> DocumentType::cloneNodeInternal(Document& document, CloningOperation, CustomElementRegistry*)
 {
-    Ref document = treeScope.documentScope();
     return create(document, m_name, m_publicId, m_systemId);
 }
 

--- a/Source/WebCore/dom/DocumentType.h
+++ b/Source/WebCore/dom/DocumentType.h
@@ -46,7 +46,7 @@ private:
     DocumentType(Document&, const String& name, const String& publicId, const String& systemId);
 
     String nodeName() const override;
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
 
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -348,8 +348,8 @@ public:
 
     String nodeName() const override;
 
-    Ref<Element> cloneElementWithChildren(TreeScope&);
-    Ref<Element> cloneElementWithoutChildren(TreeScope&);
+    Ref<Element> cloneElementWithChildren(Document&, CustomElementRegistry*);
+    Ref<Element> cloneElementWithoutChildren(Document&, CustomElementRegistry*);
 
     void normalizeAttributes();
 
@@ -404,8 +404,9 @@ public:
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
     RefPtr<ShadowRoot> shadowRootForBindings(JSC::JSGlobalObject&) const;
 
-    WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&);
-    ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable);
+    enum class CustomElementRegistryKind : bool { Window, Null };
+    WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, CustomElementRegistryKind = CustomElementRegistryKind::Window);
+    ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, CustomElementRegistryKind);
 
     WEBCORE_EXPORT ShadowRoot* userAgentShadowRoot() const;
     RefPtr<ShadowRoot> protectedUserAgentShadowRoot() const;
@@ -419,6 +420,7 @@ public:
     void setIsCustomElementUpgradeCandidate();
     void enqueueToUpgrade(JSCustomElementInterface&);
     CustomElementReactionQueue* reactionQueue() const;
+    CustomElementRegistry* customElementRegistry() const;
 
     CustomElementDefaultARIA& customElementDefaultARIA();
     CheckedRef<CustomElementDefaultARIA> checkedCustomElementDefaultARIA();
@@ -930,9 +932,9 @@ private:
     void disconnectFromResizeObserversSlow(ResizeObserverData&);
 
     // The cloneNode function is private so that non-virtual cloneElementWith/WithoutChildren are used instead.
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
-    void cloneShadowTreeIfPossible(Element& newHost);
-    virtual Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&);
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
+    void cloneShadowTreeIfPossible(Element& newHost, CustomElementRegistry*);
+    virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*);
 
     inline void removeShadowRoot(); // Defined in ElementRareData.h.
     void removeShadowRootSlow(ShadowRoot&);

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -37,6 +37,8 @@
     [CEReactions=Needed, Reflect, Unscopable] attribute DOMString slot;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList part;
 
+    [ImplementedAs=customElementRegistry, EnabledBySetting=ScopedCustomElementRegistryEnabled] readonly attribute CustomElementRegistry? customElements;
+
     [DOMJIT=ReadDOM] boolean hasAttributes();
     [SameObject, ImplementedAs=attributesMap] readonly attribute NamedNodeMap attributes;
     sequence<DOMString> getAttributeNames();

--- a/Source/WebCore/dom/ElementCreationOptions.h
+++ b/Source/WebCore/dom/ElementCreationOptions.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CustomElementRegistry.h"
+
+namespace WebCore {
+
+struct ElementCreationOptions {
+    RefPtr<CustomElementRegistry> customElements;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ElementCreationOptions.idl
+++ b/Source/WebCore/dom/ElementCreationOptions.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary ElementCreationOptions {
+    CustomElementRegistry customElements;
+};

--- a/Source/WebCore/dom/ImportNodeOptions.h
+++ b/Source/WebCore/dom/ImportNodeOptions.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class CustomElementRegistry;
+
+struct ImportNodeOptions {
+    bool deep { false };
+    RefPtr<CustomElementRegistry> customElements;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ImportNodeOptions.idl
+++ b/Source/WebCore/dom/ImportNodeOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary ImportNodeOptions {
+    boolean deep = false;
+    CustomElementRegistry customElements = null;
+};

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -33,6 +33,7 @@
 #include "ComposedTreeAncestorIterator.h"
 #include "ContainerNodeAlgorithms.h"
 #include "ContextMenuController.h"
+#include "CustomElementRegistry.h"
 #include "DataTransfer.h"
 #include "DocumentInlines.h"
 #include "DocumentType.h"
@@ -814,7 +815,8 @@ ExceptionOr<void> Node::normalize()
 Ref<Node> Node::cloneNode(bool deep)
 {
     ASSERT(!isShadowRoot());
-    return cloneNodeInternal(document(), deep ? CloningOperation::Everything : CloningOperation::OnlySelf);
+    RefPtr registry = CustomElementRegistry::registryForNodeOrTreeScope(*this, treeScope());
+    return cloneNodeInternal(document(), deep ? CloningOperation::Everything : CloningOperation::OnlySelf, registry.get());
 }
 
 ExceptionOr<Ref<Node>> Node::cloneNodeForBindings(bool deep)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -185,7 +185,7 @@ public:
         SelfWithTemplateContent,
         Everything,
     };
-    virtual Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) = 0;
+    virtual Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) = 0;
     Ref<Node> cloneNode(bool deep);
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> cloneNodeForBindings(bool deep);
 
@@ -290,6 +290,10 @@ public:
     bool isInCustomElementReactionQueue() const { return hasElementStateFlag(ElementStateFlag::IsInCustomElementReactionQueue); }
     void setIsInCustomElementReactionQueue() { setElementStateFlag(ElementStateFlag::IsInCustomElementReactionQueue); }
     void clearIsInCustomElementReactionQueue() { clearElementStateFlag(ElementStateFlag::IsInCustomElementReactionQueue); }
+
+    bool usesNullCustomElementRegistry() const { return hasElementStateFlag(ElementStateFlag::UsesNullCustomElementRegistry); }
+    void setUsesNullCustomElementRegistry() const { setElementStateFlag(ElementStateFlag::UsesNullCustomElementRegistry); }
+    void clearUsesNullCustomElementRegistry() const { clearElementStateFlag(ElementStateFlag::UsesNullCustomElementRegistry); }
 
     bool usesScopedCustomElementRegistryMap() const { return hasElementStateFlag(ElementStateFlag::UsesScopedCustomElementRegistryMap); }
     void setUsesScopedCustomElementRegistryMap() { setElementStateFlag(ElementStateFlag::UsesScopedCustomElementRegistryMap); }
@@ -651,8 +655,9 @@ protected:
 #if ENABLE(FULLSCREEN_API)
         IsFullscreen = 1 << 6,
 #endif
-        UsesScopedCustomElementRegistryMap = 1 << 7,
-        // 8-bits free.
+        UsesNullCustomElementRegistry = 1 << 7,
+        UsesScopedCustomElementRegistryMap = 1 << 8,
+        // 7-bits free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -72,11 +72,11 @@ String ProcessingInstruction::nodeName() const
     return m_target;
 }
 
-Ref<Node> ProcessingInstruction::cloneNodeInternal(TreeScope& treeScope, CloningOperation)
+Ref<Node> ProcessingInstruction::cloneNodeInternal(Document& document, CloningOperation, CustomElementRegistry*)
 {
     // FIXME: Is it a problem that this does not copy m_localHref?
     // What about other data members?
-    return create(treeScope.documentScope(), String { m_target }, String { data() });
+    return create(document, String { m_target }, String { data() });
 }
 
 void ProcessingInstruction::checkStyleSheet()

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -58,7 +58,7 @@ private:
     ProcessingInstruction(Document&, String&& target, String&& data);
 
     String nodeName() const override;
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void didFinishInsertingNode() override;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -101,7 +101,8 @@ public:
     RefPtr<Element> protectedHost() const { return m_host.get(); }
     void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTFMove(host); }
 
-    CustomElementRegistry* registryForBindings() const { return m_hasScopedCustomElementRegistry ? customElementRegistry() : nullptr; }
+    bool hasScopedCustomElementRegistry() const { return m_hasScopedCustomElementRegistry; }
+    CustomElementRegistry* registryForBindings() const;
 
     ExceptionOr<void> setHTMLUnsafe(std::variant<RefPtr<TrustedHTML>, String>&&);
     String getHTML(GetHTMLOptions&&) const;
@@ -109,7 +110,7 @@ public:
     String innerHTML() const;
     ExceptionOr<void> setInnerHTML(std::variant<RefPtr<TrustedHTML>, String>&&);
 
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
 
     Element* activeElement() const;
 

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -38,12 +38,7 @@
     readonly attribute Element host;
     attribute EventHandler onslotchange;
 
-    // FIXME: Move to DocumentOrShadowRoot.idl once it's always enabled
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled, NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName);
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled, NewObject] Element createElementNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName);
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled, CEReactions=Needed, NewObject] Node importNode(Node node, optional boolean deep = false);
-
-    [ImplementedAs=registryForBindings, EnabledBySetting=ScopedCustomElementRegistryEnabled] readonly attribute CustomElementRegistry? registry;
+    [ImplementedAs=registryForBindings, EnabledBySetting=ScopedCustomElementRegistryEnabled] readonly attribute CustomElementRegistry? customElements;
 };
 
 ShadowRoot includes DocumentOrShadowRoot;

--- a/Source/WebCore/dom/ShadowRootInit.h
+++ b/Source/WebCore/dom/ShadowRootInit.h
@@ -37,7 +37,7 @@ struct ShadowRootInit {
     bool clonable { false };
     bool serializable { false };
     SlotAssignmentMode slotAssignment { SlotAssignmentMode::Named };
-    RefPtr<CustomElementRegistry> registry;
+    RefPtr<CustomElementRegistry> customElements;
 };
 
 }

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -31,5 +31,5 @@ dictionary ShadowRootInit {
     boolean clonable = false;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry registry = null;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry customElements = null;
 };

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -157,9 +157,8 @@ String Text::nodeName() const
     return "#text"_s;
 }
 
-Ref<Node> Text::cloneNodeInternal(TreeScope& treeScope, CloningOperation)
+Ref<Node> Text::cloneNodeInternal(Document& document, CloningOperation, CustomElementRegistry*)
 {
-    Ref document = treeScope.documentScope();
     return create(document, String { data() });
 }
 

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -67,7 +67,7 @@ protected:
 
 private:
     String nodeName() const override;
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) override;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) override;
     void setDataAndUpdate(const String&, unsigned offsetOfReplacedData, unsigned oldLength, unsigned newLength, UpdateLiveRanges) final;
 
     virtual Ref<Text> virtualCreate(String&&);

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -142,33 +142,7 @@ void TreeScope::setParentTreeScope(TreeScope& newParentScope)
 
 void TreeScope::setCustomElementRegistry(Ref<CustomElementRegistry>&& registry)
 {
-    if (!m_customElementRegistry)
-        m_customElementRegistry = WTFMove(registry);
-}
-
-ExceptionOr<Ref<Node>> TreeScope::importNode(Node& nodeToImport, bool deep)
-{
-    switch (nodeToImport.nodeType()) {
-    case Node::DOCUMENT_FRAGMENT_NODE:
-        if (nodeToImport.isShadowRoot())
-            break;
-        FALLTHROUGH;
-    case Node::ELEMENT_NODE:
-    case Node::TEXT_NODE:
-    case Node::CDATA_SECTION_NODE:
-    case Node::PROCESSING_INSTRUCTION_NODE:
-    case Node::COMMENT_NODE:
-        return nodeToImport.cloneNodeInternal(*this, deep ? Node::CloningOperation::Everything : Node::CloningOperation::OnlySelf);
-
-    case Node::ATTRIBUTE_NODE: {
-        auto& attribute = uncheckedDowncast<Attr>(nodeToImport);
-        return Ref<Node> { Attr::create(documentScope(), attribute.qualifiedName(), attribute.value()) };
-    }
-    case Node::DOCUMENT_NODE: // Can't import a document into another document.
-    case Node::DOCUMENT_TYPE_NODE: // FIXME: Support cloning a DocumentType node per DOM4.
-        break;
-    }
-    return Exception { ExceptionCode::NotSupportedError };
+    m_customElementRegistry = WTFMove(registry);
 }
 
 RefPtr<Element> TreeScope::getElementById(const AtomString& elementId) const

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -79,10 +79,6 @@ public:
 
     void setCustomElementRegistry(Ref<CustomElementRegistry>&&);
     CustomElementRegistry* customElementRegistry() const { return m_customElementRegistry.get(); }
-    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName);
-    WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
-    WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser);
-    WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, bool deep);
 
     WEBCORE_EXPORT RefPtr<Element> getElementById(const AtomString&) const;
     WEBCORE_EXPORT RefPtr<Element> getElementById(const String&) const;

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1073,7 +1073,7 @@ void ApplyStyleCommand::pushDownInlineStyleAroundNode(EditingStyle& style, Node*
                 continue;
             if (!child->contains(targetNode) && elementsToPushDown.size()) {
                 for (auto& element : elementsToPushDown) {
-                    auto wrapper = element->cloneElementWithoutChildren(protectedDocument());
+                    auto wrapper = element->cloneElementWithoutChildren(protectedDocument(), nullptr);
                     wrapper->removeAttribute(styleAttr);
                     surroundNodeRangeWithElement(child, child, WTFMove(wrapper));
                 }
@@ -1506,7 +1506,7 @@ void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEn
         surroundNodeRangeWithElement(*startNode, *endNode, createHTMLElement(document, supTag));
 
     if (m_styledInlineElement && addStyledElement == AddStyledElement::Yes)
-        surroundNodeRangeWithElement(*startNode, *endNode, m_styledInlineElement->cloneElementWithoutChildren(document));
+        surroundNodeRangeWithElement(*startNode, *endNode, m_styledInlineElement->cloneElementWithoutChildren(document, nullptr));
 }
 
 float ApplyStyleCommand::computedFontSize(Node* node)

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -152,7 +152,7 @@ void BreakBlockquoteCommand::doApply()
         ancestors.append(node.copyRef());
     
     // Insert a clone of the top blockquote after the break.
-    auto clonedBlockquote = topBlockquote->cloneElementWithoutChildren(document());
+    auto clonedBlockquote = topBlockquote->cloneElementWithoutChildren(document(), nullptr);
     insertNodeAfter(clonedBlockquote.copyRef(), breakNode);
     
     // Clone startNode's ancestors into the cloned blockquote.
@@ -161,7 +161,7 @@ void BreakBlockquoteCommand::doApply()
     // or clonedBlockquote if ancestors is empty).
     RefPtr<Element> clonedAncestor = clonedBlockquote.copyRef();
     for (size_t i = ancestors.size(); i != 0; --i) {
-        auto clonedChild = ancestors[i - 1]->cloneElementWithoutChildren(document());
+        auto clonedChild = ancestors[i - 1]->cloneElementWithoutChildren(document(), nullptr);
         // Preserve list item numbering in cloned lists.
         if (clonedChild->isElementNode() && clonedChild->hasTagName(olTag)) {
             RefPtr<Node> listChildNode = i > 1 ? ancestors[i - 2].get() : startNode.get();

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -138,7 +138,7 @@ Ref<Element> InsertParagraphSeparatorCommand::cloneHierarchyUnderNewBlock(const 
     // Make clones of ancestors in between the start node and the start block.
     RefPtr<Element> parent = WTFMove(blockToInsert);
     for (size_t i = ancestors.size(); i != 0; --i) {
-        auto child = ancestors[i - 1]->cloneElementWithoutChildren(document());
+        auto child = ancestors[i - 1]->cloneElementWithoutChildren(document(), nullptr);
         // It should always be okay to remove id from the cloned elements, since the originals are not deleted.
         child->removeAttribute(idAttr);
         appendNode(child.copyRef(), parent.releaseNonNull());
@@ -299,7 +299,7 @@ void InsertParagraphSeparatorCommand::doApply()
     } else if (shouldUseDefaultParagraphElement(startBlock.get())) 
         blockToInsert = createDefaultParagraphElement(document);
     else
-        blockToInsert = startBlock->cloneElementWithoutChildren(document);
+        blockToInsert = startBlock->cloneElementWithoutChildren(document, nullptr);
 
     //---------------------------------------------------------------------
     // Handle case when position is in the last visible position in its block,

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -417,6 +417,7 @@ void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespa
             m_markup.append(" shadowrootserializable=\"\""_s);
         if (shadowRoot->isClonable())
             m_markup.append(" shadowrootclonable=\"\""_s);
+        // FIXME: Add shadowrootcustomelements
         m_markup.append('>');
     } else
         appendNonElementNode(m_markup, node, namespaces);

--- a/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -193,7 +193,7 @@ void IncreaseSelectionListLevelCommand::doApply()
         case Type::InheritedListType:
             newParent = startListChild->parentElement();
             if (newParent)
-                newParent = newParent->cloneElementWithoutChildren(document());
+                newParent = newParent->cloneElementWithoutChildren(document(), nullptr);
             break;
         case Type::OrderedList:
             newParent = HTMLOListElement::create(document());

--- a/Source/WebCore/editing/SplitElementCommand.cpp
+++ b/Source/WebCore/editing/SplitElementCommand.cpp
@@ -68,7 +68,7 @@ void SplitElementCommand::executeApply()
     
 void SplitElementCommand::doApply()
 {
-    m_element1 = protectedElement2()->cloneElementWithoutChildren(protectedDocument());
+    m_element1 = protectedElement2()->cloneElementWithoutChildren(protectedDocument(), nullptr);
     
     executeApply();
 }

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -781,7 +781,7 @@ void TextManipulationController::updateInsertions(Vector<NodeEntry>& lastTopDown
         for (;i < currentTopDownPath.size(); ++i) {
             Ref<Node> node = currentTopDownPath[i];
             if (!insertedNodes.add(node.copyRef()).isNewEntry) {
-                auto clonedNode = node->cloneNodeInternal(node->protectedDocument(), Node::CloningOperation::OnlySelf);
+                auto clonedNode = node->cloneNode(false);
                 if (auto* data = node->eventTargetData())
                     data->eventListenerMap.copyEventListenersNotCreatedFromMarkupToTarget(clonedNode.ptr());
                 node = WTFMove(clonedNode);

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1391,7 +1391,7 @@ Ref<DocumentFragment> createFragmentFromText(const SimpleRange& context, const S
             fillContainerFromString(fragment, s);
         } else {
             if (useClonesOfEnclosingBlock)
-                element = block->cloneElementWithoutChildren(document);
+                element = block->cloneElementWithoutChildren(document, nullptr);
             else
                 element = createDefaultParagraphElement(document);
             fillContainerFromString(*element, s);

--- a/Source/WebCore/html/AttachmentAssociatedElement.cpp
+++ b/Source/WebCore/html/AttachmentAssociatedElement.cpp
@@ -77,7 +77,7 @@ void AttachmentAssociatedElement::copyAttachmentAssociatedPropertiesFromElement(
 void AttachmentAssociatedElement::cloneAttachmentAssociatedElementWithoutAttributesAndChildren(AttachmentAssociatedElement& clone, Document& targetDocument)
 {
     if (auto attachment = attachmentElement()) {
-        auto attachmentClone = attachment->cloneElementWithoutChildren(targetDocument);
+        auto attachmentClone = attachment->cloneElementWithoutChildren(targetDocument, nullptr);
         clone.setAttachmentElement(downcast<HTMLAttachmentElement>(attachmentClone.get()));
     }
 }

--- a/Source/WebCore/html/AttachmentAssociatedElement.h
+++ b/Source/WebCore/html/AttachmentAssociatedElement.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class CustomElementRegistry;
 class Document;
 class Element;
 class HTMLAttachmentElement;
@@ -69,7 +70,7 @@ private:
     virtual void refAttachmentAssociatedElement() const = 0;
     virtual void derefAttachmentAssociatedElement() const = 0;
 
-    virtual Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&) = 0;
+    virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) = 0;
     virtual void copyNonAttributePropertiesFromElement(const Element&) = 0;
 
     virtual AttachmentAssociatedElement* asAttachmentAssociatedElement() = 0;

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -391,6 +391,7 @@ scrolling
 select
 selected
 shadowrootclonable
+shadowrootcustomelements
 shadowrootdelegatesfocus
 shadowrootmode
 shadowrootserializable

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1063,9 +1063,8 @@ void HTMLImageElement::invalidateAttributeMapping()
     invalidateStyle();
 }
 
-Ref<Element> HTMLImageElement::cloneElementWithoutAttributesAndChildren(TreeScope& treeScope)
+Ref<Element> HTMLImageElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*)
 {
-    Ref document = treeScope.documentScope();
     auto clone = create(document);
 #if ENABLE(ATTACHMENT_ELEMENT)
     cloneAttachmentAssociatedElementWithoutAttributesAndChildren(clone, document);

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -202,7 +202,7 @@ private:
     void invalidateAttributeMapping();
     void collectExtraStyleForPresentationalHints(MutableStyleProperties&) override;
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&) final;
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) final;
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -127,9 +127,9 @@ Ref<HTMLInputElement> HTMLInputElement::create(const QualifiedName& tagName, Doc
     return adoptRef(*new HTMLInputElement(tagName, document, form, createdByParser ? CreationType::ByParser : CreationType::Normal));
 }
 
-Ref<Element> HTMLInputElement::cloneElementWithoutAttributesAndChildren(TreeScope& treeScope)
+Ref<Element> HTMLInputElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*)
 {
-    return adoptRef(*new HTMLInputElement(tagQName(), treeScope.documentScope(), nullptr, CreationType::ByCloning));
+    return adoptRef(*new HTMLInputElement(tagQName(), document, nullptr, CreationType::ByCloning));
 }
 
 HTMLImageLoader& HTMLInputElement::ensureImageLoader()

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -361,7 +361,7 @@ private:
 
     void defaultEventHandler(Event&) final;
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&) override;
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) override;
 
     enum AutoCompleteSetting : uint8_t { Uninitialized, On, Off };
     static constexpr int defaultSize = 20;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -287,9 +287,9 @@ bool HTMLScriptElement::isScriptPreventedByAttributes() const
     return false;
 }
 
-Ref<Element> HTMLScriptElement::cloneElementWithoutAttributesAndChildren(TreeScope& treeScope)
+Ref<Element> HTMLScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*)
 {
-    return adoptRef(*new HTMLScriptElement(tagQName(), treeScope.documentScope(), false, alreadyStarted()));
+    return adoptRef(*new HTMLScriptElement(tagQName(), document, false, alreadyStarted()));
 }
 
 void HTMLScriptElement::setReferrerPolicyForBindings(const AtomString& value)

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -107,7 +107,7 @@ private:
 
     bool isScriptPreventedByAttributes() const final;
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&) final;
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) final;
 
     std::unique_ptr<DOMTokenList> m_blockingList;
     bool m_isRenderBlocking { false };

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -226,9 +226,8 @@ void HTMLSourceElement::addCandidateSubresourceURLs(ListHashSet<URL>& urls) cons
     getURLsFromSrcsetAttribute(*this, attributeWithoutSynchronization(srcsetAttr), urls);
 }
 
-Ref<Element> HTMLSourceElement::cloneElementWithoutAttributesAndChildren(TreeScope& treeScope)
+Ref<Element> HTMLSourceElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*)
 {
-    Ref document = treeScope.documentScope();
     Ref clone = create(document);
 #if ENABLE(ATTACHMENT_ELEMENT)
     cloneAttachmentAssociatedElementWithoutAttributesAndChildren(clone, document);

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -81,7 +81,7 @@ private:
     AttachmentAssociatedElementType attachmentAssociatedElementType() const final { return AttachmentAssociatedElementType::Source; }
 #endif
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&) final;
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) final;
     void copyNonAttributePropertiesFromElement(const Element&) final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -110,23 +110,23 @@ void HTMLTemplateElement::setDeclarativeShadowRoot(ShadowRoot& shadowRoot)
     m_declarativeShadowRoot = shadowRoot;
 }
 
-Ref<Node> HTMLTemplateElement::cloneNodeInternal(TreeScope& treeScope, CloningOperation type)
+Ref<Node> HTMLTemplateElement::cloneNodeInternal(Document& document, CloningOperation type, CustomElementRegistry* registry)
 {
     RefPtr<Node> clone;
     switch (type) {
     case CloningOperation::OnlySelf:
-        return cloneElementWithoutChildren(treeScope);
+        return cloneElementWithoutChildren(document, registry);
     case CloningOperation::SelfWithTemplateContent:
-        clone = cloneElementWithoutChildren(treeScope);
+        clone = cloneElementWithoutChildren(document, registry);
         break;
     case CloningOperation::Everything:
-        clone = cloneElementWithChildren(treeScope);
+        clone = cloneElementWithChildren(document, registry);
         break;
     }
     if (m_content) {
         auto& templateElement = downcast<HTMLTemplateElement>(*clone);
         Ref fragment = templateElement.content();
-        content().cloneChildNodes(fragment->document(), fragment);
+        content().cloneChildNodes(fragment->document(), nullptr, fragment);
     }
     return clone.releaseNonNull();
 }
@@ -138,43 +138,6 @@ void HTMLTemplateElement::didMoveToNewDocument(Document& oldDocument, Document& 
         return;
     ASSERT_WITH_SECURITY_IMPLICATION(&document() == &newDocument);
     m_content->setTreeScopeRecursively(newDocument.ensureTemplateDocument());
-}
-
-void HTMLTemplateElement::attachAsDeclarativeShadowRootIfNeeded(Element& host)
-{
-    if (m_declarativeShadowRoot) {
-        ASSERT(host.shadowRoot());
-        return;
-    }
-
-    auto modeString = shadowRootMode();
-    if (modeString.isEmpty())
-        return;
-
-    ASSERT(modeString == "closed"_s || modeString == "open"_s);
-    auto mode = modeString == "closed"_s ? ShadowRootMode::Closed : ShadowRootMode::Open;
-
-    auto delegatesFocus = hasAttributeWithoutSynchronization(HTMLNames::shadowrootdelegatesfocusAttr) ? ShadowRootDelegatesFocus::Yes : ShadowRootDelegatesFocus::No;
-    auto clonable = hasAttributeWithoutSynchronization(HTMLNames::shadowrootclonableAttr) ? ShadowRootClonable::Yes : ShadowRootClonable::No;
-    auto serializable = hasAttributeWithoutSynchronization(HTMLNames::shadowrootserializableAttr) ? ShadowRootSerializable::Yes : ShadowRootSerializable::No;
-
-    auto exceptionOrShadowRoot = host.attachDeclarativeShadow(mode, delegatesFocus, clonable, serializable);
-    if (exceptionOrShadowRoot.hasException())
-        return;
-
-    auto importedContent = document().importNode(content(), /* deep */ true).releaseReturnValue();
-    for (RefPtr<Node> node = NodeTraversal::next(importedContent), next; node; node = next) {
-        next = NodeTraversal::next(*node);
-        if (auto* templateElement = dynamicDowncast<HTMLTemplateElement>(*node)) {
-            if (RefPtr parentElement = node->parentElement())
-                templateElement->attachAsDeclarativeShadowRootIfNeeded(*parentElement);
-        }
-    }
-
-    Ref shadowRoot = exceptionOrShadowRoot.releaseReturnValue();
-    shadowRoot->appendChild(WTFMove(importedContent));
-
-    remove();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -52,12 +52,11 @@ public:
     void setShadowRootMode(const AtomString&);
 
     void setDeclarativeShadowRoot(ShadowRoot&);
-    void attachAsDeclarativeShadowRootIfNeeded(Element&);
 
 private:
     HTMLTemplateElement(const QualifiedName&, Document&);
 
-    Ref<Node> cloneNodeInternal(TreeScope&, CloningOperation) final;
+    Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) final;
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     mutable RefPtr<TemplateContentDocumentFragment> m_content;

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -38,4 +38,5 @@
     [CEReactions=NotNeeded, Reflect=shadowrootdelegatesfocus] attribute boolean shadowRootDelegatesFocus;
     [CEReactions=NotNeeded, Reflect=shadowrootclonable] attribute boolean shadowRootClonable;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled, CEReactions=NotNeeded, Reflect=shadowrootserializable] attribute boolean shadowRootSerializable;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled, CEReactions=NotNeeded, Reflect=shadowrootcustomelements] attribute boolean shadowRootCustomElements;
 };

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -581,9 +581,9 @@ std::optional<Style::ResolvedStyle> SliderThumbElement::resolveCustomStyle(const
     return elementStyle;
 }
 
-Ref<Element> SliderThumbElement::cloneElementWithoutAttributesAndChildren(TreeScope& treeScope)
+Ref<Element> SliderThumbElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*)
 {
-    return create(treeScope.documentScope());
+    return create(document);
 }
 
 // --------------------------------

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -61,7 +61,7 @@ private:
     explicit SliderThumbElement(Document&);
     bool isSliderThumbElement() const final { return true; }
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&) final;
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) final;
     bool isDisabledFormControl() const final;
     bool matchesReadWritePseudoClass() const final;
 

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -192,7 +192,7 @@ ExceptionOr<Ref<TextTrackCue>> TextTrackCue::create(Document& document, double s
         if (result.hasException())
             return result.releaseException();
     }
-    cueFragment.cloneChildNodes(document, fragment);
+    cueFragment.cloneChildNodes(document, nullptr, fragment);
 
     OptionSet<RequiredNodes> nodeTypes = { };
     for (Node* node = fragment->firstChild(); node; node = node->nextSibling()) {
@@ -452,7 +452,7 @@ RefPtr<DocumentFragment> TextTrackCue::getCueAsHTML()
         return nullptr;
 
     auto clonedFragment = DocumentFragment::create(*document);
-    m_cueNode->cloneChildNodes(*document, clonedFragment);
+    m_cueNode->cloneChildNodes(*document, nullptr, clonedFragment);
 
     for (Node* node = clonedFragment->firstChild(); node; node = node->nextSibling())
         removeUserAgentPartAttributes(*node);
@@ -513,7 +513,7 @@ void TextTrackCue::rebuildDisplayTree()
 
     m_displayTree->removeChildren();
     auto clonedFragment = DocumentFragment::create(*document);
-    m_cueNode->cloneChildNodes(*document, clonedFragment);
+    m_cueNode->cloneChildNodes(*document, nullptr, clonedFragment);
     m_displayTree->appendChild(clonedFragment);
 
     if (m_fontSize) {

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -540,7 +540,7 @@ RefPtr<DocumentFragment> VTTCue::createCueRenderingTree()
     // The cloned fragment is never exposed to author scripts so it's safe to dispatch events here.
     ScriptDisallowedScope::EventAllowedScope allowedScope(clonedFragment);
 
-    m_webVTTNodeTree->cloneChildNodes(*document, clonedFragment);
+    m_webVTTNodeTree->cloneChildNodes(*document, nullptr, clonedFragment);
     return clonedFragment;
 }
 

--- a/Source/WebCore/html/track/WebVTTElement.cpp
+++ b/Source/WebCore/html/track/WebVTTElement.cpp
@@ -84,9 +84,8 @@ Ref<Element> WebVTTElement::create(WebVTTNodeType nodeType, AtomString language,
     return adoptRef(*new WebVTTElement(nodeType, language, document));
 }
 
-Ref<Element> WebVTTElement::cloneElementWithoutAttributesAndChildren(TreeScope& treeScope)
+Ref<Element> WebVTTElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*)
 {
-    Ref document = treeScope.documentScope();
     return create(m_webVTTNodeType, m_language, document);
 }
 

--- a/Source/WebCore/html/track/WebVTTElement.h
+++ b/Source/WebCore/html/track/WebVTTElement.h
@@ -51,7 +51,7 @@ public:
     static Ref<Element> create(const WebVTTNodeType, AtomString language, Document&);
     Ref<HTMLElement> createEquivalentHTMLElement(Document&);
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&);
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*);
 
     void setWebVTTNodeType(WebVTTNodeType type) { m_webVTTNodeType = type; }
     WebVTTNodeType webVTTNodeType() const { return m_webVTTNodeType; }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -55,6 +55,7 @@
 #include "ContainerNode.h"
 #include "Cookie.h"
 #include "CookieJar.h"
+#include "CustomElementRegistry.h"
 #include "DOMEditor.h"
 #include "DOMException.h"
 #include "DOMPatchSupport.h"

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -620,7 +620,7 @@ CustomElementRegistry& LocalDOMWindow::ensureCustomElementRegistry()
     if (!m_customElementRegistry) {
         m_customElementRegistry = CustomElementRegistry::create(*scriptExecutionContext(), *this);
         for (Ref shadowRoot : document()->inDocumentShadowRoots()) {
-            if (shadowRoot->mode() == ShadowRootMode::UserAgent)
+            if (shadowRoot->mode() == ShadowRootMode::UserAgent || shadowRoot->hasScopedCustomElementRegistry())
                 continue;
             const_cast<ShadowRoot&>(shadowRoot.get()).setCustomElementRegistry(*m_customElementRegistry);
         }

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -92,9 +92,9 @@ void SVGScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 
     addSubresourceURL(urls, document().completeURL(href()));
 }
-Ref<Element> SVGScriptElement::cloneElementWithoutAttributesAndChildren(TreeScope& treeScope)
+Ref<Element> SVGScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*)
 {
-    return adoptRef(*new SVGScriptElement(tagQName(), treeScope.documentScope(), false, alreadyStarted()));
+    return adoptRef(*new SVGScriptElement(tagQName(), document, false, alreadyStarted()));
 }
 
 void SVGScriptElement::dispatchErrorEvent()

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -53,7 +53,7 @@ private:
     bool isURLAttribute(const Attribute& attribute) const final { return attribute.name() == AtomString { sourceAttributeValue() }; }
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(TreeScope&) final;
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
     bool supportsFocus() const final { return false; }
 

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -483,7 +483,7 @@ RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
 
 void SVGUseElement::cloneTarget(ContainerNode& container, SVGElement& target) const
 {
-    Ref targetClone = static_cast<SVGElement&>(target.cloneElementWithChildren(protectedDocument()).get());
+    Ref targetClone = static_cast<SVGElement&>(target.cloneElementWithChildren(protectedDocument(), nullptr).get());
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { targetClone };
     associateClonesWithOriginals(targetClone.get(), target);
     removeDisallowedElementsFromSubtree(targetClone.get());
@@ -499,7 +499,7 @@ static void cloneDataAndChildren(SVGElement& replacementClone, SVGElement& origi
     ASSERT(!replacementClone.parentNode());
 
     replacementClone.cloneDataFromElement(originalClone);
-    originalClone.cloneChildNodes(replacementClone.treeScope(), replacementClone);
+    originalClone.cloneChildNodes(replacementClone.document(), nullptr, replacementClone);
     associateReplacementClonesWithOriginals(replacementClone, originalClone);
     removeDisallowedElementsFromSubtree(replacementClone);
 }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -851,7 +851,8 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
         customElementReactionStack.emplace(m_currentNode->document().globalObject());
     }
 
-    auto newElement = m_currentNode->treeScope().createElement(qName, true);
+    auto newElement = m_currentNode->document().createElement(qName, true,
+        CustomElementRegistry::registryForNodeOrTreeScope(*m_currentNode, m_currentNode->treeScope()));
 
     Vector<Attribute> prefixedAttributes;
     if (!handleNamespaceAttributes(prefixedAttributes, libxmlNamespaces, numNamespaces)) {

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -59,6 +59,7 @@
 #import <WebCore/CSSRuleList.h>
 #import <WebCore/CSSStyleDeclaration.h>
 #import <WebCore/Comment.h>
+#import <WebCore/CustomElementRegistry.h>
 #import <WebCore/DocumentFragment.h>
 #import <WebCore/DocumentFullscreen.h>
 #import <WebCore/DocumentInlines.h>
@@ -68,6 +69,7 @@
 #import <WebCore/HTMLHeadElement.h>
 #import <WebCore/HTMLScriptElement.h>
 #import <WebCore/HitTestSource.h>
+#import <WebCore/ImportNodeOptions.h>
 #import <WebCore/JSExecState.h>
 #import <WebCore/LocalDOMWindow.h>
 #import <WebCore/NativeNodeFilter.h>
@@ -508,7 +510,7 @@
     WebCore::JSMainThreadNullState state;
     if (!importedNode)
         raiseTypeErrorException();
-    return kit(raiseOnDOMError(IMPL->importNode(*core(importedNode), deep)).ptr());
+    return kit(raiseOnDOMError(IMPL->importNode(*core(importedNode), static_cast<bool>(deep))).ptr());
 }
 
 - (DOMElement *)createElementNS:(NSString *)namespaceURI qualifiedName:(NSString *)qualifiedName


### PR DESCRIPTION
#### 40e520dd495b1232d62fc0342fbc409b3649426d
<pre>
Implement revamped scoped custom element registry
<a href="https://bugs.webkit.org/show_bug.cgi?id=286870">https://bugs.webkit.org/show_bug.cgi?id=286870</a>

Reviewed by Chris Dumez.

This PR implements a number of API changes we proposed in <a href="https://github.com/whatwg/html/issues/10854.">https://github.com/whatwg/html/issues/10854.</a>

Since the new API&apos;s behavior is sufficiently different from the old proposal, this PR opts to write a new set of tests
instead of retrofitting the old tests to match the new behavior.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-createElement.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-importNode.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-init-registry.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML-upgrade.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/ShadowRoot-innerHTML.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/constructor-reentry-with-different-definition.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-criteria.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/scoped-registry/scoped-registry-define-upgrade-order.tentative-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::cloneNodeInternal):
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::cloneNodeInternal):
* Source/WebCore/dom/CDATASection.h:
* Source/WebCore/dom/Comment.cpp:
(WebCore::Comment::cloneNodeInternal):
* Source/WebCore/dom/Comment.h:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::cloneChildNodes):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::tryToUpgradeElement):
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::upgradeElementsInShadowIncludingDescendants):
(WebCore::CustomElementRegistry::upgrade):
(WebCore::CustomElementRegistry::initialize):
(WebCore::CustomElementRegistry::addToScopedCustomElementRegistryMap):
* Source/WebCore/dom/CustomElementRegistry.h:
(WebCore::CustomElementRegistry::registryForElement):
(WebCore::CustomElementRegistry::registryForNodeOrTreeScope):
* Source/WebCore/dom/CustomElementRegistry.idl:
* Source/WebCore/dom/Document.cpp:
(WebCore::createUpgradeCandidateElement):
(WebCore::createHTMLElementWithNameValidation):
(WebCore::Document::createElementForBindings):
(WebCore::Document::importNode):
(WebCore::createFallbackHTMLElement):
(WebCore::Document::createElement):
(WebCore::Document::createElementNS):
(WebCore::Document::cloneNodeInternal):
(WebCore::TreeScope::createElementForBindings): Deleted.
(WebCore::TreeScope::createElement): Deleted.
(WebCore::TreeScope::createElementNS): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::setSawElementsInKnownNamespaces): Deleted.
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::cloneNodeInternal):
* Source/WebCore/dom/DocumentFragment.h:
* Source/WebCore/dom/DocumentType.cpp:
(WebCore::DocumentType::cloneNodeInternal):
* Source/WebCore/dom/DocumentType.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cloneNodeInternal):
(WebCore::Element::cloneShadowTreeIfPossible):
(WebCore::Element::cloneElementWithChildren):
(WebCore::Element::cloneElementWithoutChildren):
(WebCore::Element::cloneElementWithoutAttributesAndChildren):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::customElementRegistry const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.idl:
* Source/WebCore/dom/ElementCreationOptions.h: Copied from Source/WebCore/dom/ShadowRootInit.h.
* Source/WebCore/dom/ElementCreationOptions.idl: Copied from Source/WebCore/dom/ShadowRootInit.idl.
* Source/WebCore/dom/ImportNodeOptions.h: Copied from Source/WebCore/dom/ShadowRootInit.h.
* Source/WebCore/dom/ImportNodeOptions.idl: Copied from Source/WebCore/dom/ShadowRootInit.idl.
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::cloneNode):
* Source/WebCore/dom/Node.h:
(WebCore::Node::usesNullCustomElementRegistry const):
(WebCore::Node::setUsesNullCustomElementRegistry const):
(WebCore::Node::clearUsesNullCustomElementRegistry const):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::cloneNodeInternal):
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::insertedIntoAncestor):
(WebCore::ShadowRoot::removedFromAncestor):
(WebCore::ShadowRoot::registryForBindings const):
(WebCore::ShadowRoot::cloneNodeInternal):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/dom/ShadowRootInit.h:
* Source/WebCore/dom/ShadowRootInit.idl:
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::cloneNodeInternal):
* Source/WebCore/dom/Text.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::setCustomElementRegistry):
(WebCore::TreeScope::importNode): Deleted.
* Source/WebCore/dom/TreeScope.h:
(WebCore::TreeScope::customElementRegistry const):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::pushDownInlineStyleAroundNode):
(WebCore::ApplyStyleCommand::applyInlineStyleChange):
* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::doApply):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::InsertParagraphSeparatorCommand::cloneHierarchyUnderNewBlock):
(WebCore::InsertParagraphSeparatorCommand::doApply):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::startAppendingNode):
* Source/WebCore/editing/ModifySelectionListLevel.cpp:
(WebCore::IncreaseSelectionListLevelCommand::doApply):
* Source/WebCore/editing/SplitElementCommand.cpp:
(WebCore::SplitElementCommand::doApply):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::updateInsertions):
* Source/WebCore/editing/markup.cpp:
(WebCore::createFragmentFromText):
* Source/WebCore/html/AttachmentAssociatedElement.cpp:
(WebCore::AttachmentAssociatedElement::cloneAttachmentAssociatedElementWithoutAttributesAndChildren):
* Source/WebCore/html/AttachmentAssociatedElement.h:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::cloneNodeInternal):
(WebCore::HTMLTemplateElement::attachAsDeclarativeShadowRootIfNeeded): Deleted used code.
* Source/WebCore/html/HTMLTemplateElement.h:
* Source/WebCore/html/HTMLTemplateElement.idl:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLTemplateElement):
(WebCore::HTMLConstructionSite::createElement):
(WebCore::HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/html/shadow/SliderThumbElement.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::create):
(WebCore::TextTrackCue::getCueAsHTML):
(WebCore::TextTrackCue::rebuildDisplayTree):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::createCueRenderingTree):
* Source/WebCore/html/track/WebVTTElement.cpp:
(WebCore::WebVTTElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/html/track/WebVTTElement.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::ensureCustomElementRegistry):
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::cloneElementWithoutAttributesAndChildren):
* Source/WebCore/svg/SVGScriptElement.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::cloneTarget const):
(WebCore::cloneDataAndChildren):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:

Canonical link: <a href="https://commits.webkit.org/290096@main">https://commits.webkit.org/290096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/300f8b7f780cf1d6a94597cb9b55b72592650adc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26183 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6729 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6480 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16099 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11751 "Found 3 new test failures: http/tests/pdf/page-in-window-update-with-linearized-pdf-in-display-none-iframe.html imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16355 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76669 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21053 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9165 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16113 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21424 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19305 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->