### PR TITLE
[WPE] Test external module loading and WPE Display

### DIFF
--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -64,6 +64,8 @@ list(APPEND TestWebKit_SOURCES
     wpe/PlatformWebViewWPE.cpp
 )
 
+add_subdirectory(wpe/mock-platform)
+
 list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Source
     ${FORWARDING_HEADERS_DIR}

--- a/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
+++ b/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "TestMain.h"
+#include <glib-object.h>
+#include <glib.h>
+#include <wpe/WPEDisplay.h>
+
+static void testLoadExternalDisplay(Test*, gconstpointer)
+{
+    WPEDisplay* display = wpe_display_get_default();
+
+    g_assert_nonnull(display);
+    g_assert_cmpstr(G_OBJECT_TYPE_NAME(display), ==, "WPEDisplayMock");
+    g_assert_true(display == wpe_display_get_primary());
+}
+
+void beforeAll()
+{
+    Test::add("Display", "load-external-display", testLoadExternalDisplay);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -111,6 +111,7 @@ set(WebKitGLibAPITests_DEFINITIONS
     WEBKIT_INJECTED_BUNDLE_PATH="${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
     WEBKIT_INSPECTOR_RESOURCES_PATH="${CMAKE_BINARY_DIR}/share"
     WEBKIT_TEST_RESOURCES_DIR="${TEST_RESOURCES_DIR}"
+    WPE_MOCK_PLATFORM_DIR="${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/wpe-mock-platform"
 )
 
 add_library(WebKitGLibAPITestsCore STATIC ${WebKitGLibAPITests_SOURCES})
@@ -143,6 +144,24 @@ if (ENABLE_WPE_PLATFORM)
     if (COMPILER_IS_GCC_OR_CLANG)
         WEBKIT_ADD_TARGET_CXX_FLAGS(TestWPESettings -Wno-unused-parameter)
     endif ()
+
+    add_executable(TestWPEDisplay
+        ${TOOLS_DIR}/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+        ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
+    )
+    target_link_libraries(TestWPEDisplay
+        ${WebKitGLibAPITest_LIBRARIES}
+        WPEPlatform-${WPE_API_VERSION}
+    )
+    target_include_directories(TestWPEDisplay PRIVATE
+        ${WebKitGLibAPITests_INCLUDE_DIRECTORIES}
+        ${WPEPlatform_DERIVED_SOURCES_DIR}
+        ${WEBKIT_DIR}/WPEPlatform
+    )
+    target_compile_definitions(TestWPEDisplay PRIVATE ${WebKitGLibAPITests_DEFINITIONS})
+    set_target_properties(TestWPEDisplay PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TestWebKitAPI/WPEPlatform)
+
+    WEBKIT_ADD_TARGET_CXX_FLAGS(TestWPEDisplay -Wno-unused-parameter)
 endif ()
 
 GLIB_COMPILE_RESOURCES(

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
@@ -138,6 +138,9 @@ int main(int argc, char** argv)
     // Get rid of runtime warnings about deprecated properties and signals, since they break the tests.
     g_setenv("G_ENABLE_DIAGNOSTIC", "0", TRUE);
     g_setenv("TZ", "America/Los_Angeles", TRUE);
+#if PLATFORM(WPE)
+    g_setenv("WPE_PLATFORMS_PATH", WPE_MOCK_PLATFORM_DIR, TRUE);
+#endif
     g_test_bug_base("https://bugs.webkit.org/");
 
     registerGResource();

--- a/Tools/TestWebKitAPI/wpe/mock-platform/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/CMakeLists.txt
@@ -1,0 +1,38 @@
+set_property(DIRECTORY . PROPERTY FOLDER "mock-platform")
+
+add_library(WPEMockPlatform MODULE
+    WPEDisplayMock.cpp
+)
+
+set_target_properties(WPEMockPlatform PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    POSITION_INDEPENDENT_CODE TRUE
+    VISIBILITY_INLINES_HIDDEN TRUE
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/wpe-mock-platform"
+)
+
+target_include_directories(WPEMockPlatform PRIVATE include
+    ${CMAKE_BINARY_DIR}
+    ${WPEPlatform_DERIVED_SOURCES_DIR}
+    ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe
+    ${WEBKIT_DIR}/WPEPlatform
+    ${WEBKIT_DIR}/WPEPlatform/wpe
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${GLIB_INCLUDE_DIRS}
+)
+
+target_link_libraries(WPEMockPlatform
+    PRIVATE
+    ${GLIB_GIO_LIBRARIES}
+    ${GLIB_GOBJECT_LIBRARIES}
+    ${GLIB_GMODULE_LIBRARIES}
+    ${GLIB_LIBRARIES}
+    WPEPlatform-${WPE_API_VERSION}
+)
+
+
+WEBKIT_ADD_TARGET_C_FLAGS(WPEMockPlatform
+    -Wno-unused-parameter
+)
+
+add_library(WPE::MockPlatform ALIAS WPEMockPlatform)

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEDisplayMock.h"
+
+#include <gio/gio.h>
+#include <gmodule.h>
+
+struct _WPEDisplayMock {
+    WPEDisplay parent;
+};
+
+G_DEFINE_DYNAMIC_TYPE(WPEDisplayMock, wpe_display_mock, WPE_TYPE_DISPLAY)
+
+static void wpeDisplayMockDispose(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_display_mock_parent_class)->dispose(object);
+}
+
+static gboolean wpeDisplayMockConnect(WPEDisplay* display, GError** error)
+{
+    return TRUE;
+}
+
+static WPEView* wpeDisplayMockCreateView(WPEDisplay* display)
+{
+    return nullptr;
+}
+
+static WPEInputMethodContext* wpeDisplayMockCreateInputMethodContext(WPEDisplay* display)
+{
+    return nullptr;
+}
+
+static gpointer wpeDisplayMockGetEGLDisplay(WPEDisplay* display, GError** error)
+{
+    g_set_error_literal(error, WPE_EGL_ERROR, WPE_EGL_ERROR_NOT_AVAILABLE, "Can't get EGL display: no display connection matching mock connection found");
+    return nullptr;
+}
+
+static WPEKeymap* wpeDisplayMockGetKeymap(WPEDisplay* display, GError** error)
+{
+    return nullptr;
+}
+
+static WPEBufferDMABufFormats* wpeDisplayMockGetPreferredDMABufFormats(WPEDisplay* display)
+{
+    return nullptr;
+}
+
+static guint wpeDisplayMockGetNScreens(WPEDisplay* display)
+{
+    return 0;
+}
+
+static WPEScreen* wpeDisplayMockGetScreen(WPEDisplay* display, guint index)
+{
+    return nullptr;
+}
+
+static const char* wpeDisplayMockGetDRMDevice(WPEDisplay* display)
+{
+    return nullptr;
+}
+
+static const char* wpeDisplayMockGetDRMRenderNode(WPEDisplay* display)
+{
+    return nullptr;
+}
+
+static gboolean wpeDisplayMockUseExplicitSync(WPEDisplay* display)
+{
+    return FALSE;
+}
+
+static void wpe_display_mock_class_init(WPEDisplayMockClass* displayMockClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(displayMockClass);
+    objectClass->dispose = wpeDisplayMockDispose;
+
+    WPEDisplayClass* displayClass = WPE_DISPLAY_CLASS(displayMockClass);
+    displayClass->connect = wpeDisplayMockConnect;
+    displayClass->create_view = wpeDisplayMockCreateView;
+    displayClass->create_input_method_context = wpeDisplayMockCreateInputMethodContext;
+    displayClass->get_egl_display = wpeDisplayMockGetEGLDisplay;
+    displayClass->get_keymap = wpeDisplayMockGetKeymap;
+    displayClass->get_preferred_dma_buf_formats = wpeDisplayMockGetPreferredDMABufFormats;
+    displayClass->get_n_screens = wpeDisplayMockGetNScreens;
+    displayClass->get_screen = wpeDisplayMockGetScreen;
+    displayClass->get_drm_device = wpeDisplayMockGetDRMDevice;
+    displayClass->get_drm_render_node = wpeDisplayMockGetDRMRenderNode;
+    displayClass->use_explicit_sync = wpeDisplayMockUseExplicitSync;
+}
+
+static void wpe_display_mock_class_finalize(WPEDisplayMockClass*)
+{
+}
+
+static void wpe_display_mock_init(WPEDisplayMock* self)
+{
+}
+
+G_MODULE_EXPORT void g_io_module_load(GIOModule* module)
+{
+    wpe_display_mock_register_type(G_TYPE_MODULE(module));
+
+    g_io_extension_point_implement(WPE_DISPLAY_EXTENSION_POINT_NAME, WPE_TYPE_DISPLAY_MOCK, "wpe-display-mock", 1);
+}
+
+G_MODULE_EXPORT void g_io_module_unload(GIOModule*)
+{
+}

--- a/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.h
+++ b/Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_DISPLAY_MOCK (wpe_display_mock_get_type())
+WPE_API G_DECLARE_FINAL_TYPE(WPEDisplayMock, wpe_display_mock, WPE, DISPLAY_MOCK, WPEDisplay)
+
+G_END_DECLS


### PR DESCRIPTION
#### fc66aceff14cad31572506bddef34af5d7241e5c
<pre>
[WPE] Test external module loading and WPE Display
<a href="https://bugs.webkit.org/show_bug.cgi?id=286919">https://bugs.webkit.org/show_bug.cgi?id=286919</a>

Reviewed by Carlos Garcia Campos and Adrian Perez de Castro.

Add a mock WPE platform that is absolutely barebones, and just returns
stub values for everything. It doesn&apos;t create views nor any other
platform object.

The mock platform exercises WPE&apos;s external module loading, with a
dynamic type registered at module loading time. It also has a higher
priority than regular WPE modules.

The new TestDisplay file only has a single test, that checks if
wpe_display_get_default() is able to properly find the mock platform
and load it as expected. It checks the resulting type name.

Further tests can be added by making the mock platform configurable.

* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp: Added.
(testLoadExternalDisplay):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp:
(main):
* Tools/TestWebKitAPI/wpe/mock-platform/CMakeLists.txt: Added.
* Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.cpp: Added.
(wpeDisplayMockDispose):
(wpeDisplayMockConnect):
(wpeDisplayMockCreateView):
(wpeDisplayMockCreateInputMethodContext):
(wpeDisplayMockGetEGLDisplay):
(wpeDisplayMockGetKeymap):
(wpeDisplayMockGetPreferredDMABufFormats):
(wpeDisplayMockGetNScreens):
(wpeDisplayMockGetScreen):
(wpeDisplayMockGetDRMDevice):
(wpeDisplayMockGetDRMRenderNode):
(wpeDisplayMockUseExplicitSync):
(wpe_display_mock_class_init):
(wpe_display_mock_class_finalize):
(wpe_display_mock_init):
(g_io_module_load):
(g_io_module_unload):
* Tools/TestWebKitAPI/wpe/mock-platform/WPEDisplayMock.h: Added.

Canonical link: <a href="https://commits.webkit.org/289925@main">https://commits.webkit.org/289925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b10b41e87dd8eefb529f1497d90473027aa1233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68216 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25935 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48582 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34412 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15624 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8662 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15640 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15381 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->