### PR TITLE
ASAN_SEGV | JSArrayBufferView::ConstructionContext::ConstructionContext; JSArrayBufferView::ConstructionContext::ConstructionContext; JSC::JSGenericTypedArrayView::create

### DIFF
--- a/Source/WebCore/platform/AudioDecoder.h
+++ b/Source/WebCore/platform/AudioDecoder.h
@@ -44,7 +44,7 @@ public:
     static bool isCodecSupported(const StringView&);
 
     struct Config {
-        std::span<const uint8_t> description;
+        Vector<uint8_t> description;
         uint64_t sampleRate { 0 };
         uint64_t numberOfChannels { 0 };
     };

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -43,7 +43,7 @@ public:
     enum class HardwareBuffer : bool { No, Yes };
     enum class TreatNoOutputAsError : bool { No, Yes };
     struct Config {
-        std::span<const uint8_t> description;
+        Vector<uint8_t> description;
         uint64_t width { 0 };
         uint64_t height { 0 };
         std::optional<PlatformVideoColorSpace> colorSpace;

--- a/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp
@@ -258,10 +258,10 @@ String InternalAudioDecoderCocoa::initialize(const String& codecName, const Audi
         if (codec == kAudioFormatOpus && config.numberOfChannels > 2)
             return "Opus with more than 2 channels isn't supported"_s;
 
-        if (codec == kAudioFormatFLAC && config.description.empty())
+        if (codec == kAudioFormatFLAC && config.description.isEmpty())
             return "Decoder config description for flac codec is mandatory"_s;
 
-        if (codec == 'vorb' && config.description.empty())
+        if (codec == 'vorb' && config.description.isEmpty())
             return "Decoder config description for vorbis codec is mandatory"_s;
 
         mIsAAC = codec == kAudioFormatMPEG4AAC || codec == kAudioFormatMPEG4AAC_HE || codec == kAudioFormatMPEG4AAC_LD || codec == kAudioFormatMPEG4AAC_HE_V2 || codec == kAudioFormatMPEG4AAC_ELD;


### PR DESCRIPTION
#### 741c9b58c545f55d1165ec72658d0db615d28063
<pre>
ASAN_SEGV | JSArrayBufferView::ConstructionContext::ConstructionContext; JSArrayBufferView::ConstructionContext::ConstructionContext; JSC::JSGenericTypedArrayView::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=286900">https://bugs.webkit.org/show_bug.cgi?id=286900</a>
<a href="https://rdar.apple.com/143695448">rdar://143695448</a>

Reviewed by Youenn Fablet.

Use a Vector&lt;uint8_t&gt; in {Audio|Video}Decoder::Config::description instead of a span&lt;const uint8_t&gt;
so that we don&apos;t have to keep a reference to an ArrayBufferView.
Codec&apos;s description are typically small (under 20 bytes) and we would have
ended up copying the data anyway.

Fly-by: amend comments and order of operations to more align with the specs.

No change in observable behaviour. Covered by existing tests.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::createAudioDecoderConfig):
(WebCore::isValidDecoderConfig): Check that the ArrayBuffer is detached as per spec requirements.
(WebCore::WebCodecsAudioDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::isValidDecoderConfig):
(WebCore::createVideoDecoderConfig):
(WebCore::WebCodecsVideoDecoder::configure):
* Source/WebCore/platform/AudioDecoder.h:
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebCore/platform/audio/cocoa/AudioDecoderCocoa.cpp:
(WebCore::InternalAudioDecoderCocoa::initialize):

Canonical link: <a href="https://commits.webkit.org/289725@main">https://commits.webkit.org/289725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28d024aea615b934e9e51e80548e14c0447f40f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25538 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33852 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14970 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75879 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18685 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7972 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14986 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14730 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->