### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in XMLDocumentParserLibxml2.cpp

### DIFF
--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -137,7 +137,7 @@ public:
     void endElementNs();
     void characters(std::span<const xmlChar>);
     void processingInstruction(const xmlChar* target, const xmlChar* data);
-    void cdataBlock(const xmlChar*, int length);
+    void cdataBlock(std::span<const xmlChar>);
     void comment(const xmlChar*);
     void startDocument(const xmlChar* version, const xmlChar* encoding, int standalone);
     void internalSubset(const xmlChar* name, const xmlChar* externalID, const xmlChar* systemID);


### PR DESCRIPTION
#### b7d42aeed7400e85496099a387067a0f9c5717c1
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in XMLDocumentParserLibxml2.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286901">https://bugs.webkit.org/show_bug.cgi?id=286901</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::xmlMallocHelper):
(WebCore::XMLMalloc::malloc):
(WebCore::XMLMalloc::free):
(WebCore::unsafeSpanIncludingNullTerminator):
(WebCore::PendingCallbacks::appendStartElementNSCallback):
(WebCore::PendingCallbacks::appendCharactersCallback):
(WebCore::PendingCallbacks::appendCDATABlockCallback):
(WebCore::PendingCallbacks::PendingStartElementNSCallback::~PendingStartElementNSCallback):
(WebCore::toString):
(WebCore::toAtomString):
(WebCore::handleNamespaceAttributes):
(WebCore::handleElementAttributes):
(WebCore::XMLDocumentParser::cdataBlock):
(WebCore::charactersHandler):
(WebCore::cdataBlockHandler):
(WebCore::XMLDocumentParser::appendFragmentSource):
(WebCore::attributesStartElementNsHandler):
(WebCore::PendingCallbacks::PendingCharactersCallback::~PendingCharactersCallback): Deleted.
(WebCore::PendingCallbacks::PendingCDATABlockCallback::~PendingCDATABlockCallback): Deleted.

Canonical link: <a href="https://commits.webkit.org/289761@main">https://commits.webkit.org/289761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ad0a5ec74ce64980d2073328bef932b19bb6ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67834 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25584 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5728 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33914 "Found 2 new test failures: accessibility/negative-tabindex-does-not-expose-label.html editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37720 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94627 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15031 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11063 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html media/video-replaces-poster.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76683 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75919 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8035 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13713 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20350 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->