### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebPageProxyMac.mm

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -169,6 +169,9 @@ WTF_EXPORT_PRIVATE int overwriteEntireFile(const String& path, std::span<const u
 // Prefix is what the filename should be prefixed with, not the full path.
 WTF_EXPORT_PRIVATE std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, StringView suffix = { });
 WTF_EXPORT_PRIVATE String createTemporaryFile(StringView prefix, StringView suffix = { });
+#if PLATFORM(COCOA)
+WTF_EXPORT_PRIVATE std::pair<PlatformFileHandle, CString> createTemporaryFileInDirectory(const String& directory, const String& suffix);
+#endif
 WTF_EXPORT_PRIVATE PlatformFileHandle openFile(const String& path, FileOpenMode, FileAccessPermission = FileAccessPermission::All, bool failIfFileExists = false);
 WTF_EXPORT_PRIVATE void closeFile(PlatformFileHandle&);
 // Returns the resulting offset from the beginning of the file if successful, -1 otherwise.

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -186,6 +186,15 @@ NSString *createTemporaryDirectory(NSString *directoryPrefix)
     return [[NSFileManager defaultManager] stringWithFileSystemRepresentation:path.data() length:length];
 }
 
+std::pair<PlatformFileHandle, CString> createTemporaryFileInDirectory(const String& directory, const String& suffix)
+{
+    auto fsSuffix = fileSystemRepresentation(suffix);
+    auto templatePath = pathByAppendingComponents(directory, { StringView { "XXXXXX"_s }, StringView { suffix } });
+    auto fsTemplatePath = fileSystemRepresentation(templatePath);
+    int fd = mkstemps(fsTemplatePath.mutableSpanIncludingNullTerminator().data(), fsSuffix.length());
+    return { fd, WTFMove(fsTemplatePath) };
+}
+
 #ifdef IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES
 static int toIOPolicyScope(PolicyScope scope)
 {


### PR DESCRIPTION
#### 1e0659534b435300efb8da173e0c6a79db7adf96
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebPageProxyMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=286880">https://bugs.webkit.org/show_bug.cgi?id=286880</a>

Reviewed by Brady Eidson.

* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::createTemporaryFileInDirectory):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::pathToPDFOnDisk):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView _path]):

Canonical link: <a href="https://commits.webkit.org/289718@main">https://commits.webkit.org/289718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08169f314e551121f45b6d3c95c82edb890fa4cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38491 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67741 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25488 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48112 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33789 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37598 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80539 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94492 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86516 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76593 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18626 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7891 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20228 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109010 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14669 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26213 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->