### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ASCIIFastPath.h

### DIFF
--- a/Source/WTF/wtf/text/ParsingUtilities.h
+++ b/Source/WTF/wtf/text/ParsingUtilities.h
@@ -42,31 +42,6 @@ template<typename CharacterType> inline bool isNotASCIISpace(CharacterType c)
     return !isUnicodeCompatibleASCIIWhitespace(c);
 }
 
-template<typename T> void skip(std::span<T>& data, size_t amountToSkip)
-{
-    data = data.subspan(amountToSkip);
-}
-
-template<typename T> void dropLast(std::span<T>& data, size_t amountToDrop = 1)
-{
-    data = data.first(data.size() - amountToDrop);
-}
-
-template<typename T> T& consumeLast(std::span<T>& data)
-{
-    auto* last = &data.back();
-    data = data.first(data.size() - 1);
-    return *last;
-}
-
-template<typename T> void clampedMoveCursorWithinSpan(std::span<T>& cursor, std::span<T> container, int delta)
-{
-    ASSERT(cursor.data() >= container.data());
-    ASSERT(std::to_address(cursor.end()) == std::to_address(container.end()));
-    auto clampedNewIndex = std::clamp<int>(cursor.data() - container.data() + delta, 0, container.size());
-    cursor = container.subspan(clampedNewIndex);
-}
-
 template<typename CharacterType, typename DelimiterType> bool skipExactly(const CharacterType*& position, const CharacterType* end, DelimiterType delimiter)
 {
     if (position < end && *position == delimiter) {
@@ -265,26 +240,6 @@ template<typename CharacterType, std::size_t Extent> constexpr bool skipCharacte
     return true;
 }
 
-template<typename T> std::span<T> consumeSpan(std::span<T>& data, size_t amountToConsume)
-{
-    auto consumed = data.first(amountToConsume);
-    skip(data, amountToConsume);
-    return consumed;
-}
-
-template<typename T> T& consume(std::span<T>& data)
-{
-    T& value = data[0];
-    skip(data, 1);
-    return value;
-}
-
-template<typename DestinationType, typename SourceType>
-match_constness_t<SourceType, DestinationType>& consumeAndCastTo(std::span<SourceType>& data) requires(sizeof(SourceType) == 1)
-{
-    return spanReinterpretCast<match_constness_t<SourceType, DestinationType>>(consumeSpan(data, sizeof(DestinationType)))[0];
-}
-
 // Adapt a UChar-predicate to an LChar-predicate.
 template<bool characterPredicate(UChar)>
 static inline bool LCharPredicateAdapter(LChar c) { return characterPredicate(c); }
@@ -292,14 +247,7 @@ static inline bool LCharPredicateAdapter(LChar c) { return characterPredicate(c)
 } // namespace WTF
 
 using WTF::LCharPredicateAdapter;
-using WTF::clampedMoveCursorWithinSpan;
-using WTF::consume;
-using WTF::consumeAndCastTo;
-using WTF::consumeLast;
-using WTF::consumeSpan;
-using WTF::dropLast;
 using WTF::isNotASCIISpace;
-using WTF::skip;
 using WTF::skipCharactersExactly;
 using WTF::skipExactly;
 using WTF::skipExactlyIgnoringASCIICase;

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -216,7 +216,7 @@ template <typename T> static bool readLittleEndian(std::span<const uint8_t>& dat
     if (data.size() < sizeof(value))
         return false;
 
-    value = consumeAndCastTo<const T>(data);
+    value = consumeAndReinterpretCastTo<const T>(data);
     return true;
 }
 #endif

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3387,7 +3387,7 @@ private:
         if (span.size() < sizeof(value))
             return false;
 
-        value = consumeAndCastTo<const T>(span);
+        value = consumeAndReinterpretCastTo<const T>(span);
         return true;
     }
 #else


### PR DESCRIPTION
#### b6a54b0c5d2809cf80f213f9f736bcbd8fc56cf5
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ASCIIFastPath.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=286878">https://bugs.webkit.org/show_bug.cgi?id=286878</a>

Reviewed by Geoffrey Garen.

This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::skip):
(WTF::dropLast):
(WTF::consumeLast):
(WTF::clampedMoveCursorWithinSpan):
(WTF::consumeSpan):
(WTF::consume):
(WTF::requires):
* Source/WTF/wtf/text/ASCIIFastPath.h:
(WTF::charactersAreAllASCII):
(WTF::charactersAreAllLatin1):
* Source/WTF/wtf/text/ParsingUtilities.h:
(WTF::skip): Deleted.
(WTF::dropLast): Deleted.
(WTF::consumeLast): Deleted.
(WTF::clampedMoveCursorWithinSpan): Deleted.
(WTF::consumeSpan): Deleted.
(WTF::consume): Deleted.

Canonical link: <a href="https://commits.webkit.org/289707@main">https://commits.webkit.org/289707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae9a80b7ac7cea23ca77fc4a74a45147b61b6f98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15440 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90755 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/5840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79396 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5627 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37610 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80551 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94504 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86528 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10962 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75252 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18649 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18635 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7907 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14937 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109022 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14681 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26217 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->