### PR TITLE
[JSC] `AsyncFromSyncIterator` should close its sync-iterator when `throw` is null or undefined

### DIFF
--- a/JSTests/stress/async-from-sync-iterator-prototype-throw-close-sync-iter.js
+++ b/JSTests/stress/async-from-sync-iterator-prototype-throw-close-sync-iter.js
@@ -1,0 +1,180 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+
+function shouldThrowAsync(run, errorType, message) {
+    let actual;
+    var hadError = false;
+    run().then(function(value) { actual = value; },
+               function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    if (message !== void 0 && actual.message !== message)
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+}
+
+{
+    // When sync-iterator's `throw` is null, `AsyncFromSyncIterator#throw` throws TypeError
+    let calledReturn = 0;
+    let calledThrowGetter = 0;
+
+    const syncIterator = {
+        [Symbol.iterator]() {
+            return this;
+        },
+        next() {
+          return {value: 1, done: false};
+        },
+        return() {
+            calledReturn++;
+            return { done: true, value: 1 };
+        },
+        get throw() {
+            calledThrowGetter++;
+            return null;
+        }
+    };
+
+    const asyncIterator = (async function* () {
+        yield* syncIterator;
+    })();
+
+    function OurError() {}
+
+    asyncIterator.next();
+    drainMicrotasks();
+
+    shouldThrowAsync(async () => {
+        await asyncIterator.throw(new OurError());
+    }, TypeError);
+    drainMicrotasks();
+
+    shouldBe(calledReturn, 1);
+    shouldBe(calledThrowGetter, 1);
+}
+
+{
+    // When sync-iterator's `throw` is undefined, `AsyncFromSyncIterator#throw` throws TypeError
+    let calledReturn = 0;
+    let calledThrowGetter = 0;
+
+    const syncIterator = {
+        [Symbol.iterator]() {
+            return this;
+        },
+        next() {
+          return {value: 1, done: false};
+        },
+        return() {
+            calledReturn++;
+            return { done: true, value: 1 };
+        },
+        get throw() {
+            calledThrowGetter++;
+            return undefined;
+        }
+    };
+
+    const asyncIterator = (async function* () {
+        yield* syncIterator;
+    })();
+
+    function OurError() {}
+
+    asyncIterator.next();
+    drainMicrotasks();
+
+    shouldThrowAsync(async () => {
+        await asyncIterator.throw(new OurError());
+    }, TypeError);
+    drainMicrotasks();
+
+    shouldBe(calledReturn, 1);
+    shouldBe(calledThrowGetter, 1);
+}
+
+{
+    // When sync-iterators' `return` getter throws an error, `AsyncFromSyncIterator#throw` throw the error.
+    let calledReturnGetter = 0;
+    let calledThrowGetter = 0;
+
+    function OurError() {}
+    function NotOurError() {}
+
+    const syncIterator = {
+        [Symbol.iterator]() {
+            return this;
+        },
+        next() {
+          return {value: 1, done: false};
+        },
+        get return() {
+            calledReturnGetter++;
+            throw new OurError();
+        },
+        get throw() {
+            calledThrowGetter++;
+            return undefined;
+        }
+    };
+
+    const asyncIterator = (async function* () {
+        yield* syncIterator;
+    })();
+
+    asyncIterator.next();
+    drainMicrotasks();
+
+    shouldThrowAsync(async () => {
+        await asyncIterator.throw(new NotOurError());
+    }, OurError);
+    drainMicrotasks();
+
+    shouldBe(calledReturnGetter, 1);
+    shouldBe(calledThrowGetter, 1);
+}
+
+{
+    // When sync-iterator's `return` returns non-object, `AsyncFromSyncIterator#throw` throw TypeError.
+    let calledReturn = 0;
+    let calledThrowGetter = 0;
+
+    const syncIterator = {
+        [Symbol.iterator]() {
+            return this;
+        },
+        next() {
+          return { value: 1, done: false };
+        },
+        return() {
+            calledReturn++;
+            return 2;
+        },
+        get throw() {
+            calledThrowGetter++;
+            return null;
+        }
+    };
+
+    const asyncIterator = (async function* () {
+        yield* syncIterator;
+    })();
+
+    function OurError() {}
+
+    asyncIterator.next();
+    drainMicrotasks();
+
+    shouldThrowAsync(async () => {
+        await asyncIterator.throw(new OurError());
+    }, TypeError);
+    drainMicrotasks();
+
+    shouldBe(calledReturn, 1);
+    shouldBe(calledThrowGetter, 1);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -22,27 +22,9 @@ test/built-ins/AsyncFromSyncIteratorPrototype/next/yield-next-rejected-promise-c
 test/built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-rejected-promise-close.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but got a Object'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but got a Object'
 test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-result-poisoned-wrapper.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-poisoned-return.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a CatchError to be thrown asynchronously but thrown value was not an object'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a CatchError to be thrown asynchronously but thrown value was not an object'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Promise should be rejected Expected a TypeError to be thrown asynchronously but thrown value was not an object'
 test/built-ins/Date/prototype/setHours/date-value-read-before-tonumber-when-date-is-invalid.js:
   default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
   strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'

--- a/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js
@@ -146,7 +146,19 @@ function throw(exception)
     }
 
     if (@isUndefinedOrNull(throwMethod)) {
-        @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, exception);
+        var returnMethod;
+        try {
+            returnMethod = syncIterator.return;
+        } catch (e) {
+            @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
+            return promise;
+        }
+        var returnResult = returnMethod.@call(syncIterator);
+        if (!@isObject(returnResult)) {
+            @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @makeTypeError('Iterator result interface is not an object.'));
+            return promise;
+        }
+        @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, @makeTypeError('Iterator does not provide a throw method.'));
         return promise;
     }
     


### PR DESCRIPTION
#### 72c371adc8fe1744446197b6b816e538a83ef676
<pre>
[JSC] `AsyncFromSyncIterator` should close its sync-iterator when `throw` is null or undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=286885">https://bugs.webkit.org/show_bug.cgi?id=286885</a>

Reviewed by Yusuke Suzuki.

The normative change for `AsyncFromSyncIterator`[1] includes the following two changes:

1. AsyncFromSyncIterator now closes the sync iterator when `throw` is called on the
wrapper but is not implemented on the sync iterator. In that case, it updates the
rejection value to a `TypeError` to reflect the contract violation.
2. AsyncFromSyncIterator closes its sync iterator when the sync iterator yields a
rejected promise as its value.

This normative change has already been implemented in V8[2]. This patch changes to
implement only the first change.

[1]: <a href="https://github.com/tc39/ecma262/pull/2600">https://github.com/tc39/ecma262/pull/2600</a>
[2]: <a href="https://github.com/v8/v8/commit/6c3f7aa4c76af4c3e0c89c5c279f2b98867c35f0#diff-c18e5d5743326f6ba544801f6ce25154b785f759885651f98924d5b56dc1c2e6">https://github.com/v8/v8/commit/6c3f7aa4c76af4c3e0c89c5c279f2b98867c35f0#diff-c18e5d5743326f6ba544801f6ce25154b785f759885651f98924d5b56dc1c2e6</a>

* JSTests/stress/async-from-sync-iterator-prototype-throw-close-sync-iter.js: Added.
(shouldBe):
(shouldThrowAsync):
(throw.new.Error.const.syncIterator.get throw):
(throw.new.Error.const.asyncIterator):
(throw.new.Error.async OurError):
(throw.new.Error):
(const.syncIterator.get throw):
(throw.new.Error.async drainMicrotasks):
(const.asyncIterator):
(async OurError):
(OurError):
(NotOurError):
(const.syncIterator.get return):
(async drainMicrotasks):
(async asyncIterator):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js:
(throw):

Canonical link: <a href="https://commits.webkit.org/289726@main">https://commits.webkit.org/289726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6224ecd0bdd7cbdcda2ff728862a1f1277c119a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67747 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25493 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33797 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37604 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80545 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94498 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86522 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76597 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75832 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20198 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7897 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14931 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20234 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109016 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14675 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26214 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->