### PR TITLE
Add strongly type representations of CSS/Style Numeric + Keywords

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		AD89B6BA1E64150F0090707F /* MemoryPressureHandlerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = AD89B6B91E64150F0090707F /* MemoryPressureHandlerCocoa.mm */; };
 		ADF2CE671E39F106006889DB /* MemoryFootprintCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADF2CE651E39F106006889DB /* MemoryFootprintCocoa.cpp */; };
 		BC05ACA62CEA70E500750CB1 /* VariantListOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC2C0C212D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0C202D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC5267672C2726D600E422DD /* MakeString.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5267662C2726D600E422DD /* MakeString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFA72D1865B9003F0349 /* CompactVariant.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA62D1865B9003F0349 /* CompactVariant.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFA92D1865C4003F0349 /* CompactVariantOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1580,6 +1581,7 @@
 		ADF2CE641E39F106006889DB /* MemoryFootprint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryFootprint.h; sourceTree = "<group>"; };
 		ADF2CE651E39F106006889DB /* MemoryFootprintCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryFootprintCocoa.cpp; sourceTree = "<group>"; };
 		BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantListOperations.h; sourceTree = "<group>"; };
+		BC2C0C202D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FlatteningVariantAdaptor.h; sourceTree = "<group>"; };
 		BC5267662C2726D600E422DD /* MakeString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MakeString.h; sourceTree = "<group>"; };
 		BCE0DFA62D1865B9003F0349 /* CompactVariant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariant.h; sourceTree = "<group>"; };
 		BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariantOperations.h; sourceTree = "<group>"; };
@@ -2273,6 +2275,7 @@
 				FF910E972979FE6F00D1A24D /* FixedBitVector.h */,
 				E3E0F04F26197157004640FC /* FixedVector.h */,
 				33479C1C27236F2000B2E1B7 /* FixedWidthDouble.h */,
+				BC2C0C202D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h */,
 				0F2B66A517B6B4F700A7AE3F /* FlipBytes.h */,
 				E3B876252C40CBEC0004DF71 /* Float16.h */,
 				FE86A8741E59440200111BBF /* ForbidHeapAllocation.h */,
@@ -3377,6 +3380,7 @@
 				FF910E982979FE6F00D1A24D /* FixedBitVector.h in Headers */,
 				DD3DC96527A4BF8E007E5B61 /* FixedVector.h in Headers */,
 				339B7B1127C45EF50072BF9A /* FixedWidthDouble.h in Headers */,
+				BC2C0C212D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h in Headers */,
 				DD3DC8D327A4BF8E007E5B61 /* FlipBytes.h in Headers */,
 				E3B876262C40CBEC0004DF71 /* Float16.h in Headers */,
 				E361DB64289115D000B2A2B8 /* float_common.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -92,6 +92,7 @@ set(WTF_PUBLIC_HEADERS
     FixedBitVector.h
     FixedVector.h
     FixedWidthDouble.h
+    FlatteningVariantAdaptor.h
     FlipBytes.h
     Float16.h
     ForbidHeapAllocation.h

--- a/Source/WTF/wtf/FlatteningVariantAdaptor.h
+++ b/Source/WTF/wtf/FlatteningVariantAdaptor.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <variant>
+#include <wtf/Brigand.h>
+#include <wtf/CompactVariant.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/VariantExtras.h>
+
+namespace WTF {
+
+// `FlatteningVariantAdaptor` adapts "Variant-Like" types and attempts to
+// minimize memory usage by *flattening* nested "Variant-Like" types.
+//
+// For example, take the following usage:
+//
+//   using Foo = FlatteningVariantAdaptor<std::variant, std::variant<std::string, int>, double>;
+//
+// Here, `Foo` will be internally represented by:
+//
+//   std::variant<std::string, int, double>
+//
+// allowing a single index to be used for all options.
+//
+// To add support for flattening to variant-like type, clients can specialize
+// `FlatteningVariantTraits` to expose the list of the nested types.
+//
+// Standard aliases for a flattening `std::variant` and `CompactVariant` are
+// provided called `FlatteningVariant` and `FlatteningCompactVariant`.
+
+// MARK: - FlatteningVariantTraits
+
+template<typename T> struct FlatteningVariantTraits {
+    using TypeList = brigand::list<T>;
+};
+
+template<typename... Ts> struct FlatteningVariantTraits<std::variant<Ts...>> {
+    using TypeList = brigand::list<Ts...>;
+};
+
+template<typename... Ts> struct FlatteningVariantTraits<CompactVariant<Ts...>> {
+    using TypeList = brigand::list<Ts...>;
+};
+
+// MARK: - FlatteningVariantAdaptor
+
+template<template<typename...> typename VariantType, typename... Ts> class FlatteningVariantAdaptor {
+    template<typename... Us> using Wrapper = VariantType<Us...>;
+public:
+    using TypeList = brigand::append<typename FlatteningVariantTraits<Ts>::TypeList...>;
+    using Representation = brigand::wrap<TypeList, Wrapper>;
+
+    template<typename T> static constexpr Representation extract(T&& value)
+    {
+        if constexpr (brigand::size<typename FlatteningVariantTraits<std::remove_cvref_t<T>>::TypeList>::value == 1)
+            return std::forward<T>(value);
+        else
+            return WTF::switchOn(std::forward<T>(value), []<typename U>(U&& value) { return extract(std::forward<U>(value)); });
+    }
+
+    template<typename T> constexpr FlatteningVariantAdaptor(T&& value)
+        : m_value { extract(std::forward<T>(value)) }
+    {
+    }
+
+    // Checks if type `T` is included in the flattened list of types.
+    template<typename T> constexpr bool holdsAlternative() const
+    {
+        return holdsAlternative<T>(m_value);
+    }
+
+    // Switches on the flattened list of types.
+    template<typename... F> decltype(auto) switchOn(F&&... functors) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(functors)...);
+    }
+
+    // TODO: Add `holdsAlternativeFromOriginalList` that checks all flattened alternatives for the provided type.
+    // TODO: Add `switchOnOriginalList` that reconstructs extracted values.
+
+    bool operator==(const FlatteningVariantAdaptor&) const = default;
+
+private:
+    Representation m_value;
+};
+
+// Specialization of `FlatteningVariantTraits` for `FlatteningVariantAdaptor` itself so that
+// recursively used `FlatteningVariantAdaptor` types can flatten together.
+template<template<typename...> typename VariantType, typename... Ts> struct FlatteningVariantTraits<FlatteningVariantAdaptor<VariantType, Ts...>> {
+    using TypeList = typename FlatteningVariantAdaptor<VariantType, Ts...>::TypeList;
+};
+
+// MARK: - Standard FlatteningVariantAdaptor Aliases
+
+template<typename... Ts> using FlatteningVariant = FlatteningVariantAdaptor<std::variant, Ts...>;
+template<typename... Ts> using FlatteningCompactVariant = FlatteningVariantAdaptor<CompactVariant, Ts...>;
+
+} // namespace WTF
+
+using WTF::FlatteningCompactVariant;
+using WTF::FlatteningVariant;
+using WTF::FlatteningVariantTraits;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -86,6 +86,7 @@ template<typename, size_t = 0> class Deque;
 template<typename Key, typename, Key> class EnumeratedArray;
 template<typename, typename = WTF::EmbeddedFixedVectorMalloc> class FixedVector;
 template<typename> class Function;
+template<typename> struct FlatteningVariantTraits;
 template<typename> struct IsSmartPtr;
 template<typename, typename = AnyThreadsAccessTraits> class LazyNeverDestroyed;
 template<typename T, typename Traits = typename T::MarkableTraits> class Markable;

--- a/Source/WTF/wtf/VariantExtras.h
+++ b/Source/WTF/wtf/VariantExtras.h
@@ -80,7 +80,8 @@ template<typename Arg, typename... Ts> struct VariantBestMatch<std::variant<Ts..
 //   using Variant = std::variant<int, float>;
 //
 //   Variant foo = 5;
-//   typeForIndex<Variant>(foo.index(), /* index will be 0 for first parameter, <int> */
+//   typeForIndex<Variant>(
+//       foo.index(), /* index will be 0 for first parameter, <int> */
 //       []<typename T>() {
 //           if constexpr (std::is_same_v<T, int>) {
 //               print("we got an int");  <--- this will get called
@@ -90,74 +91,14 @@ template<typename Arg, typename... Ts> struct VariantBestMatch<std::variant<Ts..
 //       }
 //   );
 
-template<typename V, size_t I = 0, typename F> constexpr ALWAYS_INLINE decltype(auto) visitTypeForIndex(size_t index, NOESCAPE F&& f)
+template<typename V, typename F> constexpr decltype(auto) typeForIndex(size_t index, NOESCAPE F&& f)
 {
-    constexpr auto size = std::variant_size_v<V>;
-
-    // To implement dispatch for variants, this recursively looping switch will work for
-    // variants with any number of alternatives, with variants with greater than 32 recursing
-    // and starting the switch at 32 (and so on).
-
-#define WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT 32
-#define WTF_VARIANT_EXTRAS_VISIT_CASE(N, D) \
-        I + N:                                                                                      \
-        {                                                                                           \
-            if constexpr (I + N < size) {                                                           \
-                return f.template operator()<std::variant_alternative_t<I + N, V>>();               \
-            } else {                                                                                \
-                WTF_UNREACHABLE();                                                                  \
-            }                                                                                       \
-        }                                                                                           \
-
-    switch (index) {
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(0, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(1, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(2, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(3, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(4, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(5, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(6, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(7, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(8, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(9, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(10, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(11, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(12, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(13, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(14, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(15, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(16, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(17, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(18, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(19, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(20, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(21, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(22, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(23, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(24, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(25, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(26, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(27, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(28, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(29, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(30, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    case WTF_VARIANT_EXTRAS_VISIT_CASE(31, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
-    }
-
-    constexpr auto nextI = std::min(I + WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT, size);
-
-    if constexpr (nextI < size)
-        return visitTypeForIndex<V, nextI>(index, std::forward<F>(f));
-
-    WTF_UNREACHABLE();
-
-#undef WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT
-#undef WTF_VARIANT_EXTRAS_VISIT_CASE
-}
-
-template<typename V, typename... F> constexpr auto typeForIndex(size_t index, F&&... f) -> decltype(visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...)))
-{
-    return visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...));
+    return visitAtIndex<0, std::variant_size_v<std::remove_cvref_t<V>>>(
+        index,
+        [&]<size_t I>() ALWAYS_INLINE_LAMBDA {
+           return f.template operator()<std::variant_alternative_t<I, std::remove_cvref_t<V>>>();
+        }
+    );
 }
 
 } // namespace WTF

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -992,7 +992,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/values/motion/CSSRayFunction.h
 
     css/values/primitives/CSSPosition.h
+    css/values/primitives/CSSPrimitiveData.h
+    css/values/primitives/CSSPrimitiveKeywordList.h
+    css/values/primitives/CSSPrimitiveNumeric.h
     css/values/primitives/CSSPrimitiveNumericConcepts.h
+    css/values/primitives/CSSPrimitiveNumericOrKeyword.h
     css/values/primitives/CSSPrimitiveNumericRange.h
     css/values/primitives/CSSPrimitiveNumericRaw.h
     css/values/primitives/CSSPrimitiveNumericTypes+EvaluateCalc.h
@@ -2670,7 +2674,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/motion/StyleRayFunction.h
 
     style/values/primitives/StylePosition.h
+    style/values/primitives/StylePrimitiveNumeric.h
     style/values/primitives/StylePrimitiveNumericConcepts.h
+    style/values/primitives/StylePrimitiveNumericOrKeyword.h
     style/values/primitives/StylePrimitiveNumericTypes.h
     style/values/primitives/StyleUnevaluatedCalculation.h
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -1596,5 +1596,28 @@ Tree copyAndSimplify(const Tree& tree, const SimplificationOptions& options)
     };
 }
 
+// MARK: - Can Simplify
+
+bool canSimplify(const Tree& tree, const SimplificationOptions&)
+{
+    // NOTE: This is a simple and conservative implementation of `canSimplify`. A more precise implementation
+    // is possible by utilizing the provided `SimplificationOptions` if that should be necessary.
+
+    return WTF::switchOn(tree.root,
+        [&](const Number&) -> bool {
+            return false;
+        },
+        [&](const Percentage&) -> bool {
+            return false;
+        },
+        [&](const CanonicalDimension&) -> bool {
+            return false;
+        },
+        [&](auto const&) -> bool {
+            return true;
+        }
+    );
+}
+
 } // namespace CSSCalc
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -97,6 +97,11 @@ struct SimplificationOptions {
     bool allowZeroValueLengthRemovalFromSum = false;
 };
 
+
+// MARK: Can Simplify
+
+bool canSimplify(const Tree&, const SimplificationOptions&);
+
 // MARK: Copy & Simplify
 
 Tree copyAndSimplify(const Tree&, const SimplificationOptions&);

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -108,6 +108,30 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(const CSSToLengthConversionData& 
         .allowZeroValueLengthRemovalFromSum = true,
     };
 
+    if (!canSimplify(m_tree, simplificationOptions))
+        return const_cast<CSSCalcValue&>(*this);
+
+    return create(m_category, m_range, copyAndSimplify(m_tree, simplificationOptions));
+}
+
+Ref<CSSCalcValue> CSSCalcValue::copySimplified(NoConversionDataRequiredToken token) const
+{
+    return copySimplified(token, { });
+}
+
+Ref<CSSCalcValue> CSSCalcValue::copySimplified(NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) const
+{
+    auto simplificationOptions = CSSCalc::SimplificationOptions {
+        .category = m_category,
+        .range = m_range,
+        .conversionData = std::nullopt,
+        .symbolTable = symbolTable,
+        .allowZeroValueLengthRemovalFromSum = true,
+    };
+
+    if (!canSimplify(m_tree, simplificationOptions))
+        return const_cast<CSSCalcValue&>(*this);
+
     return create(m_category, m_range, copyAndSimplify(m_tree, simplificationOptions));
 }
 

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -74,6 +74,8 @@ public:
     // Creates a copy of the CSSCalc::Tree with non-canonical dimensions and any symbols present in the provided symbol table resolved.
     Ref<CSSCalcValue> copySimplified(const CSSToLengthConversionData&) const;
     Ref<CSSCalcValue> copySimplified(const CSSToLengthConversionData&, const CSSCalcSymbolTable&) const;
+    Ref<CSSCalcValue> copySimplified(NoConversionDataRequiredToken) const;
+    Ref<CSSCalcValue> copySimplified(NoConversionDataRequiredToken, const CSSCalcSymbolTable&) const;
 
     Calculation::Category category() const { return m_category; }
     CSS::Range range() const { return m_range; }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
@@ -1,0 +1,494 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveKeywordList.h"
+#include "CSSPrimitiveNumericConcepts.h"
+#include "CSSPrimitiveNumericRaw.h"
+#include "CSSUnevaluatedCalc.h"
+#include <limits>
+#include <type_traits>
+#include <wtf/EnumTraits.h>
+
+namespace WebCore {
+namespace CSS {
+
+// `PrimitiveData` is a bespoke implementation of `std::variant<Numeric, Keywords...>`
+// optimized for memory use by allowing numeric types with multiple unit representations
+// (e.g. <length>, <angle>, etc.) to utilize multiple indices for a single smaller payload.
+//
+// FIXME: Generalize this concept to support arbitrary types through traits.
+
+// MARK: - Concepts
+
+// Concept for use checking if a `ChildPrimitiveData`'s types are a subset of
+// `ParentPrimitiveData`'s types.
+// FIXME: Currently limited to the case of Parent<NumericA, KeywordB, ...> and Child == NumericA.
+template<typename ChildPrimitiveData, typename ParentPrimitiveData> concept SubsumesChildPrimitiveData
+    = (!std::same_as<ChildPrimitiveData, ParentPrimitiveData>)
+   && (std::same_as<typename ChildPrimitiveData::Index, typename ParentPrimitiveData::Index::NumericType::Base::Index>);
+
+// MARK: - Markable Support
+
+struct PrimitiveDataEmptyToken { constexpr bool operator==(const PrimitiveDataEmptyToken&) const = default; };
+
+template<typename T> struct PrimitiveDataMarkableTraits {
+    static bool isEmptyValue(const T& value) { return value.isEmpty(); }
+    static T emptyValue() { return T(PrimitiveDataEmptyToken { }); }
+};
+
+// MARK: - Index
+
+template<Numeric N, PrimitiveKeyword... Ks> struct PrimitiveDataIndex {
+    using NumericType = N;
+    using Keywords = PrimitiveKeywordList<Ks...>;
+
+    using Raw = typename N::Raw;
+    using Calc = typename N::Calc;
+    using UnitType = typename N::UnitType;
+    using UnitTraits = typename N::UnitTraits;
+
+    using Storage = std::underlying_type_t<typename N::UnitType>;
+
+    // The potential values for the `index` are:
+    //  - 0 ... # of units - 1                              -> Raw
+    //  - # of units                                        -> Calc
+    //  - # of units + 1 ... # of units + # of keywords     -> Constant<Id>
+    //
+    // (... gap ...)
+    //
+    //  - max(index_type) - 1                               -> Empty (for Markable)
+    //  - max(index_type)                                   -> Moved from
+
+    static constexpr Storage indexStorageForFirstRaw       = 0;
+    static constexpr Storage indexStorageForLastRaw        = UnitTraits::count - 1;
+    static constexpr Storage indexStorageForCalc           = UnitTraits::count;
+    static constexpr Storage indexStorageForFirstKeyword   = UnitTraits::count + 1;
+    static constexpr Storage indexStorageForLastKeyword    = UnitTraits::count + Keywords::count;
+    // (... gap ...)
+    static constexpr Storage indexStorageForEmpty          = std::numeric_limits<Storage>::max() - 1;
+    static constexpr Storage indexStorageForMovedFrom      = std::numeric_limits<Storage>::max();
+
+    static constexpr Storage indexStorageForUnit(UnitType unit)
+    {
+        return indexStorageForFirstRaw + enumToUnderlyingType(unit);
+    }
+
+    static consteval Storage indexStorageForKeyword(ValidKeywordForList<Keywords> auto keyword)
+    {
+        return indexStorageForFirstKeyword + Keywords::offsetForKeyword(keyword);
+    }
+
+    static_assert(UnitTraits::count + Keywords::count + 2 <= std::numeric_limits<Storage>::max());
+
+    // MARK: Construction
+
+    PrimitiveDataIndex(const PrimitiveDataIndex<N, Ks...>&) = default;
+
+    template<typename T>
+        requires (Keywords::count != 0) && (requires {
+            requires std::same_as<T, PrimitiveDataIndex<typename N::Base>>;
+        })
+    PrimitiveDataIndex(const T& other)
+        : storage { other.storage }
+    {
+    }
+
+    template<typename T>
+        requires (Keywords::count != 0) && (requires {
+            requires std::same_as<T, PrimitiveDataIndex<typename N::Base>>;
+        })
+    PrimitiveDataIndex& operator=(const T& other)
+    {
+        storage = other.storage;
+        return *this;
+    }
+
+    constexpr explicit PrimitiveDataIndex(Storage storage)
+        : storage { storage }
+    {
+    }
+
+    constexpr PrimitiveDataIndex(UnitType unit)
+        : storage { indexStorageForUnit(unit) }
+    {
+    }
+
+    constexpr PrimitiveDataIndex(const Raw& raw)
+        : storage { indexStorageForUnit(raw.unit) }
+    {
+    }
+
+    constexpr PrimitiveDataIndex(const Calc&)
+        : storage { indexStorageForCalc }
+    {
+    }
+
+    constexpr PrimitiveDataIndex(ValidKeywordForList<Keywords> auto keyword)
+        : storage { indexStorageForKeyword(keyword)  }
+    {
+    }
+
+    constexpr PrimitiveDataIndex(PrimitiveDataEmptyToken)
+        : storage { indexStorageForEmpty }
+    {
+    }
+
+    // MARK: Assignment
+
+    PrimitiveDataIndex& operator=(const PrimitiveDataIndex<N, Ks...>&) = default;
+
+
+    // MARK: Raw Unit
+
+    constexpr typename NumericType::Raw::UnitType unit() const
+    {
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(isRaw());
+        return static_cast<UnitType>(storage);
+    }
+
+    // MARK: Keyword
+
+    template<typename F> constexpr decltype(auto) visitKeyword(F&& f) const
+    {
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(storage <= indexStorageForLastKeyword);
+        return Keywords::visitKeywordAtOffset(storage - indexStorageForFirstKeyword, std::forward<F>(f));
+    }
+
+    // MARK: Predicates
+
+    constexpr bool isRaw() const
+    {
+        return storage >= indexStorageForFirstRaw && storage <= indexStorageForLastRaw;
+    }
+
+    constexpr bool isCalc() const
+    {
+        return storage == indexStorageForCalc;
+    }
+
+    constexpr bool isKeyword(ValidKeywordForList<Keywords> auto keyword) const
+    {
+        return storage == indexStorageForKeyword(keyword);
+    }
+
+    constexpr bool isEmpty() const
+    {
+        return storage == indexStorageForEmpty;
+    }
+
+    constexpr bool isMovedFrom() const
+    {
+        return storage == indexStorageForMovedFrom;
+    }
+
+    void setAsMovedFrom()
+    {
+        storage = indexStorageForMovedFrom;
+    }
+
+    constexpr bool operator==(const PrimitiveDataIndex&) const = default;
+    constexpr bool operator==(Storage other) const { return storage == other; }
+
+    Storage storage;
+};
+
+// MARK: - Payload
+
+union PrimitiveDataPayload {
+    double number;
+    CSSCalcValue* calc;
+
+    PrimitiveDataPayload(double number)
+        : number { number }
+    {
+    }
+
+    PrimitiveDataPayload(CSSCalcValue* calc)
+        : calc { calc }
+    {
+    }
+};
+
+// MARK: - PrimitiveData
+
+template<Numeric N, PrimitiveKeyword... Ks> struct PrimitiveData {
+    using Index = PrimitiveDataIndex<N, Ks...>;
+    using Payload = PrimitiveDataPayload;
+
+    using Keywords = typename Index::Keywords;
+    using Raw = typename N::Raw;
+    using Calc = typename N::Calc;
+    using UnitType = typename N::UnitType;
+    using UnitTraits = typename N::UnitTraits;
+
+    PrimitiveData(Raw raw)
+        : payload { raw.value }
+        , index { raw }
+    {
+    }
+
+    PrimitiveData(Calc calc)
+        : payload { &calc.protectedCalc().leakRef() }
+        , index { calc }
+    {
+    }
+
+    PrimitiveData(ValidKeywordForList<Keywords> auto keyword)
+        : payload { 0.0 }
+        , index { keyword }
+    {
+    }
+
+    PrimitiveData(PrimitiveDataEmptyToken token)
+        : payload { 0.0 }
+        , index { token }
+    {
+    }
+
+    PrimitiveData(const PrimitiveData& other)
+        : payload { other.payload }
+        , index { other.index }
+    {
+        if (isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcRef(payload.calc);
+    }
+
+    PrimitiveData(PrimitiveData&& other)
+        : payload { other.payload }
+        , index { other.index }
+    {
+        other.setAsMovedFrom();
+    }
+
+    PrimitiveData& operator=(const PrimitiveData& other)
+    {
+        if (isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(payload.calc);
+        if (other.isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcRef(other.payload.calc);
+
+        index = other.index;
+        payload = other.payload;
+
+        return *this;
+    }
+
+    PrimitiveData& operator=(PrimitiveData&& other)
+    {
+        if (isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(payload.calc);
+
+        index = other.index;
+        payload = other.payload;
+
+        other.setAsMovedFrom();
+
+        return *this;
+    }
+
+    // MARK: Constructor/Assignment for NumericType-only PrimitiveData
+    // Allows PrimitiveNumeric<T> to be efficiently assigned to PrimitiveNumericOrKeyword<T, Ks...>.
+
+    template<SubsumesChildPrimitiveData<PrimitiveData> T>
+    PrimitiveData(const T& other)
+        : payload { other.payload }
+        , index { other.index }
+    {
+        if (other.isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcRef(other.payload.calc);
+    }
+
+    template<SubsumesChildPrimitiveData<PrimitiveData> T>
+    PrimitiveData(T&& other)
+        : payload { other.payload }
+        , index { other.index }
+    {
+        other.setAsMovedFrom();
+    }
+
+    template<SubsumesChildPrimitiveData<PrimitiveData> T>
+    PrimitiveData& operator=(const T& other)
+    {
+        if (isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(payload.calc);
+        if (other.isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcRef(other.payload.calc);
+
+        index = other.index;
+        payload = other.payload;
+
+        return *this;
+    }
+
+    template<SubsumesChildPrimitiveData<PrimitiveData> T>
+    PrimitiveData& operator=(T&& other)
+    {
+        if (isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(payload.calc);
+
+        index = other.index;
+        payload = other.payload;
+
+        other.setAsMovedFrom();
+
+        return *this;
+    }
+
+    ~PrimitiveData()
+    {
+        if (isCalc())
+            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(payload.calc);
+    }
+
+    bool operator==(const PrimitiveData& other) const
+    {
+        if (index != other.index)
+            return false;
+
+        if (isCalc())
+            return asCalc() == other.asCalc();
+        return payload.number == other.payload.number;
+    }
+
+    bool operator==(ValidKeywordForList<Keywords> auto other) const
+    {
+        return index == Index(other);
+    }
+
+    bool operator==(const Raw& raw) const
+    {
+        if (index != Index(raw))
+            return false;
+
+        ASSERT(isRaw());
+        return payload.number == raw.value;
+    }
+
+    bool operator==(const Calc& calc) const
+    {
+        if (!isCalc())
+            return false;
+        return asCalc() == calc;
+    }
+
+    template<typename T>
+        requires NumericRaw<T> && NestedUnitEnumOf<typename T::UnitType, UnitType>
+    constexpr bool operator==(const T& raw) const
+    {
+        if (index != Index(unitUpcast<UnitType>(raw.unit)))
+            return false;
+
+        ASSERT(isRaw());
+        return payload.number == raw.value;
+    }
+
+    template<UnitType unitValue>
+    bool operator==(const ValueLiteral<unitValue>& literal) const
+    {
+        if (index != Index(literal.unit))
+            return false;
+
+        ASSERT(isRaw());
+        return payload.number == literal.value;
+    }
+
+    template<NestedUnitEnumOf<UnitType> E, E unitValue>
+    bool operator==(const ValueLiteral<unitValue>& literal) const
+    {
+        if (index != Index(unitUpcast<UnitType>(literal.unit)))
+            return false;
+
+        ASSERT(isRaw());
+        return payload.number == literal.value;
+    }
+
+    // MARK: Conditional Accessors
+
+    std::optional<Raw> raw() const
+    {
+        if (isRaw())
+            return asRaw();
+        return std::nullopt;
+    }
+
+    std::optional<Calc> calc() const
+    {
+        if (isCalc())
+            return asCalc();
+        return std::nullopt;
+    }
+
+    // MARK: Accessors
+
+    Raw asRaw() const
+    {
+        ASSERT(isRaw());
+        return Raw { index.unit(), payload.number };
+    }
+
+    Calc asCalc() const
+    {
+        ASSERT(isCalc());
+        return Calc { *payload.calc };
+    }
+
+    constexpr bool isRaw() const { return index.isRaw(); }
+    constexpr bool isCalc() const { return index.isCalc(); }
+    constexpr bool isKeyword(ValidKeywordForList<Keywords> auto keyword) const { return index.isKeyword(keyword); }
+    constexpr bool isEmpty() const { return index.isEmpty(); }
+    constexpr bool isMovedFrom() const { return index.isMovedFrom(); }
+
+    template<typename T> bool holdsAlternative() const
+    {
+        if constexpr (std::same_as<T, Calc>)
+            return index.isCalc();
+        else if constexpr (std::same_as<T, Raw>)
+            return index.isRaw();
+        else if constexpr (ValidKeywordForList<T, Keywords>)
+            return index.isKeyword(T { });
+    }
+
+    template<typename F> decltype(auto) visit(F&& f) const
+    {
+        if (isRaw())
+            return f(asRaw());
+        if (isCalc())
+            return f(asCalc());
+        return index.visitKeyword(std::forward<F>(f));
+    }
+
+    void setAsMovedFrom()
+    {
+        index.setAsMovedFrom();
+        payload.number = 0;
+    }
+
+    Payload payload;
+    Index index;
+};
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericConcepts.h"
+#include "CSSPrimitiveNumericRaw.h"
+#include <limits>
+#include <type_traits>
+#include <wtf/Brigand.h>
+#include <wtf/EnumTraits.h>
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - Concepts
+
+// Concept for use in generic contexts to filter on Constant keyword CSS types.
+template<typename Keyword> concept PrimitiveKeyword
+    = std::same_as<Keyword, Constant<Keyword::value>>;
+
+// Concept for use in generic contexts to filter on keywords that are valid for the provided `Keywords` list.
+template<typename Keyword, typename KeywordsList> concept ValidKeywordForList
+    = PrimitiveKeyword<Keyword> && (KeywordsList::isValidKeyword(Keyword()));
+
+// MARK: - Primitive Keywords List
+
+template<PrimitiveKeyword... Ks> struct PrimitiveKeywordList {
+    static constexpr auto count = sizeof...(Ks);
+    static constexpr auto identifiers = std::array { Ks::value... };
+    static constexpr auto tuple = std::tuple { Ks { }... };
+
+    static consteval bool isValidKeyword(PrimitiveKeyword auto keyword)
+    {
+        return std::ranges::find(identifiers, keyword.value) != identifiers.end();
+    }
+
+    static consteval size_t offsetForKeyword(PrimitiveKeyword auto keyword)
+    {
+         return std::distance(identifiers.begin(), std::ranges::find(identifiers, keyword.value));
+    }
+
+    template<typename F> static constexpr decltype(auto) visitKeywordAtOffset(size_t offset, F&& f)
+    {
+        return WTF::visitTupleElementAtIndex(std::forward<F>(f), offset, tuple);
+    }
+};
+
+// Specialization for an empty keyword list.
+template<> struct PrimitiveKeywordList<> {
+    static constexpr auto count = 0;
+
+    static consteval bool isValidKeyword(PrimitiveKeyword auto)
+    {
+        return false;
+    }
+
+    static consteval size_t offsetForKeyword(PrimitiveKeyword auto)
+    {
+        return 0;
+    }
+};
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveData.h"
+#include "CSSPrimitiveNumericConcepts.h"
+#include "CSSPrimitiveNumericRaw.h"
+#include "CSSUnevaluatedCalc.h"
+#include <limits>
+#include <type_traits>
+#include <wtf/Brigand.h>
+#include <wtf/EnumTraits.h>
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - Forward Declarations
+
+template<NumericRaw> struct PrimitiveNumeric;
+template<Numeric, PrimitiveKeyword...> struct PrimitiveNumericOrKeyword;
+
+// MARK: - Primitive Numeric (Raw + UnevaluatedCalc)
+
+// NOTE: As is the case for `PrimitiveNumericRaw`, `ResolvedValueType` here only effects the type
+// the CSS value gets resolved to. Unresolved CSS primitive numeric types always use a `double` as
+// its internal representation.
+
+template<NumericRaw RawType> struct PrimitiveNumeric {
+    using Raw = RawType;
+    using Calc = UnevaluatedCalc<Raw>;
+    using UnitType = typename Raw::UnitType;
+    using UnitTraits = typename Raw::UnitTraits;
+    using ResolvedValueType = typename Raw::ResolvedValueType;
+    using Data = PrimitiveData<PrimitiveNumeric<RawType>>;
+    using Index = typename Data::Index;
+    static constexpr auto range = Raw::range;
+    static constexpr auto category = Raw::category;
+
+    PrimitiveNumeric(Raw raw)
+        : m_data { raw }
+    {
+    }
+
+    PrimitiveNumeric(Calc calc)
+        : m_data { WTFMove(calc) }
+    {
+    }
+
+    template<typename T>
+        requires std::integral<T> || std::floating_point<T>
+    PrimitiveNumeric(T value) requires (requires { { Raw(value) }; })
+        : m_data { Raw { value } }
+    {
+    }
+
+    template<typename T>
+        requires std::integral<T> || std::floating_point<T>
+    PrimitiveNumeric(UnitEnum auto unit, T value) requires (requires { { Raw(unit, value) }; })
+        : m_data { Raw { unit, value } }
+    {
+    }
+
+    template<UnitEnum E, E unitValue>
+    constexpr PrimitiveNumeric(ValueLiteral<unitValue> value) requires (requires { { Raw(value) }; })
+        : m_data { Raw { value } }
+    {
+    }
+
+    // MARK: Copy/Move Construction/Assignment
+
+    PrimitiveNumeric(const PrimitiveNumeric& other)
+        : m_data { other.m_data }
+    {
+    }
+
+    PrimitiveNumeric(PrimitiveNumeric&& other)
+        : m_data { WTFMove(other.m_data) }
+    {
+    }
+
+    PrimitiveNumeric& operator=(const PrimitiveNumeric& other)
+    {
+        m_data = other.m_data;
+        return *this;
+    }
+
+    PrimitiveNumeric& operator=(PrimitiveNumeric&& other)
+    {
+        m_data = WTFMove(other.m_data);
+        return *this;
+    }
+
+    // MARK: Equality
+
+    bool operator==(const PrimitiveNumeric& other) const
+    {
+        return m_data == other.m_data;
+    }
+
+    bool operator==(const Raw& other) const
+    {
+        return m_data == other;
+    }
+
+    template<typename T>
+        requires NumericRaw<T> && NestedUnitEnumOf<typename T::UnitType, UnitType>
+    constexpr bool operator==(const T& other) const
+    {
+        return m_data == other;
+    }
+
+    template<UnitType unitValue>
+    bool operator==(const ValueLiteral<unitValue>& other) const
+    {
+        return m_data == other;
+    }
+
+    template<NestedUnitEnumOf<UnitType> E, E unitValue>
+    bool operator==(const ValueLiteral<unitValue>& other) const
+    {
+        return m_data == other;
+    }
+
+    // MARK: Conditional Accessors
+
+    std::optional<Raw> raw() const { return m_data.raw(); }
+    std::optional<Calc> calc() const { return m_data.calc(); }
+
+    // MARK: Variant-Like Conformance
+
+    template<typename T> bool holdsAlternative() const
+    {
+        if constexpr (std::same_as<T, Calc>)
+            return isCalc();
+        else if constexpr (std::same_as<T, Raw>)
+            return isRaw();
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (isCalc())
+            return visitor(asCalc());
+        return visitor(asRaw());
+    }
+
+    bool isKnownZero() const { return isRaw() && m_data.payload.number == 0; }
+    bool isKnownNotZero() const { return isRaw() && m_data.payload.number != 0; }
+
+    bool isRaw() const { return m_data.isRaw(); }
+    bool isCalc() const { return m_data.isCalc(); }
+    bool isEmpty() const { return m_data.isEmpty(); }
+
+private:
+    template<typename> friend struct PrimitiveDataMarkableTraits;
+    template<Numeric, PrimitiveKeyword...> friend struct PrimitiveNumericOrKeyword;
+
+    PrimitiveNumeric(PrimitiveDataEmptyToken token)
+        : m_data { token }
+    {
+    }
+
+    Raw asRaw() const { return m_data.asRaw(); }
+    Calc asCalc() const { return m_data.asCalc(); }
+
+    Data m_data;
+};
+
+// MARK: Integer Primitive
+
+template<Range R = All, typename V = int> struct Integer : PrimitiveNumeric<IntegerRaw<R, V>> {
+    using Base = PrimitiveNumeric<IntegerRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Integer>;
+};
+
+// MARK: Number Primitive
+
+template<Range R = All, typename V = double> struct Number : PrimitiveNumeric<NumberRaw<R, V>> {
+    using Base = PrimitiveNumeric<NumberRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Number>;
+};
+
+// MARK: Percentage Primitive
+
+template<Range R = All, typename V = double> struct Percentage : PrimitiveNumeric<PercentageRaw<R, V>> {
+    using Base = PrimitiveNumeric<PercentageRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Percentage>;
+};
+
+// MARK: Dimension Primitives
+
+template<Range R = All, typename V = double> struct Angle : PrimitiveNumeric<AngleRaw<R, V>> {
+    using Base = PrimitiveNumeric<AngleRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Angle>;
+};
+template<Range R = All, typename V = float> struct Length : PrimitiveNumeric<LengthRaw<R, V>> {
+    using Base = PrimitiveNumeric<LengthRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Length>;
+};
+template<Range R = All, typename V = double> struct Time : PrimitiveNumeric<TimeRaw<R, V>> {
+    using Base = PrimitiveNumeric<TimeRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Time>;
+};
+template<Range R = All, typename V = double> struct Frequency : PrimitiveNumeric<FrequencyRaw<R, V>> {
+    using Base = PrimitiveNumeric<FrequencyRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Frequency>;
+};
+template<Range R = Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<ResolutionRaw<R, V>> {
+    using Base = PrimitiveNumeric<ResolutionRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Resolution>;
+};
+template<Range R = All, typename V = double> struct Flex : PrimitiveNumeric<FlexRaw<R, V>> {
+    using Base = PrimitiveNumeric<FlexRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<Flex>;
+};
+
+// MARK: Dimension + Percentage Primitives
+
+template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R, V>> {
+    using Base = PrimitiveNumeric<AnglePercentageRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<AnglePercentage<R, V>>;
+};
+template<Range R = All, typename V = float> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
+    using Base = PrimitiveNumeric<LengthPercentageRaw<R, V>>;
+    using Base::Base;
+    using MarkableTraits = PrimitiveDataMarkableTraits<LengthPercentage<R, V>>;
+};
+
+} // namespace CSS
+} // namespace WebCore
+
+template<typename Raw> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::PrimitiveNumeric<Raw>> = true;
+
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Integer<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Number<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Percentage<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Angle<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Length<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Time<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Frequency<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Resolution<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Flex<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::AnglePercentage<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::LengthPercentage<R, V>> = true;

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericConcepts.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericConcepts.h
@@ -32,7 +32,10 @@
 
 namespace WebCore {
 
+enum CSSValueID : uint16_t;
 enum class CSSUnitType : uint8_t;
+
+template<CSSValueID> struct Constant;
 
 namespace Calculation {
 enum class Category : uint8_t;

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericOrKeyword.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericOrKeyword.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumeric.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: Primitive Numeric or Keyword
+
+template<Numeric NumericType, PrimitiveKeyword... Ks> struct PrimitiveNumericOrKeyword {
+    using Raw = typename NumericType::Raw;
+    using Calc = typename NumericType::Calc;
+    using UnitType = typename NumericType::UnitType;
+    using UnitTraits = typename NumericType::UnitTraits;
+    using ResolvedValueType = typename NumericType::ResolvedValueType;
+    using Data = PrimitiveData<NumericType, Ks...>;
+    using Index = typename Data::Index;
+    using Keywords = typename Data::Keywords;
+    static constexpr auto range = NumericType::range;
+    static constexpr auto category = NumericType::category;
+
+    // MARK: Constructors
+
+    PrimitiveNumericOrKeyword(Raw raw)
+        : m_data { raw }
+    {
+    }
+
+    PrimitiveNumericOrKeyword(Calc calc)
+        : m_data { WTFMove(calc) }
+    {
+    }
+
+    template<typename T>
+        requires std::integral<T> || std::floating_point<T>
+    PrimitiveNumericOrKeyword(T value) requires (requires { { Raw(value) }; })
+        : m_data { Raw { value } }
+    {
+    }
+
+    template<typename T>
+        requires std::integral<T> || std::floating_point<T>
+    PrimitiveNumericOrKeyword(UnitEnum auto unit, T value) requires (requires { { Raw(unit, value) }; })
+        : m_data { Raw { unit, value } }
+    {
+    }
+
+    template<UnitEnum E, E unitValue>
+    constexpr PrimitiveNumericOrKeyword(ValueLiteral<unitValue> value) requires (requires { { Raw(value) }; })
+        : m_data { Raw { value } }
+    {
+    }
+
+    template<typename... U>
+    constexpr PrimitiveNumericOrKeyword(std::variant<U...>&& variant)
+        : m_data {
+            WTF::switchOn(WTFMove(variant),
+                [](NumericType&& numeric) {
+                    return Data { WTFMove(numeric.m_data) };
+                },
+                [](ValidKeywordForList<Keywords> auto keyword) {
+                    return Data { keyword };
+                }
+            )
+        }
+    {
+    }
+
+    // MARK: Copy/Move Construction/Assignment
+
+    PrimitiveNumericOrKeyword(const PrimitiveNumericOrKeyword& other)
+        : m_data { other.m_data }
+    {
+    }
+
+    PrimitiveNumericOrKeyword(PrimitiveNumericOrKeyword&& other)
+        : m_data { WTFMove(other.m_data) }
+    {
+    }
+
+    PrimitiveNumericOrKeyword& operator=(const PrimitiveNumericOrKeyword& other)
+    {
+        m_data = other.m_data;
+        return *this;
+    }
+
+    PrimitiveNumericOrKeyword& operator=(PrimitiveNumericOrKeyword&& other)
+    {
+        m_data = WTFMove(other.m_data);
+        return *this;
+    }
+
+    // MARK: Construction/Assignment from `NumericType`
+
+    PrimitiveNumericOrKeyword(const NumericType& other)
+        : m_data { other.m_data }
+    {
+    }
+
+    PrimitiveNumericOrKeyword(NumericType&& other)
+        : m_data { WTFMove(other.m_data) }
+    {
+    }
+
+    PrimitiveNumericOrKeyword& operator=(const NumericType& other)
+    {
+        m_data = other;
+        return *this;
+    }
+
+    PrimitiveNumericOrKeyword& operator=(NumericType&& other)
+    {
+        m_data = WTFMove(other);
+        return *this;
+    }
+
+    // MARK: Construction/Assignment from `Keywords...`
+
+    PrimitiveNumericOrKeyword(ValidKeywordForList<Keywords> auto keyword)
+        : m_data { keyword }
+    {
+    }
+
+    // MARK: Equality
+
+    bool operator==(const PrimitiveNumericOrKeyword& other) const
+    {
+        return m_data == other.m_data;
+    }
+
+    bool operator==(ValidKeywordForList<Keywords> auto const& other) const
+    {
+        return m_data == other;
+    }
+
+    bool operator==(const Raw& other) const
+    {
+        return m_data == other;
+    }
+
+    template<typename T>
+        requires NumericRaw<T> && NestedUnitEnumOf<typename T::UnitType, UnitType>
+    constexpr bool operator==(const T& other) const
+    {
+        return m_data == other;
+    }
+
+    template<UnitType unitValue>
+    bool operator==(const ValueLiteral<unitValue>& other) const
+    {
+        return m_data == other;
+    }
+
+    template<NestedUnitEnumOf<UnitType> E, E unitValue>
+    bool operator==(const ValueLiteral<unitValue>& other) const
+    {
+        return m_data == other;
+    }
+
+    // MARK: Conditional Accessors
+
+    std::optional<Raw> raw() const { return m_data.raw(); }
+    std::optional<Calc> calc() const { return m_data.calc(); }
+
+    // MARK: Variant-Like Conformance
+
+    template<typename T> bool holdsAlternative() const
+    {
+        if constexpr (std::same_as<T, NumericType>)
+            return isCalc() || isRaw();
+        else if constexpr (std::same_as<T, Calc>)
+            return isCalc();
+        else if constexpr (std::same_as<T, Raw>)
+            return isRaw();
+        else if constexpr (ValidKeywordForList<T, Keywords>)
+            return isKeyword<T>();
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return m_data.visit(WTF::makeVisitor(std::forward<F>(f)...));
+    }
+
+    bool isKnownZero() const { return isRaw() && m_data.payload.number == 0; }
+    bool isKnownNotZero() const { return isRaw() && m_data.payload.number != 0; }
+
+    bool isRaw() const { return m_data.isRaw(); }
+    bool isCalc() const { return m_data.isCalc(); }
+    template<ValidKeywordForList<Keywords> Keyword>
+    bool isKeyword() const { return m_data.template isKeyword<Keyword>(); }
+    bool isEmpty() const { return m_data.isEmpty(); }
+
+    struct MarkableTraits {
+        static bool isEmptyValue(const PrimitiveNumericOrKeyword& value) { return value.isEmpty(); }
+        static PrimitiveNumericOrKeyword emptyValue() { return { PrimitiveDataEmptyToken { } }; }
+    };
+
+private:
+    friend struct MarkableTraits;
+
+    PrimitiveNumericOrKeyword(PrimitiveDataEmptyToken token)
+        : m_data { token }
+    {
+    }
+
+    Raw asRaw() const { return m_data.asRaw(); }
+    Calc asCalc() const { return m_data.asCalc(); }
+
+    Data m_data;
+};
+
+} // namespace CSS
+} // namespace WebCore
+
+template<typename N, typename... Ks> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::PrimitiveNumericOrKeyword<N, Ks...>> = true;

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
@@ -219,7 +219,7 @@ template<Range R = All, typename V = double> struct FlexRaw : PrimitiveNumericRa
 
 // MARK: Dimension + Percentage Primitives Raw
 
-template<Range R = All, typename V = double> struct AnglePercentageRaw : PrimitiveNumericRaw<R, AnglePercentageUnit, V> {
+template<Range R = All, typename V = float> struct AnglePercentageRaw : PrimitiveNumericRaw<R, AnglePercentageUnit, V> {
     using Base = PrimitiveNumericRaw<R, AnglePercentageUnit, V>;
     using Base::Base;
 };

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueConversions.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueConversions.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericTypes.h"
+#include "CSSPrimitiveValue.h"
+
+namespace WebCore {
+namespace CSS {
+
+// MARK: - Conversion from `WebCore::CSSValue` types to strongly typed `CSS::` value types.
+
+template<typename CSSType> struct CSSValueConversions;
+
+template<typename CSSType> CSSType convertFromCSSValue(const CSSValue& value)
+{
+    return CSSValueConversions<CSSType>{}(value);
+}
+
+template<Numeric CSSType> struct CSSValueConversions<CSSType> {
+    CSSType operator()(const CSSValue& value)
+    {
+        auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
+        if (RefPtr calc = const_cast<CSSCalcValue*>(primitiveValue.cssCalcValue()))
+            return { typename CSSType::Calc { calc.releaseNonNull() } };
+
+        auto unit = CSSType::UnitTraits::validate(primitiveValue.primitiveType());
+        RELEASE_ASSERT(unit);
+        return CSSType { typename CSSType::Raw { *unit, primitiveValue.valueNoConversionDataRequired() } };
+    }
+};
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
@@ -24,341 +24,13 @@
 
 #pragma once
 
-#include "CSSPrimitiveNumericConcepts.h"
-#include "CSSPrimitiveNumericRaw.h"
-#include "CSSUnevaluatedCalc.h"
-#include <limits>
-#include <type_traits>
-#include <wtf/Brigand.h>
-#include <wtf/EnumTraits.h>
+// Umbrella header for family of CSS numeric types.
+
+#include "CSSPrimitiveNumeric.h"
+#include "CSSPrimitiveNumericOrKeyword.h"
 
 namespace WebCore {
 namespace CSS {
-
-// MARK: - Primitive Numeric (Raw + UnevaluatedCalc)
-
-// NOTE: As is the case for `PrimitiveNumericRaw`, `ResolvedValueType` here only effects the type
-// the CSS value gets resolved to. Unresolved CSS primitive numeric types always use a `double` as
-// its internal representation.
-
-template<typename T> struct PrimitiveNumericMarkableTraits {
-    static bool isEmptyValue(const T& value) { return value.isEmpty(); }
-    static T emptyValue() { return T(typename T::EmptyToken { }); }
-};
-
-template<NumericRaw RawType> struct PrimitiveNumeric {
-    using Raw = RawType;
-    using Calc = UnevaluatedCalc<Raw>;
-    using UnitType = typename Raw::UnitType;
-    using UnitTraits = typename Raw::UnitTraits;
-    using ResolvedValueType = typename Raw::ResolvedValueType;
-    using Index = std::underlying_type_t<UnitType>;
-    static constexpr auto range = Raw::range;
-    static constexpr auto category = Raw::category;
-
-    // The potential values for the `index` are:
-    //  - 0 ..< number of unit variations   -> Raw
-    //  - number of unit variations         -> Calc
-    //  - number of unit variations + 1     -> Empty (for Markable)
-    //  - number of unit variations + 2     -> Moved from
-    static constexpr Index indexForFirstRaw  = 0;
-    static constexpr Index indexForCalc      = UnitTraits::count;
-    static constexpr Index indexForEmpty     = UnitTraits::count + 1;
-    static constexpr Index indexForMovedFrom = UnitTraits::count + 2;
-    static_assert(UnitTraits::count < std::numeric_limits<Index>::max() - 2);
-
-    PrimitiveNumeric(Raw raw)
-    {
-        m_index = enumToUnderlyingType(raw.unit);
-        m_value.number = raw.value;
-    }
-
-    PrimitiveNumeric(Calc calc)
-    {
-        m_index = indexForCalc;
-        m_value.calc = &calc.leakRef();
-    }
-
-    PrimitiveNumeric(UnitEnum auto unit, double value) requires (requires { { Raw(unit, value) }; })
-        : PrimitiveNumeric { Raw { unit, value } }
-    {
-    }
-
-    template<typename T>
-        requires std::integral<T> || std::floating_point<T>
-    PrimitiveNumeric(T value) requires (requires { { Raw(value) }; })
-        : PrimitiveNumeric { Raw { value } }
-    {
-    }
-
-    template<UnitEnum E, E unitValue>
-    constexpr PrimitiveNumeric(ValueLiteral<unitValue> value) requires (requires { { Raw(value) }; })
-        : PrimitiveNumeric { Raw { value } }
-    {
-    }
-
-    PrimitiveNumeric(const PrimitiveNumeric& other)
-    {
-        if (other.isCalc()) {
-            m_index = indexForCalc;
-            m_value.calc = other.m_value.calc;
-            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcRef(m_value.calc);
-        } else {
-            m_index = other.m_index;
-            m_value.number = other.m_value.number;
-        }
-    }
-
-    PrimitiveNumeric(PrimitiveNumeric&& other)
-    {
-        if (other.isCalc()) {
-            m_index = indexForCalc;
-            m_value.calc = other.m_value.calc;
-        } else {
-            m_index = other.m_index;
-            m_value.number = other.m_value.number;
-        }
-
-        other.m_index = indexForMovedFrom;
-        other.m_value.number = 0;
-    }
-
-    PrimitiveNumeric& operator=(const PrimitiveNumeric& other)
-    {
-        if (isCalc())
-            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(m_value.calc);
-
-        if (other.isCalc()) {
-            m_index = indexForCalc;
-            m_value.calc = other.m_value.calc;
-            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcRef(m_value.calc);
-        } else {
-            m_index = other.m_index;
-            m_value.number = other.m_value.number;
-        }
-
-        return *this;
-    }
-
-    PrimitiveNumeric& operator=(PrimitiveNumeric&& other)
-    {
-        if (isCalc())
-            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(m_value.calc);
-
-        if (other.isCalc()) {
-            m_index = indexForCalc;
-            m_value.calc = other.m_value.calc;
-        } else {
-            m_index = other.m_index;
-            m_value.number = other.m_value.number;
-        }
-
-        other.m_index = indexForMovedFrom;
-        other.m_value.number = 0;
-
-        return *this;
-    }
-
-    ~PrimitiveNumeric()
-    {
-        if (isCalc())
-            SUPPRESS_UNCOUNTED_ARG unevaluatedCalcDeref(m_value.calc);
-    }
-
-    bool operator==(const PrimitiveNumeric& other) const
-    {
-        if (m_index != other.m_index)
-            return false;
-
-        if (isCalc())
-            return asCalc() == other.asCalc();
-        return m_value.number == other.m_value.number;
-    }
-
-    bool operator==(const Raw& otherRaw) const
-    {
-        if (m_index != enumToUnderlyingType(otherRaw.unit))
-            return false;
-
-        ASSERT(isRaw());
-        return m_value.number == otherRaw.value;
-    }
-
-    template<typename T>
-        requires NumericRaw<T> && NestedUnitEnumOf<typename T::UnitType, UnitType>
-    constexpr bool operator==(const T& other) const
-    {
-        if (m_index != enumToUnderlyingType(unitUpcast<UnitType>(other.unit)))
-            return false;
-
-        ASSERT(isRaw());
-        return m_value.number == other.value;
-    }
-
-    template<UnitType unitValue>
-    bool operator==(const ValueLiteral<unitValue>& other) const
-    {
-        if (m_index != enumToUnderlyingType(other.unit))
-            return false;
-
-        ASSERT(isRaw());
-        return m_value.number == other.value;
-    }
-
-    template<NestedUnitEnumOf<UnitType> E, E unitValue>
-    bool operator==(const ValueLiteral<unitValue>& other) const
-    {
-        if (m_index != enumToUnderlyingType(unitUpcast<UnitType>(other.unit)))
-            return false;
-
-        ASSERT(isRaw());
-        return m_value.number == other.value;
-    }
-
-    std::optional<Raw> raw() const
-    {
-        if (isRaw())
-            return asRaw();
-        return std::nullopt;
-    }
-
-    std::optional<Calc> calc() const
-    {
-        if (isCalc())
-            return asCalc();
-        return std::nullopt;
-    }
-
-    template<typename T> bool holdsAlternative() const
-    {
-        if constexpr (std::same_as<T, Calc>)
-            return isCalc();
-        else if constexpr (std::same_as<T, Raw>)
-            return isRaw();
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... f) const
-    {
-        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
-
-        if (isCalc())
-            return visitor(asCalc());
-        return visitor(asRaw());
-    }
-
-    bool isKnownZero() const { return isRaw() && m_value.number == 0; }
-    bool isKnownNotZero() const { return isRaw() && m_value.number != 0; }
-
-    bool isCalc() const { return m_index == indexForCalc; }
-    bool isRaw() const { return m_index < indexForCalc; }
-
-private:
-    template<typename> friend struct PrimitiveNumericMarkableTraits;
-
-    struct EmptyToken { constexpr bool operator==(const EmptyToken&) const = default; };
-    PrimitiveNumeric(EmptyToken)
-    {
-        m_index = indexForEmpty;
-        m_value.number = 0;
-    }
-
-    bool isEmpty() const { return m_index == indexForEmpty; }
-
-    Raw asRaw() const
-    {
-        ASSERT(isRaw());
-        return Raw { static_cast<UnitType>(m_index), m_value.number };
-    }
-
-    Calc asCalc() const
-    {
-        ASSERT(isCalc());
-        return Calc { *m_value.calc };
-    }
-
-    // A std::variant is not used here to allow tighter packing.
-
-    // FIXME: This could be even more packed types with only a single alternative (e.g. CSS::Number/CSS::Percentage/CSS::Flex),
-    // by using NaN encoding scheme for the `calc` case.
-
-    union {
-        double number;
-        CSSCalcValue* calc;
-    } m_value;
-    Index m_index;
-};
-
-// MARK: Integer Primitive
-
-template<Range R = All, typename V = int> struct Integer : PrimitiveNumeric<IntegerRaw<R, V>> {
-    using Base = PrimitiveNumeric<IntegerRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Integer>;
-};
-
-// MARK: Number Primitive
-
-template<Range R = All, typename V = double> struct Number : PrimitiveNumeric<NumberRaw<R, V>> {
-    using Base = PrimitiveNumeric<NumberRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Number>;
-};
-
-// MARK: Percentage Primitive
-
-template<Range R = All, typename V = double> struct Percentage : PrimitiveNumeric<PercentageRaw<R, V>> {
-    using Base = PrimitiveNumeric<PercentageRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Percentage>;
-};
-
-// MARK: Dimension Primitives
-
-template<Range R = All, typename V = double> struct Angle : PrimitiveNumeric<AngleRaw<R, V>> {
-    using Base = PrimitiveNumeric<AngleRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Angle>;
-};
-template<Range R = All, typename V = float> struct Length : PrimitiveNumeric<LengthRaw<R, V>> {
-    using Base = PrimitiveNumeric<LengthRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Length>;
-};
-template<Range R = All, typename V = double> struct Time : PrimitiveNumeric<TimeRaw<R, V>> {
-    using Base = PrimitiveNumeric<TimeRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Time>;
-};
-template<Range R = All, typename V = double> struct Frequency : PrimitiveNumeric<FrequencyRaw<R, V>> {
-    using Base = PrimitiveNumeric<FrequencyRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Frequency>;
-};
-template<Range R = Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<ResolutionRaw<R, V>> {
-    using Base = PrimitiveNumeric<ResolutionRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Resolution>;
-};
-template<Range R = All, typename V = double> struct Flex : PrimitiveNumeric<FlexRaw<R, V>> {
-    using Base = PrimitiveNumeric<FlexRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<Flex>;
-};
-
-// MARK: Dimension + Percentage Primitives
-
-template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R, V>> {
-    using Base = PrimitiveNumeric<AnglePercentageRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<AnglePercentage<R, V>>;
-};
-template<Range R = All, typename V = float> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
-    using Base = PrimitiveNumeric<LengthPercentageRaw<R, V>>;
-    using Base::Base;
-    using MarkableTraits = PrimitiveNumericMarkableTraits<LengthPercentage<R, V>>;
-};
-
-// MARK: Additional Common Groupings
 
 // NOTE: This is spelled with an explicit "Or" to distinguish it from types like AnglePercentage/LengthPercentage that have behavior distinctions beyond just being a union of the two types (specifically, calc() has specific behaviors for those types).
 template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPercentage {
@@ -398,7 +70,7 @@ template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPerc
         using ResultType = decltype(visitor(std::declval<Number>()));
 
         return WTF::switchOn(value,
-            [](EmptyToken) -> ResultType {
+            [](PrimitiveDataEmptyToken) -> ResultType {
                 RELEASE_ASSERT_NOT_REACHED();
             },
             [&](const Number& number) -> ResultType {
@@ -412,19 +84,18 @@ template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPerc
 
     struct MarkableTraits {
         static bool isEmptyValue(const NumberOrPercentage& value) { return value.isEmpty(); }
-        static NumberOrPercentage emptyValue() { return NumberOrPercentage(EmptyToken()); }
+        static NumberOrPercentage emptyValue() { return NumberOrPercentage(PrimitiveDataEmptyToken()); }
     };
 
 private:
-    struct EmptyToken { constexpr bool operator==(const EmptyToken&) const = default; };
-    NumberOrPercentage(EmptyToken token)
+    NumberOrPercentage(PrimitiveDataEmptyToken token)
         : value { WTFMove(token) }
     {
     }
 
-    bool isEmpty() const { return std::holds_alternative<EmptyToken>(value); }
+    bool isEmpty() const { return std::holds_alternative<PrimitiveDataEmptyToken>(value); }
 
-    std::variant<EmptyToken, Number, Percentage> value;
+    std::variant<PrimitiveDataEmptyToken, Number, Percentage> value;
 };
 
 template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPercentageResolvedToNumber {
@@ -464,7 +135,7 @@ template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPerc
         using ResultType = decltype(visitor(std::declval<Number>()));
 
         return WTF::switchOn(value,
-            [](EmptyToken) -> ResultType {
+            [](PrimitiveDataEmptyToken) -> ResultType {
                 RELEASE_ASSERT_NOT_REACHED();
             },
             [&](const Number& number) -> ResultType {
@@ -478,36 +149,22 @@ template<Range nR = All, Range pR = nR, typename V = double> struct NumberOrPerc
 
     struct MarkableTraits {
         static bool isEmptyValue(const NumberOrPercentageResolvedToNumber& value) { return value.isEmpty(); }
-        static NumberOrPercentageResolvedToNumber emptyValue() { return NumberOrPercentageResolvedToNumber(EmptyToken()); }
+        static NumberOrPercentageResolvedToNumber emptyValue() { return NumberOrPercentageResolvedToNumber(PrimitiveDataEmptyToken()); }
     };
 
 private:
-    struct EmptyToken { constexpr bool operator==(const EmptyToken&) const = default; };
-    NumberOrPercentageResolvedToNumber(EmptyToken token)
+    NumberOrPercentageResolvedToNumber(PrimitiveDataEmptyToken token)
         : value { WTFMove(token) }
     {
     }
 
-    bool isEmpty() const { return std::holds_alternative<EmptyToken>(value); }
+    bool isEmpty() const { return std::holds_alternative<PrimitiveDataEmptyToken>(value); }
 
-    std::variant<EmptyToken, Number, Percentage> value;
+    std::variant<PrimitiveDataEmptyToken, Number, Percentage> value;
 };
 
 } // namespace CSS
 } // namespace WebCore
 
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Integer<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Number<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Percentage<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Angle<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Length<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Time<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Frequency<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Resolution<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::Flex<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::AnglePercentage<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::LengthPercentage<R, V>> = true;
-
-template<typename Raw> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::PrimitiveNumeric<Raw>> = true;
 template<auto nR, auto pR, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::NumberOrPercentage<nR, pR, V>> = true;
 template<auto nR, auto pR, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::CSS::NumberOrPercentageResolvedToNumber<nR, pR, V>> = true;

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -62,7 +62,7 @@ struct Position  {
     }
 
     Position(FloatPoint point)
-        : value { LengthPercentage<> { Length<> { point.x() } }, LengthPercentage<> { Length<> { point.y() } } }
+        : value { LengthPercentage<>::Dimension { point.x() }, LengthPercentage<>::Dimension { point.y() } }
     {
     }
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumeric.h"
+#include "StylePrimitiveNumericConcepts.h"
+#include "StyleUnevaluatedCalculation.h"
+#include "StyleValueTypes.h"
+#include <algorithm>
+#include <wtf/CompactVariant.h>
+#include <wtf/Forward.h>
+
+namespace WebCore {
+namespace Style {
+
+template<typename> struct DimensionPercentageMapping;
+
+// Default implementation of `PrimitiveNumeric` for non-composite numeric types.
+template<CSS::Numeric CSSType> struct PrimitiveNumeric {
+    using CSS = CSSType;
+    using Raw = typename CSS::Raw;
+    using UnitType = typename CSS::UnitType;
+    using UnitTraits = typename CSS::UnitTraits;
+    using ResolvedValueType = typename CSS::ResolvedValueType;
+    static constexpr auto range = CSS::range;
+    static constexpr auto category = CSS::category;
+
+    static constexpr auto unit = UnitTraits::canonical;
+    ResolvedValueType value { 0 };
+
+    constexpr PrimitiveNumeric(ResolvedValueType value)
+        : value { value }
+    {
+    }
+
+    constexpr PrimitiveNumeric(WebCore::CSS::ValueLiteral<UnitTraits::canonical> value)
+        : value { clampTo<ResolvedValueType>(value.value) }
+    {
+    }
+
+    constexpr bool isZero() const { return !value; }
+
+    constexpr bool operator==(const PrimitiveNumeric&) const = default;
+    constexpr bool operator==(ResolvedValueType other) const { return value == other; };
+};
+
+// Specialization of `PrimitiveNumeric` for composite dimension-percentage types.
+template<CSS::DimensionPercentageNumeric CSSType> struct PrimitiveNumeric<CSSType> {
+    using CSS = CSSType;
+    using Raw = typename CSS::Raw;
+    using UnitType = typename CSS::UnitType;
+    using UnitTraits = typename CSS::UnitTraits;
+    using ResolvedValueType = typename CSS::ResolvedValueType;
+    static constexpr auto range = CSS::range;
+    static constexpr auto category = CSS::category;
+
+    // Composite types only currently support float as the `ResolvedValueType`, allowing unconditional use of `CompactVariant`.
+    static_assert(std::same_as<ResolvedValueType, float>);
+
+    using Dimension = typename DimensionPercentageMapping<CSS>::Dimension;
+    using Percentage = typename DimensionPercentageMapping<CSS>::Percentage;
+    using Calc = UnevaluatedCalculation<CSS>;
+    using Representation = CompactVariant<Dimension, Percentage, Calc>;
+
+    PrimitiveNumeric(Dimension dimension)
+        : m_value { WTFMove(dimension) }
+    {
+    }
+
+    PrimitiveNumeric(Percentage percentage)
+        : m_value { WTFMove(percentage) }
+    {
+    }
+
+    PrimitiveNumeric(Calc calc)
+        : m_value { WTFMove(calc) }
+    {
+    }
+
+    // NOTE: CalculatedValue is intentionally not part of IPCData.
+    using IPCData = std::variant<Dimension, Percentage>;
+    PrimitiveNumeric(IPCData&& data)
+        : m_value { WTF::switchOn(WTFMove(data), [&](auto&& data) -> Representation { return { WTFMove(data) }; }) }
+    {
+    }
+
+    IPCData ipcData() const
+    {
+        return WTF::switchOn(m_value,
+            [](const Dimension& dimension) -> IPCData { return dimension; },
+            [](const Percentage& percentage) -> IPCData { return percentage; },
+            [](const Calc&) -> IPCData { ASSERT_NOT_REACHED(); return Dimension { 0 }; }
+        );
+    }
+
+    constexpr size_t index() const { return m_value.index(); }
+
+    template<typename T> constexpr bool holdsAlternative() const { return WTF::holdsAlternative<T>(m_value); }
+    template<size_t I> constexpr bool holdsAlternative() const { return WTF::holdsAlternative<I>(m_value); }
+
+    template<typename T> T get() const
+    {
+        return WTF::switchOn(m_value,
+            []<std::same_as<T> U>(const U& alternative) -> T { return alternative; },
+            [](const auto&) -> T { RELEASE_ASSERT_NOT_REACHED(); }
+        );
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... functors) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(functors)...);
+    }
+
+    constexpr bool isZero() const
+    {
+        return WTF::switchOn(m_value,
+            []<HasIsZero T>(const T& alternative) { return alternative.isZero(); },
+            [](const auto&) { return false; }
+        );
+    }
+
+    bool operator==(const PrimitiveNumeric&) const = default;
+
+private:
+    Representation m_value;
+};
+
+// MARK: Integer Primitive
+
+template<CSS::Range R = CSS::All, typename V = int> struct Integer : PrimitiveNumeric<CSS::Integer<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Integer<R, V>>;
+};
+
+// MARK: Number Primitive
+
+template<CSS::Range R = CSS::All, typename V = double> struct Number : PrimitiveNumeric<CSS::Number<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Number<R, V>>;
+    using Base::Base;
+};
+
+// MARK: Percentage Primitive
+
+template<CSS::Range R = CSS::All, typename V = double> struct Percentage : PrimitiveNumeric<CSS::Percentage<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Percentage<R, V>>;
+    using Base::Base;
+};
+
+// MARK: Dimension Primitives
+
+template<CSS::Range R = CSS::All, typename V = double> struct Angle : PrimitiveNumeric<CSS::Angle<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Angle<R, V>>;
+    using Base::Base;
+};
+template<CSS::Range R = CSS::All, typename V = float> struct Length : PrimitiveNumeric<CSS::Length<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Length<R, V>>;
+    using Base::Base;
+};
+template<CSS::Range R = CSS::All, typename V = double> struct Time : PrimitiveNumeric<CSS::Time<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Time<R, V>>;
+    using Base::Base;
+};
+template<CSS::Range R = CSS::All, typename V = double> struct Frequency : PrimitiveNumeric<CSS::Frequency<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Frequency<R, V>>;
+    using Base::Base;
+};
+template<CSS::Range R = CSS::Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<CSS::Resolution<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Resolution<R, V>>;
+    using Base::Base;
+};
+template<CSS::Range R = CSS::All, typename V = double> struct Flex : PrimitiveNumeric<CSS::Flex<R, V>> {
+    using Base = PrimitiveNumeric<CSS::Flex<R, V>>;
+    using Base::Base;
+};
+
+// MARK: Dimension + Percentage Primitives
+
+template<CSS::Range R = CSS::All, typename V = float> struct AnglePercentage : PrimitiveNumeric<CSS::AnglePercentage<R, V>> {
+    using Base = PrimitiveNumeric<CSS::AnglePercentage<R, V>>;
+    using Base::Base;
+};
+template<CSS::Range R = CSS::All, typename V = float> struct LengthPercentage : PrimitiveNumeric<CSS::LengthPercentage<R, V>> {
+    using Base = PrimitiveNumeric<CSS::LengthPercentage<R, V>>;
+    using Base::Base;
+};
+
+template<auto R, typename V> struct DimensionPercentageMapping<CSS::AnglePercentage<R, V>> {
+    using Dimension = Style::Angle<R, V>;
+    using Percentage = Style::Percentage<R, V>;
+};
+template<auto R, typename V> struct DimensionPercentageMapping<CSS::LengthPercentage<R, V>> {
+    using Dimension = Style::Length<R, V>;
+    using Percentage = Style::Percentage<R, V>;
+};
+
+template<typename T> T get(DimensionPercentageNumeric auto const& dimensionPercentage)
+{
+    return dimensionPercentage.template get<T>();
+}
+
+// MARK: CSS -> Style
+
+template<auto R, typename V> struct ToStyleMapping<CSS::Integer<R, V>>          { using type = Integer<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Number<R, V>>           { using type = Number<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Percentage<R, V>>       { using type = Percentage<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Angle<R, V>>            { using type = Angle<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Length<R, V>>           { using type = Length<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Time<R, V>>             { using type = Time<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Frequency<R, V>>        { using type = Frequency<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Resolution<R, V>>       { using type = Resolution<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::Flex<R, V>>             { using type = Flex<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::AnglePercentage<R, V>>  { using type = AnglePercentage<R, V>; };
+template<auto R, typename V> struct ToStyleMapping<CSS::LengthPercentage<R, V>> { using type = LengthPercentage<R, V>; };
+
+// MARK: Style -> CSS
+
+template<Numeric T> struct ToCSSMapping<T> {
+    using type = typename T::CSS;
+};
+
+// MARK: Utility Concepts
+
+template<typename T> concept IsPercentageOrCalc =
+       std::same_as<T, Percentage<T::range, typename T::ResolvedValueType>>
+    || std::same_as<T, UnevaluatedCalculation<typename T::CSS>>;
+
+} // namespace Style
+} // namespace WebCore
+
+template<WebCore::Style::DimensionPercentageNumeric T>
+struct WTF::FlatteningVariantTraits<T> {
+    using TypeList = typename FlatteningVariantTraits<typename T::Representation>::TypeList;
+};
+
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::AnglePercentage<R, V>> = true;
+template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::LengthPercentage<R, V>> = true;

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumericOrKeyword.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+
+namespace WebCore {
+namespace Style {
+
+template<auto R, typename V, CSS::PrimitiveKeyword... Ks> struct ToCSS<PrimitiveNumericOrKeyword<LengthPercentage<R, V>, Ks...>> {
+    using Result = CSS::PrimitiveNumericOrKeyword<CSS::LengthPercentage<R, V>, Ks...>;
+
+    auto operator()(const PrimitiveNumericOrKeyword<LengthPercentage<R, V>, Ks...>& value, const RenderStyle& style) -> Result
+    {
+        return WTF::switchOn(value,
+            [&](const typename LengthPercentage<R, V>::Dimension& length) -> Result {
+                return CSS::LengthPercentageRaw<R, V> { length.unit, adjustForZoom(length.value, style) };
+            },
+            [&](const typename LengthPercentage<R, V>::Percentage& percentage) -> Result {
+                return CSS::LengthPercentageRaw<R, V> { percentage.unit, percentage.value };
+            },
+            [&](const typename LengthPercentage<R, V>::Calc& calculation) -> Result {
+                return CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R, V>> { makeCalc(calculation.protectedCalculation(), style) };
+            },
+            [&]<CSSValueID Id>(const Constant<Id>& identifier) -> Result {
+                return toCSS(identifier, style);
+            }
+        );
+    }
+};
+
+template<CSS::Numeric N, CSS::PrimitiveKeyword... Ks> struct ToStyle<CSS::PrimitiveNumericOrKeyword<N, Ks...>> {
+    using From = CSS::PrimitiveNumericOrKeyword<N, Ks...>;
+    using To = typename ToStyleMapping<From>::type;
+
+    template<typename... Rest> auto operator()(const From& value, Rest&&... rest) -> To
+    {
+        return WTF::switchOn(value, [&](const auto& value) -> To { return toStyle(value, std::forward<Rest>(rest)...); });
+    }
+
+    // Implement `BuilderState` overload to explicitly forward to the `CSSToLengthConversionData` overload.
+    template<typename... Rest> auto operator()(const From& value, const BuilderState& state, Rest&&... rest) -> To
+    {
+        return toStyle(value, conversionData<typename N::Raw>(state), std::forward<Rest>(rest)...);
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericOrKeyword.h"
+#include "StylePrimitiveNumeric.h"
+#include <algorithm>
+#include <wtf/CompactVariant.h>
+#include <wtf/FlatteningVariantAdaptor.h>
+
+namespace WebCore {
+namespace Style {
+
+template<Numeric N, CSS::PrimitiveKeyword... Ks> class PrimitiveNumericOrKeyword {
+public:
+    using CSS = typename N::CSS;
+    using Raw = typename N::Raw;
+    using Calc = typename N::Calc;
+    using Dimension = typename N::Dimension;
+    using Keywords = WebCore::CSS::PrimitiveKeywordList<Ks...>;
+    using Representation = FlatteningCompactVariant<N, Ks...>;
+
+    template<typename U>
+        requires std::same_as<std::remove_cvref_t<U>, N>
+    PrimitiveNumericOrKeyword(U&& value) : m_value { std::forward<U>(value) } { }
+
+    PrimitiveNumericOrKeyword(WebCore::CSS::ValidKeywordForList<Keywords> auto keyword) : m_value { keyword } { }
+
+    // "Variant-Like" operators.
+    template<typename> constexpr bool holdsAlternative() const;
+    template<typename... F> constexpr decltype(auto) switchOn(F&&...) const;
+
+    constexpr bool isZero() const;
+
+    bool operator==(const PrimitiveNumericOrKeyword&) const = default;
+
+private:
+    Representation m_value;
+};
+
+template<Numeric N, CSS::PrimitiveKeyword... Ks>
+template<typename U>
+constexpr bool PrimitiveNumericOrKeyword<N, Ks...>::holdsAlternative() const
+{
+    return WTF::holdsAlternative<U>(m_value);
+}
+
+template<Numeric N, CSS::PrimitiveKeyword... Ks>
+template<typename... F>
+constexpr decltype(auto) PrimitiveNumericOrKeyword<N, Ks...>::switchOn(F&&... functors) const
+{
+    return WTF::switchOn(m_value, std::forward<F>(functors)...);
+}
+
+template<Numeric N, CSS::PrimitiveKeyword... Ks>
+constexpr bool PrimitiveNumericOrKeyword<N, Ks...>::isZero() const
+{
+    return switchOn(
+        []<HasIsZero U>(const U& value) { return value.isZero(); },
+        [](const auto&) { return false; }
+    );
+}
+
+// MARK: CSS -> Style
+
+template<typename N, typename... Ks>
+struct ToStyleMapping<CSS::PrimitiveNumericOrKeyword<N, Ks...>> {
+    using type = PrimitiveNumericOrKeyword<StyleType<N>, Ks...>;
+};
+
+// MARK: Style -> CSS
+
+template<typename N, typename... Ks>
+struct ToCSSMapping<PrimitiveNumericOrKeyword<N, Ks...>> {
+    using type = CSS::PrimitiveNumericOrKeyword<CSSType<N>, Ks...>;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+template<typename N, typename... Ks>
+struct WTF::FlatteningVariantTraits<WebCore::Style::PrimitiveNumericOrKeyword<N, Ks...>> {
+    using TypeList = typename WTF::FlatteningVariantTraits<typename WebCore::Style::PrimitiveNumericOrKeyword<N, Ks...>::Representation>::TypeList;
+};
+
+template<typename N, typename... Ks> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::PrimitiveNumericOrKeyword<N, Ks...>> = true;

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h
@@ -25,194 +25,11 @@
 #pragma once
 
 #include "CSSPrimitiveNumericTypes.h"
-#include "StylePrimitiveNumericConcepts.h"
-#include "StyleUnevaluatedCalculation.h"
-#include "StyleValueTypes.h"
-#include <wtf/CompactVariant.h>
+#include "StylePrimitiveNumeric.h"
+#include "StylePrimitiveNumericOrKeyword.h"
 
 namespace WebCore {
 namespace Style {
-
-// Default implementation of `PrimitiveNumeric` for non-composite numeric types.
-template<CSS::Numeric CSSType> struct PrimitiveNumeric {
-    using CSS = CSSType;
-    using Raw = typename CSS::Raw;
-    using UnitType = typename CSS::UnitType;
-    using UnitTraits = typename CSS::UnitTraits;
-    using ResolvedValueType = typename CSS::ResolvedValueType;
-    static constexpr auto range = CSS::range;
-    static constexpr auto category = CSS::category;
-
-    static constexpr auto unit = UnitTraits::canonical;
-    ResolvedValueType value { 0 };
-
-    constexpr PrimitiveNumeric(ResolvedValueType value)
-        : value { value }
-    {
-    }
-
-    constexpr bool isZero() const { return !value; }
-
-    constexpr bool operator==(const PrimitiveNumeric&) const = default;
-    constexpr bool operator==(ResolvedValueType other) const { return value == other; };
-};
-
-template<typename> struct DimensionPercentageMapping;
-
-// Specialization of `PrimitiveNumeric` for composite dimension-percentage types.
-template<CSS::DimensionPercentageNumeric CSSType> struct PrimitiveNumeric<CSSType> {
-    using CSS = CSSType;
-    using Raw = typename CSS::Raw;
-    using UnitType = typename CSS::UnitType;
-    using UnitTraits = typename CSS::UnitTraits;
-    using ResolvedValueType = typename CSS::ResolvedValueType;
-    static constexpr auto range = CSS::range;
-    static constexpr auto category = CSS::category;
-
-    // Composite types only currently support float as the `ResolvedValueType`, allowing unconditional use of `CompactVariant`.
-    static_assert(std::same_as<ResolvedValueType, float>);
-
-    using Dimension = typename DimensionPercentageMapping<CSS>::Dimension;
-    using Percentage = typename DimensionPercentageMapping<CSS>::Percentage;
-    using Calc = UnevaluatedCalculation<CSS>;
-    using Representation = CompactVariant<Dimension, Percentage, Calc>;
-
-    PrimitiveNumeric(Dimension dimension)
-        : m_value { WTFMove(dimension) }
-    {
-    }
-
-    PrimitiveNumeric(Percentage percentage)
-        : m_value { WTFMove(percentage) }
-    {
-    }
-
-    PrimitiveNumeric(Calc calc)
-        : m_value { WTFMove(calc) }
-    {
-    }
-
-    // NOTE: CalculatedValue is intentionally not part of IPCData.
-    using IPCData = std::variant<Dimension, Percentage>;
-    PrimitiveNumeric(IPCData&& data)
-        : m_value { WTF::switchOn(WTFMove(data), [&](auto&& data) -> Representation { return { WTFMove(data) }; }) }
-    {
-    }
-
-    IPCData ipcData() const
-    {
-        return WTF::switchOn(m_value,
-            [](const Dimension& dimension) -> IPCData { return dimension; },
-            [](const Percentage& percentage) -> IPCData { return percentage; },
-            [](const Calc&) -> IPCData { ASSERT_NOT_REACHED(); return Dimension { 0 }; }
-        );
-    }
-
-    constexpr size_t index() const { return m_value.index(); }
-
-    template<typename T> constexpr bool holdsAlternative() const { return WTF::holdsAlternative<T>(m_value); }
-    template<size_t I> constexpr bool holdsAlternative() const { return WTF::holdsAlternative<I>(m_value); }
-
-    template<typename T> T get() const
-    {
-        return WTF::switchOn(m_value,
-            []<std::same_as<T> U>(const U& alternative) -> T { return alternative; },
-            [](const auto&) -> T { RELEASE_ASSERT_NOT_REACHED(); }
-        );
-    }
-
-    template<typename... F> decltype(auto) switchOn(F&&... functors) const
-    {
-        return WTF::switchOn(m_value, std::forward<F>(functors)...);
-    }
-
-    constexpr bool isZero() const
-    {
-        return WTF::switchOn(m_value,
-            []<HasIsZero T>(const T& alternative) { return alternative.isZero(); },
-            [](const auto&) { return false; }
-        );
-    }
-
-    bool operator==(const PrimitiveNumeric&) const = default;
-
-private:
-    Representation m_value;
-};
-
-// MARK: Integer Primitive
-
-template<CSS::Range R = CSS::All, typename V = int> struct Integer : PrimitiveNumeric<CSS::Integer<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Integer<R, V>>;
-};
-
-// MARK: Number Primitive
-
-template<CSS::Range R = CSS::All, typename V = double> struct Number : PrimitiveNumeric<CSS::Number<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Number<R, V>>;
-    using Base::Base;
-};
-
-// MARK: Percentage Primitive
-
-template<CSS::Range R = CSS::All, typename V = double> struct Percentage : PrimitiveNumeric<CSS::Percentage<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Percentage<R, V>>;
-    using Base::Base;
-};
-
-// MARK: Dimension Primitives
-
-template<CSS::Range R = CSS::All, typename V = double> struct Angle : PrimitiveNumeric<CSS::Angle<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Angle<R, V>>;
-    using Base::Base;
-};
-template<CSS::Range R = CSS::All, typename V = float> struct Length : PrimitiveNumeric<CSS::Length<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Length<R, V>>;
-    using Base::Base;
-};
-template<CSS::Range R = CSS::All, typename V = double> struct Time : PrimitiveNumeric<CSS::Time<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Time<R, V>>;
-    using Base::Base;
-};
-template<CSS::Range R = CSS::All, typename V = double> struct Frequency : PrimitiveNumeric<CSS::Frequency<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Frequency<R, V>>;
-    using Base::Base;
-};
-template<CSS::Range R = CSS::Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<CSS::Resolution<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Resolution<R, V>>;
-    using Base::Base;
-};
-template<CSS::Range R = CSS::All, typename V = double> struct Flex : PrimitiveNumeric<CSS::Flex<R, V>> {
-    using Base = PrimitiveNumeric<CSS::Flex<R, V>>;
-    using Base::Base;
-};
-
-// MARK: Dimension + Percentage Primitives
-
-template<CSS::Range R = CSS::All, typename V = float> struct AnglePercentage : PrimitiveNumeric<CSS::AnglePercentage<R, V>> {
-    using Base = PrimitiveNumeric<CSS::AnglePercentage<R, V>>;
-    using Base::Base;
-};
-template<CSS::Range R = CSS::All, typename V = float> struct LengthPercentage : PrimitiveNumeric<CSS::LengthPercentage<R, V>> {
-    using Base = PrimitiveNumeric<CSS::LengthPercentage<R, V>>;
-    using Base::Base;
-};
-
-template<auto R, typename V> struct DimensionPercentageMapping<CSS::AnglePercentage<R, V>> {
-    using Dimension = Style::Angle<R, V>;
-    using Percentage = Style::Percentage<R, V>;
-};
-template<auto R, typename V> struct DimensionPercentageMapping<CSS::LengthPercentage<R, V>> {
-    using Dimension = Style::Length<R, V>;
-    using Percentage = Style::Percentage<R, V>;
-};
-
-template<typename T> T get(DimensionPercentageNumeric auto const& dimensionPercentage)
-{
-    return dimensionPercentage.template get<T>();
-}
-
-// MARK: Additional Common Types and Groupings
 
 // NOTE: This is spelled with an explicit "Or" to distinguish it from types like AnglePercentage/LengthPercentage that have behavior distinctions beyond just being a union of the two types (specifically, calc() has specific behaviors for those types).
 template<CSS::Range nR = CSS::All, CSS::Range pR = nR, typename V = double> struct NumberOrPercentage {
@@ -242,7 +59,7 @@ template<CSS::Range nR = CSS::All, CSS::Range pR = nR, typename V = double> stru
         using ResultType = decltype(visitor(std::declval<Number>()));
 
         return WTF::switchOn(value,
-            [](EmptyToken) -> ResultType {
+            [](CSS::PrimitiveDataEmptyToken) -> ResultType {
                 RELEASE_ASSERT_NOT_REACHED();
             },
             [&](const Number& number) -> ResultType {
@@ -256,19 +73,18 @@ template<CSS::Range nR = CSS::All, CSS::Range pR = nR, typename V = double> stru
 
     struct MarkableTraits {
         static bool isEmptyValue(const NumberOrPercentage& value) { return value.isEmpty(); }
-        static NumberOrPercentage emptyValue() { return NumberOrPercentage(EmptyToken()); }
+        static NumberOrPercentage emptyValue() { return NumberOrPercentage(CSS::PrimitiveDataEmptyToken()); }
     };
 
 private:
-    struct EmptyToken { constexpr bool operator==(const EmptyToken&) const = default; };
-    NumberOrPercentage(EmptyToken token)
+    NumberOrPercentage(CSS::PrimitiveDataEmptyToken token)
         : value { WTFMove(token) }
     {
     }
 
-    bool isEmpty() const { return std::holds_alternative<EmptyToken>(value); }
+    bool isEmpty() const { return std::holds_alternative<CSS::PrimitiveDataEmptyToken>(value); }
 
-    std::variant<EmptyToken, Number, Percentage> value;
+    std::variant<CSS::PrimitiveDataEmptyToken, Number, Percentage> value;
 };
 
 template<CSS::Range nR = CSS::All, CSS::Range pR = nR, typename V = double> struct NumberOrPercentageResolvedToNumber {
@@ -330,20 +146,8 @@ using LengthPercentageSpaceSeparatedSizeNonnegative = SpaceSeparatedSize<LengthP
 
 // MARK: CSS -> Style
 
-template<auto R, typename V> struct ToStyleMapping<CSS::Integer<R, V>>          { using type = Integer<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Number<R, V>>           { using type = Number<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Percentage<R, V>>       { using type = Percentage<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Angle<R, V>>            { using type = Angle<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Length<R, V>>           { using type = Length<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Time<R, V>>             { using type = Time<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Frequency<R, V>>        { using type = Frequency<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Resolution<R, V>>       { using type = Resolution<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::Flex<R, V>>             { using type = Flex<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::AnglePercentage<R, V>>  { using type = AnglePercentage<R, V>; };
-template<auto R, typename V> struct ToStyleMapping<CSS::LengthPercentage<R, V>> { using type = LengthPercentage<R, V>; };
-
 template<auto nR, auto pR, typename V> struct ToStyleMapping<CSS::NumberOrPercentage<nR, pR, V>> {
-    using type = NumberOrPercentage<nR, pR>;
+    using type = NumberOrPercentage<nR, pR, V>;
 };
 
 template<auto nR, auto pR, typename V> struct ToStyleMapping<CSS::NumberOrPercentageResolvedToNumber<nR, pR, V>> {
@@ -351,10 +155,6 @@ template<auto nR, auto pR, typename V> struct ToStyleMapping<CSS::NumberOrPercen
 };
 
 // MARK: Style -> CSS
-
-template<Numeric T> struct ToCSSMapping<T> {
-    using type = typename T::CSS;
-};
 
 template<auto nR, auto pR, typename V> struct ToCSSMapping<NumberOrPercentage<nR, pR, V>> {
     using type = CSS::NumberOrPercentage<nR, pR, V>;
@@ -364,15 +164,7 @@ template<auto nR, auto pR, typename V> struct ToCSSMapping<NumberOrPercentageRes
     using type = CSS::NumberOrPercentageResolvedToNumber<nR, pR, V>;
 };
 
-// MARK: Utility Concepts
-
-template<typename T> concept IsPercentageOrCalc =
-       std::same_as<T, Percentage<T::range, typename T::ResolvedValueType>>
-    || std::same_as<T, UnevaluatedCalculation<typename T::CSS>>;
-
 } // namespace Style
 } // namespace WebCore
 
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::AnglePercentage<R, V>> = true;
-template<auto R, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::LengthPercentage<R, V>> = true;
 template<auto nR, auto pR, typename V> inline constexpr auto WebCore::TreatAsVariantLike<WebCore::Style::NumberOrPercentage<nR, pR, V>> = true;

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -327,9 +327,9 @@ private:
     {
         switch (mode) {
         case AbsoluteCoordinates:
-            return typename Command::To { .offset = { LengthPercentage<> { Length<> { offset } } } };
+            return typename Command::To { .offset = { LengthPercentage<>::Dimension { offset } } };
         case RelativeCoordinates:
-            return typename Command::By { .offset = LengthPercentage<> { Length<> { offset } } };
+            return typename Command::By { .offset = LengthPercentage<>::Dimension { offset } };
         }
         RELEASE_ASSERT_NOT_REACHED();
     }
@@ -507,7 +507,7 @@ private:
         m_commands.append(
             ArcCommand {
                 .toBy = fromOffsetPoint(offsetPoint, mode),
-                .size = { Length<> { r1 }, Length<> { r2 } },
+                .size = { LengthPercentage<>::Dimension { r1 }, LengthPercentage<>::Dimension { r2 } },
                 .arcSweep = sweepFlag ? ArcSweep { CSS::Keyword::Cw { } } : ArcSweep { CSS::Keyword::Ccw { } },
                 .arcSize = largeArcFlag ? ArcSize { CSS::Keyword::Large { } } : ArcSize { CSS::Keyword::Small { } },
                 .rotation = { angle },
@@ -658,7 +658,7 @@ std::optional<Shape> makeShapeFromPath(const Path& path)
 
     return Shape {
         .fillRule = path.fillRule,
-        .startingPoint = converter.initialMove().value_or(Position { LengthPercentage<> { Length<> { 0 } }, LengthPercentage<> { Length<> { 0 } } }),
+        .startingPoint = converter.initialMove().value_or(Position { LengthPercentage<>::Dimension { 0 }, LengthPercentage<>::Dimension { 0 } }),
         .commands = { WTFMove(shapeCommands) }
     };
 }


### PR DESCRIPTION
#### b6da0e1efbd8b6680f85b03505b125ec08aa40bd
<pre>
Add strongly type representations of CSS/Style Numeric + Keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=286889">https://bugs.webkit.org/show_bug.cgi?id=286889</a>

Reviewed by Antti Koivisto.

Partially re-applies only the new base types from 288829@main after
having the subset tested and finding no performance regression.

Refactors CSS::PrimitiveNumeric and Style::PrimitiveNumeric so that
their underlying data structure can be used to implement
CSS::PrimitiveNumericOrKeyword and Style::PrimitiveNumericOrKeyword.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/FlatteningVariantAdaptor.h: Added.
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/VariantExtras.h:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/CSSValueConcepts.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveData.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericConcepts.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericOrKeyword.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueConversions.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+CSSValueCreation.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
* Source/WebCore/rendering/TextPainter.cpp:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h: Copied from Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+Conversions.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:

Canonical link: <a href="https://commits.webkit.org/289736@main">https://commits.webkit.org/289736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b50016ac1cb5613fa0bc3311a74aed4ca7c33fad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87755 "38 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67753 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25500 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33803 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37612 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80553 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94506 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86530 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15178 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18662 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7911 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20242 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109024 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14683 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26218 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->