### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/webpushd/webpushtool

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */; };
 		46B0FB5D2D24BFBA0012184C /* ParsingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		46B4C53C2D4F2D0A00BAA3FE /* NSStringExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
 		46BEB6EB22FFE24900269868 /* RefTrackerMixin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */; };
 		46CEA3FA2CC2D39B00FE325C /* SpanCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */; };
@@ -1245,6 +1246,7 @@
 		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
 		467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnicodeExtras.cpp; sourceTree = "<group>"; };
 		46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParsingUtilities.h; sourceTree = "<group>"; };
+		46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSStringExtras.h; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269867 /* RefCounted.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefCounted.cpp; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefTrackerMixin.cpp; sourceTree = "<group>"; };
@@ -3170,6 +3172,7 @@
 				A8A472C5151A825A004123FF /* MainThreadCocoa.mm */,
 				ADF2CE651E39F106006889DB /* MemoryFootprintCocoa.cpp */,
 				AD89B6B91E64150F0090707F /* MemoryPressureHandlerCocoa.mm */,
+				46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */,
 				5CC0EE872162BC2200A1A842 /* NSURLExtras.h */,
 				5CC0EE882162BC2200A1A842 /* NSURLExtras.mm */,
 				E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */,
@@ -3490,6 +3493,7 @@
 				DD3DC89527A4BF8E007E5B61 /* NotFound.h in Headers */,
 				DDF306E327C08654006A526F /* NSLocaleSPI.h in Headers */,
 				DDF306E227C08654006A526F /* NSObjCRuntimeSPI.h in Headers */,
+				46B4C53C2D4F2D0A00BAA3FE /* NSStringExtras.h in Headers */,
 				DDF3070E27C086CC006A526F /* NSURLExtras.h in Headers */,
 				DDF307D627C086DF006A526F /* NullTextBreakIterator.h in Headers */,
 				DD3DC86C27A4BF8E007E5B61 /* NumberOfCores.h in Headers */,

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1154,8 +1154,8 @@ template <class T> inline typename std::enable_if<std::is_pointer<T>::value, T>:
 
 #define SAFE_PRINTF_TYPE(...) WTF_FOR_EACH(WTF::safePrintfType, __VA_ARGS__)
 
-#define SAFE_PRINTF(format, ...) printf(format, SAFE_PRINTF_TYPE(__VA_ARGS__))
-#define SAFE_FPRINTF(file, format, ...) fprintf(file, format, SAFE_PRINTF_TYPE(__VA_ARGS__))
+#define SAFE_PRINTF(format, ...) printf(format __VA_OPT__(, SAFE_PRINTF_TYPE(__VA_ARGS__)))
+#define SAFE_FPRINTF(file, format, ...) fprintf(file, format __VA_OPT__(, SAFE_PRINTF_TYPE(__VA_ARGS__)))
 #define SAFE_SPRINTF(destinationSpan, format, ...) snprintf(destinationSpan.data(), destinationSpan.size_bytes(), format, SAFE_PRINTF_TYPE(__VA_ARGS__))
 
 template<typename T> concept ByteType = sizeof(T) == 1 && ((std::is_integral_v<T> && !std::same_as<T, bool>) || std::same_as<T, std::byte>) && !std::is_const_v<T>;

--- a/Source/WTF/wtf/cocoa/NSStringExtras.h
+++ b/Source/WTF/wtf/cocoa/NSStringExtras.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+inline const char* safePrintfType(NSString *string) { return string.UTF8String; }
+
+}

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -132,12 +132,10 @@ void Connection::sendAuditToken()
     audit_token_t token = { 0, 0, 0, 0, 0, 0, 0, 0 };
     mach_msg_type_number_t auditTokenCount = TASK_AUDIT_TOKEN_COUNT;
     kern_return_t result = task_info(mach_task_self(), TASK_AUDIT_TOKEN, (task_info_t)(&token), &auditTokenCount);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     if (result != KERN_SUCCESS) {
-        printf("Unable to get audit token to send\n");
+        SAFE_PRINTF("Unable to get audit token to send\n");
         return;
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     WebKit::WebPushD::WebPushDaemonConnectionConfiguration configuration;
     configuration.bundleIdentifierOverride = m_bundleIdentifier;

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -30,52 +30,50 @@
 #import "WebPushToolConnection.h"
 #import <optional>
 #import <wtf/MainThread.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WTFProcess.h>
+#import <wtf/cocoa/NSStringExtras.h>
 
 #if HAVE(OS_LAUNCHD_JOB) && (PLATFORM(MAC) || PLATFORM(IOS))
 
 using WebKit::WebPushD::PushMessageForTesting;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 __attribute__((__noreturn__))
 static void printUsageAndTerminate(NSString *message)
 {
-    fprintf(stderr, "%s\n\n", message.UTF8String);
+    SAFE_FPRINTF(stderr, "%s\n\n", message);
 
-    fprintf(stderr, "Usage: webpushtool [options] verb [verb_args]\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "options is one or more of:\n");
-    fprintf(stderr, "  --development\n");
-    fprintf(stderr, "    Connects to mach service \"org.webkit.webpushtestdaemon.service\" (Default)\n");
-    fprintf(stderr, "  --production\n");
-    fprintf(stderr, "    Connects to mach service \"com.apple.webkit.webpushd.service\"\n");
-    fprintf(stderr, "  --bundleIdentifier <bundleIdentifier>\n");
-    fprintf(stderr, "    Sets connection config to use bundle identifier <bundleIdentifier>.\n");
-    fprintf(stderr, "  --pushPartition <partition>\n");
-    fprintf(stderr, "    Sets connection config to use push partition <partition>.\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "verb is one of:\n");
+    SAFE_FPRINTF(stderr, "Usage: webpushtool [options] verb [verb_args]\n");
+    SAFE_FPRINTF(stderr, "\n");
+    SAFE_FPRINTF(stderr, "options is one or more of:\n");
+    SAFE_FPRINTF(stderr, "  --development\n");
+    SAFE_FPRINTF(stderr, "    Connects to mach service \"org.webkit.webpushtestdaemon.service\" (Default)\n");
+    SAFE_FPRINTF(stderr, "  --production\n");
+    SAFE_FPRINTF(stderr, "    Connects to mach service \"com.apple.webkit.webpushd.service\"\n");
+    SAFE_FPRINTF(stderr, "  --bundleIdentifier <bundleIdentifier>\n");
+    SAFE_FPRINTF(stderr, "    Sets connection config to use bundle identifier <bundleIdentifier>.\n");
+    SAFE_FPRINTF(stderr, "  --pushPartition <partition>\n");
+    SAFE_FPRINTF(stderr, "    Sets connection config to use push partition <partition>.\n");
+    SAFE_FPRINTF(stderr, "\n");
+    SAFE_FPRINTF(stderr, "verb is one of:\n");
 #if HAVE(OS_LAUNCHD_JOB)
-    fprintf(stderr, "  host\n");
-    fprintf(stderr, "    Dynamically registers the service with launchd so it is visible to other applications\n");
-    fprintf(stderr, "    The service name of the registration depends on either the --development or --production option chosen\n");
+    SAFE_FPRINTF(stderr, "  host\n");
+    SAFE_FPRINTF(stderr, "    Dynamically registers the service with launchd so it is visible to other applications\n");
+    SAFE_FPRINTF(stderr, "    The service name of the registration depends on either the --development or --production option chosen\n");
 #endif
-    fprintf(stderr, "  streamDebugMessages\n");
-    fprintf(stderr, "    Stream debug messages from webpushd\n");
-    fprintf(stderr, "  injectPushMessage <scope URL> <message>\n");
-    fprintf(stderr, "    Inject a test push message <message> to the provided --bundleIdentifier and --pushPartition with service worker scope <scope URL>\n");
-    fprintf(stderr, "  getPushPermissionState <scope URL>\n");
-    fprintf(stderr, "    Gets the permission state for the given service worker scope.\n");
-    fprintf(stderr, "  requestPushPermission <scope URL>\n");
-    fprintf(stderr, "    Requests permission state for the given service worker scope.\n");
-    fprintf(stderr, "\n");
+    SAFE_FPRINTF(stderr, "  streamDebugMessages\n");
+    SAFE_FPRINTF(stderr, "    Stream debug messages from webpushd\n");
+    SAFE_FPRINTF(stderr, "  injectPushMessage <scope URL> <message>\n");
+    SAFE_FPRINTF(stderr, "    Inject a test push message <message> to the provided --bundleIdentifier and --pushPartition with service worker scope <scope URL>\n");
+    SAFE_FPRINTF(stderr, "  getPushPermissionState <scope URL>\n");
+    SAFE_FPRINTF(stderr, "    Gets the permission state for the given service worker scope.\n");
+    SAFE_FPRINTF(stderr, "  requestPushPermission <scope URL>\n");
+    SAFE_FPRINTF(stderr, "    Requests permission state for the given service worker scope.\n");
+    SAFE_FPRINTF(stderr, "\n");
 
     exitProcess(-1);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static std::unique_ptr<PushMessageForTesting> pushMessageFromArguments(NSEnumerator<NSString *> *enumerator)
 {
@@ -178,15 +176,13 @@ public:
         pushMessage.targetAppCodeSigningIdentifier = connection.bundleIdentifier();
         pushMessage.pushPartitionString = connection.pushPartition();
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         connection.sendPushMessage(WTFMove(pushMessage), [this, bundleIdentifier = connection.bundleIdentifier(), webClipIdentifier = connection.pushPartition()](String error) mutable {
             if (error.isEmpty())
-                printf("Successfully injected push message %s for [bundleID = %s, webClipIdentifier = %s, scope = %s]\n", m_pushMessage.payload.utf8().data(), bundleIdentifier.utf8().data(), webClipIdentifier.utf8().data(), m_pushMessage.registrationURL.string().utf8().data());
+                SAFE_PRINTF("Successfully injected push message %s for [bundleID = %s, webClipIdentifier = %s, scope = %s]\n", m_pushMessage.payload.utf8(), bundleIdentifier.utf8(), webClipIdentifier.utf8(), m_pushMessage.registrationURL.string().utf8());
             else
-                printf("Injected push message with error: %s\n", error.utf8().data());
+                SAFE_PRINTF("Injected push message with error: %s\n", error.utf8());
             done();
         });
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
 private:


### PR DESCRIPTION
#### e6d184dc1aaa1b74bf09137c0b228f008a18ad49
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebKit/webpushd/webpushtool
<a href="https://bugs.webkit.org/show_bug.cgi?id=286879">https://bugs.webkit.org/show_bug.cgi?id=286879</a>

Reviewed by Geoffrey Garen.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/StdLibExtras.h:
Make SAFE_PRINTF macros work even when there are not parameters, due to
the format string not having any formatters.

* Source/WTF/wtf/cocoa/NSStringExtras.h: Added.
(WTF::safePrintfType):
Allow passing a `NSString *` to SAFE_PRINTF macros.

* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::sendAuditToken):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(printUsageAndTerminate):
Adopt SAFE_PRINTF macros.

Canonical link: <a href="https://commits.webkit.org/289705@main">https://commits.webkit.org/289705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b8eaaffbc28bebefe88c4e6c640ffdf9bfbe6f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87739 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38488 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67739 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25486 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5614 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33787 "Found 3 new test failures: editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37596 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80537 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94490 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86514 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14907 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10944 "Found 1 new test failure: ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76591 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75826 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7887 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13681 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14923 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20226 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109008 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14667 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26211 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->