### PR TITLE
[WebRTC] Add more webrtc fuzzers

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/aom_av1_encoder_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/aom_av1_encoder_fuzzer.xcconfig
@@ -1,0 +1,35 @@
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "BaseTarget-libaom.xcconfig"
+
+PRODUCT_NAME = aom_av1_encoder_fuzzer;
+
+CODE_SIGN_STYLE = Automatic;
+ENABLE_LIBFUZZER = YES;
+
+HEADER_SEARCH_PATHS = $(inherited) Source/webrtc Source/third_party/abseil-cpp;
+
+OTHER_CFLAGS = $(inherited) -DENCODER=av1;
+
+WARNING_CFLAGS = $(inherited) -Wno-constant-logical-operand;

--- a/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_h264_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_h264_fuzzer.xcconfig
@@ -1,0 +1,31 @@
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libwebrtc.xcconfig"
+
+PRODUCT_NAME = rtp_packetizer_h264_fuzzer;
+
+CODE_SIGN_STYLE = Automatic;
+ENABLE_LIBFUZZER = YES;
+
+OTHER_LDFLAGS = $(inherited) -lwebrtc;

--- a/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_h265_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_h265_fuzzer.xcconfig
@@ -1,0 +1,31 @@
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libwebrtc.xcconfig"
+
+PRODUCT_NAME = rtp_packetizer_h265_fuzzer;
+
+CODE_SIGN_STYLE = Automatic;
+ENABLE_LIBFUZZER = YES;
+
+OTHER_LDFLAGS = $(inherited) -lwebrtc;

--- a/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_vp8_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_vp8_fuzzer.xcconfig
@@ -1,0 +1,31 @@
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libwebrtc.xcconfig"
+
+PRODUCT_NAME = rtp_packetizer_vp8_fuzzer;
+
+CODE_SIGN_STYLE = Automatic;
+ENABLE_LIBFUZZER = YES;
+
+OTHER_LDFLAGS = $(inherited) -lwebrtc;

--- a/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_vp9_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_vp9_fuzzer.xcconfig
@@ -1,0 +1,31 @@
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libwebrtc.xcconfig"
+
+PRODUCT_NAME = rtp_packetizer_vp9_fuzzer;
+
+CODE_SIGN_STYLE = Automatic;
+ENABLE_LIBFUZZER = YES;
+
+OTHER_LDFLAGS = $(inherited) -lwebrtc;

--- a/Source/ThirdParty/libwebrtc/Configurations/vp8_encoder_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/vp8_encoder_fuzzer.xcconfig
@@ -1,0 +1,36 @@
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libvpx.xcconfig"
+
+PRODUCT_NAME = vp8_encoder_fuzzer;
+
+CODE_SIGN_STYLE = Automatic;
+ENABLE_LIBFUZZER = YES;
+
+HEADER_SEARCH_PATHS = $(inherited) Source/webrtc Source/third_party/abseil-cpp;
+
+OTHER_CFLAGS = $(inherited) -DENCODER=vp8;
+OTHER_LDFLAGS = $(inherited) -lwebrtc;
+
+WARNING_CFLAGS = $(inherited) -Wno-constant-logical-operand;

--- a/Source/ThirdParty/libwebrtc/Configurations/vp9_encoder_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/vp9_encoder_fuzzer.xcconfig
@@ -1,0 +1,36 @@
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libvpx.xcconfig"
+
+PRODUCT_NAME = vp9_encoder_fuzzer;
+
+CODE_SIGN_STYLE = Automatic;
+ENABLE_LIBFUZZER = YES;
+
+HEADER_SEARCH_PATHS = $(inherited) Source/webrtc Source/third_party/abseil-cpp;
+
+OTHER_CFLAGS = $(inherited) -DENCODER=vp9;
+OTHER_LDFLAGS = $(inherited) -lwebrtc;
+
+WARNING_CFLAGS = $(inherited) -Wno-constant-logical-operand;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/examples/aom_av1_encoder_fuzzer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/examples/aom_av1_encoder_fuzzer.cc
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2016, Alliance for Open Media. All rights reserved
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * This source code is subject to the terms of the BSD 2 Clause License and
+ * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+ * was not distributed with this source code in the LICENSE file, you can
+ * obtain it at www.aomedia.org/license/software. If the Alliance for Open
+ * Media Patent License 1.0 was not distributed with this source code in the
+ * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+ */
+
+// Simple Encoder
+// ==============
+//
+// This is an example of a simple encoder loop. It takes an input file in
+// YV12 format, passes it through the encoder, and writes the compressed
+// frames to disk in IVF format. Other decoder examples build upon this
+// one.
+//
+// The details of the IVF format have been elided from this example for
+// simplicity of presentation, as IVF files will not generally be used by
+// your application. In general, an IVF file consists of a file header,
+// followed by a variable number of frames. Each frame consists of a frame
+// header followed by a variable length payload. The length of the payload
+// is specified in the first four bytes of the frame header. The payload is
+// the raw compressed data.
+//
+// Standard Includes
+// -----------------
+// For encoders, you only have to include `aom_encoder.h` and then any
+// header files for the specific codecs you use. In this case, we're using
+// aom.
+//
+// Getting The Default Configuration
+// ---------------------------------
+// Encoders have the notion of "usage profiles." For example, an encoder
+// may want to publish default configurations for both a video
+// conferencing application and a best quality offline encoder. These
+// obviously have very different default settings. Consult the
+// documentation for your codec to see if it provides any default
+// configurations. All codecs provide a default configuration, number 0,
+// which is valid for material in the vacinity of QCIF/QVGA.
+//
+// Updating The Configuration
+// ---------------------------------
+// Almost all applications will want to update the default configuration
+// with settings specific to their usage. Here we set the width and height
+// of the video file to that specified on the command line. We also scale
+// the default bitrate based on the ratio between the default resolution
+// and the resolution specified on the command line.
+//
+// Initializing The Codec
+// ----------------------
+// The encoder is initialized by the following code.
+//
+// Encoding A Frame
+// ----------------
+// The frame is read as a continuous block (size width * height * 3 / 2)
+// from the input file. If a frame was read (the input file has not hit
+// EOF) then the frame is passed to the encoder. Otherwise, a NULL
+// is passed, indicating the End-Of-Stream condition to the encoder. The
+// `frame_cnt` is reused as the presentation time stamp (PTS) and each
+// frame is shown for one frame-time in duration. The flags parameter is
+// unused in this example.
+
+// Forced Keyframes
+// ----------------
+// Keyframes can be forced by setting the AOM_EFLAG_FORCE_KF bit of the
+// flags passed to `aom_codec_control()`. In this example, we force a
+// keyframe every <keyframe-interval> frames. Note, the output stream can
+// contain additional keyframes beyond those that have been forced using the
+// AOM_EFLAG_FORCE_KF flag because of automatic keyframe placement by the
+// encoder.
+//
+// Processing The Encoded Data
+// ---------------------------
+// Each packet of type `AOM_CODEC_CX_FRAME_PKT` contains the encoded data
+// for this frame. We write a IVF frame header, followed by the raw data.
+//
+// Cleanup
+// -------
+// The `aom_codec_destroy` call frees any memory allocated by the codec.
+//
+// Error Handling
+// --------------
+// This example does not special case any error return codes. If there was
+// an error, a descriptive message is printed and the program exits. With
+// few exeptions, aom_codec functions return an enumerated error status,
+// with the value `0` indicating success.
+//
+// Error Resiliency Features
+// -------------------------
+// Error resiliency is controlled by the g_error_resilient member of the
+// configuration structure. Use the `decode_with_drops` example to decode with
+// frames 5-10 dropped. Compare the output for a file encoded with this example
+// versus one encoded with the `simple_encoder` example.
+
+#include <span>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aom/aom_encoder.h"
+#include "aom/aomcx.h"
+#include "common/tools_common.h"
+#include "common/video_writer.h"
+#include "config/aom_config.h"
+#include "test/fuzzers/fuzz_data_helper.h"
+
+#if WEBRTC_WEBKIT_BUILD
+
+#define AOM_ENCODER_NAME(name) AOM_ENCODER_NAME_(name)
+#define AOM_ENCODER_NAME_(name) #name
+
+// Taken from libaom/source/libaom/common/tools_common.c.
+static bool aom_img_read(aom_image_t *img, webrtc::test::FuzzDataHelper& fuzz_input) {
+  const int bytespp = (img->fmt & AOM_IMG_FMT_HIGHBITDEPTH) ? 2 : 1;
+
+  for (int plane = 0; plane < 3; ++plane) {
+    if (plane == AOM_PLANE_V && img->fmt == AOM_IMG_FMT_NV12)
+      continue;
+    unsigned char *buf = img->planes[plane];
+    if (!buf && img->fmt == AOM_IMG_FMT_NONE)
+      continue;
+    const int stride = img->stride[plane];
+    const int w = aom_img_plane_width(img, plane) * bytespp;
+    const int h = aom_img_plane_height(img, plane);
+
+    for (int y = 0; y < h; ++y) {
+      auto byte_array = fuzz_input.ReadByteArray((size_t)w);
+      if (byte_array.empty())
+        return false;
+      memcpy(buf, byte_array.data(), byte_array.size());
+      buf += stride;
+    }
+  }
+
+  return true;
+}
+
+static std::span<uint8_t> encode_frame(aom_codec_ctx_t *codec, aom_image_t *img,
+                                       int frame_index, int flags) {
+  bool got_pkts = false;
+  aom_codec_iter_t iter = NULL;
+  const aom_codec_cx_pkt_t *pkt = NULL;
+  const aom_codec_err_t res =
+      aom_codec_encode(codec, img, frame_index, 1, flags);
+  if (res != AOM_CODEC_OK)
+    return { };
+
+  std::span<uint8_t> buffer { (uint8_t *)malloc(0), 0 };
+  size_t buffer_offset = 0;
+
+  while ((pkt = aom_codec_get_cx_data(codec, &iter)) != NULL) {
+    got_pkts = true;
+
+    if (pkt->kind == AOM_CODEC_CX_FRAME_PKT) {
+        size_t buffer_size = buffer.size() + pkt->data.frame.sz;
+        buffer = { (uint8_t *)reallocf(buffer.data(), buffer_size), buffer_size };
+        if (buffer.empty())
+          return { };
+        memcpy(buffer.subspan(buffer_offset).data(), pkt->data.frame.buf, pkt->data.frame.sz);
+        buffer_offset = buffer.size();
+    }
+  }
+
+  return buffer;
+}
+
+extern "C" void usage_exit(void) { exit(EXIT_FAILURE); }
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  webrtc::test::FuzzDataHelper fuzz_input(rtc::MakeArrayView(data, size));
+
+  aom_codec_ctx_t codec;
+  aom_codec_enc_cfg_t cfg;
+  int frame_count = 0;
+  aom_codec_err_t res;
+#if CONFIG_REALTIME_ONLY
+  const int usage = 1;
+  const int speed = 7;
+#else
+#error "Expect CONFIG_REALTIME_ONLY=1"
+  const int usage = 0;
+  const int speed = 2;
+#endif
+
+  aom_codec_iface_t *encoder = get_aom_encoder_by_short_name(AOM_ENCODER_NAME(ENCODER));
+  const int fps = abs(fuzz_input.ReadOrDefaultValue<int>(30)) || 30;
+  const unsigned bitrate = fuzz_input.ReadOrDefaultValue<unsigned>(200) || 200;
+  const int keyframe_interval = abs(fuzz_input.ReadOrDefaultValue<int>(0));
+  int frame_width = abs(fuzz_input.ReadOrDefaultValue<int>(320)) || 320;
+  frame_width += (frame_width % 2);
+  int frame_height = abs(fuzz_input.ReadOrDefaultValue<int>(240)) || 240;
+  frame_height += (frame_height % 2);
+  const uint32_t error_resilient = fuzz_input.ReadOrDefaultValue<uint32_t>(0);
+
+  enum aom_img_fmt kAomImageFormats[] = {
+    AOM_IMG_FMT_NONE,
+    AOM_IMG_FMT_YV12,
+    AOM_IMG_FMT_I420,
+    AOM_IMG_FMT_AOMYV12,
+    AOM_IMG_FMT_AOMI420,
+    AOM_IMG_FMT_I422,
+    AOM_IMG_FMT_I444,
+    AOM_IMG_FMT_NV12,
+    AOM_IMG_FMT_I42016,
+    AOM_IMG_FMT_YV1216,
+    AOM_IMG_FMT_I42216,
+    AOM_IMG_FMT_I44416,
+  };
+  aom_img_fmt_t aom_image_format = fuzz_input.SelectOneOf(kAomImageFormats);
+
+  auto raw = std::unique_ptr<aom_image_t, void(*)(aom_image_t*)>(aom_img_alloc(NULL, aom_image_format, frame_width, frame_height, 1), aom_img_free);
+  if (!raw)
+    return 0;
+
+  res = aom_codec_enc_config_default(encoder, &cfg, usage);
+  if (res)
+    die_codec(&codec, "Failed to get default codec config.");
+
+  cfg.g_w = frame_width;
+  cfg.g_h = frame_height;
+  cfg.g_threads = 1U << (fuzz_input.ReadOrDefaultValue<unsigned>(0) % 4);
+  cfg.g_timebase.num = 1;
+  cfg.g_timebase.den = fps;
+  cfg.rc_target_bitrate = bitrate;
+  cfg.g_error_resilient = (aom_codec_er_flags_t)error_resilient;
+
+#if CONFIG_AV1_HIGHBITDEPTH
+  aom_codec_flags_t aom_codec_flags = raw->bit_depth == 16 ? AOM_CODEC_USE_HIGHBITDEPTH : 0;
+#else
+  aom_codec_flags_t aom_codec_flags = 0;
+#endif
+  if (aom_codec_enc_init(&codec, encoder, &cfg, aom_codec_flags))
+    die("Failed to initialize encoder");
+
+  if (aom_codec_control(&codec, AOME_SET_CPUUSED, speed))
+    die_codec(&codec, "Failed to set cpu-used");
+
+  // TODO: Set more options here.
+  // if (aom_codec_set_option(&codec, "name", "value"))
+  //   die_codec(&codec, "Failed to set option 'name' to 'value'");
+
+  // Encode frames.
+  while (aom_img_read(raw.get(), fuzz_input)) {
+    int flags = 0;
+    if (keyframe_interval > 0 && frame_count % keyframe_interval == 0)
+      flags |= AOM_EFLAG_FORCE_KF;
+    auto encoded_frame = encode_frame(&codec, raw.get(), frame_count++, flags);
+    if (encoded_frame.empty())
+      break;
+    free(encoded_frame.data());
+  }
+
+  // Flush encoder.
+  while (true) {
+    auto encoded_frame = encode_frame(&codec, NULL, -1, 0);
+    if (encoded_frame.empty())
+      break;
+    free(encoded_frame.data());
+  }
+
+  if (aom_codec_destroy(&codec))
+    die_codec(&codec, "Failed to destroy codec.");
+
+  return 0;
+}
+
+#endif // WEBRTC_WEBKIT_BUILD

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/examples/vpx_encoder_fuzzer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/examples/vpx_encoder_fuzzer.cc
@@ -1,0 +1,259 @@
+/*
+ *  Copyright (c) 2010 The WebM project authors. All Rights Reserved.
+ *  Copyright (c) 2023 Apple Inc. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#if WEBRTC_WEBKIT_BUILD
+
+// Simple Encoder
+// ==============
+//
+// This is an example of a simple encoder loop. It takes an input file in
+// YV12 format, passes it through the encoder, and writes the compressed
+// frames to disk in IVF format. Other decoder examples build upon this
+// one.
+//
+// The details of the IVF format have been elided from this example for
+// simplicity of presentation, as IVF files will not generally be used by
+// your application. In general, an IVF file consists of a file header,
+// followed by a variable number of frames. Each frame consists of a frame
+// header followed by a variable length payload. The length of the payload
+// is specified in the first four bytes of the frame header. The payload is
+// the raw compressed data.
+//
+// Standard Includes
+// -----------------
+// For encoders, you only have to include `vpx_encoder.h` and then any
+// header files for the specific codecs you use. In this case, we're using
+// vp8.
+//
+// Getting The Default Configuration
+// ---------------------------------
+// Encoders have the notion of "usage profiles." For example, an encoder
+// may want to publish default configurations for both a video
+// conferencing application and a best quality offline encoder. These
+// obviously have very different default settings. Consult the
+// documentation for your codec to see if it provides any default
+// configurations. All codecs provide a default configuration, number 0,
+// which is valid for material in the vacinity of QCIF/QVGA.
+//
+// Updating The Configuration
+// ---------------------------------
+// Almost all applications will want to update the default configuration
+// with settings specific to their usage. Here we set the width and height
+// of the video file to that specified on the command line. We also scale
+// the default bitrate based on the ratio between the default resolution
+// and the resolution specified on the command line.
+//
+// Initializing The Codec
+// ----------------------
+// The encoder is initialized by the following code.
+//
+// Encoding A Frame
+// ----------------
+// The frame is read as a continuous block (size width * height * 3 / 2)
+// from the input file. If a frame was read (the input file has not hit
+// EOF) then the frame is passed to the encoder. Otherwise, a NULL
+// is passed, indicating the End-Of-Stream condition to the encoder. The
+// `frame_cnt` is reused as the presentation time stamp (PTS) and each
+// frame is shown for one frame-time in duration. The flags parameter is
+// unused in this example. The deadline is set to VPX_DL_REALTIME to
+// make the example run as quickly as possible.
+
+// Forced Keyframes
+// ----------------
+// Keyframes can be forced by setting the VPX_EFLAG_FORCE_KF bit of the
+// flags passed to `vpx_codec_control()`. In this example, we force a
+// keyframe every <keyframe-interval> frames. Note, the output stream can
+// contain additional keyframes beyond those that have been forced using the
+// VPX_EFLAG_FORCE_KF flag because of automatic keyframe placement by the
+// encoder.
+//
+// Processing The Encoded Data
+// ---------------------------
+// Each packet of type `VPX_CODEC_CX_FRAME_PKT` contains the encoded data
+// for this frame. We write a IVF frame header, followed by the raw data.
+//
+// Cleanup
+// -------
+// The `vpx_codec_destroy` call frees any memory allocated by the codec.
+//
+// Error Handling
+// --------------
+// This example does not special case any error return codes. If there was
+// an error, a descriptive message is printed and the program exits. With
+// few exeptions, vpx_codec functions return an enumerated error status,
+// with the value `0` indicating success.
+//
+// Error Resiliency Features
+// -------------------------
+// Error resiliency is controlled by the g_error_resilient member of the
+// configuration structure. Use the `decode_with_drops` example to decode with
+// frames 5-10 dropped. Compare the output for a file encoded with this example
+// versus one encoded with the `simple_encoder` example.
+
+#include <span>
+
+#include "test/fuzzers/fuzz_data_helper.h"
+#include "tools_common.h"
+#include "vpx/vpx_encoder.h"
+
+#define VPX_ENCODER_NAME(name) VPX_ENCODER_NAME_(name)
+#define VPX_ENCODER_NAME_(name) #name
+
+// Taken from libvpx/source/libvpx/tools_common.c.
+static bool vpx_img_read(vpx_image_t *img, webrtc::test::FuzzDataHelper& fuzz_input) {
+  for (int plane = 0; plane < 3; ++plane) {
+    if (plane == VPX_PLANE_V && img->fmt == VPX_IMG_FMT_NV12)
+      continue;
+    unsigned char *buf = img->planes[plane];
+    if (!buf && img->fmt == VPX_IMG_FMT_NONE)
+      continue;
+    const int stride = img->stride[plane];
+    const int w = vpx_img_plane_width(img, plane) *
+                  ((img->fmt & VPX_IMG_FMT_HIGHBITDEPTH) ? 2 : 1);
+    const int h = vpx_img_plane_height(img, plane);
+
+    for (int y = 0; y < h; ++y) {
+      auto byte_array = fuzz_input.ReadByteArray((size_t)w);
+      if (byte_array.empty())
+        return false;
+      memcpy(buf, byte_array.data(), byte_array.size());
+      buf += stride;
+    }
+  }
+
+  return true;
+}
+
+static std::span<uint8_t> encode_frame(vpx_codec_ctx_t *codec, vpx_image_t *img,
+                                       int frame_index, int flags, unsigned long deadline) {
+  bool got_pkts = false;
+  vpx_codec_iter_t iter = NULL;
+  const vpx_codec_cx_pkt_t *pkt = NULL;
+  const vpx_codec_err_t res =
+      vpx_codec_encode(codec, img, frame_index, 1, flags, deadline);
+  if (res != VPX_CODEC_OK)
+    return { };
+
+  std::span<uint8_t> buffer { (uint8_t *)malloc(0), 0 };
+  size_t buffer_offset = 0;
+
+  while ((pkt = vpx_codec_get_cx_data(codec, &iter)) != NULL) {
+    got_pkts = true;
+    if (pkt->kind == VPX_CODEC_CX_FRAME_PKT) {
+      size_t buffer_size = buffer.size() + pkt->data.frame.sz;
+      buffer = { (uint8_t *)reallocf(buffer.data(), buffer_size), buffer_size };
+      if (buffer.empty())
+        return { };
+      memcpy(buffer.subspan(buffer_offset).data(), pkt->data.frame.buf, pkt->data.frame.sz);
+      buffer_offset = buffer.size();
+    }
+  }
+
+  if (!got_pkts) {
+    free(buffer.data());
+    return { };
+  }
+
+  return buffer;
+}
+
+extern "C" void usage_exit(void) { exit(EXIT_FAILURE); }
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  webrtc::test::FuzzDataHelper fuzz_input(rtc::MakeArrayView(data, size));
+
+  vpx_codec_ctx_t codec;
+  vpx_codec_enc_cfg_t cfg;
+  int frame_count = 0;
+  vpx_codec_err_t res;
+
+  const VpxInterface *encoder = get_vpx_encoder_by_name(VPX_ENCODER_NAME(ENCODER));
+  const int fps = abs(fuzz_input.ReadOrDefaultValue<int>(30)) || 30;
+  const unsigned bitrate = fuzz_input.ReadOrDefaultValue<unsigned>(200) || 200;
+  const int keyframe_interval = abs(fuzz_input.ReadOrDefaultValue<int>(0));
+  int frame_width = abs(fuzz_input.ReadOrDefaultValue<int>(320)) || 320;
+  frame_width += (frame_width % 2);
+  int frame_height = abs(fuzz_input.ReadOrDefaultValue<int>(240)) || 240;
+  frame_height += (frame_height % 2);
+  const uint32_t error_resilient = fuzz_input.ReadOrDefaultValue<uint32_t>(0);
+
+  // See vpx_encoder.h.
+  const unsigned long kVpxEncoderDeadline[] = {
+    VPX_DL_BEST_QUALITY,
+    VPX_DL_REALTIME,
+    VPX_DL_GOOD_QUALITY,
+  };
+  unsigned long deadline = fuzz_input.SelectOneOf(kVpxEncoderDeadline);
+
+  enum vpx_img_fmt kVpxImageFormats[] = {
+      VPX_IMG_FMT_NONE,
+      VPX_IMG_FMT_YV12,
+      VPX_IMG_FMT_I420,
+      VPX_IMG_FMT_I422,
+      VPX_IMG_FMT_I444,
+      VPX_IMG_FMT_I440,
+      VPX_IMG_FMT_NV12,
+      VPX_IMG_FMT_I42016,
+      VPX_IMG_FMT_I42216,
+      VPX_IMG_FMT_I44416,
+      VPX_IMG_FMT_I44016,
+  };
+  vpx_img_fmt_t vpx_image_format = fuzz_input.SelectOneOf(kVpxImageFormats);
+
+  auto raw = std::unique_ptr<vpx_image_t, void(*)(vpx_image_t*)>(vpx_img_alloc(NULL, vpx_image_format, frame_width, frame_height, 1), vpx_img_free);
+  if (!raw)
+      return 0;
+
+  res = vpx_codec_enc_config_default(encoder->codec_interface(), &cfg, 0);
+  if (res)
+    die_codec(&codec, "Failed to get default codec config.");
+
+  cfg.g_w = frame_width;
+  cfg.g_h = frame_height;
+  cfg.g_threads = 1U << (fuzz_input.ReadOrDefaultValue<unsigned>(0) % 4);
+  cfg.g_timebase.num = 1;
+  cfg.g_timebase.den = fps;
+  cfg.rc_target_bitrate = bitrate;
+  cfg.g_error_resilient = (vpx_codec_er_flags_t)error_resilient;
+
+  if (vpx_codec_enc_init(&codec, encoder->codec_interface(), &cfg, raw->bit_depth == 16 ? VPX_CODEC_USE_HIGHBITDEPTH : 0))
+    die("Failed to initialize encoder");
+
+  // TODO: Set more options here.
+  // if (vpx_codec_control_(&codec, VP9E_SET_LOSSLESS, 1))
+  //   die_codec(&codec, "Failed to use lossless mode");
+
+  // Encode frames.
+  while (vpx_img_read(raw.get(), fuzz_input)) {
+    int flags = 0;
+    if (keyframe_interval > 0 && frame_count % keyframe_interval == 0)
+        flags |= VPX_EFLAG_FORCE_KF;
+    auto encoded_frame = encode_frame(&codec, raw.get(), frame_count++, flags, deadline);
+    if (encoded_frame.empty())
+      break;
+    free(encoded_frame.data());
+  }
+
+  // Flush encoder.
+  while (true) {
+    auto encoded_frame = encode_frame(&codec, NULL, -1, 0, deadline);
+    if (encoded_frame.empty())
+      break;
+    free(encoded_frame.data());
+  }
+
+  if (vpx_codec_destroy(&codec))
+    die_codec(&codec, "Failed to destroy codec.");
+
+  return 0;
+}
+
+#endif // WEBRTC_WEBKIT_BUILD

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h264_fuzzer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h264_fuzzer.cc
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2024 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2023-2025 Apple Inc. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -14,6 +15,9 @@
 #include "modules/rtp_rtcp/source/rtp_format.h"
 #include "modules/rtp_rtcp/source/rtp_format_h264.h"
 #include "modules/rtp_rtcp/source/rtp_packet_to_send.h"
+#if WEBRTC_WEBKIT_BUILD
+#include "modules/rtp_rtcp/source/video_rtp_depacketizer_h264.h"
+#endif
 #include "rtc_base/checks.h"
 #include "test/fuzzers/fuzz_data_helper.h"
 
@@ -46,18 +50,28 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
   }
   // When packetization was successful, validate NextPacket function too.
   // While at it, check that packets respect the payload size limits.
+#if WEBRTC_WEBKIT_BUILD
+  // While at it, also depacketize the generated payloads.
+  VideoRtpDepacketizerH264 depacketizer;
+#endif
   RtpPacketToSend rtp_packet(nullptr);
   // Single packet.
   if (num_packets == 1) {
     RTC_CHECK(packetizer.NextPacket(&rtp_packet));
     RTC_CHECK_LE(rtp_packet.payload_size(),
                  limits.max_payload_len - limits.single_packet_reduction_len);
+#if WEBRTC_WEBKIT_BUILD
+    depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
     return;
   }
   // First packet.
   RTC_CHECK(packetizer.NextPacket(&rtp_packet));
   RTC_CHECK_LE(rtp_packet.payload_size(),
                limits.max_payload_len - limits.first_packet_reduction_len);
+#if WEBRTC_WEBKIT_BUILD
+  depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
   // Middle packets.
   for (size_t i = 1; i < num_packets - 1; ++i) {
     rtp_packet.Clear();
@@ -65,11 +79,17 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
         << "Failed to get packet#" << i;
     RTC_CHECK_LE(rtp_packet.payload_size(), limits.max_payload_len)
         << "Packet #" << i << " exceeds it's limit";
+#if WEBRTC_WEBKIT_BUILD
+    depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
   }
   // Last packet.
   rtp_packet.Clear();
   RTC_CHECK(packetizer.NextPacket(&rtp_packet));
   RTC_CHECK_LE(rtp_packet.payload_size(),
                limits.max_payload_len - limits.last_packet_reduction_len);
+#if WEBRTC_WEBKIT_BUILD
+  depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
 }
 }  // namespace webrtc

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_vp9_fuzzer.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_vp9_fuzzer.cc
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2024 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2023-2025 Apple Inc. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source
@@ -14,6 +15,9 @@
 #include "modules/rtp_rtcp/source/rtp_format.h"
 #include "modules/rtp_rtcp/source/rtp_format_vp9.h"
 #include "modules/rtp_rtcp/source/rtp_packet_to_send.h"
+#if WEBRTC_WEBKIT_BUILD
+#include "modules/rtp_rtcp/source/video_rtp_depacketizer_vp9.h"
+#endif
 #include "rtc_base/checks.h"
 #include "test/fuzzers/fuzz_data_helper.h"
 
@@ -31,10 +35,21 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
       fuzz_input.ReadOrDefaultValue<uint8_t>(0);
 
   RTPVideoHeaderVP9 hdr_info;
+#if WEBRTC_WEBKIT_BUILD
+  RTPVideoHeader video_header;
+  if (int offset = VideoRtpDepacketizerVp9::ParseRtpPayload(
+        rtc::MakeArrayView(&data[fuzz_input.BytesRead()], fuzz_input.BytesLeft()), &video_header)) {
+    (void)fuzz_input.ReadByteArray(offset);
+    hdr_info = absl::get<RTPVideoHeaderVP9>(video_header.video_type_header);
+  } else {
+#endif
   hdr_info.InitRTPVideoHeaderVP9();
   uint16_t picture_id = fuzz_input.ReadOrDefaultValue<uint16_t>(0);
   hdr_info.picture_id =
       picture_id >= 0x8000 ? kNoPictureId : picture_id & 0x7fff;
+#if WEBRTC_WEBKIT_BUILD
+  }
+#endif
 
   // Main function under test: RtpPacketizerVp9's constructor.
   RtpPacketizerVp9 packetizer(fuzz_input.ReadByteArray(fuzz_input.BytesLeft()),
@@ -46,28 +61,44 @@ void FuzzOneInput(const uint8_t* data, size_t size) {
   }
   // When packetization was successful, validate NextPacket function too.
   // While at it, check that packets respect the payload size limits.
+#if WEBRTC_WEBKIT_BUILD
+  // While at it, also depacketize the generated payloads.
+  VideoRtpDepacketizerVp9 depacketizer;
+#endif
   RtpPacketToSend rtp_packet(nullptr);
   // Single packet.
   if (num_packets == 1) {
     RTC_CHECK(packetizer.NextPacket(&rtp_packet));
     RTC_CHECK_LE(rtp_packet.payload_size(),
                  limits.max_payload_len - limits.single_packet_reduction_len);
+#if WEBRTC_WEBKIT_BUILD
+    depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
     return;
   }
   // First packet.
   RTC_CHECK(packetizer.NextPacket(&rtp_packet));
   RTC_CHECK_LE(rtp_packet.payload_size(),
                limits.max_payload_len - limits.first_packet_reduction_len);
+#if WEBRTC_WEBKIT_BUILD
+  depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
   // Middle packets.
   for (size_t i = 1; i < num_packets - 1; ++i) {
     RTC_CHECK(packetizer.NextPacket(&rtp_packet))
         << "Failed to get packet#" << i;
     RTC_CHECK_LE(rtp_packet.payload_size(), limits.max_payload_len)
         << "Packet #" << i << " exceeds it's limit";
+#if WEBRTC_WEBKIT_BUILD
+    depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
   }
   // Last packet.
   RTC_CHECK(packetizer.NextPacket(&rtp_packet));
   RTC_CHECK_LE(rtp_packet.payload_size(),
                limits.max_payload_len - limits.last_packet_reduction_len);
+#if WEBRTC_WEBKIT_BUILD
+  depacketizer.Parse(rtp_packet.PayloadBuffer());
+#endif
 }
 }  // namespace webrtc

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -13,19 +13,26 @@
 			buildPhases = (
 			);
 			dependencies = (
+				448C3AA12D4C48C400AA535D /* PBXTargetDependency */,
 				4469C10E2B5F24DA00E32E5A /* PBXTargetDependency */,
 				44D88ACE2AF0495A005C956E /* PBXTargetDependency */,
 				44D8D11C2B6AFBCF00B3CF91 /* PBXTargetDependency */,
 				44D88AE32AF04AE4005C956E /* PBXTargetDependency */,
 				449467D32AE05DD200A9FED0 /* PBXTargetDependency */,
 				449467BF2AE05CA800A9FED0 /* PBXTargetDependency */,
+				44905A102D4EC7BF002B3379 /* PBXTargetDependency */,
+				44905A222D4ECD31002B3379 /* PBXTargetDependency */,
+				44905A372D4EEC6B002B3379 /* PBXTargetDependency */,
+				44905A482D4EF129002B3379 /* PBXTargetDependency */,
 				449CF1612ADEDE9B00F22CAF /* PBXTargetDependency */,
 				449CF1632ADEDE9D00F22CAF /* PBXTargetDependency */,
 				4460B8C92B155B9200392062 /* PBXTargetDependency */,
+				44905A642D4F16E7002B3379 /* PBXTargetDependency */,
 				4460B8CB2B155B9200392062 /* PBXTargetDependency */,
 				446359E02AEA14F000551EEE /* PBXTargetDependency */,
 				449CF1652ADEDEA000F22CAF /* PBXTargetDependency */,
 				4460B8CD2B155B9200392062 /* PBXTargetDependency */,
+				44905A752D4F17B3002B3379 /* PBXTargetDependency */,
 				4460B8CF2B155B9200392062 /* PBXTargetDependency */,
 				444A6F0C2AEAE064005FE121 /* PBXTargetDependency */,
 				44945C6F2B9BA22A00447FFD /* PBXTargetDependency */,
@@ -3325,7 +3332,39 @@
 		4469C1072B5F24C500E32E5A /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
 		4469C1112B5F255500E32E5A /* h264_bitstream_parser_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4469C10F2B5F255500E32E5A /* h264_bitstream_parser_fuzzer.cc */; };
 		446CFE442AC694AB00F870D9 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		448C3A9A2D4C48B300AA535D /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		448C3AA22D4C4CBF00AA535D /* aom_av1_encoder_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 448C3A902D4C3AB700AA535D /* aom_av1_encoder_fuzzer.cc */; };
+		448C3AA32D4C4CE800AA535D /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
+		448C3AA42D4C4CF400AA535D /* ivfenc.c in Sources */ = {isa = PBXBuildFile; fileRef = 410B385A292B81210003E515 /* ivfenc.c */; };
+		448C3AA92D4C4D4B00AA535D /* video_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = 448C3AA52D4C4D4A00AA535D /* video_writer.c */; };
+		448C3AAA2D4C4D4B00AA535D /* tools_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 448C3AA62D4C4D4A00AA535D /* tools_common.c */; };
 		448D48422AB0BEBA0065014C /* vpx_dec_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */; };
+		44905A042D4EC6E6002B3379 /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		44905A062D4EC6E6002B3379 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		44905A0C2D4EC714002B3379 /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
+		44905A0E2D4EC752002B3379 /* rtp_format_h264_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44905A0D2D4EC751002B3379 /* rtp_format_h264_fuzzer.cc */; };
+		44905A172D4ECD1D002B3379 /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
+		44905A192D4ECD1D002B3379 /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		44905A1B2D4ECD1D002B3379 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		44905A242D4ECD83002B3379 /* rtp_format_h265_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44905A232D4ECD83002B3379 /* rtp_format_h265_fuzzer.cc */; };
+		44905A2A2D4EE93B002B3379 /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
+		44905A2C2D4EE93B002B3379 /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		44905A2E2D4EE93B002B3379 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		44905A352D4EEC58002B3379 /* rtp_format_vp8_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44905A342D4EEC57002B3379 /* rtp_format_vp8_fuzzer.cc */; };
+		44905A3D2D4EF116002B3379 /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
+		44905A3F2D4EF116002B3379 /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		44905A412D4EF116002B3379 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		44905A4A2D4EF1B4002B3379 /* rtp_format_vp9_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44905A492D4EF1B4002B3379 /* rtp_format_vp9_fuzzer.cc */; };
+		44905A542D4F1471002B3379 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4105EB83212E01D2008C0C20 /* libvpx.a */; };
+		44905A5A2D4F1486002B3379 /* vpx_encoder_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44905A4D2D4F144D002B3379 /* vpx_encoder_fuzzer.cc */; };
+		44905A5B2D4F149C002B3379 /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
+		44905A5E2D4F14E0002B3379 /* y4minput.c in Sources */ = {isa = PBXBuildFile; fileRef = 44905A5D2D4F14DF002B3379 /* y4minput.c */; };
+		44905A622D4F152F002B3379 /* tools_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 44905A602D4F152F002B3379 /* tools_common.c */; };
+		44905A692D4F179E002B3379 /* fuzz_data_helper.cc in Sources */ = {isa = PBXBuildFile; fileRef = 441380CD2AE06BC200C928CB /* fuzz_data_helper.cc */; };
+		44905A6A2D4F179E002B3379 /* tools_common.c in Sources */ = {isa = PBXBuildFile; fileRef = 44905A602D4F152F002B3379 /* tools_common.c */; };
+		44905A6B2D4F179E002B3379 /* vpx_encoder_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44905A4D2D4F144D002B3379 /* vpx_encoder_fuzzer.cc */; };
+		44905A6C2D4F179E002B3379 /* y4minput.c in Sources */ = {isa = PBXBuildFile; fileRef = 44905A5D2D4F14DF002B3379 /* y4minput.c */; };
+		44905A6E2D4F179E002B3379 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4105EB83212E01D2008C0C20 /* libvpx.a */; };
 		44945C6D2B9BA20C00447FFD /* libwebm.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CDEBB11924C0187400ADBD44 /* libwebm.a */; };
 		44945C712B9BA37800447FFD /* webm_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44945C702B9BA37800447FFD /* webm_fuzzer.cc */; };
 		44945C742B9BA3D200447FFD /* webm.dict in Copy Fuzzer Dictionary */ = {isa = PBXBuildFile; fileRef = 44945C722B9BA39200447FFD /* webm.dict */; };
@@ -5447,12 +5486,110 @@
 			remoteGlobalIDString = 4469C0FF2B5F24C500E32E5A;
 			remoteInfo = h264_bitstream_parser_fuzzer;
 		};
+		448C3A942D4C48B300AA535D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		448C3AA02D4C48C400AA535D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 448C3A922D4C48B300AA535D;
+			remoteInfo = aom_av1_encoder_fuzzer;
+		};
 		448D483C2AB0BDB80065014C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 4105EB69212E01D2008C0C20;
 			remoteInfo = vpx;
+		};
+		44905A012D4EC6E6002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		44905A0F2D4EC7BF002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 449059FF2D4EC6E6002B3379;
+			remoteInfo = rtp_packetizer_h264_fuzzer;
+		};
+		44905A152D4ECD1D002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		44905A212D4ECD31002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44905A132D4ECD1D002B3379;
+			remoteInfo = rtp_packetizer_h265_fuzzer;
+		};
+		44905A282D4EE93B002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		44905A362D4EEC6B002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44905A262D4EE93B002B3379;
+			remoteInfo = rtp_packetizer_vp8_fuzzer;
+		};
+		44905A3B2D4EF116002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		44905A472D4EF129002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44905A392D4EF116002B3379;
+			remoteInfo = rtp_packetizer_vp9_fuzzer;
+		};
+		44905A502D4F1471002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4105EB69212E01D2008C0C20;
+			remoteInfo = vpx;
+		};
+		44905A632D4F16E7002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44905A4E2D4F1471002B3379;
+			remoteInfo = vp8_encoder_fuzzer;
+		};
+		44905A672D4F179E002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4105EB69212E01D2008C0C20;
+			remoteInfo = vpx;
+		};
+		44905A742D4F17B3002B3379 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44905A652D4F179E002B3379;
+			remoteInfo = vp9_encoder_fuzzer;
 		};
 		44945C6B2B9BA20300447FFD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -9590,8 +9727,36 @@
 		44871D222AC69336007538BC /* Base-libwebrtc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-libwebrtc.xcconfig"; sourceTree = "<group>"; };
 		448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = h264_depacketizer_fuzzer.xcconfig; sourceTree = "<group>"; };
 		448A76AE2AF064FE00C0A67C /* h265_depacketizer_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = h265_depacketizer_fuzzer.xcconfig; sourceTree = "<group>"; };
+		448C3A902D4C3AB700AA535D /* aom_av1_encoder_fuzzer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = aom_av1_encoder_fuzzer.cc; sourceTree = "<group>"; };
+		448C3A912D4C3AC300AA535D /* aom_av1_encoder_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = aom_av1_encoder_fuzzer.xcconfig; sourceTree = "<group>"; };
+		448C3A9F2D4C48B300AA535D /* aom_av1_encoder_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = aom_av1_encoder_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		448C3AA52D4C4D4A00AA535D /* video_writer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = video_writer.c; sourceTree = "<group>"; };
+		448C3AA62D4C4D4A00AA535D /* tools_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tools_common.c; sourceTree = "<group>"; };
+		448C3AA72D4C4D4B00AA535D /* tools_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tools_common.h; sourceTree = "<group>"; };
+		448C3AA82D4C4D4B00AA535D /* video_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_writer.h; sourceTree = "<group>"; };
 		448D48342AB0BDB00065014C /* vp8_dec_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp8_dec_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
 		448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vpx_dec_fuzzer.cc; sourceTree = "<group>"; };
+		44905A0B2D4EC6E6002B3379 /* rtp_packetizer_h264_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = rtp_packetizer_h264_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		44905A0D2D4EC751002B3379 /* rtp_format_h264_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_format_h264_fuzzer.cc; sourceTree = "<group>"; };
+		44905A112D4EC958002B3379 /* rtp_packetizer_h264_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = rtp_packetizer_h264_fuzzer.xcconfig; sourceTree = "<group>"; };
+		44905A122D4ECD11002B3379 /* rtp_packetizer_h265_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = rtp_packetizer_h265_fuzzer.xcconfig; sourceTree = "<group>"; };
+		44905A202D4ECD1D002B3379 /* rtp_packetizer_h265_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = rtp_packetizer_h265_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		44905A232D4ECD83002B3379 /* rtp_format_h265_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_format_h265_fuzzer.cc; sourceTree = "<group>"; };
+		44905A252D4EE933002B3379 /* rtp_packetizer_vp8_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = rtp_packetizer_vp8_fuzzer.xcconfig; sourceTree = "<group>"; };
+		44905A332D4EE93B002B3379 /* rtp_packetizer_vp8_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = rtp_packetizer_vp8_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		44905A342D4EEC57002B3379 /* rtp_format_vp8_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_format_vp8_fuzzer.cc; sourceTree = "<group>"; };
+		44905A382D4EF0FC002B3379 /* rtp_packetizer_vp9_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = rtp_packetizer_vp9_fuzzer.xcconfig; sourceTree = "<group>"; };
+		44905A462D4EF116002B3379 /* rtp_packetizer_vp9_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = rtp_packetizer_vp9_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		44905A492D4EF1B4002B3379 /* rtp_format_vp9_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_format_vp9_fuzzer.cc; sourceTree = "<group>"; };
+		44905A4B2D4F1415002B3379 /* vp9_encoder_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = vp9_encoder_fuzzer.xcconfig; sourceTree = "<group>"; };
+		44905A4C2D4F1415002B3379 /* vp8_encoder_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = vp8_encoder_fuzzer.xcconfig; sourceTree = "<group>"; };
+		44905A4D2D4F144D002B3379 /* vpx_encoder_fuzzer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = vpx_encoder_fuzzer.cc; sourceTree = "<group>"; };
+		44905A592D4F1471002B3379 /* vp8_encoder_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp8_encoder_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		44905A5C2D4F14DF002B3379 /* y4minput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = y4minput.h; sourceTree = "<group>"; };
+		44905A5D2D4F14DF002B3379 /* y4minput.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = y4minput.c; sourceTree = "<group>"; };
+		44905A602D4F152F002B3379 /* tools_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tools_common.c; sourceTree = "<group>"; };
+		44905A612D4F152F002B3379 /* tools_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tools_common.h; sourceTree = "<group>"; };
+		44905A732D4F179E002B3379 /* vp9_encoder_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = vp9_encoder_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
 		449187232AB3800D007266F2 /* Base-libvpx.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-libvpx.xcconfig"; sourceTree = "<group>"; };
 		449187242AB380BE007266F2 /* vp8_dec_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = vp8_dec_fuzzer.xcconfig; sourceTree = "<group>"; };
 		449187252AB380BE007266F2 /* vp9_dec_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = vp9_dec_fuzzer.xcconfig; sourceTree = "<group>"; };
@@ -11308,11 +11473,67 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		448C3A992D4C48B300AA535D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				448C3A9A2D4C48B300AA535D /* libwebrtc.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		448D48312AB0BDB00065014C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				44A402A92AB0BFB000463B4B /* libvpx.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A052D4EC6E6002B3379 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A062D4EC6E6002B3379 /* libwebrtc.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A1A2D4ECD1D002B3379 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A1B2D4ECD1D002B3379 /* libwebrtc.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A2D2D4EE93B002B3379 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A2E2D4EE93B002B3379 /* libwebrtc.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A402D4EF116002B3379 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A412D4EF116002B3379 /* libwebrtc.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A532D4F1471002B3379 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A542D4F1471002B3379 /* libvpx.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A6D2D4F179E002B3379 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A6E2D4F179E002B3379 /* libvpx.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11512,6 +11733,10 @@
 				4105EBAB212E030B008C0C20 /* vpx_ports */,
 				4105EBAC212E0319008C0C20 /* vpx_scale */,
 				4105EBAD212E0327008C0C20 /* vpx_util */,
+				44905A602D4F152F002B3379 /* tools_common.c */,
+				44905A612D4F152F002B3379 /* tools_common.h */,
+				44905A5D2D4F14DF002B3379 /* y4minput.c */,
+				44905A5C2D4F14DF002B3379 /* y4minput.h */,
 			);
 			path = libvpx;
 			sourceTree = "<group>";
@@ -12477,6 +12702,10 @@
 				410B3857292B81200003E515 /* ivfdec.h */,
 				410B385A292B81210003E515 /* ivfenc.c */,
 				410B3858292B81200003E515 /* ivfenc.h */,
+				448C3AA62D4C4D4A00AA535D /* tools_common.c */,
+				448C3AA72D4C4D4B00AA535D /* tools_common.h */,
+				448C3AA52D4C4D4A00AA535D /* video_writer.c */,
+				448C3AA82D4C4D4B00AA535D /* video_writer.h */,
 			);
 			path = common;
 			sourceTree = "<group>";
@@ -15755,6 +15984,7 @@
 				41C8D5D2292B6A5D00D49979 /* aom_util */,
 				41C8D5D3292B6A7100D49979 /* av1 */,
 				410B3852292B80EF0003E515 /* common */,
+				44CDF4D12D4C3A5E00B60493 /* examples */,
 				410B384C292B80980003E515 /* third_party */,
 			);
 			path = libaom;
@@ -16780,6 +17010,7 @@
 			isa = PBXGroup;
 			children = (
 				448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */,
+				44905A4D2D4F144D002B3379 /* vpx_encoder_fuzzer.cc */,
 			);
 			path = examples;
 			sourceTree = "<group>";
@@ -16833,6 +17064,10 @@
 				44D8D10B2B6AFB9A00B3CF91 /* h265_bitstream_parser_fuzzer.cc */,
 				44D88AE02AF04AC3005C956E /* h265_depacketizer_fuzzer.cc */,
 				449467C02AE05D6B00A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer.cc */,
+				44905A0D2D4EC751002B3379 /* rtp_format_h264_fuzzer.cc */,
+				44905A232D4ECD83002B3379 /* rtp_format_h265_fuzzer.cc */,
+				44905A342D4EEC57002B3379 /* rtp_format_vp8_fuzzer.cc */,
+				44905A492D4EF1B4002B3379 /* rtp_format_vp9_fuzzer.cc */,
 				449467D02AE05DBF00A9FED0 /* rtp_packetizer_av1_fuzzer.cc */,
 				44ABBE872AC63EF3006B44DD /* sdp_integration_fuzzer.cc */,
 				4460B8852B15572D00392062 /* vp8_depacketizer_fuzzer.cc */,
@@ -16844,6 +17079,14 @@
 				44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */,
 			);
 			path = fuzzers;
+			sourceTree = "<group>";
+		};
+		44CDF4D12D4C3A5E00B60493 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				448C3A902D4C3AB700AA535D /* aom_av1_encoder_fuzzer.cc */,
+			);
+			path = examples;
 			sourceTree = "<group>";
 		};
 		44E751682AC738DB00828AC4 /* test */ = {
@@ -20067,6 +20310,7 @@
 		5D7C59C41208C68B001C873E /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
+				448C3A912D4C3AC300AA535D /* aom_av1_encoder_fuzzer.xcconfig */,
 				449187232AB3800D007266F2 /* Base-libvpx.xcconfig */,
 				44871D222AC69336007538BC /* Base-libwebrtc.xcconfig */,
 				5D7C59C61208C68B001C873E /* Base.xcconfig */,
@@ -20092,13 +20336,19 @@
 				5C4B4A8F1E42C431002651C8 /* opus.xcconfig */,
 				441380CB2AE069CB00C928CB /* rtp_depacketizer_av1_assemble_frame_fuzzer.xcconfig */,
 				441380CA2AE069CB00C928CB /* rtp_packetizer_av1_fuzzer.xcconfig */,
+				44905A112D4EC958002B3379 /* rtp_packetizer_h264_fuzzer.xcconfig */,
+				44905A122D4ECD11002B3379 /* rtp_packetizer_h265_fuzzer.xcconfig */,
+				44905A252D4EE933002B3379 /* rtp_packetizer_vp8_fuzzer.xcconfig */,
+				44905A382D4EF0FC002B3379 /* rtp_packetizer_vp9_fuzzer.xcconfig */,
 				44ABBE972AC641B4006B44DD /* sdp_integration_fuzzer.xcconfig */,
 				449187242AB380BE007266F2 /* vp8_dec_fuzzer.xcconfig */,
 				4460B8882B155A8700392062 /* vp8_depacketizer_fuzzer.xcconfig */,
+				44905A4C2D4F1415002B3379 /* vp8_encoder_fuzzer.xcconfig */,
 				4460B8892B155A8700392062 /* vp8_qp_parser_fuzzer.xcconfig */,
 				44FD166E2AEA16CC003636CB /* vp8_replay_fuzzer.xcconfig */,
 				449187252AB380BE007266F2 /* vp9_dec_fuzzer.xcconfig */,
 				4460B88B2B155A8800392062 /* vp9_depacketizer_fuzzer.xcconfig */,
+				44905A4B2D4F1415002B3379 /* vp9_encoder_fuzzer.xcconfig */,
 				4460B88A2B155A8800392062 /* vp9_qp_parser_fuzzer.xcconfig */,
 				444A6F0A2AEAE01D005FE121 /* vp9_replay_fuzzer.xcconfig */,
 				44945C752B9BA41D00447FFD /* webm_fuzzer.xcconfig */,
@@ -20588,6 +20838,13 @@
 				4460B8C62B155B6A00392062 /* vp9_qp_parser_fuzzer */,
 				44D8D1192B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */,
 				44945C692B9BA1C300447FFD /* webm_fuzzer */,
+				448C3A9F2D4C48B300AA535D /* aom_av1_encoder_fuzzer */,
+				44905A0B2D4EC6E6002B3379 /* rtp_packetizer_h264_fuzzer */,
+				44905A202D4ECD1D002B3379 /* rtp_packetizer_h265_fuzzer */,
+				44905A332D4EE93B002B3379 /* rtp_packetizer_vp8_fuzzer */,
+				44905A462D4EF116002B3379 /* rtp_packetizer_vp9_fuzzer */,
+				44905A592D4F1471002B3379 /* vp8_encoder_fuzzer */,
+				44905A732D4F179E002B3379 /* vp9_encoder_fuzzer */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -23526,6 +23783,23 @@
 			productReference = 4469C10C2B5F24C500E32E5A /* h264_bitstream_parser_fuzzer */;
 			productType = "com.apple.product-type.tool";
 		};
+		448C3A922D4C48B300AA535D /* aom_av1_encoder_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 448C3A9B2D4C48B300AA535D /* Build configuration list for PBXNativeTarget "aom_av1_encoder_fuzzer" */;
+			buildPhases = (
+				448C3A962D4C48B300AA535D /* Sources */,
+				448C3A992D4C48B300AA535D /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				448C3A932D4C48B300AA535D /* PBXTargetDependency */,
+			);
+			name = aom_av1_encoder_fuzzer;
+			productName = aom_av1_encoder_fuzzer;
+			productReference = 448C3A9F2D4C48B300AA535D /* aom_av1_encoder_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
 		448D48332AB0BDB00065014C /* vp8_dec_fuzzer */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 448D483B2AB0BDB10065014C /* Build configuration list for PBXNativeTarget "vp8_dec_fuzzer" */;
@@ -23541,6 +23815,108 @@
 			name = vp8_dec_fuzzer;
 			productName = vp8_dec_fuzzer;
 			productReference = 448D48342AB0BDB00065014C /* vp8_dec_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
+		449059FF2D4EC6E6002B3379 /* rtp_packetizer_h264_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44905A072D4EC6E6002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_h264_fuzzer" */;
+			buildPhases = (
+				44905A022D4EC6E6002B3379 /* Sources */,
+				44905A052D4EC6E6002B3379 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44905A002D4EC6E6002B3379 /* PBXTargetDependency */,
+			);
+			name = rtp_packetizer_h264_fuzzer;
+			productName = rtp_packetizer_h264_fuzzer;
+			productReference = 44905A0B2D4EC6E6002B3379 /* rtp_packetizer_h264_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
+		44905A132D4ECD1D002B3379 /* rtp_packetizer_h265_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44905A1C2D4ECD1D002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_h265_fuzzer" */;
+			buildPhases = (
+				44905A162D4ECD1D002B3379 /* Sources */,
+				44905A1A2D4ECD1D002B3379 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44905A142D4ECD1D002B3379 /* PBXTargetDependency */,
+			);
+			name = rtp_packetizer_h265_fuzzer;
+			productName = rtp_packetizer_h265_fuzzer;
+			productReference = 44905A202D4ECD1D002B3379 /* rtp_packetizer_h265_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
+		44905A262D4EE93B002B3379 /* rtp_packetizer_vp8_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44905A2F2D4EE93B002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_vp8_fuzzer" */;
+			buildPhases = (
+				44905A292D4EE93B002B3379 /* Sources */,
+				44905A2D2D4EE93B002B3379 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44905A272D4EE93B002B3379 /* PBXTargetDependency */,
+			);
+			name = rtp_packetizer_vp8_fuzzer;
+			productName = rtp_packetizer_vp8_fuzzer;
+			productReference = 44905A332D4EE93B002B3379 /* rtp_packetizer_vp8_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
+		44905A392D4EF116002B3379 /* rtp_packetizer_vp9_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44905A422D4EF116002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_vp9_fuzzer" */;
+			buildPhases = (
+				44905A3C2D4EF116002B3379 /* Sources */,
+				44905A402D4EF116002B3379 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44905A3A2D4EF116002B3379 /* PBXTargetDependency */,
+			);
+			name = rtp_packetizer_vp9_fuzzer;
+			productName = rtp_packetizer_vp9_fuzzer;
+			productReference = 44905A462D4EF116002B3379 /* rtp_packetizer_vp9_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
+		44905A4E2D4F1471002B3379 /* vp8_encoder_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44905A552D4F1471002B3379 /* Build configuration list for PBXNativeTarget "vp8_encoder_fuzzer" */;
+			buildPhases = (
+				44905A512D4F1471002B3379 /* Sources */,
+				44905A532D4F1471002B3379 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44905A4F2D4F1471002B3379 /* PBXTargetDependency */,
+			);
+			name = vp8_encoder_fuzzer;
+			productName = vp8_encoder_fuzzer;
+			productReference = 44905A592D4F1471002B3379 /* vp8_encoder_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
+		44905A652D4F179E002B3379 /* vp9_encoder_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44905A6F2D4F179E002B3379 /* Build configuration list for PBXNativeTarget "vp9_encoder_fuzzer" */;
+			buildPhases = (
+				44905A682D4F179E002B3379 /* Sources */,
+				44905A6D2D4F179E002B3379 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44905A662D4F179E002B3379 /* PBXTargetDependency */,
+			);
+			name = vp9_encoder_fuzzer;
+			productName = vp9_encoder_fuzzer;
+			productReference = 44905A732D4F179E002B3379 /* vp9_encoder_fuzzer */;
 			productType = "com.apple.product-type.tool";
 		};
 		44945C512B9BA1C300447FFD /* webm_fuzzer */ = {
@@ -23911,19 +24287,26 @@
 				DDEBB11824C0187400ADBD44 /* aom */,
 				DDF30D0527C5C003006A526F /* absl */,
 				449CF1592ADEDE8500F22CAF /* Fuzzers (libwebrtc) */,
+				448C3A922D4C48B300AA535D /* aom_av1_encoder_fuzzer */,
 				4469C0FF2B5F24C500E32E5A /* h264_bitstream_parser_fuzzer */,
 				44D88ABD2AF04946005C956E /* h264_depacketizer_fuzzer */,
 				44D8D10C2B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */,
 				44D88AD12AF04AA1005C956E /* h265_depacketizer_fuzzer */,
 				449467C22AE05DA200A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer */,
 				449467A22AE05C9600A9FED0 /* rtp_packetizer_av1_fuzzer */,
+				449059FF2D4EC6E6002B3379 /* rtp_packetizer_h264_fuzzer */,
+				44905A132D4ECD1D002B3379 /* rtp_packetizer_h265_fuzzer */,
+				44905A262D4EE93B002B3379 /* rtp_packetizer_vp8_fuzzer */,
+				44905A392D4EF116002B3379 /* rtp_packetizer_vp9_fuzzer */,
 				44ABBE882AC63F0C006B44DD /* sdp_integration_fuzzer */,
 				448D48332AB0BDB00065014C /* vp8_dec_fuzzer */,
 				4460B88C2B155AFD00392062 /* vp8_depacketizer_fuzzer */,
+				44905A4E2D4F1471002B3379 /* vp8_encoder_fuzzer */,
 				4460B8AA2B155B4E00392062 /* vp8_qp_parser_fuzzer */,
 				446359B62AEA108C00551EEE /* vp8_replay_fuzzer */,
 				44C20E892AB39FA80046C6A8 /* vp9_dec_fuzzer */,
 				4460B89B2B155B2E00392062 /* vp9_depacketizer_fuzzer */,
+				44905A652D4F179E002B3379 /* vp9_encoder_fuzzer */,
 				4460B8B92B155B6A00392062 /* vp9_qp_parser_fuzzer */,
 				444A6EF02AEADFC9005FE121 /* vp9_replay_fuzzer */,
 				44945C512B9BA1C300447FFD /* webm_fuzzer */,
@@ -24556,11 +24939,85 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		448C3A962D4C48B300AA535D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				448C3AA22D4C4CBF00AA535D /* aom_av1_encoder_fuzzer.cc in Sources */,
+				448C3AA32D4C4CE800AA535D /* fuzz_data_helper.cc in Sources */,
+				448C3AA42D4C4CF400AA535D /* ivfenc.c in Sources */,
+				448C3AAA2D4C4D4B00AA535D /* tools_common.c in Sources */,
+				448C3AA92D4C4D4B00AA535D /* video_writer.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		448D48302AB0BDB00065014C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				448D48422AB0BEBA0065014C /* vpx_dec_fuzzer.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A022D4EC6E6002B3379 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A0C2D4EC714002B3379 /* fuzz_data_helper.cc in Sources */,
+				44905A0E2D4EC752002B3379 /* rtp_format_h264_fuzzer.cc in Sources */,
+				44905A042D4EC6E6002B3379 /* webrtc_fuzzer_main.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A162D4ECD1D002B3379 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A172D4ECD1D002B3379 /* fuzz_data_helper.cc in Sources */,
+				44905A242D4ECD83002B3379 /* rtp_format_h265_fuzzer.cc in Sources */,
+				44905A192D4ECD1D002B3379 /* webrtc_fuzzer_main.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A292D4EE93B002B3379 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A2A2D4EE93B002B3379 /* fuzz_data_helper.cc in Sources */,
+				44905A352D4EEC58002B3379 /* rtp_format_vp8_fuzzer.cc in Sources */,
+				44905A2C2D4EE93B002B3379 /* webrtc_fuzzer_main.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A3C2D4EF116002B3379 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A3D2D4EF116002B3379 /* fuzz_data_helper.cc in Sources */,
+				44905A4A2D4EF1B4002B3379 /* rtp_format_vp9_fuzzer.cc in Sources */,
+				44905A3F2D4EF116002B3379 /* webrtc_fuzzer_main.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A512D4F1471002B3379 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A5B2D4F149C002B3379 /* fuzz_data_helper.cc in Sources */,
+				44905A622D4F152F002B3379 /* tools_common.c in Sources */,
+				44905A5A2D4F1486002B3379 /* vpx_encoder_fuzzer.cc in Sources */,
+				44905A5E2D4F14E0002B3379 /* y4minput.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44905A682D4F179E002B3379 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44905A692D4F179E002B3379 /* fuzz_data_helper.cc in Sources */,
+				44905A6A2D4F179E002B3379 /* tools_common.c in Sources */,
+				44905A6B2D4F179E002B3379 /* vpx_encoder_fuzzer.cc in Sources */,
+				44905A6C2D4F179E002B3379 /* y4minput.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -26724,10 +27181,80 @@
 			target = 4469C0FF2B5F24C500E32E5A /* h264_bitstream_parser_fuzzer */;
 			targetProxy = 4469C10D2B5F24DA00E32E5A /* PBXContainerItemProxy */;
 		};
+		448C3A932D4C48B300AA535D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 448C3A942D4C48B300AA535D /* PBXContainerItemProxy */;
+		};
+		448C3AA12D4C48C400AA535D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 448C3A922D4C48B300AA535D /* aom_av1_encoder_fuzzer */;
+			targetProxy = 448C3AA02D4C48C400AA535D /* PBXContainerItemProxy */;
+		};
 		448D483D2AB0BDB80065014C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 4105EB69212E01D2008C0C20 /* vpx */;
 			targetProxy = 448D483C2AB0BDB80065014C /* PBXContainerItemProxy */;
+		};
+		44905A002D4EC6E6002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 44905A012D4EC6E6002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A102D4EC7BF002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 449059FF2D4EC6E6002B3379 /* rtp_packetizer_h264_fuzzer */;
+			targetProxy = 44905A0F2D4EC7BF002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A142D4ECD1D002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 44905A152D4ECD1D002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A222D4ECD31002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44905A132D4ECD1D002B3379 /* rtp_packetizer_h265_fuzzer */;
+			targetProxy = 44905A212D4ECD31002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A272D4EE93B002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 44905A282D4EE93B002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A372D4EEC6B002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44905A262D4EE93B002B3379 /* rtp_packetizer_vp8_fuzzer */;
+			targetProxy = 44905A362D4EEC6B002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A3A2D4EF116002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 44905A3B2D4EF116002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A482D4EF129002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44905A392D4EF116002B3379 /* rtp_packetizer_vp9_fuzzer */;
+			targetProxy = 44905A472D4EF129002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A4F2D4F1471002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4105EB69212E01D2008C0C20 /* vpx */;
+			targetProxy = 44905A502D4F1471002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A642D4F16E7002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44905A4E2D4F1471002B3379 /* vp8_encoder_fuzzer */;
+			targetProxy = 44905A632D4F16E7002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A662D4F179E002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4105EB69212E01D2008C0C20 /* vpx */;
+			targetProxy = 44905A672D4F179E002B3379 /* PBXContainerItemProxy */;
+		};
+		44905A752D4F17B3002B3379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44905A652D4F179E002B3379 /* vp9_encoder_fuzzer */;
+			targetProxy = 44905A742D4F17B3002B3379 /* PBXContainerItemProxy */;
 		};
 		44945C6C2B9BA20300447FFD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -27040,6 +27567,30 @@
 			};
 			name = Production;
 		};
+		448C3A9C2D4C48B300AA535D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 448C3A912D4C3AC300AA535D /* aom_av1_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		448C3A9D2D4C48B300AA535D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 448C3A912D4C3AC300AA535D /* aom_av1_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		448C3A9E2D4C48B300AA535D /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 448C3A912D4C3AC300AA535D /* aom_av1_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
 		448D48382AB0BDB10065014C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 449187242AB380BE007266F2 /* vp8_dec_fuzzer.xcconfig */;
@@ -27058,6 +27609,150 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 449187242AB380BE007266F2 /* vp8_dec_fuzzer.xcconfig */;
 			buildSettings = {
+			};
+			name = Production;
+		};
+		44905A082D4EC6E6002B3379 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A112D4EC958002B3379 /* rtp_packetizer_h264_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44905A092D4EC6E6002B3379 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A112D4EC958002B3379 /* rtp_packetizer_h264_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44905A0A2D4EC6E6002B3379 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A112D4EC958002B3379 /* rtp_packetizer_h264_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		44905A1D2D4ECD1D002B3379 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A122D4ECD11002B3379 /* rtp_packetizer_h265_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44905A1E2D4ECD1D002B3379 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A122D4ECD11002B3379 /* rtp_packetizer_h265_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44905A1F2D4ECD1D002B3379 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A122D4ECD11002B3379 /* rtp_packetizer_h265_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		44905A302D4EE93B002B3379 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A252D4EE933002B3379 /* rtp_packetizer_vp8_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44905A312D4EE93B002B3379 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A252D4EE933002B3379 /* rtp_packetizer_vp8_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44905A322D4EE93B002B3379 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A252D4EE933002B3379 /* rtp_packetizer_vp8_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		44905A432D4EF116002B3379 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A382D4EF0FC002B3379 /* rtp_packetizer_vp9_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44905A442D4EF116002B3379 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A382D4EF0FC002B3379 /* rtp_packetizer_vp9_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44905A452D4EF116002B3379 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A382D4EF0FC002B3379 /* rtp_packetizer_vp9_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		44905A562D4F1471002B3379 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A4C2D4F1415002B3379 /* vp8_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44905A572D4F1471002B3379 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A4C2D4F1415002B3379 /* vp8_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44905A582D4F1471002B3379 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A4C2D4F1415002B3379 /* vp8_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		44905A702D4F179E002B3379 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A4B2D4F1415002B3379 /* vp9_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44905A712D4F179E002B3379 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A4B2D4F1415002B3379 /* vp9_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44905A722D4F179E002B3379 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44905A4B2D4F1415002B3379 /* vp9_encoder_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Production;
 		};
@@ -27551,12 +28246,82 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
+		448C3A9B2D4C48B300AA535D /* Build configuration list for PBXNativeTarget "aom_av1_encoder_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				448C3A9C2D4C48B300AA535D /* Debug */,
+				448C3A9D2D4C48B300AA535D /* Release */,
+				448C3A9E2D4C48B300AA535D /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
 		448D483B2AB0BDB10065014C /* Build configuration list for PBXNativeTarget "vp8_dec_fuzzer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				448D48382AB0BDB10065014C /* Debug */,
 				448D48392AB0BDB10065014C /* Release */,
 				448D483A2AB0BDB10065014C /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44905A072D4EC6E6002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_h264_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44905A082D4EC6E6002B3379 /* Debug */,
+				44905A092D4EC6E6002B3379 /* Release */,
+				44905A0A2D4EC6E6002B3379 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44905A1C2D4ECD1D002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_h265_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44905A1D2D4ECD1D002B3379 /* Debug */,
+				44905A1E2D4ECD1D002B3379 /* Release */,
+				44905A1F2D4ECD1D002B3379 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44905A2F2D4EE93B002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_vp8_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44905A302D4EE93B002B3379 /* Debug */,
+				44905A312D4EE93B002B3379 /* Release */,
+				44905A322D4EE93B002B3379 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44905A422D4EF116002B3379 /* Build configuration list for PBXNativeTarget "rtp_packetizer_vp9_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44905A432D4EF116002B3379 /* Debug */,
+				44905A442D4EF116002B3379 /* Release */,
+				44905A452D4EF116002B3379 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44905A552D4F1471002B3379 /* Build configuration list for PBXNativeTarget "vp8_encoder_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44905A562D4F1471002B3379 /* Debug */,
+				44905A572D4F1471002B3379 /* Release */,
+				44905A582D4F1471002B3379 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44905A6F2D4F179E002B3379 /* Build configuration list for PBXNativeTarget "vp9_encoder_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44905A702D4F179E002B3379 /* Debug */,
+				44905A712D4F179E002B3379 /* Release */,
+				44905A722D4F179E002B3379 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### 0d11ff2da8be8eb0bc8fc20f0500f305d08e1445
<pre>
[WebRTC] Add more webrtc fuzzers
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=286888">https://bugs.webkit.org/show_bug.cgi?id=286888</a>&gt;
&lt;<a href="https://rdar.apple.com/144052006">rdar://144052006</a>&gt;

Reviewed by Jonathan Bedard.

* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/examples/aom_av1_encoder_fuzzer.cc: Copied from Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/examples/simple_encoder.c.
- Modify libaom/examples/simple_encoder.c into a fuzzer.
- Also borrow code from libaom/common/tools_common.c.
* Source/ThirdParty/libwebrtc/Configurations/aom_av1_encoder_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_h264_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_h265_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_vp8_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/rtp_packetizer_vp9_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/vp8_encoder_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Configurations/vp9_encoder_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/examples/vpx_encoder_fuzzer.cc: Copied from Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/examples/simple_encoder.c.
- Modify libvpx/examples/simple_encoder.c into a fuzzer.
- Also borrow code from libvpx/tools_common.c.
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h264_fuzzer.cc:
- Run generated packets through depacketizer when fuzzing.
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h265_fuzzer.cc: Copied from Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_h264_fuzzer.cc.
- Modify rtp_format_h264_fuzzer.cc to fuzz H265/HEVC format.
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_vp8_fuzzer.cc:
- Set more fields in RTPVideoHeaderVP8 from fuzzer input.
- Run generated packets through depacketizer when fuzzing.
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/rtp_format_vp9_fuzzer.cc:
- Generate RTPVideoHeaderVP9 from fuzzer input.
- Run generated packets through depacketizer when fuzzing.
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
- Add sources and fuzzer targets to the Xcode project.

Canonical link: <a href="https://commits.webkit.org/289734@main">https://commits.webkit.org/289734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b45f9942169c8eb2d62bf525a3bf9d6254a56448

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38504 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67751 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25498 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48120 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37611 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94505 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14922 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10963 "Found 2 new test failures: imported/w3c/web-platform-tests/screen-orientation/unlock.html ipc/create-media-source-with-invalid-constraints-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76601 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75837 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7909 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13696 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14938 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->