### PR TITLE
Further reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE in /WebKit/

### DIFF
--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -133,6 +133,20 @@ bool operator==(const CString& a, const CString& b)
     return equal(a.span().data(), b.span());
 }
 
+bool operator==(const CString& a, ASCIILiteral b)
+{
+    if (a.isNull() != b.isNull())
+        return false;
+    if (a.length() != b.length())
+        return false;
+    return equal(a.span().data(), b.span8());
+}
+
+bool operator!=(const CString& a, ASCIILiteral b)
+{
+    return !(a == b);
+}
+
 unsigned CString::hash() const
 {
     if (isNull())

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -66,7 +66,7 @@ class CString final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     CString() { }
-    WTF_EXPORT_PRIVATE CString(const char*);
+    WTF_EXPORT_PRIVATE CString(const char*); // FIXME: Remove this constructor and replace callers with unsafeMakeCString(char*).
     WTF_EXPORT_PRIVATE CString(std::span<const char>);
     CString(std::span<const LChar>);
     CString(std::span<const char8_t> characters) : CString(byteCast<LChar>(characters)) { }
@@ -105,6 +105,9 @@ private:
 
 WTF_EXPORT_PRIVATE bool operator==(const CString&, const CString&);
 WTF_EXPORT_PRIVATE bool operator<(const CString&, const CString&);
+
+WTF_EXPORT_PRIVATE bool operator==(const CString&, ASCIILiteral);
+WTF_EXPORT_PRIVATE bool operator!=(const CString&, ASCIILiteral);
 
 struct CStringHash {
     static unsigned hash(const CString& string) { return string.hash(); }
@@ -147,9 +150,16 @@ inline size_t CString::length() const
     return m_buffer ? m_buffer->length() : 0;
 }
 
+// Caller must ensure the argument is null terminated
+inline CString unsafeMakeCString(const char* nullTerminated)
+{
+    return nullTerminated;
+}
+
 // CString is null terminated
 inline const char* safePrintfType(const CString& cstring) { return cstring.data(); }
 
 } // namespace WTF
 
 using WTF::CString;
+using WTF::unsafeMakeCString;

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -162,7 +162,7 @@ void TextCodecICU::createICUConverter() const
     if (cachedConverter) {
         UErrorCode error = U_ZERO_ERROR;
         const char* cachedConverterName = ucnv_getName(cachedConverter.get(), &error);
-        if (U_SUCCESS(error) && m_canonicalConverterName == cachedConverterName) {
+        if (U_SUCCESS(error) && m_canonicalConverterName.characters() == cachedConverterName) {
             m_converter = WTFMove(cachedConverter);
             return;
         }

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.h
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.h
@@ -36,7 +36,7 @@ class Encoder;
 
 namespace WebKit {
 
-void startListeningForMachServiceConnections(const char* serviceName, ASCIILiteral entitlement, void(*connectionAdded)(xpc_connection_t), void(*connectionRemoved)(xpc_connection_t), void(*eventHandler)(xpc_object_t));
+void startListeningForMachServiceConnections(const CString& serviceName, ASCIILiteral entitlement, void(*connectionAdded)(xpc_connection_t), void(*connectionRemoved)(xpc_connection_t), void(*eventHandler)(xpc_object_t));
 RetainPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
 OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
@@ -271,5 +271,5 @@ gchar* webkit_security_origin_to_string(WebKitSecurityOrigin* origin)
     g_return_val_if_fail(origin, nullptr);
 
     CString cstring = origin->securityOriginData.toString().utf8();
-    return cstring == "null" || cstring == "" ? nullptr : g_strdup (cstring.data());
+    return cstring == "null"_s || cstring == ""_s ? nullptr : g_strdup (cstring.data());
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -764,49 +764,49 @@ TEST(WTF_Vector, RemoveAll)
     Vector<CString> vExpected;
     Vector<CString> v2;
     EXPECT_TRUE(v2.isEmpty());
-    EXPECT_FALSE(v2.removeAll("1"));
+    EXPECT_FALSE(v2.removeAll("1"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2.fill("1", 10);
     EXPECT_EQ(10U, v2.size());
-    EXPECT_EQ(10U, v2.removeAll("1"));
+    EXPECT_EQ(10U, v2.removeAll("1"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2.fill("2", 10);
     EXPECT_EQ(10U, v2.size());
-    EXPECT_EQ(0U, v2.removeAll("1"));
+    EXPECT_EQ(0U, v2.removeAll("1"_s));
     EXPECT_EQ(10U, v2.size());
 
     v2 = {"1", "2", "1", "2", "1", "2", "2", "1", "1", "1"};
     EXPECT_EQ(10U, v2.size());
-    EXPECT_EQ(6U, v2.removeAll("1"));
+    EXPECT_EQ(6U, v2.removeAll("1"_s));
     EXPECT_EQ(4U, v2.size());
-    EXPECT_TRUE(v2.find("1") == notFound);
-    EXPECT_EQ(4U, v2.removeAll("2"));
+    EXPECT_TRUE(v2.find("1"_s) == notFound);
+    EXPECT_EQ(4U, v2.removeAll("2"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2 = {"3", "1", "2", "1", "2", "1", "2", "2", "1", "1", "1", "3"};
     EXPECT_EQ(12U, v2.size());
-    EXPECT_EQ(6U, v2.removeAll("1"));
+    EXPECT_EQ(6U, v2.removeAll("1"_s));
     EXPECT_EQ(6U, v2.size());
-    EXPECT_TRUE(v2.find("1") == notFound);
+    EXPECT_TRUE(v2.find("1"_s) == notFound);
     vExpected = {"3", "2", "2", "2", "2", "3"};
     EXPECT_TRUE(v2 == vExpected);
 
-    EXPECT_EQ(4U, v2.removeAll("2"));
+    EXPECT_EQ(4U, v2.removeAll("2"_s));
     EXPECT_EQ(2U, v2.size());
-    EXPECT_TRUE(v2.find("2") == notFound);
+    EXPECT_TRUE(v2.find("2"_s) == notFound);
     vExpected = {"3", "3"};
     EXPECT_TRUE(v2 == vExpected);
 
-    EXPECT_EQ(2U, v2.removeAll("3"));
+    EXPECT_EQ(2U, v2.removeAll("3"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2 = {"1", "1", "1", "3", "2", "4", "2", "2", "2", "4", "4", "3"};
     EXPECT_EQ(12U, v2.size());
-    EXPECT_EQ(3U, v2.removeAll("1"));
+    EXPECT_EQ(3U, v2.removeAll("1"_s));
     EXPECT_EQ(9U, v2.size());
-    EXPECT_TRUE(v2.find("1") == notFound);
+    EXPECT_TRUE(v2.find("1"_s) == notFound);
     vExpected = {"3", "2", "4", "2", "2", "2", "4", "4", "3"};
     EXPECT_TRUE(v2 == vExpected);
 }


### PR DESCRIPTION
#### 908f2733fc462a12c960a7b90b42de73bf1dde32
<pre>
Further reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE in /WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=286887">https://bugs.webkit.org/show_bug.cgi?id=286887</a>
<a href="https://rdar.apple.com/144050406">rdar://144050406</a>

Reviewed by NOBODY (OOPS!).

Burn down some of the WTF_ALLOW_UNSAFE_BUFFER_USAGE we added back when we
started applying -Wunsafe-buffer-usage-in-libc-call.

* Source/WTF/wtf/text/CString.cpp:
(WTF::operator==):
(WTF::operator!=): Offer comparison against ASCIILiteral so we can compare
null-terminated strings without allocating.

* Source/WTF/wtf/text/CString.h:
(WTF::unsafeMakeCString): New helper function, like unsafeMakeSpan, to call out
the fact that the caller must attest to null termination (like the
unsafeMakeSpan caller must attest to having the right length).

* Source/WebKit/Shared/Daemon/DaemonUtilities.h: const char* =&gt; const CString&amp;.

In a future patch, we might need to add an CStringView type to avoid allocation.
But this code path is not hot.

* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::startListeningForMachServiceConnections): NSLog =&gt; SAFE_PRINTF and
const char* =&gt; CString.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::PCMDaemonMain): const char* =&gt; CString.

* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::sendAuditToken): Never needed an annotation here.

* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, RemoveAll)): Resolve ambiguity in favor of
ASCIILiteral. This code is not hot, but we might as well avoid allocation.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/908f2733fc462a12c960a7b90b42de73bf1dde32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67784 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25529 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33838 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37646 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80587 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94541 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86564 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76635 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75871 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7959 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20276 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109058 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14717 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26227 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->