### PR TITLE
[CoordinatedGraphics] Force repaint should not flush layers when still waiting for renderer

### DIFF
--- a/LayoutTests/platform/glib/printing/print-with-media-query-destory-expected.txt
+++ b/LayoutTests/platform/glib/printing/print-with-media-query-destory-expected.txt
@@ -1,1 +1,0 @@
-Pass if no crash or assert

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -184,6 +184,7 @@ private:
     bool m_layerTreeStateIsFrozen { false };
     bool m_isPurgingBackingStores { false };
     bool m_pendingResize { false };
+    bool m_pendingForceRepaint { false };
     bool m_isSuspended { false };
     bool m_isWaitingForRenderer { false };
     bool m_scheduledWhileWaitingForRenderer { false };
@@ -197,7 +198,7 @@ private:
     struct {
         CompletionHandler<void()> callback;
 #if HAVE(DISPLAY_LINK)
-        uint32_t compositionRequestID { 0 };
+        std::optional<uint32_t> compositionRequestID;
 #else
         bool needsFreshFlush { false };
 #endif


### PR DESCRIPTION
#### 83b17af2597654b199941e98506368ecfb8059e1
<pre>
[CoordinatedGraphics] Force repaint should not flush layers when still waiting for renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=286908">https://bugs.webkit.org/show_bug.cgi?id=286908</a>

Reviewed by Miguel Gomez.

Force repaint should also check waiting for rendering flag, and wait until current composition is done.

* LayoutTests/platform/glib/printing/print-with-media-query-destory-expected.txt: Removed.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::forceRepaint):
(WebKit::LayerTreeHost::forceRepaintAsync):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::didComposite):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:

Canonical link: <a href="https://commits.webkit.org/289732@main">https://commits.webkit.org/289732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7365b205c997e0b45ab2221360cd783cd0c458de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67816 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25558 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37681 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34753 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94581 "Failed to checkout and rebase branch from PR 39898") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11034 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/94581 "Failed to checkout and rebase branch from PR 39898") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75322 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/94581 "Failed to checkout and rebase branch from PR 39898") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7996 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13694 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15008 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14752 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->