### PR TITLE
[GLib] Fix crash verifying ed25519 keys

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2417,9 +2417,6 @@ imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_RSA-OAEP.http
 imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_ctr.https.any.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/WebCryptoAPI/encrypt_decrypt/aes_cbc.https.any.html [ DumpJSConsoleLogInStdErr ]
 
-webkit.org/b/280672 imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any.html [ Crash ]
-webkit.org/b/280672 imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any.worker.html [ Crash ]
-
 webkit.org/b/150806 imported/w3c/web-platform-tests/xhr/send-timeout-events.htm [ Failure Pass ]
 
 webkit.org/b/202736 [ Release ] http/wpt/cache-storage/quota-third-party.https.html [ Pass Timeout ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Ed25519 Verification checks with small-order key of order - Test 0
+PASS Ed25519 Verification checks with small-order key of order - Test 1
+PASS Ed25519 Verification checks with small-order key of order - Test 2
+FAIL Ed25519 Verification checks with small-order key of order - Test 3 assert_equals: Signature verification result. expected true but got false
+PASS Ed25519 Verification checks with small-order key of order - Test 4
+PASS Ed25519 Verification checks with small-order key of order - Test 5
+PASS Ed25519 Verification checks with small-order key of order - Test 6
+PASS Ed25519 Verification checks with small-order key of order - Test 7
+PASS Ed25519 Verification checks with small-order key of order - Test 8
+PASS Ed25519 Verification checks with small-order key of order - Test 9
+PASS Ed25519 Verification checks with small-order key of order - Test 10
+PASS Ed25519 Verification checks with small-order key of order - Test 11
+PASS Ed25519 Verification checks with small-order key of order - Test 12
+PASS Ed25519 Verification checks with small-order key of order - Test 13
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any.worker-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Ed25519 Verification checks with small-order key of order - Test 0
+PASS Ed25519 Verification checks with small-order key of order - Test 1
+PASS Ed25519 Verification checks with small-order key of order - Test 2
+FAIL Ed25519 Verification checks with small-order key of order - Test 3 assert_equals: Signature verification result. expected true but got false
+PASS Ed25519 Verification checks with small-order key of order - Test 4
+PASS Ed25519 Verification checks with small-order key of order - Test 5
+PASS Ed25519 Verification checks with small-order key of order - Test 6
+PASS Ed25519 Verification checks with small-order key of order - Test 7
+PASS Ed25519 Verification checks with small-order key of order - Test 8
+PASS Ed25519 Verification checks with small-order key of order - Test 9
+PASS Ed25519 Verification checks with small-order key of order - Test 10
+PASS Ed25519 Verification checks with small-order key of order - Test 11
+PASS Ed25519 Verification checks with small-order key of order - Test 12
+PASS Ed25519 Verification checks with small-order key of order - Test 13
+

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -132,6 +132,9 @@ static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLen
         return false;
     }
 
+    if (gcry_sexp_length(keySexp) != gcry_sexp_length(dataSexp))
+        return false;
+
     // Perform the PK verification. We report success if there's no error returned, or
     // a failure in any other case. OperationError should not be returned at this point,
     // avoiding spilling information about the exact cause of verification failure.


### PR DESCRIPTION
#### a626e704f8aacf341e7da0d2e86d70109f962e45
<pre>
[GLib] Fix crash verifying ed25519 keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=280672">https://bugs.webkit.org/show_bug.cgi?id=280672</a>

Reviewed by NOBODY (OOPS!).

libgcrypt asserts if these are not the same size.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_small_order_points.https.any.worker-expected.txt: Added.
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp:
(WebCore::verifyEd25519):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a626e704f8aacf341e7da0d2e86d70109f962e45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15450 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67760 "Found 3 new test failures: imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_curve25519.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25505 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48129 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33809 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94514 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10972 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76609 "Found 4 new test failures: imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_curve25519.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_curve25519.https.any.worker.html imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.html imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75845 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7923 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20250 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->