### PR TITLE
Add service worker InstallEvent skeleton

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/idlharness.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/idlharness.https.any.serviceworker-expected.txt
@@ -204,13 +204,13 @@ PASS ExtendableEvent must be primary interface of new ExtendableEvent("type")
 PASS Stringification of new ExtendableEvent("type")
 PASS ExtendableEvent interface: new ExtendableEvent("type") must inherit property "waitUntil(Promise<any>)" with the proper type
 PASS ExtendableEvent interface: calling waitUntil(Promise<any>) on new ExtendableEvent("type") with too few arguments must throw TypeError
-FAIL InstallEvent interface: existence and properties of interface object assert_own_property: self does not have own property "InstallEvent" expected property "InstallEvent" missing
-FAIL InstallEvent interface object length assert_own_property: self does not have own property "InstallEvent" expected property "InstallEvent" missing
-FAIL InstallEvent interface object name assert_own_property: self does not have own property "InstallEvent" expected property "InstallEvent" missing
-FAIL InstallEvent interface: existence and properties of interface prototype object assert_own_property: self does not have own property "InstallEvent" expected property "InstallEvent" missing
-FAIL InstallEvent interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "InstallEvent" expected property "InstallEvent" missing
-FAIL InstallEvent interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "InstallEvent" expected property "InstallEvent" missing
-FAIL InstallEvent interface: operation addRoutes((RouterRule or sequence<RouterRule>)) assert_own_property: self does not have own property "InstallEvent" expected property "InstallEvent" missing
+PASS InstallEvent interface: existence and properties of interface object
+FAIL InstallEvent interface object length assert_equals: wrong value for InstallEvent.length expected 0 but got 1
+PASS InstallEvent interface object name
+PASS InstallEvent interface: existence and properties of interface prototype object
+PASS InstallEvent interface: existence and properties of interface prototype object's "constructor" property
+PASS InstallEvent interface: existence and properties of interface prototype object's @@unscopables property
+PASS InstallEvent interface: operation addRoutes((RouterRule or sequence<RouterRule>))
 PASS FetchEvent interface: existence and properties of interface object
 PASS FetchEvent interface object length
 PASS FetchEvent interface object name

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6678,6 +6678,20 @@ ServiceWorkerEntitlementDisabledForTesting:
     WebKit:
       default: false
 
+ServiceWorkerInstallEventEnabled:
+  type: bool
+  status: testable
+  category: networking
+  humanReadableName: "Service Worker Install Event"
+  humanReadableDescription: "Enable Service Worker Install Event API"
+  defaultValue:
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 ServiceWorkerNavigationPreloadEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1536,6 +1536,12 @@ set(WebCore_NON_SVG_IDL_FILES
     workers/service/ExtendableEventInit.idl
     workers/service/ExtendableMessageEvent.idl
     workers/service/FetchEvent.idl
+    workers/service/InstallEvent.idl
+    workers/service/RouterCondition.idl
+    workers/service/RouterRule.idl
+    workers/service/RouterSourceDict.idl
+    workers/service/RouterSourceEnum.idl
+    workers/service/RunningStatus.idl
     workers/service/NavigationPreloadManager.idl
     workers/service/NavigationPreloadState.idl
     workers/service/ServiceWorker.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -2106,11 +2106,17 @@ $(PROJECT_DIR)/workers/service/ExtendableEvent.idl
 $(PROJECT_DIR)/workers/service/ExtendableEventInit.idl
 $(PROJECT_DIR)/workers/service/ExtendableMessageEvent.idl
 $(PROJECT_DIR)/workers/service/FetchEvent.idl
+$(PROJECT_DIR)/workers/service/InstallEvent.idl
 $(PROJECT_DIR)/workers/service/NavigationPreloadManager.idl
 $(PROJECT_DIR)/workers/service/NavigationPreloadState.idl
 $(PROJECT_DIR)/workers/service/PushEvent.idl
 $(PROJECT_DIR)/workers/service/PushEventInit.idl
 $(PROJECT_DIR)/workers/service/PushMessageData.idl
+$(PROJECT_DIR)/workers/service/RouterCondition.idl
+$(PROJECT_DIR)/workers/service/RouterRule.idl
+$(PROJECT_DIR)/workers/service/RouterSourceDict.idl
+$(PROJECT_DIR)/workers/service/RouterSourceEnum.idl
+$(PROJECT_DIR)/workers/service/RunningStatus.idl
 $(PROJECT_DIR)/workers/service/ServiceWorker.idl
 $(PROJECT_DIR)/workers/service/ServiceWorkerClient.idl
 $(PROJECT_DIR)/workers/service/ServiceWorkerClientType.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1735,6 +1735,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInspectorAuditResourcesObject.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInspectorAuditResourcesObject.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInspectorFrontendHost.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInspectorFrontendHost.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInstallEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInstallEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInternalSettings.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInternalSettings.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInternalSettingsGenerated.cpp
@@ -2549,6 +2551,14 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverSize.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSResizeObserverSize.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterCondition.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterCondition.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterRule.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterRule.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterSourceDict.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterSourceDict.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterSourceEnum.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRouterSourceEnum.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRsaHashedImportParams.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRsaHashedImportParams.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRsaHashedKeyGenParams.cpp
@@ -2561,6 +2571,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRsaOtherPrimesInfo.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRsaOtherPrimesInfo.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRsaPssParams.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRsaPssParams.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRunningStatus.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRunningStatus.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSQLError.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSQLError.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSSQLResultSet.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1760,6 +1760,12 @@ JS_BINDING_IDLS := \
     $(WebCore)/workers/service/ExtendableEventInit.idl \
     $(WebCore)/workers/service/ExtendableMessageEvent.idl \
     $(WebCore)/workers/service/FetchEvent.idl \
+    $(WebCore)/workers/service/InstallEvent.idl \
+    $(WebCore)/workers/service/RouterCondition.idl \
+    $(WebCore)/workers/service/RouterRule.idl \
+    $(WebCore)/workers/service/RouterSourceDict.idl \
+    $(WebCore)/workers/service/RouterSourceEnum.idl \
+    $(WebCore)/workers/service/RunningStatus.idl \
     $(WebCore)/workers/service/NavigationPreloadManager.idl \
     $(WebCore)/workers/service/NavigationPreloadState.idl \
     $(WebCore)/workers/service/ServiceWorker.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2757,7 +2757,13 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/service/ExtendableEvent.h
     workers/service/ExtendableEventInit.h
     workers/service/FetchEvent.h
+    workers/service/InstallEvent.h
     workers/service/NavigationPreloadState.h
+    workers/service/RouterCondition.h
+    workers/service/RouterRule.h
+    workers/service/RouterSourceDict.h
+    workers/service/RouterSourceEnum.h
+    workers/service/RunningStatus.h
     workers/service/SWClientConnection.h
     workers/service/ServiceWorkerClientData.h
     workers/service/ServiceWorkerClientPendingMessage.h

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -279,6 +279,18 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
     return create(context, WTFMove(*input), String { }, WTFMove(options));
 }
 
+// https://urlpattern.spec.whatwg.org/#build-a-url-pattern-from-a-web-idl-value
+ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, Compatible&& value, const String& baseURL)
+{
+    return switchOn(WTFMove(value), [&](RefPtr<URLPattern>&& pattern) -> ExceptionOr<Ref<URLPattern>> {
+        return pattern.releaseNonNull();
+    }, [&](URLPatternInit&& init) -> ExceptionOr<Ref<URLPattern>> {
+        return URLPattern::create(context, WTFMove(init), { }, { });
+    }, [&](String&& string) -> ExceptionOr<Ref<URLPattern>> {
+        return URLPattern::create(context, WTFMove(string), String { baseURL }, { });
+    });
+}
+
 URLPattern::~URLPattern() = default;
 
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-test

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -27,6 +27,7 @@
 
 #include "ExceptionOr.h"
 #include "URLPatternComponent.h"
+#include "URLPatternInit.h"
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -36,7 +37,6 @@
 namespace WebCore {
 
 class ScriptExecutionContext;
-struct URLPatternInit;
 struct URLPatternOptions;
 struct URLPatternResult;
 enum class BaseURLStringType : bool { Pattern, URL };
@@ -52,6 +52,10 @@ public:
 
     static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
     static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, std::optional<URLPatternInput>&&, URLPatternOptions&&);
+
+    using Compatible = std::variant<String, URLPatternInit, RefPtr<URLPattern>>;
+    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, Compatible&&, const String&);
+
     ~URLPattern();
 
     ExceptionOr<bool> test(ScriptExecutionContext&, std::optional<URLPatternInput>&&, String&& baseURL) const;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3346,6 +3346,7 @@ workers/WorkerThread.cpp
 workers/service/ExtendableEvent.cpp
 workers/service/ExtendableMessageEvent.cpp
 workers/service/FetchEvent.cpp
+workers/service/InstallEvent.cpp
 workers/service/NavigationPreloadManager.cpp
 workers/service/SWClientConnection.cpp
 workers/service/ServiceWorker.cpp
@@ -4126,6 +4127,7 @@ JSInspectorAuditAccessibilityObject.cpp
 JSInspectorAuditDOMObject.cpp
 JSInspectorAuditResourcesObject.cpp
 JSInspectorFrontendHost.cpp
+JSInstallEvent.cpp
 JSIntersectionObserver.cpp
 JSIntersectionObserverCallback.cpp
 JSIntersectionObserverEntry.cpp
@@ -4468,12 +4470,17 @@ JSResizeObserverCallback.cpp
 JSResizeObserverEntry.cpp
 JSResizeObserverOptions.cpp
 JSResizeObserverSize.cpp
+JSRouterCondition.cpp
+JSRouterRule.cpp
+JSRouterSourceDict.cpp
+JSRouterSourceEnum.cpp
 JSRsaHashedImportParams.cpp
 JSRsaHashedKeyGenParams.cpp
 JSRsaKeyGenParams.cpp
 JSRsaOaepParams.cpp
 JSRsaOtherPrimesInfo.cpp
 JSRsaPssParams.cpp
+JSRunningStatus.cpp
 JSSQLError.cpp
 JSSQLResultSet.cpp
 JSSQLResultSetRowList.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -287,6 +287,7 @@ namespace WebCore {
     macro(IdleDeadline) \
     macro(InputDeviceInfo) \
     macro(InputEvent) \
+    macro(InstallEvent) \
     macro(IntersectionObserver) \
     macro(IntersectionObserverEntry) \
     macro(KeyframeEffect) \

--- a/Source/WebCore/dom/EventInterfaces.in
+++ b/Source/WebCore/dom/EventInterfaces.in
@@ -30,6 +30,7 @@ FormDataEvent
 HashChangeEvent
 InputEvent
 InputEvents interfaceName=InputEvent
+InstallEvent
 KeyboardEvent
 KeyboardEvents interfaceName=KeyboardEvent
 MediaQueryListEvent

--- a/Source/WebCore/workers/service/InstallEvent.cpp
+++ b/Source/WebCore/workers/service/InstallEvent.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InstallEvent.h"
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(InstallEvent);
+
+InstallEvent::InstallEvent(const AtomString& type, ExtendableEventInit&& initializer, IsTrusted isTrusted)
+    : ExtendableEvent(EventInterfaceType::InstallEvent, type, initializer, isTrusted)
+{
+}
+
+InstallEvent::~InstallEvent() = default;
+
+void InstallEvent::addRoutes(ScriptExecutionContext&, std::variant<RouterRule, Vector<RouterRule>>&&, Ref<DeferredPromise>&&)
+{
+    // FIXME: Implement addRoutes.
+}
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/InstallEvent.h
+++ b/Source/WebCore/workers/service/InstallEvent.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ExtendableEvent.h"
+#include "RouterRule.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class DeferredPromise;
+class ScriptExecutionContext;
+
+class InstallEvent final : public ExtendableEvent {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(InstallEvent);
+public:
+    static Ref<InstallEvent> create(const AtomString& type, ExtendableEventInit&& initializer, IsTrusted isTrusted = IsTrusted::No)
+    {
+        return adoptRef(*new InstallEvent(type, WTFMove(initializer), isTrusted));
+    }
+    ~InstallEvent();
+
+    void addRoutes(ScriptExecutionContext&, std::variant<RouterRule, Vector<RouterRule>>&&, Ref<DeferredPromise>&&);
+
+private:
+    WEBCORE_EXPORT InstallEvent(const AtomString&, ExtendableEventInit&&, IsTrusted);
+};
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/InstallEvent.idl
+++ b/Source/WebCore/workers/service/InstallEvent.idl
@@ -1,0 +1,35 @@
+/*
+* Copyright (C) 2025 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+[
+    EnabledBySetting=ServiceWorkersEnabled&ServiceWorkerInstallEventEnabled,
+    ExportMacro=WEBCORE_EXPORT,
+    Exposed=ServiceWorker,
+    JSGenerateToNativeObject
+]
+interface InstallEvent : ExtendableEvent {
+    constructor([AtomString] DOMString type, optional ExtendableEventInit eventInitDict = {});
+    [CallWith=CurrentScriptExecutionContext] Promise<undefined> addRoutes((RouterRule or sequence<RouterRule>) rules);
+};

--- a/Source/WebCore/workers/service/RouterCondition.h
+++ b/Source/WebCore/workers/service/RouterCondition.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FetchRequestDestination.h"
+#include "FetchRequestMode.h"
+#include "RunningStatus.h"
+#include "URLPattern.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct RouterCondition;
+class RouterNotCondition {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    RouterNotCondition(RouterCondition&&);
+
+    RouterCondition& value() & { return m_value.get(); }
+    RouterCondition&& value() && { return WTFMove(m_value.get()); }
+
+private:
+    UniqueRef<RouterCondition> m_value;
+};
+
+struct RouterCondition {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    std::optional<URLPattern::Compatible> urlPattern;
+    String requestMethod;
+    std::optional<FetchRequestMode> requestMode;
+    std::optional<FetchRequestDestination> requestDestination;
+    std::optional<RunningStatus> runningStatus;
+
+    using Condition = RouterCondition;
+    Vector<Condition> orConditions;
+    std::optional<RouterNotCondition> notCondition;
+};
+
+inline RouterNotCondition::RouterNotCondition(RouterCondition&& value)
+    : m_value(makeUniqueRef<RouterCondition>(WTFMove(value)))
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/RouterCondition.idl
+++ b/Source/WebCore/workers/service/RouterCondition.idl
@@ -1,0 +1,37 @@
+/*
+* Copyright (C) 2025 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+typedef (USVString or URLPatternInit or URLPattern) URLPatternCompatible;
+
+dictionary RouterCondition {
+    URLPatternCompatible urlPattern;
+    ByteString requestMethod;
+    FetchRequestMode requestMode;
+    FetchRequestDestination requestDestination;
+    RunningStatus runningStatus;
+
+    [ImplementedAs=orConditions] sequence<RouterCondition> _or;
+    [ImplementedAs=notCondition] RouterCondition not;
+};

--- a/Source/WebCore/workers/service/RouterRule.h
+++ b/Source/WebCore/workers/service/RouterRule.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RouterCondition.h"
+#include "RouterSourceDict.h"
+#include "RouterSourceEnum.h"
+
+namespace WebCore {
+
+struct RouterRule {
+    RouterCondition condition;
+    std::variant<RouterSourceDict, RouterSourceEnum> source;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/RouterRule.idl
+++ b/Source/WebCore/workers/service/RouterRule.idl
@@ -1,0 +1,30 @@
+/*
+* Copyright (C) 2025 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+typedef (RouterSourceDict or RouterSourceEnum) RouterSource;
+dictionary RouterRule {
+    required RouterCondition condition;
+    required RouterSource source;
+};

--- a/Source/WebCore/workers/service/RouterSourceDict.h
+++ b/Source/WebCore/workers/service/RouterSourceDict.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct RouterSourceDict {
+    String cacheName;
+
+    RouterSourceDict isolatedCopy() && { return { WTFMove(cacheName).isolatedCopy() }; }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/RouterSourceDict.idl
+++ b/Source/WebCore/workers/service/RouterSourceDict.idl
@@ -1,0 +1,28 @@
+/*
+* Copyright (C) 2025 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+dictionary RouterSourceDict {
+    DOMString cacheName;
+};

--- a/Source/WebCore/workers/service/RouterSourceEnum.h
+++ b/Source/WebCore/workers/service/RouterSourceEnum.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class RouterSourceEnum : uint8_t { Cache, FetchEvent, Network };
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/RouterSourceEnum.idl
+++ b/Source/WebCore/workers/service/RouterSourceEnum.idl
@@ -1,0 +1,30 @@
+/*
+* Copyright (C) 2025 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+enum RouterSourceEnum {
+    "cache",
+    "fetch-event",
+    "network",
+};

--- a/Source/WebCore/workers/service/RunningStatus.h
+++ b/Source/WebCore/workers/service/RunningStatus.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class RunningStatus : bool { Running, NotRunning };
+
+} // namespace WebCore

--- a/Source/WebCore/workers/service/RunningStatus.idl
+++ b/Source/WebCore/workers/service/RunningStatus.idl
@@ -1,0 +1,26 @@
+/*
+* Copyright (C) 2025 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+enum RunningStatus { "running", "not-running" };


### PR DESCRIPTION
#### 041ed08c270ce08b5b96c1f344e8718bc79a091d
<pre>
Add service worker InstallEvent skeleton
<a href="https://rdar.apple.com/144076933">rdar://144076933</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286911">https://bugs.webkit.org/show_bug.cgi?id=286911</a>

Reviewed by Brady Eidson.

We add a feature flag and expose InstallEvent based on it.
When flag is off, we use ExtendableEvent.

We do not implement yet InstallEvent::addRoutes, this will be for a future patch.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/idlharness.https.any.serviceworker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::create):
* Source/WebCore/Modules/url-pattern/URLPattern.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventInterfaces.in:
* Source/WebCore/workers/service/InstallEvent.cpp: Added.
(WebCore::InstallEvent::InstallEvent):
(WebCore::InstallEvent::addRoutes):
* Source/WebCore/workers/service/InstallEvent.h: Added.
* Source/WebCore/workers/service/InstallEvent.idl: Added.
* Source/WebCore/workers/service/RouterCondition.h: Added.
(WebCore::RouterNotCondition::value const):
(WebCore::RouterNotCondition::value):
(WebCore::RouterNotCondition::RouterNotCondition):
* Source/WebCore/workers/service/RouterCondition.idl: Added.
* Source/WebCore/workers/service/RouterRule.h: Added.
* Source/WebCore/workers/service/RouterRule.idl: Added.
* Source/WebCore/workers/service/RouterSourceDict.h: Added.
(WebCore::RouterSourceDict::isolatedCopy):
* Source/WebCore/workers/service/RouterSourceDict.idl: Added.
* Source/WebCore/workers/service/RouterSourceEnum.h: Added.
* Source/WebCore/workers/service/RouterSourceEnum.idl: Added.
* Source/WebCore/workers/service/RunningStatus.h: Added.
* Source/WebCore/workers/service/RunningStatus.idl: Added.
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::createInstallEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireInstallEvent):

Canonical link: <a href="https://commits.webkit.org/289921@main">https://commits.webkit.org/289921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7287f7c096cdee332db6f53887974ad3a8f0fac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16134 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25920 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91433 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/79986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48573 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/87930 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38293 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81230 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95231 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87207 "Found 1 new JSC binary failure: testapi (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15606 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/88016 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18781 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20715 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8643 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15622 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109700 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15363 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26377 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->