### PR TITLE
[visionOS] Web process hangs under createDragImageFor{Link|Selection} when starting a drag for the first time

### DIFF
--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -40,6 +40,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTMLImageElement.h"
+#include "HostWindow.h"
 #include "Image.h"
 #include "LocalFrame.h"
 #include "Page.h"
@@ -64,14 +65,16 @@ class DragImageLoader final : public CachedImageClient {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DragImageLoader);
     WTF_MAKE_NONCOPYABLE(DragImageLoader);
 public:
-    explicit DragImageLoader(DataTransfer&);
+    explicit DragImageLoader(DataTransfer&, const Document&);
     void startLoading(CachedResourceHandle<CachedImage>&);
     void stopLoading(CachedResourceHandle<CachedImage>&);
     void moveToDataTransfer(DataTransfer&);
 
 private:
     void imageChanged(CachedImage*, const IntRect*) override;
+
     WeakRef<DataTransfer> m_dataTransfer;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DragImageLoader);
@@ -554,12 +557,13 @@ void DataTransfer::setDragImage(Ref<Element>&& element, int x, int y)
 
     m_dragLocation = IntPoint(x, y);
 
+    Ref document = element->protectedDocument();
     if (m_dragImageLoader && m_dragImage)
         m_dragImageLoader->stopLoading(m_dragImage);
     m_dragImage = image;
     if (m_dragImage) {
         if (!m_dragImageLoader)
-            m_dragImageLoader = makeUnique<DragImageLoader>(*this);
+            m_dragImageLoader = makeUnique<DragImageLoader>(*this, document);
         m_dragImageLoader->startLoading(m_dragImage);
     }
 
@@ -568,10 +572,10 @@ void DataTransfer::setDragImage(Ref<Element>&& element, int x, int y)
     else
         m_dragImageElement = WTFMove(element);
 
-    updateDragImage();
+    updateDragImage(document.ptr());
 }
 
-void DataTransfer::updateDragImage()
+void DataTransfer::updateDragImage(const Document* document)
 {
     // Don't allow setting the image if we haven't started dragging yet; we'll rely on the dragging code
     // to install this drag image as part of getting the drag kicked off.
@@ -579,7 +583,7 @@ void DataTransfer::updateDragImage()
         return;
 
     IntPoint computedHotSpot;
-    auto computedImage = DragImage { createDragImage(computedHotSpot) };
+    auto computedImage = DragImage { createDragImage(document, computedHotSpot) };
     if (!computedImage)
         return;
 
@@ -593,12 +597,15 @@ RefPtr<Element> DataTransfer::dragImageElement() const
 
 #if !PLATFORM(MAC)
 
-DragImageRef DataTransfer::createDragImage(IntPoint& location) const
+DragImageRef DataTransfer::createDragImage(const Document* document, IntPoint& location) const
 {
     location = m_dragLocation;
 
-    if (m_dragImage)
-        return createDragImageFromImage(m_dragImage->protectedImage().get(), ImageOrientation::Orientation::None);
+    if (m_dragImage) {
+        HostWindow* hostWindow = document && document->view() ? document->view()->hostWindow() : nullptr;
+        auto deviceScaleFactor = document ? document->deviceScaleFactor() : 1.f;
+        return createDragImageFromImage(m_dragImage->protectedImage().get(), ImageOrientation::Orientation::None, hostWindow, deviceScaleFactor);
+    }
 
     if (m_dragImageElement) {
         if (RefPtr frame = m_dragImageElement->document().frame())
@@ -611,8 +618,9 @@ DragImageRef DataTransfer::createDragImage(IntPoint& location) const
 
 #endif
 
-DragImageLoader::DragImageLoader(DataTransfer& dataTransfer)
+DragImageLoader::DragImageLoader(DataTransfer& dataTransfer, const Document& document)
     : m_dataTransfer(dataTransfer)
+    , m_document { document }
 {
 }
 
@@ -634,7 +642,8 @@ void DragImageLoader::stopLoading(CachedResourceHandle<WebCore::CachedImage>& im
 
 void DragImageLoader::imageChanged(CachedImage*, const IntRect*)
 {
-    m_dataTransfer->updateDragImage();
+    RefPtr document = m_document.get();
+    m_dataTransfer->updateDragImage(document.get());
 }
 
 static OptionSet<DragOperation> dragOpFromIEOp(const String& operation)

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -104,8 +104,8 @@ public:
     void setDestinationOperationMask(OptionSet<DragOperation>);
 
     void setDragHasStarted() { m_shouldUpdateDragImage = true; }
-    DragImageRef createDragImage(IntPoint& dragLocation) const;
-    void updateDragImage();
+    DragImageRef createDragImage(const Document*, IntPoint& dragLocation) const;
+    void updateDragImage(const Document*);
     RefPtr<Element> dragImageElement() const;
 
     void moveDragState(Ref<DataTransfer>&&);

--- a/Source/WebCore/dom/DataTransferMac.mm
+++ b/Source/WebCore/dom/DataTransferMac.mm
@@ -39,7 +39,7 @@ namespace WebCore {
 // FIXME: Need to refactor and figure out how to handle the flipping in a more sensible way so we can
 // use the default DataTransfer::dragImage from DataTransfer.cpp. Note also that this handles cases that
 // DataTransfer::dragImage in DataTransfer.cpp does not handle correctly, so must resolve that as well.
-DragImageRef DataTransfer::createDragImage(IntPoint& location) const
+DragImageRef DataTransfer::createDragImage(const Document*, IntPoint& location) const
 {
     DragImageRef result = nil;
     if (m_dragImageElement) {

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -61,6 +61,7 @@
 #include "HTMLPlugInElement.h"
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
+#include "HostWindow.h"
 #include "Image.h"
 #include "ImageOrientation.h"
 #include "ImageOverlay.h"
@@ -1021,7 +1022,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 
     Ref dataTransfer = *state.dataTransfer;
     if (state.type == DragSourceAction::DHTML) {
-        dragImage = DragImage { dataTransfer->createDragImage(dragImageOffset) };
+        dragImage = DragImage { dataTransfer->createDragImage(src.protectedDocument().get(), dragImageOffset) };
         // We allow DHTML/JS to set the drag image, even if its a link, image or text we're dragging.
         // This is in the spirit of the IE API, which allows overriding of pasteboard data and DragOp.
         if (dragImage) {
@@ -1315,7 +1316,8 @@ void DragController::doImageDrag(Element& element, const IntPoint& dragOrigin, c
     ImageOrientation orientation = element.renderer()->imageOrientation();
 
     RefPtr image = getImage(element);
-    if (image && !layoutRect.isEmpty() && shouldUseCachedImageForDragImage(*image) && (dragImage = DragImage { createDragImageFromImage(image.get(), orientation) })) {
+    if (image && !layoutRect.isEmpty() && shouldUseCachedImageForDragImage(*image)
+        && (dragImage = DragImage { createDragImageFromImage(image.get(), orientation, frame.view() ? frame.view()->hostWindow() : nullptr, element.document().deviceScaleFactor()) })) {
         dragImage = DragImage { fitDragImageToMaxSize(dragImage.get(), layoutRect.size(), maxDragImageSize()) };
         IntSize fittedSize = dragImageSize(dragImage.get());
 

--- a/Source/WebCore/platform/DragImage.cpp
+++ b/Source/WebCore/platform/DragImage.cpp
@@ -305,7 +305,7 @@ DragImageRef dissolveDragImageToFraction(DragImageRef, float)
     return nullptr;
 }
 
-DragImageRef createDragImageFromImage(Image*, ImageOrientation)
+DragImageRef createDragImageFromImage(Image*, ImageOrientation, GraphicsClient*, float)
 {
     notImplemented();
     return nullptr;

--- a/Source/WebCore/platform/DragImage.h
+++ b/Source/WebCore/platform/DragImage.h
@@ -50,6 +50,7 @@ typedef struct HBITMAP__* HBITMAP;
 namespace WebCore {
 
 class Element;
+class GraphicsClient;
 class Image;
 class IntRect;
 class LocalFrame;
@@ -85,9 +86,10 @@ DragImageRef scaleDragImage(DragImageRef, FloatSize scale);
 DragImageRef platformAdjustDragImageForDeviceScaleFactor(DragImageRef, float deviceScaleFactor);
 DragImageRef dissolveDragImageToFraction(DragImageRef, float delta);
 
-DragImageRef createDragImageFromImage(Image*, ImageOrientation);
+DragImageRef createDragImageFromImage(Image*, ImageOrientation, GraphicsClient* = nullptr, float deviceScaleFactor = 1);
 DragImageRef createDragImageIconForCachedImageFilename(const String&);
 
+// FIXME: These platform helpers should be refactored to avoid using `LocalFrame` and `Node`.
 WEBCORE_EXPORT DragImageRef createDragImageForNode(LocalFrame&, Node&);
 WEBCORE_EXPORT DragImageRef createDragImageForSelection(LocalFrame&, TextIndicatorData&, bool forceBlackText = false);
 WEBCORE_EXPORT DragImageRef createDragImageForRange(LocalFrame&, const SimpleRange&, bool forceBlackText = false);

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -92,7 +92,7 @@ RetainPtr<NSImage> dissolveDragImageToFraction(RetainPtr<NSImage> image, float d
     return dissolvedImage;
 }
 
-RetainPtr<NSImage> createDragImageFromImage(Image* image, ImageOrientation orientation)
+RetainPtr<NSImage> createDragImageFromImage(Image* image, ImageOrientation orientation, GraphicsClient*, float)
 {
     if (auto* bitmapImage = dynamicDowncast<BitmapImage>(*image)) {
         if (orientation == ImageOrientation::Orientation::FromImage)

--- a/Source/WebCore/platform/gtk/DragImageGtk.cpp
+++ b/Source/WebCore/platform/gtk/DragImageGtk.cpp
@@ -131,7 +131,7 @@ DragImageRef dissolveDragImageToFraction(DragImageRef image, float fraction)
 #endif
 }
 
-DragImageRef createDragImageFromImage(Image* image, ImageOrientation)
+DragImageRef createDragImageFromImage(Image* image, ImageOrientation, GraphicsClient*, float)
 {
     return image->currentNativeImage()->platformImage();
 }

--- a/Source/WebCore/platform/win/DragImageWin.cpp
+++ b/Source/WebCore/platform/win/DragImageWin.cpp
@@ -221,7 +221,7 @@ DragImageRef createDragImageForColor(const Color&, const FloatRect&, float, Path
 }
 
 #if USE(SKIA)
-DragImageRef createDragImageFromImage(Image*, ImageOrientation)
+DragImageRef createDragImageFromImage(Image*, ImageOrientation, GraphicsClient*, float)
 {
     return nullptr;
 }

--- a/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
+++ b/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
@@ -141,7 +141,7 @@ DragImageRef scaleDragImage(DragImageRef imageRef, FloatSize scale)
     return hbmp.leak();
 }
 
-DragImageRef createDragImageFromImage(Image* img, ImageOrientation)
+DragImageRef createDragImageFromImage(Image* img, ImageOrientation, GraphicsClient*, float)
 {
     HWndDC dc(0);
     auto workingDC = adoptGDIObject(::CreateCompatibleDC(dc));


### PR DESCRIPTION
#### 75ce30b7aa9189dbf22f9fee5ae9d0a581e0dd84
<pre>
[visionOS] Web process hangs under createDragImageFor{Link|Selection} when starting a drag for the first time
<a href="https://bugs.webkit.org/show_bug.cgi?id=286819">https://bugs.webkit.org/show_bug.cgi?id=286819</a>
<a href="https://rdar.apple.com/141448897">rdar://141448897</a>

Reviewed by Abrar Rahman Protyasha.

On visionOS, when starting a drag for the first time on a webpage, we end up spending a large amount
of time underneath `+[UIScreen initialize]` within the web process, while trying to render the drag
image using the helpers in `DragImageIOS.mm` (which instantiate `UIGraphicsImageRenderer`). This
causes the web process to hang briefly, which in turn may cause the drag to fail entirely.

To mitigate this, we refactor these helpers such that they no longer rely (indirectly) on
instantiating `UIScreen` via `UIGraphicsImageRenderer`, and instead use `WebCore::ImageBuffer` and
`sinkIntoNativeImage`. See below for more details.

* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::setDragImage):
(WebCore::DataTransfer::updateDragImage):
(WebCore::DataTransfer::createDragImage const):
(WebCore::DragImageLoader::DragImageLoader):
(WebCore::DragImageLoader::imageChanged):
* Source/WebCore/dom/DataTransfer.h:
* Source/WebCore/dom/DataTransferMac.mm:
(WebCore::DataTransfer::createDragImage const):

Plumb the `Document` through here, so that we can get the `deviceScaleFactor` / `HostWindow` and
pass them through to `createDragImageFromImage`.

* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::startDrag):
(WebCore::DragController::doImageDrag):

Pass the device scale factor and host window into `createDragImageFromImage`.

* Source/WebCore/platform/DragImage.cpp:
(WebCore::createDragImageFromImage):
* Source/WebCore/platform/DragImage.h:
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::createDragImageFromImage):
* Source/WebCore/platform/gtk/DragImageGtk.cpp:
(WebCore::createDragImageFromImage):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::scaleDragImage):

Make this helper function a no-op. This logic was actually unnecessary from the start, since the
drag image will always perform lift and cancel animations using targeted previews which scale to fit
the bounds of the dragged element. As such, there&apos;s no need to artificially clamp the drag image to
an arbitrary maximum size of 400x400.

(WebCore::createDragImageFromImage):

Make this take both a device scale factor and `HostWindow`, which allows us to create a new
`ImageBuffer`, paint the given image into the buffer (scaling down if needed), and finally extract
a native image from the image buffer. This avoids the need for `UIGraphicsImageRenderer` entirely.

(WebCore::deleteDragImage):
(WebCore::cgImageFromTextIndicator):
(WebCore::createDragImageForLink):

Remove logic for creating a drag image representing a link (URL) platter. This has been unnecessary
ever since we (1) adopted `+[UIDragPreview previewForURL:title:]`, and (2) use text indicator for
the lift preview. Instead, just return the content image of the text indicator here.

(WebCore::createDragImageForSelection):

Adjust these helper methods, so that they simply return the content image of the text indicator.
Note that we just use the text indicator itself for the targeted preview anyways, so this image is
effectively unused. In a future patch, we should refactor `DragController` to not bail if the drag
image&apos;s `image` is `nullptr` (but the `DragImage` is instead backed by a `TextIndicator`), which
would allow us to avoid some of this extra work.

(WebCore::cascadeForSystemFont): Deleted.
* Source/WebCore/platform/win/DragImageWin.cpp:
(WebCore::createDragImageFromImage):
* Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp:
(WebCore::createDragImageFromImage):

Canonical link: <a href="https://commits.webkit.org/289740@main">https://commits.webkit.org/289740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6270ff4705120be33abed896b926bfbde2b4ad1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67755 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25503 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48124 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5631 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33806 "Found 3 new test failures: editing/undo/redo-reapply-edit-command-crash.html fullscreen/element-clear-during-fullscreen-crash.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37615 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14926 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10967 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76605 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75841 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18666 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7914 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20245 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18130 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->