### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in AuxiliaryProcessMac.mm

### DIFF
--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -149,7 +149,7 @@ std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, Strin
     
     // Append the file name suffix.
     CString suffixUTF8 = suffix.utf8();
-    temporaryFilePath.append(suffixUTF8.unsafeSpanIncludingNullTerminator());
+    temporaryFilePath.append(suffixUTF8.spanIncludingNullTerminator());
 
     platformFileHandle = mkostemps(temporaryFilePath.data(), suffixUTF8.length(), O_CLOEXEC);
     if (platformFileHandle == invalidPlatformFileHandle)

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -158,7 +158,7 @@ public:
         case WebXRCPFrameStartSubmissionStart:
         case WebXRCPFrameEndSubmissionStart:
         case WakeUpAndApplyDisplayListStart:
-            beginMark(nullptr, tracePointCodeName(code).unsafeSpanIncludingNullTerminator(), "%s", "");
+            beginMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
 
         case VMEntryScopeEnd:
@@ -218,7 +218,7 @@ public:
         case WebXRCPFrameStartSubmissionEnd:
         case WebXRCPFrameEndSubmissionEnd:
         case WakeUpAndApplyDisplayListEnd:
-            endMark(nullptr, tracePointCodeName(code).unsafeSpanIncludingNullTerminator(), "%s", "");
+            endMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
 
         case DisplayRefreshDispatchingToMainThread:
@@ -228,7 +228,7 @@ public:
         case SyntheticMomentumEvent:
         case RemoteLayerTreeScheduleRenderingUpdate:
         case DisplayLinkUpdate:
-            instantMark(tracePointCodeName(code).unsafeSpanIncludingNullTerminator(), "%s", "");
+            instantMark(tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
             break;
 
         case WTFRange:

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -79,7 +79,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
     constexpr std::span<const char> span() const { return m_charactersWithNullTerminator.first(length()); }
     std::span<const LChar> span8() const { return byteCast<LChar>(m_charactersWithNullTerminator.first(length())); }
-    std::span<const char> unsafeSpanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
+    std::span<const char> spanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
     size_t isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
     constexpr char operator[](size_t index) const { return m_charactersWithNullTerminator[index]; }

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -107,7 +107,7 @@ void CString::copyBufferIfNeeded()
     RefPtr<CStringBuffer> buffer = WTFMove(m_buffer);
     size_t length = buffer->length();
     m_buffer = CStringBuffer::createUninitialized(length);
-    memcpySpan(m_buffer->mutableSpanIncludingNullTerminator(), buffer->unsafeSpanIncludingNullTerminator());
+    memcpySpan(m_buffer->mutableSpanIncludingNullTerminator(), buffer->spanIncludingNullTerminator());
 }
 
 bool CString::isSafeToSendToAnotherThread() const
@@ -120,7 +120,7 @@ void CString::grow(size_t newLength)
     ASSERT(newLength > length());
 
     auto newBuffer = CStringBuffer::createUninitialized(newLength);
-    memcpySpan(newBuffer->mutableSpanIncludingNullTerminator(), m_buffer->unsafeSpanIncludingNullTerminator());
+    memcpySpan(newBuffer->mutableSpanIncludingNullTerminator(), m_buffer->spanIncludingNullTerminator());
     m_buffer = WTFMove(newBuffer);
 }
 

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -45,7 +45,7 @@ public:
     size_t length() const { return m_length; }
 
     std::span<const char> span() const LIFETIME_BOUND { return unsafeMakeSpan(m_data, m_length); }
-    std::span<const char> unsafeSpanIncludingNullTerminator() const LIFETIME_BOUND { return unsafeMakeSpan(m_data, m_length + 1); }
+    std::span<const char> spanIncludingNullTerminator() const LIFETIME_BOUND { return unsafeMakeSpan(m_data, m_length + 1); }
 
 private:
     friend class CString;
@@ -76,10 +76,10 @@ public:
 
     const char* data() const LIFETIME_BOUND;
 
-    std::string toStdString() const { return m_buffer ? std::string(m_buffer->unsafeSpanIncludingNullTerminator().data()) : std::string(); }
+    std::string toStdString() const { return m_buffer ? std::string(m_buffer->spanIncludingNullTerminator().data()) : std::string(); }
 
     std::span<const LChar> span() const LIFETIME_BOUND;
-    std::span<const char> unsafeSpanIncludingNullTerminator() const LIFETIME_BOUND;
+    std::span<const char> spanIncludingNullTerminator() const LIFETIME_BOUND;
 
     WTF_EXPORT_PRIVATE std::span<char> mutableSpan() LIFETIME_BOUND;
     WTF_EXPORT_PRIVATE std::span<char> mutableSpanIncludingNullTerminator() LIFETIME_BOUND;
@@ -125,7 +125,7 @@ inline CString::CString(std::span<const LChar> bytes)
 
 inline const char* CString::data() const
 {
-    return m_buffer ? m_buffer->unsafeSpanIncludingNullTerminator().data() : nullptr;
+    return m_buffer ? m_buffer->spanIncludingNullTerminator().data() : nullptr;
 }
 
 inline std::span<const LChar> CString::span() const
@@ -135,10 +135,10 @@ inline std::span<const LChar> CString::span() const
     return { };
 }
 
-inline std::span<const char> CString::unsafeSpanIncludingNullTerminator() const
+inline std::span<const char> CString::spanIncludingNullTerminator() const
 {
     if (m_buffer)
-        return m_buffer->unsafeSpanIncludingNullTerminator();
+        return m_buffer->spanIncludingNullTerminator();
     return { };
 }
 

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -623,7 +623,7 @@ Vector<char> asciiDebug(StringImpl* impl)
         }
     }
     CString narrowString = buffer.toString().ascii();
-    return { narrowString.unsafeSpanIncludingNullTerminator() };
+    return { narrowString.spanIncludingNullTerminator() };
 }
 
 Vector<char> asciiDebug(String& string)

--- a/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
@@ -268,7 +268,7 @@ std::optional<Vector<uint8_t>> decryptAESGCMPayload(const ClientKeys& clientKeys
      */
     static constexpr auto cekInfoHeader = "Content-Encoding: aesgcm"_s;
     std::array<uint8_t, cekInfoHeader.length() + 1 + sizeof(context)> cekInfo;
-    memcpySpan(std::span { cekInfo }, cekInfoHeader.unsafeSpanIncludingNullTerminator());
+    memcpySpan(std::span { cekInfo }, cekInfoHeader.spanIncludingNullTerminator());
     memcpySpan(std::span { cekInfo }.subspan(cekInfoHeader.length() + 1), asByteSpan(context));
 
     auto cek = hmacSHA256(prk, cekInfo);
@@ -280,7 +280,7 @@ std::optional<Vector<uint8_t>> decryptAESGCMPayload(const ClientKeys& clientKeys
      */
     static constexpr auto nonceInfoHeader = "Content-Encoding: nonce"_s;
     std::array<uint8_t, nonceInfoHeader.length() + 1 + sizeof(context)> nonceInfo;
-    memcpySpan(std::span { nonceInfo }, nonceInfoHeader.unsafeSpanIncludingNullTerminator());
+    memcpySpan(std::span { nonceInfo }, nonceInfoHeader.spanIncludingNullTerminator());
     memcpySpan(std::span { nonceInfo }.subspan(nonceInfoHeader.length() + 1), asByteSpan(context));
 
     auto nonce = hmacSHA256(prk, nonceInfo);

--- a/Source/WebCore/bridge/objc/objc_class.mm
+++ b/Source/WebCore/bridge/objc/objc_class.mm
@@ -85,7 +85,7 @@ ObjcClass* ObjcClass::classForIsA(ClassStructPtr isa)
 typedef Vector<char, 256> JSNameConversionBuffer;
 static inline void convertJSMethodNameToObjc(const CString& jsName, JSNameConversionBuffer& buffer)
 {
-    auto characters = jsName.unsafeSpanIncludingNullTerminator();
+    auto characters = jsName.spanIncludingNullTerminator();
     buffer.reserveInitialCapacity(characters.size());
     for (size_t i = 0; i < characters.size(); ++i) {
         if (characters[i] == '$') {

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -779,7 +779,7 @@ static Expected<sqlite3_stmt*, int> constructAndPrepareStatement(SQLiteDatabase&
 Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatementSlow(StringView queryString)
 {
     auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
-    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
         return makeUnexpected(sqlStatement.error());
@@ -789,7 +789,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatementSlow(StringView q
 
 Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral query)
 {
-    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.characters());
         return makeUnexpected(sqlStatement.error());
@@ -800,7 +800,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral que
 Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatementSlow(StringView queryString)
 {
     auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
-    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareHeapStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
         return makeUnexpected(sqlStatement.error());
@@ -810,7 +810,7 @@ Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatementSl
 
 Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatement(ASCIILiteral query)
 {
-    auto sqlStatement = constructAndPrepareStatement(*this, query.unsafeSpanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareHeapStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.characters());
         return makeUnexpected(sqlStatement.error());

--- a/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp
@@ -67,7 +67,7 @@ Instance::Impl::Impl()
 
         auto createInfo = createStructure<XrInstanceCreateInfo, XR_TYPE_INSTANCE_CREATE_INFO>();
         createInfo.createFlags = 0;
-        memcpySpan(std::span { createInfo.applicationInfo.applicationName }, s_applicationName.unsafeSpanIncludingNullTerminator());
+        memcpySpan(std::span { createInfo.applicationInfo.applicationName }, s_applicationName.spanIncludingNullTerminator());
         createInfo.applicationInfo.apiVersion = XR_CURRENT_API_VERSION;
         createInfo.applicationInfo.applicationVersion = s_applicationVersion;
         createInfo.enabledApiLayerCount = 0;


### PR DESCRIPTION
#### 8d52b022564ffb17851071101596828e355b8d52
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in AuxiliaryProcessMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=286903">https://bugs.webkit.org/show_bug.cgi?id=286903</a>

Reviewed by Per Arne Vollan.

* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::copyBufferIfNeeded):
(WTF::CString::grow):
* Source/WTF/wtf/text/CString.h:
(WTF::CString::data const):
(WTF::CString::spanIncludingNullTerminator const):
(WTF::CString::unsafeSpanIncludingNullTerminator const): Deleted.
* Source/WTF/wtf/text/WTFString.cpp:
(asciiDebug):
* Source/WebCore/Modules/push-api/PushMessageCrypto.cpp:
(WebCore::PushCrypto::decryptAESGCMPayload):
* Source/WebCore/bridge/objc/objc_class.mm:
(JSC::Bindings::convertJSMethodNameToObjc):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::prepareStatementSlow):
(WebCore::SQLiteDatabase::prepareStatement):
(WebCore::SQLiteDatabase::prepareHeapStatementSlow):
(WebCore::SQLiteDatabase::prepareHeapStatement):
* Source/WebCore/platform/xr/openxr/OpenXRInstance.cpp:
(PlatformXR::Instance::Impl::Impl):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndCacheSandboxProfile):
(WebKit::tryApplyCachedSandbox):

Canonical link: <a href="https://commits.webkit.org/289719@main">https://commits.webkit.org/289719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59095140df9113771fd434ce45158f3b8a28c7cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67783 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25523 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37639 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80580 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94534 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86557 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10991 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75282 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7951 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13691 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20269 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109051 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14710 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26225 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->