### PR TITLE
Web Inspector: remove unused `frameId` property from timeline event data

### DIFF
--- a/LayoutTests/inspector/timeline/line-column-expected.txt
+++ b/LayoutTests/inspector/timeline/line-column-expected.txt
@@ -12,7 +12,6 @@ PASS: Capturing started.
   "children": [
     {
       "startTime": "<filtered>",
-      "frameId": "<filtered>",
       "data": {
         "type": "click",
         "defaultPrevented": false
@@ -23,7 +22,6 @@ PASS: Capturing started.
     },
     {
       "startTime": "<filtered>",
-      "frameId": "<filtered>",
       "data": {
         "type": "click",
         "defaultPrevented": false
@@ -56,7 +54,6 @@ PASS: Capturing started.
               }
             ]
           },
-          "frameId": "<filtered>",
           "data": {
             "scriptName": "timeline/line-column.html",
             "scriptLine": 17,
@@ -97,7 +94,6 @@ PASS: Capturing started.
           }
         ]
       },
-      "frameId": "<filtered>",
       "data": {
         "title": ""
       },
@@ -145,7 +141,6 @@ PASS: Capturing started.
           }
         ]
       },
-      "frameId": "<filtered>",
       "data": {
         "title": ""
       },

--- a/LayoutTests/inspector/timeline/line-column.html
+++ b/LayoutTests/inspector/timeline/line-column.html
@@ -56,7 +56,7 @@ function test()
         
         if (key === "children" && this.startTime)
             return value.filter(e => eventAllowlist.has(e.type));
-        if (key === "startTime" || key === "endTime" || key === "scriptId" || key === "frameId")
+        if (key === "startTime" || key === "endTime" || key === "scriptId")
             return "<filtered>";
         if ((key === "lineNumber" || key === "columnNumber") && !functionNameLength && !urlLength)
             return "<filtered>";

--- a/LayoutTests/platform/gtk/inspector/timeline/line-column-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/timeline/line-column-expected.txt
@@ -8,7 +8,6 @@ Evaluating in page...
 PASS: Capturing started.
 {
   "startTime": "<filtered>",
-  "frameId": "<filtered>",
   "data": {
     "type": "click",
     "defaultPrevented": false
@@ -19,7 +18,6 @@ PASS: Capturing started.
 }
 {
   "startTime": "<filtered>",
-  "frameId": "<filtered>",
   "data": {
     "type": "click",
     "defaultPrevented": false
@@ -52,7 +50,6 @@ PASS: Capturing started.
           }
         ]
       },
-      "frameId": "<filtered>",
       "data": {
         "scriptName": "timeline/line-column.html",
         "scriptLine": 17,
@@ -93,7 +90,6 @@ PASS: Capturing started.
       }
     ]
   },
-  "frameId": "<filtered>",
   "data": {
     "title": ""
   },
@@ -133,7 +129,6 @@ PASS: Capturing started.
       }
     ]
   },
-  "frameId": "<filtered>",
   "data": {
     "title": ""
   },

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -326,9 +326,7 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
     ASSERT(scriptExecutionContext());
 
     Ref context = *scriptExecutionContext();
-    auto* document = dynamicDowncast<Document>(context.get());
-    if (document)
-        InspectorInstrumentation::willDispatchEvent(*document, event);
+    InspectorInstrumentation::willDispatchEvent(context, event);
 
     for (auto& registeredListener : listeners) {
         if (UNLIKELY(registeredListener->wasRemoved()))
@@ -378,8 +376,7 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
             event.setInPassiveListener(false);
     }
 
-    if (document)
-        InspectorInstrumentation::didDispatchEvent(*document, event);
+    InspectorInstrumentation::didDispatchEvent(context, event);
 }
 
 Vector<AtomString> EventTarget::eventTypes() const

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -98,20 +98,6 @@ void InspectorInstrumentation::lastFrontendDeleted()
     platformStrategies()->loaderStrategy()->setCaptureExtraNetworkLoadMetricsEnabled(false);
 }
 
-static LocalFrame* frameForScriptExecutionContext(ScriptExecutionContext* context)
-{
-    if (RefPtr document = dynamicDowncast<Document>(*context))
-        return document->frame();
-    return nullptr;
-}
-
-static LocalFrame* frameForScriptExecutionContext(ScriptExecutionContext& context)
-{
-    if (RefPtr document = dynamicDowncast<Document>(context))
-        return document->frame();
-    return nullptr;
-}
-
 void InspectorInstrumentation::didClearWindowObjectInWorldImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, DOMWrapperWorld& world)
 {
     if (auto* pageDebuggerAgent = instrumentingAgents.enabledPageDebuggerAgent())
@@ -357,15 +343,15 @@ void InspectorInstrumentation::didInstallTimerImpl(InstrumentingAgents& instrume
         webDebuggerAgent->didScheduleAsyncCall(context.globalObject(), InspectorDebuggerAgent::AsyncCallType::DOMTimer, timerId, singleShot);
 
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didInstallTimer(timerId, timeout, singleShot, frameForScriptExecutionContext(context));
+        timelineAgent->didInstallTimer(timerId, timeout, singleShot);
 }
 
-void InspectorInstrumentation::didRemoveTimerImpl(InstrumentingAgents& instrumentingAgents, int timerId, ScriptExecutionContext& context)
+void InspectorInstrumentation::didRemoveTimerImpl(InstrumentingAgents& instrumentingAgents, int timerId)
 {
     if (auto* webDebuggerAgent = instrumentingAgents.enabledWebDebuggerAgent())
         webDebuggerAgent->didCancelAsyncCall(InspectorDebuggerAgent::AsyncCallType::DOMTimer, timerId);
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didRemoveTimer(timerId, frameForScriptExecutionContext(context));
+        timelineAgent->didRemoveTimer(timerId);
 }
 
 void InspectorInstrumentation::didAddEventListenerImpl(InstrumentingAgents& instrumentingAgents, EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
@@ -426,22 +412,22 @@ void InspectorInstrumentation::didDispatchPostMessageImpl(InstrumentingAgents& i
         webDebuggerAgent->didDispatchPostMessage(postMessageIdentifier);
 }
 
-void InspectorInstrumentation::willCallFunctionImpl(InstrumentingAgents& instrumentingAgents, const String& scriptName, int scriptLine, int scriptColumn, ScriptExecutionContext* context)
+void InspectorInstrumentation::willCallFunctionImpl(InstrumentingAgents& instrumentingAgents, const String& scriptName, int scriptLine, int scriptColumn)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willCallFunction(scriptName, scriptLine, scriptColumn, frameForScriptExecutionContext(context));
+        timelineAgent->willCallFunction(scriptName, scriptLine, scriptColumn);
 }
 
-void InspectorInstrumentation::didCallFunctionImpl(InstrumentingAgents& instrumentingAgents, ScriptExecutionContext* context)
+void InspectorInstrumentation::didCallFunctionImpl(InstrumentingAgents& instrumentingAgents)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didCallFunction(frameForScriptExecutionContext(context));
+        timelineAgent->didCallFunction();
 }
 
-void InspectorInstrumentation::willDispatchEventImpl(InstrumentingAgents& instrumentingAgents, Document& document, const Event& event)
+void InspectorInstrumentation::willDispatchEventImpl(InstrumentingAgents& instrumentingAgents, const Event& event)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willDispatchEvent(event, document.frame());
+        timelineAgent->willDispatchEvent(event);
 }
 
 void InspectorInstrumentation::willHandleEventImpl(InstrumentingAgents& instrumentingAgents, ScriptExecutionContext& context, Event& event, const RegisteredEventListener& listener)
@@ -468,10 +454,10 @@ void InspectorInstrumentation::didDispatchEventImpl(InstrumentingAgents& instrum
         timelineAgent->didDispatchEvent(event.defaultPrevented());
 }
 
-void InspectorInstrumentation::willDispatchEventOnWindowImpl(InstrumentingAgents& instrumentingAgents, const Event& event, LocalDOMWindow& window)
+void InspectorInstrumentation::willDispatchEventOnWindowImpl(InstrumentingAgents& instrumentingAgents, const Event& event)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willDispatchEvent(event, window.frame());
+        timelineAgent->willDispatchEvent(event);
 }
 
 void InspectorInstrumentation::didDispatchEventOnWindowImpl(InstrumentingAgents& instrumentingAgents, const Event& event)
@@ -486,26 +472,26 @@ void InspectorInstrumentation::eventDidResetAfterDispatchImpl(InstrumentingAgent
         domAgent->eventDidResetAfterDispatch(event);
 }
 
-void InspectorInstrumentation::willEvaluateScriptImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, const String& url, int lineNumber, int columnNumber)
+void InspectorInstrumentation::willEvaluateScriptImpl(InstrumentingAgents& instrumentingAgents, const String& url, int lineNumber, int columnNumber)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willEvaluateScript(url, lineNumber, columnNumber, frame);
+        timelineAgent->willEvaluateScript(url, lineNumber, columnNumber);
 }
 
-void InspectorInstrumentation::didEvaluateScriptImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)
+void InspectorInstrumentation::didEvaluateScriptImpl(InstrumentingAgents& instrumentingAgents)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didEvaluateScript(frame);
+        timelineAgent->didEvaluateScript();
 }
 
-void InspectorInstrumentation::willFireTimerImpl(InstrumentingAgents& instrumentingAgents, int timerId, bool oneShot, ScriptExecutionContext& context)
+void InspectorInstrumentation::willFireTimerImpl(InstrumentingAgents& instrumentingAgents, int timerId, bool oneShot)
 {
     if (auto* webDebuggerAgent = instrumentingAgents.enabledWebDebuggerAgent())
         webDebuggerAgent->willDispatchAsyncCall(InspectorDebuggerAgent::AsyncCallType::DOMTimer, timerId);
     if (auto* domDebuggerAgent = instrumentingAgents.enabledDOMDebuggerAgent())
         domDebuggerAgent->willFireTimer(oneShot);
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willFireTimer(timerId, frameForScriptExecutionContext(context));
+        timelineAgent->willFireTimer(timerId);
 }
 
 void InspectorInstrumentation::didFireTimerImpl(InstrumentingAgents& instrumentingAgents, int timerId, bool oneShot)
@@ -518,16 +504,16 @@ void InspectorInstrumentation::didFireTimerImpl(InstrumentingAgents& instrumenti
         timelineAgent->didFireTimer();
 }
 
-void InspectorInstrumentation::didInvalidateLayoutImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)
+void InspectorInstrumentation::didInvalidateLayoutImpl(InstrumentingAgents& instrumentingAgents)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didInvalidateLayout(frame);
+        timelineAgent->didInvalidateLayout();
 }
 
-void InspectorInstrumentation::willLayoutImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)
+void InspectorInstrumentation::willLayoutImpl(InstrumentingAgents& instrumentingAgents)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willLayout(frame);
+        timelineAgent->willLayout();
 }
 
 void InspectorInstrumentation::didLayoutImpl(InstrumentingAgents& instrumentingAgents, RenderObject& root)
@@ -538,10 +524,10 @@ void InspectorInstrumentation::didLayoutImpl(InstrumentingAgents& instrumentingA
         pageAgent->didLayout();
 }
 
-void InspectorInstrumentation::willCompositeImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)
+void InspectorInstrumentation::willCompositeImpl(InstrumentingAgents& instrumentingAgents)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willComposite(frame);
+        timelineAgent->willComposite();
 }
 
 void InspectorInstrumentation::didCompositeImpl(InstrumentingAgents& instrumentingAgents)
@@ -550,10 +536,10 @@ void InspectorInstrumentation::didCompositeImpl(InstrumentingAgents& instrumenti
         timelineAgent->didComposite();
 }
 
-void InspectorInstrumentation::willPaintImpl(InstrumentingAgents& instrumentingAgents, RenderObject& renderer)
+void InspectorInstrumentation::willPaintImpl(InstrumentingAgents& instrumentingAgents)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willPaint(renderer.frame());
+        timelineAgent->willPaint();
 }
 
 void InspectorInstrumentation::didPaintImpl(InstrumentingAgents& instrumentingAgents, RenderObject& renderer, const LayoutRect& rect)
@@ -565,10 +551,10 @@ void InspectorInstrumentation::didPaintImpl(InstrumentingAgents& instrumentingAg
         pageAgent->didPaint(renderer, rect);
 }
 
-void InspectorInstrumentation::willRecalculateStyleImpl(InstrumentingAgents& instrumentingAgents, Document& document)
+void InspectorInstrumentation::willRecalculateStyleImpl(InstrumentingAgents& instrumentingAgents)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willRecalculateStyle(document.frame());
+        timelineAgent->willRecalculateStyle();
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->willRecalculateStyle();
 }
@@ -586,7 +572,7 @@ void InspectorInstrumentation::didRecalculateStyleImpl(InstrumentingAgents& inst
 void InspectorInstrumentation::didScheduleStyleRecalculationImpl(InstrumentingAgents& instrumentingAgents, Document& document)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didScheduleStyleRecalculation(document.frame());
+        timelineAgent->didScheduleStyleRecalculation();
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->didScheduleStyleRecalculation(document);
 }
@@ -962,22 +948,13 @@ void InspectorInstrumentation::takeHeapSnapshotImpl(InstrumentingAgents& instrum
         consoleAgent->takeHeapSnapshot(title);
 }
 
-void InspectorInstrumentation::startConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, Frame& frame, JSC::JSGlobalObject* exec, const String& label)
-{
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
-        return;
-
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->time(frame, label);
-    if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
-        consoleAgent->startTiming(exec, label);
-}
-
 void InspectorInstrumentation::startConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& label)
 {
     if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
         return;
 
+    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
+        timelineAgent->time(label);
     if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
         consoleAgent->startTiming(exec, label);
 }
@@ -991,17 +968,6 @@ void InspectorInstrumentation::logConsoleTimingImpl(InstrumentingAgents& instrum
         consoleAgent->logTiming(exec, label, WTFMove(arguments));
 }
 
-void InspectorInstrumentation::stopConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, Frame& frame, JSC::JSGlobalObject* exec, const String& label)
-{
-    if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
-        return;
-
-    if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
-        consoleAgent->stopTiming(exec, label);
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->timeEnd(frame, label);
-}
-
 void InspectorInstrumentation::stopConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& label)
 {
     if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
@@ -1009,33 +975,35 @@ void InspectorInstrumentation::stopConsoleTimingImpl(InstrumentingAgents& instru
 
     if (auto* consoleAgent = instrumentingAgents.webConsoleAgent())
         consoleAgent->stopTiming(exec, label);
+    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
+        timelineAgent->timeEnd(label);
 }
 
-void InspectorInstrumentation::consoleTimeStampImpl(InstrumentingAgents& instrumentingAgents, Frame& frame, Ref<ScriptArguments>&& arguments)
+void InspectorInstrumentation::consoleTimeStampImpl(InstrumentingAgents& instrumentingAgents, Ref<ScriptArguments>&& arguments)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent()) {
         String message;
         arguments->getFirstArgumentAsString(message);
-        timelineAgent->didTimeStamp(frame, message);
+        timelineAgent->didTimeStamp(message);
      }
 }
 
-void InspectorInstrumentation::startProfilingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& title)
+void InspectorInstrumentation::startProfilingImpl(InstrumentingAgents& instrumentingAgents, const String& title)
 {
     if (auto* timelineAgent = instrumentingAgents.enabledTimelineAgent())
-        timelineAgent->startFromConsole(exec, title);
+        timelineAgent->startFromConsole(title);
 }
 
-void InspectorInstrumentation::stopProfilingImpl(InstrumentingAgents& instrumentingAgents, JSC::JSGlobalObject* exec, const String& title)
+void InspectorInstrumentation::stopProfilingImpl(InstrumentingAgents& instrumentingAgents, const String& title)
 {
     if (auto* timelineAgent = instrumentingAgents.enabledTimelineAgent())
-        timelineAgent->stopFromConsole(exec, title);
+        timelineAgent->stopFromConsole(title);
 }
 
-void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrumentingAgents, const String& label, std::optional<MonotonicTime> timestamp, LocalFrame* frame)
+void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrumentingAgents, const String& label, std::optional<MonotonicTime> timestamp)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didPerformanceMark(label, timestamp, frame);
+        timelineAgent->didPerformanceMark(label, timestamp);
 }
 
 void InspectorInstrumentation::consoleStartRecordingCanvasImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context, JSC::JSGlobalObject& exec, JSC::JSObject* options)
@@ -1264,25 +1232,25 @@ void InspectorInstrumentation::didRequestAnimationFrameImpl(InstrumentingAgents&
     if (auto* pageDebuggerAgent = instrumentingAgents.enabledPageDebuggerAgent())
         pageDebuggerAgent->didRequestAnimationFrame(callbackId, document);
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didRequestAnimationFrame(callbackId, document.frame());
+        timelineAgent->didRequestAnimationFrame(callbackId);
 }
 
-void InspectorInstrumentation::didCancelAnimationFrameImpl(InstrumentingAgents& instrumentingAgents, int callbackId, Document& document)
+void InspectorInstrumentation::didCancelAnimationFrameImpl(InstrumentingAgents& instrumentingAgents, int callbackId)
 {
     if (auto* pageDebuggerAgent = instrumentingAgents.enabledPageDebuggerAgent())
         pageDebuggerAgent->didCancelAnimationFrame(callbackId);
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didCancelAnimationFrame(callbackId, document.frame());
+        timelineAgent->didCancelAnimationFrame(callbackId);
 }
 
-void InspectorInstrumentation::willFireAnimationFrameImpl(InstrumentingAgents& instrumentingAgents, int callbackId, Document& document)
+void InspectorInstrumentation::willFireAnimationFrameImpl(InstrumentingAgents& instrumentingAgents, int callbackId)
 {
     if (auto* pageDebuggerAgent = instrumentingAgents.enabledPageDebuggerAgent())
         pageDebuggerAgent->willFireAnimationFrame(callbackId);
     if (auto* pageDOMDebuggerAgent = instrumentingAgents.enabledPageDOMDebuggerAgent())
         pageDOMDebuggerAgent->willFireAnimationFrame();
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willFireAnimationFrame(callbackId, document.frame());
+        timelineAgent->willFireAnimationFrame(callbackId);
 }
 
 void InspectorInstrumentation::didFireAnimationFrameImpl(InstrumentingAgents& instrumentingAgents, int callbackId)
@@ -1295,10 +1263,10 @@ void InspectorInstrumentation::didFireAnimationFrameImpl(InstrumentingAgents& in
         timelineAgent->didFireAnimationFrame();
 }
 
-void InspectorInstrumentation::willFireObserverCallbackImpl(InstrumentingAgents& instrumentingAgents, const String& callbackType, ScriptExecutionContext& context)
+void InspectorInstrumentation::willFireObserverCallbackImpl(InstrumentingAgents& instrumentingAgents, const String& callbackType)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willFireObserverCallback(callbackType, frameForScriptExecutionContext(&context));
+        timelineAgent->willFireObserverCallback(callbackType);
 }
 
 void InspectorInstrumentation::didFireObserverCallbackImpl(InstrumentingAgents& instrumentingAgents)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -170,11 +170,11 @@ public:
     static void didAddEventListener(EventTarget&, const AtomString& eventType, EventListener&, bool capture);
     static void willRemoveEventListener(EventTarget&, const AtomString& eventType, EventListener&, bool capture);
     static bool isEventListenerDisabled(EventTarget&, const AtomString& eventType, EventListener&, bool capture);
-    static void willDispatchEvent(Document&, const Event&);
-    static void didDispatchEvent(Document&, const Event&);
+    static void willDispatchEvent(ScriptExecutionContext&, const Event&);
+    static void didDispatchEvent(ScriptExecutionContext&, const Event&);
     static void willHandleEvent(ScriptExecutionContext&, Event&, const RegisteredEventListener&);
     static void didHandleEvent(ScriptExecutionContext&, Event&, const RegisteredEventListener&);
-    static void willDispatchEventOnWindow(LocalFrame*, const Event&, LocalDOMWindow&);
+    static void willDispatchEventOnWindow(LocalFrame*, const Event&);
     static void didDispatchEventOnWindow(LocalFrame*, const Event&);
     static void eventDidResetAfterDispatch(const Event&);
     static void willEvaluateScript(LocalFrame&, const String& url, int lineNumber, int columnNumber);
@@ -265,12 +265,12 @@ public:
     static void stopConsoleTiming(Frame&, JSC::JSGlobalObject*, const String& label);
     static void stopConsoleTiming(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label);
     static void consoleTimeStamp(Frame&, Ref<Inspector::ScriptArguments>&&);
-    static void startProfiling(Page&, JSC::JSGlobalObject*, const String& title);
-    static void stopProfiling(Page&, JSC::JSGlobalObject*, const String& title);
+    static void startProfiling(Page&, const String& title);
+    static void stopProfiling(Page&, const String& title);
     static void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     static void consoleStopRecordingCanvas(CanvasRenderingContext&);
 
-    static void performanceMark(ScriptExecutionContext&, const String&, std::optional<MonotonicTime>, LocalFrame*);
+    static void performanceMark(ScriptExecutionContext&, const String&, std::optional<MonotonicTime>);
 
     static void didRequestAnimationFrame(Document&, int callbackId);
     static void didCancelAnimationFrame(Document&, int callbackId);
@@ -383,7 +383,7 @@ private:
     static void willSendXMLHttpRequestImpl(InstrumentingAgents&, const String& url);
     static void willFetchImpl(InstrumentingAgents&, const String& url);
     static void didInstallTimerImpl(InstrumentingAgents&, int timerId, Seconds timeout, bool singleShot, ScriptExecutionContext&);
-    static void didRemoveTimerImpl(InstrumentingAgents&, int timerId, ScriptExecutionContext&);
+    static void didRemoveTimerImpl(InstrumentingAgents&, int timerId);
 
     static int willPostMessageImpl(InstrumentingAgents&);
     static void didPostMessageImpl(InstrumentingAgents&, int postMessageIdentifier, JSC::JSGlobalObject&);
@@ -391,31 +391,31 @@ private:
     static void willDispatchPostMessageImpl(InstrumentingAgents&, int postMessageIdentifier);
     static void didDispatchPostMessageImpl(InstrumentingAgents&, int postMessageIdentifier);
 
-    static void willCallFunctionImpl(InstrumentingAgents&, const String& scriptName, int scriptLine, int scriptColumn, ScriptExecutionContext*);
-    static void didCallFunctionImpl(InstrumentingAgents&, ScriptExecutionContext*);
+    static void willCallFunctionImpl(InstrumentingAgents&, const String& scriptName, int scriptLine, int scriptColumn);
+    static void didCallFunctionImpl(InstrumentingAgents&);
     static void didAddEventListenerImpl(InstrumentingAgents&, EventTarget&, const AtomString& eventType, EventListener&, bool capture);
     static void willRemoveEventListenerImpl(InstrumentingAgents&, EventTarget&, const AtomString& eventType, EventListener&, bool capture);
     static bool isEventListenerDisabledImpl(InstrumentingAgents&, EventTarget&, const AtomString& eventType, EventListener&, bool capture);
-    static void willDispatchEventImpl(InstrumentingAgents&, Document&, const Event&);
+    static void willDispatchEventImpl(InstrumentingAgents&, const Event&);
     static void willHandleEventImpl(InstrumentingAgents&, ScriptExecutionContext&, Event&, const RegisteredEventListener&);
     static void didHandleEventImpl(InstrumentingAgents&, ScriptExecutionContext&, Event&, const RegisteredEventListener&);
     static void didDispatchEventImpl(InstrumentingAgents&, const Event&);
-    static void willDispatchEventOnWindowImpl(InstrumentingAgents&, const Event&, LocalDOMWindow&);
+    static void willDispatchEventOnWindowImpl(InstrumentingAgents&, const Event&);
     static void didDispatchEventOnWindowImpl(InstrumentingAgents&, const Event&);
     static void eventDidResetAfterDispatchImpl(InstrumentingAgents&, const Event&);
-    static void willEvaluateScriptImpl(InstrumentingAgents&, LocalFrame&, const String& url, int lineNumber, int columnNumber);
-    static void didEvaluateScriptImpl(InstrumentingAgents&, LocalFrame&);
-    static void willFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot, ScriptExecutionContext&);
+    static void willEvaluateScriptImpl(InstrumentingAgents&, const String& url, int lineNumber, int columnNumber);
+    static void didEvaluateScriptImpl(InstrumentingAgents&);
+    static void willFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
     static void didFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
-    static void didInvalidateLayoutImpl(InstrumentingAgents&, LocalFrame&);
-    static void willLayoutImpl(InstrumentingAgents&, LocalFrame&);
+    static void didInvalidateLayoutImpl(InstrumentingAgents&);
+    static void willLayoutImpl(InstrumentingAgents&);
     static void didLayoutImpl(InstrumentingAgents&, RenderObject&);
     static void didScrollImpl(InstrumentingAgents&);
-    static void willCompositeImpl(InstrumentingAgents&, LocalFrame&);
+    static void willCompositeImpl(InstrumentingAgents&);
     static void didCompositeImpl(InstrumentingAgents&);
-    static void willPaintImpl(InstrumentingAgents&, RenderObject&);
+    static void willPaintImpl(InstrumentingAgents&);
     static void didPaintImpl(InstrumentingAgents&, RenderObject&, const LayoutRect&);
-    static void willRecalculateStyleImpl(InstrumentingAgents&, Document&);
+    static void willRecalculateStyleImpl(InstrumentingAgents&);
     static void didRecalculateStyleImpl(InstrumentingAgents&);
     static void didScheduleStyleRecalculationImpl(InstrumentingAgents&, Document&);
     static void applyUserAgentOverrideImpl(InstrumentingAgents&, String&);
@@ -466,25 +466,23 @@ private:
     static void consoleCountImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
     static void consoleCountResetImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
     static void takeHeapSnapshotImpl(InstrumentingAgents&, const String& title);
-    static void startConsoleTimingImpl(InstrumentingAgents&, Frame&, JSC::JSGlobalObject*, const String& label);
     static void startConsoleTimingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
     static void logConsoleTimingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label, Ref<Inspector::ScriptArguments>&&);
-    static void stopConsoleTimingImpl(InstrumentingAgents&, Frame&, JSC::JSGlobalObject*, const String& label);
     static void stopConsoleTimingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
-    static void consoleTimeStampImpl(InstrumentingAgents&, Frame&, Ref<Inspector::ScriptArguments>&&);
-    static void startProfilingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& title);
-    static void stopProfilingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& title);
+    static void consoleTimeStampImpl(InstrumentingAgents&, Ref<Inspector::ScriptArguments>&&);
+    static void startProfilingImpl(InstrumentingAgents&, const String& title);
+    static void stopProfilingImpl(InstrumentingAgents&, const String& title);
     static void consoleStartRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     static void consoleStopRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&);
 
-    static void performanceMarkImpl(InstrumentingAgents&, const String& label, std::optional<MonotonicTime>, LocalFrame*);
+    static void performanceMarkImpl(InstrumentingAgents&, const String& label, std::optional<MonotonicTime>);
 
     static void didRequestAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
-    static void didCancelAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
-    static void willFireAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
+    static void didCancelAnimationFrameImpl(InstrumentingAgents&, int callbackId);
+    static void willFireAnimationFrameImpl(InstrumentingAgents&, int callbackId);
     static void didFireAnimationFrameImpl(InstrumentingAgents&, int callbackId);
 
-    static void willFireObserverCallbackImpl(InstrumentingAgents&, const String&, ScriptExecutionContext&);
+    static void willFireObserverCallbackImpl(InstrumentingAgents&, const String&);
     static void didFireObserverCallbackImpl(InstrumentingAgents&);
 
     static void didOpenDatabaseImpl(InstrumentingAgents&, Database&);
@@ -824,7 +822,7 @@ inline void InspectorInstrumentation::didRemoveTimer(ScriptExecutionContext& con
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context))
-        didRemoveTimerImpl(*agents, timerId, context);
+        didRemoveTimerImpl(*agents, timerId);
 }
 
 inline void InspectorInstrumentation::didAddEventListener(EventTarget& target, const AtomString& eventType, EventListener& listener, bool capture)
@@ -889,27 +887,27 @@ inline void InspectorInstrumentation::willCallFunction(ScriptExecutionContext* c
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context))
-        willCallFunctionImpl(*agents, scriptName, scriptLine, scriptColumn, context);
+        willCallFunctionImpl(*agents, scriptName, scriptLine, scriptColumn);
 }
 
 inline void InspectorInstrumentation::didCallFunction(ScriptExecutionContext* context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context))
-        didCallFunctionImpl(*agents, context);
+        didCallFunctionImpl(*agents);
 }
 
-inline void InspectorInstrumentation::willDispatchEvent(Document& document, const Event& event)
+inline void InspectorInstrumentation::willDispatchEvent(ScriptExecutionContext& context, const Event& event)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
-        willDispatchEventImpl(*agents, document, event);
+    if (auto* agents = instrumentingAgents(context))
+        willDispatchEventImpl(*agents, event);
 }
 
-inline void InspectorInstrumentation::didDispatchEvent(Document& document, const Event& event)
+inline void InspectorInstrumentation::didDispatchEvent(ScriptExecutionContext& context, const Event& event)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(document))
+    if (auto* agents = instrumentingAgents(context))
         didDispatchEventImpl(*agents, event);
 }
 
@@ -927,11 +925,11 @@ inline void InspectorInstrumentation::didHandleEvent(ScriptExecutionContext& con
         return didHandleEventImpl(*agents, context, event, listener);
 }
 
-inline void InspectorInstrumentation::willDispatchEventOnWindow(LocalFrame* frame, const Event& event, LocalDOMWindow& window)
+inline void InspectorInstrumentation::willDispatchEventOnWindow(LocalFrame* frame, const Event& event)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        willDispatchEventOnWindowImpl(*agents, event, window);
+        willDispatchEventOnWindowImpl(*agents, event);
 }
 
 inline void InspectorInstrumentation::didDispatchEventOnWindow(LocalFrame* frame, const Event& event)
@@ -957,21 +955,21 @@ inline void InspectorInstrumentation::willEvaluateScript(LocalFrame& frame, cons
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        willEvaluateScriptImpl(*agents, frame, url, lineNumber, columnNumber);
+        willEvaluateScriptImpl(*agents, url, lineNumber, columnNumber);
 }
 
 inline void InspectorInstrumentation::didEvaluateScript(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        didEvaluateScriptImpl(*agents, frame);
+        didEvaluateScriptImpl(*agents);
 }
 
 inline void InspectorInstrumentation::willFireTimer(ScriptExecutionContext& context, int timerId, bool oneShot)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context))
-        willFireTimerImpl(*agents, timerId, oneShot, context);
+        willFireTimerImpl(*agents, timerId, oneShot);
 }
 
 inline void InspectorInstrumentation::didFireTimer(ScriptExecutionContext& context, int timerId, bool oneShot)
@@ -985,14 +983,14 @@ inline void InspectorInstrumentation::didInvalidateLayout(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        didInvalidateLayoutImpl(*agents, frame);
+        didInvalidateLayoutImpl(*agents);
 }
 
 inline void InspectorInstrumentation::willLayout(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        willLayoutImpl(*agents, frame);
+        willLayoutImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didLayout(LocalFrame& frame, RenderObject& root)
@@ -1012,7 +1010,7 @@ inline void InspectorInstrumentation::willComposite(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        willCompositeImpl(*agents, frame);
+        willCompositeImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didComposite(LocalFrame& frame)
@@ -1026,7 +1024,7 @@ inline void InspectorInstrumentation::willPaint(RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(renderer))
-        return willPaintImpl(*agents, renderer);
+        return willPaintImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didPaint(RenderObject& renderer, const LayoutRect& rect)
@@ -1040,7 +1038,7 @@ inline void InspectorInstrumentation::willRecalculateStyle(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(document))
-        willRecalculateStyleImpl(*agents, document);
+        willRecalculateStyleImpl(*agents);
 }
 
 inline void InspectorInstrumentation::didRecalculateStyle(Document& document)
@@ -1611,7 +1609,7 @@ inline void InspectorInstrumentation::takeHeapSnapshot(Frame& frame, const Strin
 inline void InspectorInstrumentation::startConsoleTiming(Frame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
     if (auto* agents = instrumentingAgents(frame))
-        startConsoleTimingImpl(*agents, frame, exec, label);
+        startConsoleTimingImpl(*agents, exec, label);
 }
 
 inline void InspectorInstrumentation::startConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label)
@@ -1633,7 +1631,7 @@ inline void InspectorInstrumentation::logConsoleTiming(WorkerOrWorkletGlobalScop
 inline void InspectorInstrumentation::stopConsoleTiming(Frame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
     if (auto* agents = instrumentingAgents(frame))
-        stopConsoleTimingImpl(*agents, frame, exec, label);
+        stopConsoleTimingImpl(*agents, exec, label);
 }
 
 inline void InspectorInstrumentation::stopConsoleTiming(WorkerOrWorkletGlobalScope& globalScope, JSC::JSGlobalObject* exec, const String& label)
@@ -1645,19 +1643,19 @@ inline void InspectorInstrumentation::consoleTimeStamp(Frame& frame, Ref<Inspect
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
-        consoleTimeStampImpl(*agents, frame, WTFMove(arguments));
+        consoleTimeStampImpl(*agents, WTFMove(arguments));
 }
 
-inline void InspectorInstrumentation::startProfiling(Page& page, JSC::JSGlobalObject* exec, const String &title)
+inline void InspectorInstrumentation::startProfiling(Page& page, const String &title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    startProfilingImpl(instrumentingAgents(page), exec, title);
+    startProfilingImpl(instrumentingAgents(page), title);
 }
 
-inline void InspectorInstrumentation::stopProfiling(Page& page, JSC::JSGlobalObject* exec, const String &title)
+inline void InspectorInstrumentation::stopProfiling(Page& page, const String &title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    stopProfilingImpl(instrumentingAgents(page), exec, title);
+    stopProfilingImpl(instrumentingAgents(page), title);
 }
 
 inline void InspectorInstrumentation::consoleStartRecordingCanvas(CanvasRenderingContext& context, JSC::JSGlobalObject& exec, JSC::JSObject* options)
@@ -1672,11 +1670,11 @@ inline void InspectorInstrumentation::consoleStopRecordingCanvas(CanvasRendering
         consoleStopRecordingCanvasImpl(*agents, context);
 }
 
-inline void InspectorInstrumentation::performanceMark(ScriptExecutionContext& context, const String& label, std::optional<MonotonicTime> startTime, LocalFrame* frame)
+inline void InspectorInstrumentation::performanceMark(ScriptExecutionContext& context, const String& label, std::optional<MonotonicTime> startTime)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context))
-        performanceMarkImpl(*agents, label, WTFMove(startTime), frame);
+        performanceMarkImpl(*agents, label, WTFMove(startTime));
 }
 
 inline void InspectorInstrumentation::didRequestAnimationFrame(Document& document, int callbackId)
@@ -1690,14 +1688,14 @@ inline void InspectorInstrumentation::didCancelAnimationFrame(Document& document
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(document))
-        didCancelAnimationFrameImpl(*agents, callbackId, document);
+        didCancelAnimationFrameImpl(*agents, callbackId);
 }
 
 inline void InspectorInstrumentation::willFireAnimationFrame(Document& document, int callbackId)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(document))
-        willFireAnimationFrameImpl(*agents, callbackId, document);
+        willFireAnimationFrameImpl(*agents, callbackId);
 }
 
 inline void InspectorInstrumentation::didFireAnimationFrame(Document& document, int callbackId)
@@ -1711,7 +1709,7 @@ inline void InspectorInstrumentation::willFireObserverCallback(ScriptExecutionCo
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(context))
-        willFireObserverCallbackImpl(*agents, callbackType, context);
+        willFireObserverCallbackImpl(*agents, callbackType);
 }
 
 inline void InspectorInstrumentation::didFireObserverCallback(ScriptExecutionContext& context)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -47,8 +47,6 @@ namespace WebCore {
 
 class Event;
 class FloatQuad;
-class Frame;
-class LocalFrame;
 class RenderObject;
 class RunLoopObserver;
 
@@ -108,43 +106,43 @@ public:
     void breakpointActionProbe(JSC::JSGlobalObject*, JSC::BreakpointActionID, unsigned batchId, unsigned sampleId, JSC::JSValue result);
 
     // InspectorInstrumentation
-    void didInstallTimer(int timerId, Seconds timeout, bool singleShot, LocalFrame*);
-    void didRemoveTimer(int timerId, LocalFrame*);
-    void willFireTimer(int timerId, LocalFrame*);
+    void didInstallTimer(int timerId, Seconds timeout, bool singleShot);
+    void didRemoveTimer(int timerId);
+    void willFireTimer(int timerId);
     void didFireTimer();
-    void willCallFunction(const String& scriptName, int scriptLine, int scriptColumn, LocalFrame*);
-    void didCallFunction(LocalFrame*);
-    void willDispatchEvent(const Event&, LocalFrame*);
+    void willCallFunction(const String& scriptName, int scriptLine, int scriptColumn);
+    void didCallFunction();
+    void willDispatchEvent(const Event&);
     void didDispatchEvent(bool defaultPrevented);
-    void willEvaluateScript(const String&, int lineNumber, int columnNumber, LocalFrame&);
-    void didEvaluateScript(LocalFrame&);
-    void didInvalidateLayout(LocalFrame&);
-    void willLayout(LocalFrame&);
+    void willEvaluateScript(const String&, int lineNumber, int columnNumber);
+    void didEvaluateScript();
+    void didInvalidateLayout();
+    void willLayout();
     void didLayout(RenderObject&);
-    void willComposite(LocalFrame&);
+    void willComposite();
     void didComposite();
-    void willPaint(LocalFrame&);
+    void willPaint();
     void didPaint(RenderObject&, const LayoutRect&);
-    void willRecalculateStyle(LocalFrame*);
+    void willRecalculateStyle();
     void didRecalculateStyle();
-    void didScheduleStyleRecalculation(LocalFrame*);
-    void didTimeStamp(Frame&, const String&);
-    void didPerformanceMark(const String&, std::optional<MonotonicTime>, Frame*);
-    void didRequestAnimationFrame(int callbackId, LocalFrame*);
-    void didCancelAnimationFrame(int callbackId, LocalFrame*);
-    void willFireAnimationFrame(int callbackId, LocalFrame*);
+    void didScheduleStyleRecalculation();
+    void didTimeStamp(const String&);
+    void didPerformanceMark(const String&, std::optional<MonotonicTime>);
+    void didRequestAnimationFrame(int callbackId);
+    void didCancelAnimationFrame(int callbackId);
+    void willFireAnimationFrame(int callbackId);
     void didFireAnimationFrame();
-    void willFireObserverCallback(const String& callbackType, LocalFrame*);
+    void willFireObserverCallback(const String& callbackType);
     void didFireObserverCallback();
-    void time(Frame&, const String&);
-    void timeEnd(Frame&, const String&);
+    void time(const String&);
+    void timeEnd(const String&);
     void mainFrameStartedLoading();
     void mainFrameNavigated();
     void didCompleteRenderingFrame();
 
     // Console
-    void startFromConsole(JSC::JSGlobalObject*, const String& title);
-    void stopFromConsole(JSC::JSGlobalObject*, const String& title);
+    void startFromConsole(const String& title);
+    void stopFromConsole(const String& title);
 
 private:
     void startProgrammaticCapture();
@@ -162,8 +160,6 @@ private:
     void enableBreakpoints();
 
     void captureScreenshot();
-
-    friend class TimelineRecordStack;
 
     struct TimelineRecordEntry {
         TimelineRecordEntry(Ref<JSON::Object>&& record, Ref<JSON::Object>&& data, RefPtr<JSON::Array>&& children, TimelineRecordType type)
@@ -186,13 +182,11 @@ private:
     std::optional<double> timestampFromMonotonicTime(MonotonicTime);
 
     void sendEvent(Ref<JSON::Object>&&);
-    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, Frame*, std::optional<double> startTime = std::nullopt);
-    void pushCurrentRecord(Ref<JSON::Object>&&, TimelineRecordType, bool captureCallStack, LocalFrame*, std::optional<double> startTime = std::nullopt);
+    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
+    void pushCurrentRecord(Ref<JSON::Object>&&, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
     void pushCurrentRecord(const TimelineRecordEntry& record) { m_recordStack.append(record); }
 
-    TimelineRecordEntry createRecordEntry(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, LocalFrame*, std::optional<double> startTime = std::nullopt);
-
-    void setFrameIdentifier(JSON::Object* record, Frame*);
+    TimelineRecordEntry createRecordEntry(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
 
     void didCompleteRecordEntry(const TimelineRecordEntry&);
     void didCompleteCurrentRecord(TimelineRecordType);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2394,7 +2394,7 @@ void LocalDOMWindow::dispatchEvent(Event& event, EventTarget* target)
         protectedFrame = frame();
         hasListenersForEvent = hasEventListeners(event.type());
         if (hasListenersForEvent)
-            InspectorInstrumentation::willDispatchEventOnWindow(protectedFrame.get(), event, *this);
+            InspectorInstrumentation::willDispatchEventOnWindow(protectedFrame.get(), event);
     }
 
     // FIXME: We should use EventDispatcher everywhere.

--- a/Source/WebCore/page/PageConsoleClient.cpp
+++ b/Source/WebCore/page/PageConsoleClient.cpp
@@ -241,16 +241,16 @@ void PageConsoleClient::countReset(JSC::JSGlobalObject* lexicalGlobalObject, con
     InspectorInstrumentation::consoleCountReset(protectedPage(), lexicalGlobalObject, label);
 }
 
-void PageConsoleClient::profile(JSC::JSGlobalObject* lexicalGlobalObject, const String& title)
+void PageConsoleClient::profile(JSC::JSGlobalObject*, const String& title)
 {
     // FIXME: <https://webkit.org/b/153499> Web Inspector: console.profile should use the new Sampling Profiler
-    InspectorInstrumentation::startProfiling(protectedPage(), lexicalGlobalObject, title);
+    InspectorInstrumentation::startProfiling(protectedPage(), title);
 }
 
-void PageConsoleClient::profileEnd(JSC::JSGlobalObject* lexicalGlobalObject, const String& title)
+void PageConsoleClient::profileEnd(JSC::JSGlobalObject*, const String& title)
 {
     // FIXME: <https://webkit.org/b/153499> Web Inspector: console.profile should use the new Sampling Profiler
-    InspectorInstrumentation::stopProfiling(protectedPage(), lexicalGlobalObject, title);
+    InspectorInstrumentation::stopProfiling(protectedPage(), title);
 }
 
 void PageConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String& title)

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -105,7 +105,7 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
         timestamp = m_performance->monotonicTimeFromRelativeTime(*markOptions->startTime);
 
     RefPtr document = dynamicDowncast<Document>(context);
-    InspectorInstrumentation::performanceMark(context.get(), markName, timestamp, document ? document->protectedFrame().get() : nullptr);
+    InspectorInstrumentation::performanceMark(context.get(), markName, timestamp);
 
     auto mark = PerformanceMark::create(globalObject, context, markName, WTFMove(markOptions));
     if (mark.hasException())


### PR DESCRIPTION
#### 323063884259a103168acd51f8bf52bbcef73f27
<pre>
Web Inspector: remove unused `frameId` property from timeline event data
<a href="https://bugs.webkit.org/show_bug.cgi?id=286890">https://bugs.webkit.org/show_bug.cgi?id=286890</a>

Reviewed by BJ Burg.

Nothing in the frontend uses `frameId`, so there&apos;s no need to provide it.

This will also massively simplify adding support for `Timeline` in `Worker`, as well as implenting PPO with respect to Web Inspector.

* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::internalStart):
(WebCore::InspectorTimelineAgent::startFromConsole):
(WebCore::InspectorTimelineAgent::stopFromConsole):
(WebCore::InspectorTimelineAgent::willCallFunction):
(WebCore::InspectorTimelineAgent::didCallFunction):
(WebCore::InspectorTimelineAgent::willDispatchEvent):
(WebCore::InspectorTimelineAgent::didInvalidateLayout):
(WebCore::InspectorTimelineAgent::willLayout):
(WebCore::InspectorTimelineAgent::didScheduleStyleRecalculation):
(WebCore::InspectorTimelineAgent::willRecalculateStyle):
(WebCore::InspectorTimelineAgent::willComposite):
(WebCore::InspectorTimelineAgent::willPaint):
(WebCore::InspectorTimelineAgent::didInstallTimer):
(WebCore::InspectorTimelineAgent::didRemoveTimer):
(WebCore::InspectorTimelineAgent::willFireTimer):
(WebCore::InspectorTimelineAgent::willEvaluateScript):
(WebCore::InspectorTimelineAgent::didEvaluateScript):
(WebCore::InspectorTimelineAgent::didTimeStamp):
(WebCore::InspectorTimelineAgent::time):
(WebCore::InspectorTimelineAgent::timeEnd):
(WebCore::InspectorTimelineAgent::didPerformanceMark):
(WebCore::InspectorTimelineAgent::captureScreenshot):
(WebCore::InspectorTimelineAgent::didRequestAnimationFrame):
(WebCore::InspectorTimelineAgent::didCancelAnimationFrame):
(WebCore::InspectorTimelineAgent::willFireAnimationFrame):
(WebCore::InspectorTimelineAgent::willFireObserverCallback):
(WebCore::InspectorTimelineAgent::breakpointActionProbe):
(WebCore::InspectorTimelineAgent::appendRecord):
(WebCore::InspectorTimelineAgent::createRecordEntry):
(WebCore::InspectorTimelineAgent::pushCurrentRecord):
(WebCore::frame): Deleted.
(WebCore::InspectorTimelineAgent::setFrameIdentifier): Deleted.

* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didRemoveTimer):
(WebCore::InspectorInstrumentation::willCallFunction):
(WebCore::InspectorInstrumentation::didCallFunction):
(WebCore::InspectorInstrumentation::willDispatchEvent):
(WebCore::InspectorInstrumentation::didDispatchEvent):
(WebCore::InspectorInstrumentation::willDispatchEventOnWindow):
(WebCore::InspectorInstrumentation::willEvaluateScript):
(WebCore::InspectorInstrumentation::didEvaluateScript):
(WebCore::InspectorInstrumentation::willFireTimer):
(WebCore::InspectorInstrumentation::didInvalidateLayout):
(WebCore::InspectorInstrumentation::willLayout):
(WebCore::InspectorInstrumentation::willComposite):
(WebCore::InspectorInstrumentation::willPaint):
(WebCore::InspectorInstrumentation::willRecalculateStyle):
(WebCore::InspectorInstrumentation::startConsoleTiming):
(WebCore::InspectorInstrumentation::stopConsoleTiming):
(WebCore::InspectorInstrumentation::consoleTimeStamp):
(WebCore::InspectorInstrumentation::startProfiling):
(WebCore::InspectorInstrumentation::stopProfiling):
(WebCore::InspectorInstrumentation::performanceMark):
(WebCore::InspectorInstrumentation::didCancelAnimationFrame):
(WebCore::InspectorInstrumentation::willFireAnimationFrame):
(WebCore::InspectorInstrumentation::willFireObserverCallback):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didInstallTimerImpl):
(WebCore::InspectorInstrumentation::didRemoveTimerImpl):
(WebCore::InspectorInstrumentation::willCallFunctionImpl):
(WebCore::InspectorInstrumentation::didCallFunctionImpl):
(WebCore::InspectorInstrumentation::willDispatchEventImpl):
(WebCore::InspectorInstrumentation::willDispatchEventOnWindowImpl):
(WebCore::InspectorInstrumentation::willEvaluateScriptImpl):
(WebCore::InspectorInstrumentation::didEvaluateScriptImpl):
(WebCore::InspectorInstrumentation::willFireTimerImpl):
(WebCore::InspectorInstrumentation::didInvalidateLayoutImpl):
(WebCore::InspectorInstrumentation::willLayoutImpl):
(WebCore::InspectorInstrumentation::willCompositeImpl):
(WebCore::InspectorInstrumentation::willPaintImpl):
(WebCore::InspectorInstrumentation::willRecalculateStyleImpl):
(WebCore::InspectorInstrumentation::didScheduleStyleRecalculationImpl):
(WebCore::InspectorInstrumentation::startConsoleTimingImpl):
(WebCore::InspectorInstrumentation::stopConsoleTimingImpl):
(WebCore::InspectorInstrumentation::consoleTimeStampImpl):
(WebCore::InspectorInstrumentation::startProfilingImpl):
(WebCore::InspectorInstrumentation::stopProfilingImpl):
(WebCore::InspectorInstrumentation::performanceMarkImpl):
(WebCore::InspectorInstrumentation::didRequestAnimationFrameImpl):
(WebCore::InspectorInstrumentation::didCancelAnimationFrameImpl):
(WebCore::InspectorInstrumentation::willFireAnimationFrameImpl):
(WebCore::InspectorInstrumentation::willFireObserverCallbackImpl):
(WebCore::frameForScriptExecutionContext): Deleted.

* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::innerInvokeEventListeners):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchEvent):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::profile):
(WebCore::PageConsoleClient::profileEnd):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::mark):

* LayoutTests/inspector/timeline/line-column.html:
* LayoutTests/inspector/timeline/line-column-expected.txt:
* LayoutTests/platform/gtk/inspector/timeline/line-column-expected.txt:

Canonical link: <a href="https://commits.webkit.org/289839@main">https://commits.webkit.org/289839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2f2cf9a6771e9bb3e914a55cf054dd90cf62f26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33814 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94518 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10974 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76611 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75847 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18723 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7929 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20254 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->