### PR TITLE
[scroll-animations] allow timeline ranges to be used when specifying keyframes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
@@ -8,13 +8,13 @@ PASS animation-timeline: view(y) without timeline range name
 PASS animation-timeline: view(x 50px) without timeline range name
 PASS animation-timeline: view(50px), view(inline 50px) without timeline range name
 PASS animation-timeline: view(inline) changes to view(inline 50px), withouttimeline range name
-FAIL animation-timeline: view() assert_equals: At entry 0% expected "0" but got "1"
-FAIL animation-timeline: view(50px) assert_equals: At entry 0% expected "0" but got "1"
-FAIL animation-timeline: view(auto 50px) assert_equals: At entry 0% expected "0" but got "1"
-FAIL animation-timeline: view(inline) assert_equals: At exit 50% expected "0.5" but got "1"
-FAIL animation-timeline: view(x) assert_equals: At exit 50% expected "0.5" but got "1"
-FAIL animation-timeline: view(y) assert_equals: At exit 50% expected "0.5" but got "1"
-FAIL animation-timeline: view(x 50px) assert_equals: At exit 50% expected "0.5" but got "1"
-FAIL animation-timeline: view(), view(inline) assert_equals: At exit 0% inline expected "10px" but got "16px"
-FAIL animation-timeline: view(inline) changes to view(inline 50px) assert_equals: At exit 50% expected "0.5" but got "1"
+PASS animation-timeline: view()
+PASS animation-timeline: view(50px)
+FAIL animation-timeline: view(auto 50px) assert_equals: At exit 0% expected "1" but got "0.666667"
+PASS animation-timeline: view(inline)
+PASS animation-timeline: view(x)
+PASS animation-timeline: view(y)
+PASS animation-timeline: view(x 50px)
+FAIL animation-timeline: view(), view(inline) assert_equals: At exit 0% inline expected "10px" but got "10.000001px"
+PASS animation-timeline: view(inline) changes to view(inline 50px)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Keyframes with same easing and timeline offset are merged. assert_equals: number of frames:  expected 4 but got 0
-FAIL Keyframes with same timeline offset but different easing function are not merged. assert_equals: number of frames:  expected 5 but got 0
+PASS Keyframes with same easing and timeline offset are merged.
+PASS Keyframes with same timeline offset but different easing function are not merged.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getKeyframes with timeline-offsets assert_equals: number of frames:  expected 2 but got 0
+PASS getKeyframes with timeline-offsets
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Keyframes with timeline-offsets ignored when timeline is inactive assert_equals: number of frames: Initial keyframes with active view-timeline expected 5 but got 3
+PASS Keyframes with timeline-offsets ignored when timeline is inactive
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html
@@ -94,11 +94,11 @@
       // ignored.
       frames = anim.effect.getKeyframes();
       let expected_unresolved_offsets = [
-        { offset: 0, computedOffset: 0, opacity: "1", easing: "linear",
+        { offset: 0, computedOffset: 0, marginRight: "10px", opacity: "1", easing: "linear",
           composite: "replace" },
         { offset: 0.5, computedOffset: 0.5, opacity: "0.5", easing: "linear",
           composite: "auto", },
-        { offset: 1, computedOffset: 1, opacity: "1", easing: "linear",
+        { offset: 1, computedOffset: 1, marginLeft: "10px", opacity: "1", easing: "linear",
           composite: "replace" },
         { offset: { rangeName: 'cover', offset: CSS.percent(0) },
           computedOffset: null, easing: "linear",

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Keyframes with timeline-offsets reported but not reachable when using a document timeline assert_equals: number of frames:  expected 5 but got 3
+PASS Keyframes with timeline-offsets reported but not reachable when using a document timeline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-range-name-offset-in-keyframes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-range-name-offset-in-keyframes.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Timeline offset in Animation Keyframes assert_equals: Effect at entry 0% expected "0" but got "1"
+PASS Timeline offset in Animation Keyframes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-keyframe-boundary-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-keyframe-boundary-interpolation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline with timeline offset keyframes outside [0,1] promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'style.match(regex)[captureGroupIndex]')"
+PASS ViewTimeline with timeline offset keyframes outside [0,1]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-keyframe-boundary-interpolation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-keyframe-boundary-interpolation.html
@@ -51,15 +51,18 @@
 </body>
 <script type="text/javascript">
   async function runTest() {
+
+    const epsilon = 1e-5;
+
     function assert_progress_equals(anim, expected, errorMessage) {
       assert_approx_equals(
           anim.effect.getComputedTiming().progress,
-          expected, 1e-6, errorMessage);
+          expected, epsilon, errorMessage);
     }
 
     function assert_opacity_equals(expected, errorMessage) {
       assert_approx_equals(
-          parseFloat(getComputedStyle(target).opacity), expected, 1e-6,
+          parseFloat(getComputedStyle(target).opacity), expected, epsilon,
                      errorMessage);
     }
 
@@ -70,12 +73,12 @@
       const translateIndex = 4;
       const match = style.match(regex)[captureGroupIndex];
       const translateX = parseFloat(match.split(',')[translateIndex].trim());
-      assert_approx_equals(translateX, expected, 1e-6, errorMessage);
+      assert_approx_equals(translateX, expected, epsilon, errorMessage);
     }
 
     function assert_property_equals(property, expected, errorMessage) {
       const value = parseFloat(getComputedStyle(target)[property]);
-      assert_approx_equals(value, expected, 1e-6, errorMessage);
+      assert_approx_equals(value, expected, epsilon, errorMessage);
     }
 
     promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
@@ -2,5 +2,5 @@
 
 
 
-FAIL Stability of animated elements aligned to the bounds of a contain region assert_approx_equals: a: Unexpected progress expected a number but got a "object"
+FAIL Stability of animated elements aligned to the bounds of a contain region assert_equals: a: Mismatched background color expected "rgb(0, 254, 0)" but got "rgb(136, 136, 136)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Report specified timeline offsets promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Computed offsets can be outside [0,1] for keyframes with timeline offsets promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Retain specified ordering of keyframes with timeline offsets promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Include unreachable keyframes promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Mix of computed and timeline offsets. promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
+PASS Report specified timeline offsets
+PASS Computed offsets can be outside [0,1] for keyframes with timeline offsets
+PASS Retain specified ordering of keyframes with timeline offsets
+PASS Include unreachable keyframes
+PASS Mix of computed and timeline offsets.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Timeline offsets in programmatic keyframes promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL String offsets in programmatic keyframes promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
+PASS Timeline offsets in programmatic keyframes
+PASS String offsets in programmatic keyframes
 PASS Invalid timeline offset in programmatic keyframe throws
-FAIL Timeline offsets in programmatic keyframes adjust for change in timeline promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Timeline offsets in programmatic keyframes resolved when updating the animation effect promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
+PASS Timeline offsets in programmatic keyframes adjust for change in timeline
+PASS Timeline offsets in programmatic keyframes resolved when updating the animation effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt
@@ -1,5 +1,6 @@
 
-FAIL Default source for a View timeline is the nearest scroll ancestor to the subject assert_true: No source expected true got false
-FAIL View timeline ignores explicitly set source assert_true: No source expected true got false
-FAIL View timeline source is null when display:none assert_true: No source expected true got false
+FAIL Default source for a View timeline is the nearest scroll ancestor to the subject assert_equals: expected "outer" but got "inner"
+PASS View timeline ignores explicitly set source
+FAIL View timeline source is null when display:none assert_equals: expected null but got Element node <div id="inner" class="scroller">
+      <div id="target" ...
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Intrinsic iteration duration is non-negative assert_approx_equals: values do not match for "Duration is zero when start > end" expected 0 +/- 0.125 but got -33.333335876464844
+FAIL Intrinsic iteration duration is non-negative assert_approx_equals: values do not match for "Duration is zero when start > end" expected 0 +/- 0.125 but got -33.33333333333333
 

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -416,9 +416,10 @@ void AnimationEffect::animationPlaybackRateDidChange()
     m_timingDidMutate = true;
 }
 
-void AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics()
+void AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const TimelineRange& animationAttachmentRange)
 {
-    m_timingDidMutate = true;
+    if (!animationAttachmentRange.isDefault())
+        m_timingDidMutate = true;
 }
 
 void AnimationEffect::animationRangeDidChange()

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -69,7 +69,7 @@ public:
     virtual void animationTimelineDidChange(const AnimationTimeline*);
     virtual void animationDidFinish() { };
     void animationPlaybackRateDidChange();
-    void animationProgressBasedTimelineSourceDidChangeMetrics();
+    virtual void animationProgressBasedTimelineSourceDidChangeMetrics(const TimelineRange&);
     void animationRangeDidChange();
 
     AnimationEffectTiming timing() const { return m_timing; }

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -29,14 +29,17 @@
 #include "AnimationTimelinesController.h"
 #include "CSSAnimation.h"
 #include "CSSKeyframeRule.h"
+#include "CSSNumericFactory.h"
 #include "CSSParserContext.h"
 #include "CSSPropertyAnimation.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
+#include "CSSPropertyParserConsumer+Animations.h"
 #include "CSSPropertyParserConsumer+Easing.h"
 #include "CSSSelector.h"
 #include "CSSStyleDeclaration.h"
 #include "CSSTransition.h"
+#include "CSSUnitValue.h"
 #include "CSSValue.h"
 #include "CSSValueKeywords.h"
 #include "ComputedStyleExtractor.h"
@@ -60,16 +63,19 @@
 #include "RenderStyleInlines.h"
 #include "Settings.h"
 #include "StyleAdjuster.h"
+#include "StyleEasingFunction.h"
 #include "StylePendingResources.h"
 #include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include "StyledElement.h"
+#include "TimelineRangeOffset.h"
 #include "TimingFunction.h"
 #include "TransformOperationData.h"
 #include "TransformOperationsSharedPrimitivesPrefix.h"
 #include "TranslateTransformOperation.h"
+#include "ViewTimeline.h"
 #include <JavaScriptCore/Exception.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
@@ -150,30 +156,167 @@ static inline CSSPropertyID IDLAttributeNameToAnimationPropertyName(const AtomSt
     return cssPropertyId;
 }
 
-static inline void computeMissingKeyframeOffsets(Vector<KeyframeEffect::ParsedKeyframe>& keyframes)
+static SingleTimelineRange::Name rangeStringToSingleTimelineRangeName(const String& rangeString)
+{
+    if (rangeString == "cover"_s)
+        return SingleTimelineRange::Name::Cover;
+    if (rangeString == "contain"_s)
+        return SingleTimelineRange::Name::Contain;
+    if (rangeString == "entry"_s)
+        return SingleTimelineRange::Name::Entry;
+    if (rangeString == "exit"_s)
+        return SingleTimelineRange::Name::Exit;
+    if (rangeString == "entry-crossing"_s)
+        return SingleTimelineRange::Name::EntryCrossing;
+    if (rangeString == "exit-crossing"_s)
+        return SingleTimelineRange::Name::ExitCrossing;
+    return SingleTimelineRange::Name::Normal;
+}
+
+static bool isTimelineRangeOffsetValid(const TimelineRangeOffset& timelineRangeOffset)
+{
+    if (rangeStringToSingleTimelineRangeName(timelineRangeOffset.rangeName) == SingleTimelineRange::Name::Normal)
+        return false;
+    RefPtr offsetUnitValue = dynamicDowncast<CSSUnitValue>(timelineRangeOffset.offset);
+    return offsetUnitValue && offsetUnitValue->unitEnum() == CSSUnitType::CSS_PERCENTAGE;
+}
+
+static String rangeStringFromSingleTimelineRangeName(SingleTimelineRange::Name rangeName)
+{
+    switch (rangeName) {
+    case SingleTimelineRange::Name::Normal:
+        return "normal"_s;
+    case SingleTimelineRange::Name::Omitted:
+        return "omitted"_s;
+    case SingleTimelineRange::Name::Cover:
+        return "cover"_s;
+    case SingleTimelineRange::Name::Contain:
+        return "contain"_s;
+    case SingleTimelineRange::Name::Entry:
+        return "entry"_s;
+    case SingleTimelineRange::Name::Exit:
+        return "exit"_s;
+    case SingleTimelineRange::Name::EntryCrossing:
+        return "entry-crossing"_s;
+    case SingleTimelineRange::Name::ExitCrossing:
+        return "exit-crossing"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return "normal"_s;
+}
+
+static std::optional<std::variant<double, TimelineRangeOffset>> doubleOrTimelineRangeOffsetFromString(const String& offsetString, const Document& document)
+{
+    bool doubleParsingSuccess = true;
+    auto doubleValue = offsetString.toDouble(&doubleParsingSuccess);
+    if (doubleParsingSuccess)
+        return { doubleValue };
+
+    CSSParserContext parserContext(document);
+    CSSTokenizer tokenizer(offsetString);
+    auto tokenRange = tokenizer.tokenRange();
+    auto offsets = CSSPropertyParserHelpers::consumeKeyframeKeyList(tokenRange, parserContext);
+    if (offsets.size() != 1)
+        return { };
+
+    auto [rangeCSSValueID, value] = offsets[0];
+    auto rangeName = SingleTimelineRange::timelineName(rangeCSSValueID);
+    if (rangeName == SingleTimelineRange::Name::Normal)
+        return value;
+
+    return { TimelineRangeOffset { rangeStringFromSingleTimelineRangeName(rangeName), CSSNumericFactory::percent(value * 100) } };
+}
+
+static std::optional<KeyframeEffect::KeyframeOffset> validateKeyframeOffset(const KeyframeEffect::KeyframeOffset& offset, const Document& document)
+{
+    if (auto* doubleValue = std::get_if<double>(&offset))
+        return *doubleValue;
+
+    if (auto* timelineRangeOffset = std::get_if<TimelineRangeOffset>(&offset)) {
+        if (!isTimelineRangeOffsetValid(*timelineRangeOffset))
+            return { };
+        return *timelineRangeOffset;
+    }
+
+    if (auto* stringOffset = std::get_if<String>(&offset)) {
+        auto parsedValue = doubleOrTimelineRangeOffsetFromString(*stringOffset, document);
+        if (!parsedValue)
+            return { };
+        if (auto doubleOffset = std::get_if<double>(&*parsedValue))
+            return *doubleOffset;
+        return std::get<TimelineRangeOffset>(*parsedValue);
+    }
+
+    ASSERT(std::holds_alternative<std::nullptr_t>(offset));
+    return nullptr;
+};
+
+static double computedOffset(SingleTimelineRange::Name rangeName, double offset, const ViewTimeline* viewTimeline, WebAnimation* animation)
+{
+    if ((rangeName == SingleTimelineRange::Name::Normal || rangeName == SingleTimelineRange::Name::Omitted))
+        return offset;
+
+    if (!viewTimeline)
+        return std::numeric_limits<double>::quiet_NaN();
+
+    Ref timeline { *viewTimeline };
+
+    auto [namedRangeStartOffset, namedRangeEndOffset] = timeline->offsetIntervalForTimelineRangeName(rangeName);
+    auto namedRangeOffsetDelta = namedRangeEndOffset - namedRangeStartOffset;
+    auto computedOffsetWithinNamedRange = namedRangeStartOffset + offset * namedRangeOffsetDelta;
+
+    if (!animation)
+        return computedOffsetWithinNamedRange;
+
+    auto attachmentRange = Ref { *animation }->range();
+    if (attachmentRange.isDefault())
+        return computedOffsetWithinNamedRange;
+
+    auto [attachmentRangeStartOffset, attachmentRangeEndOffset] = timeline->offsetIntervalForAttachmentRange(attachmentRange);
+    auto attachmentRangeOffsetDelta = attachmentRangeEndOffset - attachmentRangeStartOffset;
+    return (computedOffsetWithinNamedRange - attachmentRangeStartOffset) / attachmentRangeOffsetDelta;
+}
+
+static inline void computeMissingKeyframeOffsets(Vector<KeyframeEffect::ParsedKeyframe>& keyframes, const ViewTimeline* viewTimeline, WebAnimation* animation)
 {
     // https://drafts.csswg.org/web-animations-1/#compute-missing-keyframe-offsets
 
     if (keyframes.isEmpty())
         return;
 
+    Vector<KeyframeEffect::ParsedKeyframe*> keyframesWithDoubleOrNullOffset;
+
     // 1. For each keyframe, in keyframes, let the computed keyframe offset of the keyframe be equal to its keyframe offset value.
     // In our implementation, we only set non-null values to avoid making computedOffset std::optional<double>. Instead, we'll know
     // that a keyframe hasn't had a computed offset by checking if it has a null offset and a 0 computedOffset, since the first
     // keyframe will already have a 0 computedOffset.
     for (auto& keyframe : keyframes) {
-        auto computedOffset = keyframe.offset;
-        keyframe.computedOffset = computedOffset ? *computedOffset : 0;
+        auto& offset = keyframe.offset;
+        if (auto* timelineRangeOffset = std::get_if<TimelineRangeOffset>(&offset)) {
+            auto rangeName = rangeStringToSingleTimelineRangeName(timelineRangeOffset->rangeName);
+            RefPtr offsetUnitValue = dynamicDowncast<CSSUnitValue>(timelineRangeOffset->offset);
+            ASSERT(offsetUnitValue && offsetUnitValue->unitEnum() == CSSUnitType::CSS_PERCENTAGE);
+            keyframe.computedOffset = computedOffset(rangeName, offsetUnitValue->value() / 100, viewTimeline, animation);
+        } else {
+            keyframesWithDoubleOrNullOffset.append(&keyframe);
+            if (auto* doubleValue = std::get_if<double>(&offset))
+                keyframe.computedOffset = *doubleValue;
+            else
+                keyframe.computedOffset = std::numeric_limits<double>::quiet_NaN();
+        }
     }
+
+    if (keyframesWithDoubleOrNullOffset.isEmpty())
+        return;
 
     // 2. If keyframes contains more than one keyframe and the computed keyframe offset of the first keyframe in keyframes is null,
     //    set the computed keyframe offset of the first keyframe to 0.
-    if (keyframes.size() > 1 && !keyframes[0].offset)
-        keyframes[0].computedOffset = 0;
+    if (keyframesWithDoubleOrNullOffset.size() > 1 && std::isnan(keyframesWithDoubleOrNullOffset[0]->computedOffset))
+        keyframesWithDoubleOrNullOffset[0]->computedOffset = 0;
 
     // 3. If the computed keyframe offset of the last keyframe in keyframes is null, set its computed keyframe offset to 1.
-    if (!keyframes.last().offset)
-        keyframes.last().computedOffset = 1;
+    if (std::isnan(keyframesWithDoubleOrNullOffset.last()->computedOffset))
+        keyframesWithDoubleOrNullOffset.last()->computedOffset = 1;
 
     // 4. For each pair of keyframes A and B where:
     //    - A appears before B in keyframes, and
@@ -184,20 +327,21 @@ static inline void computeMissingKeyframeOffsets(Vector<KeyframeEffect::ParsedKe
     //    2. Let n be the number of keyframes between and including A and B minus 1.
     //    3. Let index refer to the position of keyframe in the sequence of keyframes between A and B such that the first keyframe after A has an index of 1.
     //    4. Set the computed keyframe offset of keyframe to offsetA + (offsetB − offsetA) × index / n.
+
     size_t indexOfLastKeyframeWithNonNullOffset = 0;
-    for (size_t i = 1; i < keyframes.size(); ++i) {
-        auto& keyframe = keyframes[i];
+    for (size_t i = 1; i < keyframesWithDoubleOrNullOffset.size(); ++i) {
+        auto& keyframe = *keyframesWithDoubleOrNullOffset[i];
         // Keyframes with a null offset that don't yet have a non-zero computed offset are keyframes
         // with an offset that needs to be computed.
-        if (!keyframe.offset && !keyframe.computedOffset)
+        if (std::isnan(keyframe.computedOffset))
             continue;
         if (indexOfLastKeyframeWithNonNullOffset != i - 1) {
-            double lastNonNullOffset = keyframes[indexOfLastKeyframeWithNonNullOffset].computedOffset;
+            double lastNonNullOffset = keyframesWithDoubleOrNullOffset[indexOfLastKeyframeWithNonNullOffset]->computedOffset;
             double offsetDelta = keyframe.computedOffset - lastNonNullOffset;
             double offsetIncrement = offsetDelta / (i - indexOfLastKeyframeWithNonNullOffset);
             size_t indexOfFirstKeyframeWithNullOffset = indexOfLastKeyframeWithNonNullOffset + 1;
             for (size_t j = indexOfFirstKeyframeWithNullOffset; j < i; ++j)
-                keyframes[j].computedOffset = lastNonNullOffset + (j - indexOfLastKeyframeWithNonNullOffset) * offsetIncrement;
+                keyframesWithDoubleOrNullOffset[j]->computedOffset = lastNonNullOffset + (j - indexOfLastKeyframeWithNonNullOffset) * offsetIncrement;
         }
         indexOfLastKeyframeWithNonNullOffset = i;
     }
@@ -235,15 +379,48 @@ static inline ExceptionOr<KeyframeEffect::KeyframeLikeObject> processKeyframeLik
         if (UNLIKELY(basePropertiesConversionResult.hasException(scope)))
             return Exception { ExceptionCode::TypeError };
         baseProperties = basePropertiesConversionResult.releaseReturnValue();
+
+        // Convert string offsets to TimelineRangeOffset in case we were provided with a list of offsets.
+        if (auto* offsets = std::get_if<Vector<KeyframeEffect::KeyframeOffset>>(&baseProperties.offset)) {
+            for (auto& offset : *offsets) {
+                auto* stringOffset = std::get_if<String>(&offset);
+                if (!stringOffset)
+                    continue;
+                if (auto parsedValue = doubleOrTimelineRangeOffsetFromString(*stringOffset, document)) {
+                    if (auto doubleOffset = std::get_if<double>(&*parsedValue))
+                        offset = *doubleOffset;
+                    else
+                        offset = std::get<TimelineRangeOffset>(*parsedValue);
+                } else
+                    return Exception { ExceptionCode::TypeError };
+            }
+        }
     } else {
         auto baseKeyframeConversionResult = convert<IDLDictionary<KeyframeEffect::BaseKeyframe>>(lexicalGlobalObject, keyframesInput.get());
         if (UNLIKELY(baseKeyframeConversionResult.hasException(scope)))
             return Exception { ExceptionCode::TypeError };
 
         auto baseKeyframe = baseKeyframeConversionResult.releaseReturnValue();
-        if (baseKeyframe.offset)
-            baseProperties.offset = baseKeyframe.offset.value();
-        else
+        auto* baseKeyframeOffset = &baseKeyframe.offset;
+        if (auto* doubleValue = std::get_if<double>(baseKeyframeOffset))
+            baseProperties.offset = *doubleValue;
+        else if (auto* timelineRangeOffsetValue = std::get_if<TimelineRangeOffset>(baseKeyframeOffset)) {
+            if (!isTimelineRangeOffsetValid(*timelineRangeOffsetValue)) {
+                throwException(&lexicalGlobalObject, scope, JSC::Exception::create(vm, createTypeError(&lexicalGlobalObject)));
+                return Exception { ExceptionCode::TypeError };
+            }
+            baseProperties.offset = *timelineRangeOffsetValue;
+        } else if (auto* stringOffset = std::get_if<String>(baseKeyframeOffset)) {
+            if (auto parsedValue = doubleOrTimelineRangeOffsetFromString(*stringOffset, document)) {
+                if (auto doubleOffset = std::get_if<double>(&*parsedValue))
+                    baseProperties.offset = *doubleOffset;
+                else
+                    baseProperties.offset = std::get<TimelineRangeOffset>(*parsedValue);
+            } else {
+                throwException(&lexicalGlobalObject, scope, JSC::Exception::create(vm, createTypeError(&lexicalGlobalObject)));
+                return Exception { ExceptionCode::TypeError };
+            }
+        } else
             baseProperties.offset = nullptr;
         baseProperties.easing = baseKeyframe.easing;
         baseProperties.composite = baseKeyframe.composite;
@@ -398,10 +575,15 @@ static inline ExceptionOr<void> processIterableKeyframes(JSGlobalObject& lexical
 
         // When calling processKeyframeLikeObject() with the "allow lists" flag set to false, the only offset
         // alternatives we should expect are double and nullptr.
-        if (std::holds_alternative<double>(keyframeLikeObject.baseProperties.offset))
-            keyframeOutput.offset = std::get<double>(keyframeLikeObject.baseProperties.offset);
-        else
-            ASSERT(std::holds_alternative<std::nullptr_t>(keyframeLikeObject.baseProperties.offset));
+        if (auto* doubleValue = std::get_if<double>(&keyframeLikeObject.baseProperties.offset))
+            keyframeOutput.offset = *doubleValue;
+        else if (auto* timelineRangeOffset = std::get_if<TimelineRangeOffset>(&keyframeLikeObject.baseProperties.offset)) {
+            if (!isTimelineRangeOffsetValid(*timelineRangeOffset)) {
+                throwException(&lexicalGlobalObject, scope, JSC::Exception::create(vm, createTypeError(&lexicalGlobalObject)));
+                return Exception { ExceptionCode::TypeError };
+            }
+            keyframeOutput.offset = *timelineRangeOffset;
+        }
 
         // When calling processKeyframeLikeObject() with the "allow lists" flag set to false, the only easing
         // alternative we should expect is String.
@@ -471,7 +653,7 @@ static inline ExceptionOr<void> processPropertyIndexedKeyframes(JSGlobalObject& 
             propertyKeyframes.append(WTFMove(k));
         }
         // 6. Apply the procedure to compute missing keyframe offsets to property keyframes.
-        computeMissingKeyframeOffsets(propertyKeyframes);
+        computeMissingKeyframeOffsets(propertyKeyframes, nullptr, nullptr);
 
         // 7. Add keyframes in property keyframes to processed keyframes.
         parsedKeyframes.appendVector(propertyKeyframes);
@@ -479,7 +661,10 @@ static inline ExceptionOr<void> processPropertyIndexedKeyframes(JSGlobalObject& 
 
     // 3. Sort processed keyframes by the computed keyframe offset of each keyframe in increasing order.
     std::sort(parsedKeyframes.begin(), parsedKeyframes.end(), [](auto& lhs, auto& rhs) {
-        return lhs.computedOffset < rhs.computedOffset;
+        if (!std::isnan(lhs.computedOffset) && !std::isnan(rhs.computedOffset))
+            return lhs.computedOffset < rhs.computedOffset;
+        // This will sort nullopt values prior to other values.
+        return !std::isnan(lhs.computedOffset);
     });
 
     // 4. Merge adjacent keyframes in processed keyframes when they have equal computed keyframe offsets.
@@ -517,13 +702,31 @@ static inline ExceptionOr<void> processPropertyIndexedKeyframes(JSGlobalObject& 
     // 5. Let offsets be a sequence of nullable double values assigned based on the type of the “offset” member of the property-indexed keyframe as follows:
     //    - sequence<double?>, the value of “offset” as-is.
     //    - double?, a sequence of length one with the value of “offset” as its single item, i.e. « offset »,
-    Vector<std::optional<double>> offsets;
-    if (std::holds_alternative<Vector<std::optional<double>>>(propertyIndexedKeyframe.baseProperties.offset))
-        offsets = std::get<Vector<std::optional<double>>>(propertyIndexedKeyframe.baseProperties.offset);
-    else if (std::holds_alternative<double>(propertyIndexedKeyframe.baseProperties.offset))
-        offsets.append(std::get<double>(propertyIndexedKeyframe.baseProperties.offset));
-    else if (std::holds_alternative<std::nullptr_t>(propertyIndexedKeyframe.baseProperties.offset))
-        offsets.append(std::nullopt);
+    Vector<KeyframeEffect::KeyframeOffset> offsets;
+    auto* sourceOffsets = &propertyIndexedKeyframe.baseProperties.offset;
+    if (auto* vectorOfKeyframeOffsets = std::get_if<Vector<KeyframeEffect::KeyframeOffset>>(sourceOffsets)) {
+        for (auto& keyframeOffset : *vectorOfKeyframeOffsets) {
+            auto validatedOffset = validateKeyframeOffset(keyframeOffset, document);
+            if (!validatedOffset)
+                return Exception { ExceptionCode::TypeError };
+            offsets.append(*validatedOffset);
+        }
+    } else if (auto* doubleValue = std::get_if<double>(sourceOffsets))
+        offsets.append(*doubleValue);
+    else if (auto* timelineRangeOffset = std::get_if<TimelineRangeOffset>(sourceOffsets)) {
+        if (!isTimelineRangeOffsetValid(*timelineRangeOffset))
+            return Exception { ExceptionCode::TypeError };
+        offsets.append(*timelineRangeOffset);
+    } else if (auto* stringOffset = std::get_if<String>(sourceOffsets)) {
+        if (auto parsedValue = doubleOrTimelineRangeOffsetFromString(*stringOffset, document)) {
+            if (auto doubleOffset = std::get_if<double>(&*parsedValue))
+                offsets.append(*doubleOffset);
+            else
+                offsets.append(std::get<TimelineRangeOffset>(*parsedValue));
+        } else
+            return Exception { ExceptionCode::TypeError };
+    } else
+        offsets.append(nullptr);
 
     // 6. Assign each value in offsets to the keyframe offset of the keyframe with corresponding position in property keyframes until the end of either sequence is reached.
     for (size_t i = 0; i < offsets.size() && i < parsedKeyframes.size(); ++i)
@@ -692,12 +895,20 @@ void KeyframeEffect::copyPropertiesFromSource(Ref<KeyframeEffect>&& source)
     setBlendingKeyframes(WTFMove(blendingKeyframes));
 }
 
+static TimelineRangeOffset timelineRangeOffsetFromSpecifiedOffset(const BlendingKeyframe::Offset& specifiedOffset)
+{
+    auto name = rangeStringFromSingleTimelineRangeName(specifiedOffset.name);
+    return TimelineRangeOffset { name, CSSNumericFactory::percent(specifiedOffset.value * 100) };
+}
+
 auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
 {
     // https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectreadonly-getkeyframes
 
     if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
         styleOriginatedAnimation->flushPendingStyleChanges();
+
+    updateComputedKeyframeOffsetsIfNeeded();
 
     Vector<ComputedKeyframe> computedKeyframes;
 
@@ -725,7 +936,9 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
 
     BlendingKeyframes computedBlendingKeyframes(m_blendingKeyframes.animationName());
     computedBlendingKeyframes.copyKeyframes(m_blendingKeyframes);
-    computedBlendingKeyframes.fillImplicitKeyframes(*this, elementStyle);
+
+    if (computedBlendingKeyframes.hasKeyframeNotUsingRangeOffset() || activeViewTimeline())
+        computedBlendingKeyframes.fillImplicitKeyframes(*this, elementStyle);
 
     auto keyframeRules = [&]() -> const Vector<Ref<StyleRuleKeyframe>> {
         auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation());
@@ -740,11 +953,49 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
         if (!styleScope)
             return { };
 
-        return styleScope->resolver().keyframeRulesForName(computedBlendingKeyframes.animationName());
+        return styleScope->resolver().keyframeRulesForName(computedBlendingKeyframes.animationName(), backingAnimation.timingFunction());
     }();
 
-    auto keyframeRuleForKey = [&](double key) -> StyleRuleKeyframe* {
+    auto matchingStyleRuleKeyframe = [&](const BlendingKeyframe& keyframe) -> StyleRuleKeyframe* {
+        auto* cssAnimation = dynamicDowncast<CSSAnimation>(animation());
+        if (!cssAnimation)
+            return nullptr;
+
+        auto& backingAnimation = cssAnimation->backingAnimation();
+        auto defaultCompositeOperation = backingAnimation.compositeOperation();
+        auto* defaultTimingFunction = backingAnimation.timingFunction();
+
+        auto compositeOperation = keyframe.compositeOperation().value_or(defaultCompositeOperation);
+        auto* timingFunction = keyframe.timingFunction();
+        if (!timingFunction)
+            timingFunction = defaultTimingFunction;
+
+        auto compositeOperationForStyleRuleKeyframe = [&](Ref<StyleRuleKeyframe>& styleRuleKeyframe) {
+            if (auto compositeOperationCSSValue = styleRuleKeyframe->properties().getPropertyCSSValue(CSSPropertyAnimationComposition)) {
+                if (auto compositeOperation = toCompositeOperation(*compositeOperationCSSValue))
+                    return *compositeOperation;
+            }
+            return defaultCompositeOperation;
+        };
+
+        auto timingFunctionForStyleRuleKeyframe = [&](Ref<StyleRuleKeyframe>& styleRuleKeyframe) -> RefPtr<const TimingFunction> {
+            if (auto timingFunctionCSSValue = styleRuleKeyframe->properties().getPropertyCSSValue(CSSPropertyAnimationTimingFunction)) {
+                if (auto timingFunction = Style::createTimingFunctionDeprecated(*timingFunctionCSSValue))
+                    return timingFunction;
+            }
+            if (defaultTimingFunction)
+                return defaultTimingFunction;
+            return &CubicBezierTimingFunction::defaultTimingFunction();
+        };
+
+        auto& specifiedOffset = keyframe.specifiedOffset();
+        StyleRuleKeyframe::Key key { SingleTimelineRange::valueID(specifiedOffset.name), specifiedOffset.value };
+
         for (auto& keyframeRule : keyframeRules) {
+            if (compositeOperationForStyleRuleKeyframe(keyframeRule) != compositeOperation)
+                continue;
+            if (timingFunctionForStyleRuleKeyframe(keyframeRule) != timingFunction)
+                continue;
             for (auto keyframeRuleKey : keyframeRule->keys()) {
                 if (keyframeRuleKey == key)
                     return keyframeRule.ptr();
@@ -764,12 +1015,19 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
         }
     }
 
+    Vector<ComputedKeyframe> computedKeyframesWithTimelineRangeOffset;
+    Vector<ComputedKeyframe> computedKeyframesWithDoubleOffset;
+
     for (auto& keyframe : computedBlendingKeyframes) {
         auto& style = *keyframe.style();
-        auto* keyframeRule = keyframeRuleForKey(keyframe.offset());
+        auto* keyframeRule = matchingStyleRuleKeyframe(keyframe);
 
         ComputedKeyframe computedKeyframe;
-        computedKeyframe.offset = keyframe.offset();
+        computedKeyframe.offset = [&] -> KeyframeOffset {
+            if (keyframe.usesRangeOffset())
+                return timelineRangeOffsetFromSpecifiedOffset(keyframe.specifiedOffset());
+            return keyframe.specifiedOffset().value;
+        }();
         computedKeyframe.computedOffset = keyframe.offset();
         // For CSS transitions, all keyframes should return "linear" since the effect's global timing function applies.
         computedKeyframe.easing = is<CSSTransition>(animation()) ? "linear"_s : timingFunctionForBlendingKeyframe(keyframe)->cssText();
@@ -831,8 +1089,18 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
             );
         }
 
-        computedKeyframes.append(WTFMove(computedKeyframe));
+        // FIXME: this is so that we mimic the Chrome behavior since this isn't
+        // spec'd out, but it makes little sense to me. Items ought to be sorted
+        // by computed offset just like BlendingKeyframes would organize its keyframes.
+        // https://github.com/w3c/csswg-drafts/issues/11467
+        if (std::holds_alternative<double>(computedKeyframe.offset))
+            computedKeyframesWithDoubleOffset.append(WTFMove(computedKeyframe));
+        else
+            computedKeyframesWithTimelineRangeOffset.append(WTFMove(computedKeyframe));
     }
+
+    computedKeyframes.appendVector(WTFMove(computedKeyframesWithDoubleOffset));
+    computedKeyframes.appendVector(WTFMove(computedKeyframesWithTimelineRangeOffset));
 
     return computedKeyframes;
 }
@@ -916,9 +1184,10 @@ ExceptionOr<void> KeyframeEffect::processKeyframes(JSGlobalObject& lexicalGlobal
     //    zero or greater than one, throw a TypeError and abort these steps.
     double lastNonNullOffset = -1;
     for (auto& keyframe : parsedKeyframes) {
-        if (!keyframe.offset)
+        auto* doubleOffset = std::get_if<double>(&keyframe.offset);
+        if (!doubleOffset)
             continue;
-        auto offset = keyframe.offset.value();
+        auto offset = *doubleOffset;
         if (offset < lastNonNullOffset || offset < 0 || offset > 1)
             return Exception { ExceptionCode::TypeError };
         lastNonNullOffset = offset;
@@ -926,7 +1195,7 @@ ExceptionOr<void> KeyframeEffect::processKeyframes(JSGlobalObject& lexicalGlobal
 
     // We take a slight detour from the spec text and compute the missing keyframe offsets right away
     // since they can be computed up-front.
-    computeMissingKeyframeOffsets(parsedKeyframes);
+    computeMissingKeyframeOffsets(parsedKeyframes, activeViewTimeline(), animation());
 
     CSSParserContext parserContext(document);
 
@@ -962,8 +1231,23 @@ ExceptionOr<void> KeyframeEffect::processKeyframes(JSGlobalObject& lexicalGlobal
     return { };
 }
 
+static BlendingKeyframe::Offset specifiedOffsetForParsedKeyframe(const KeyframeEffect::ParsedKeyframe& keyframe)
+{
+    if (auto* timelineRangeOffset = std::get_if<TimelineRangeOffset>(&keyframe.offset)) {
+        auto rangeName = rangeStringToSingleTimelineRangeName(timelineRangeOffset->rangeName);
+        RefPtr offsetUnitValue = dynamicDowncast<CSSUnitValue>(timelineRangeOffset->offset);
+        ASSERT(offsetUnitValue && offsetUnitValue->unitEnum() == CSSUnitType::CSS_PERCENTAGE);
+        return { rangeName, offsetUnitValue->value() / 100 };
+    }
+
+    ASSERT(!std::isnan(keyframe.computedOffset));
+    return keyframe.computedOffset;
+}
+
 void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const Style::ResolutionContext& resolutionContext)
 {
+    updateComputedKeyframeOffsetsIfNeeded();
+
     if (!m_blendingKeyframes.isEmpty() || !m_target)
         return;
 
@@ -971,7 +1255,7 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
     auto& styleResolver = m_target->styleResolver();
 
     for (auto& keyframe : m_parsedKeyframes) {
-        BlendingKeyframe blendingKeyframe(keyframe.computedOffset, nullptr);
+        BlendingKeyframe blendingKeyframe(specifiedOffsetForParsedKeyframe(keyframe), nullptr);
         blendingKeyframe.setTimingFunction(keyframe.timingFunction->clone());
 
         switch (keyframe.composite) {
@@ -1072,6 +1356,8 @@ void KeyframeEffect::setBlendingKeyframes(BlendingKeyframes&& blendingKeyframes)
     m_blendingKeyframes = WTFMove(blendingKeyframes);
     m_animatedProperties.clear();
 
+    m_needsComputedKeyframeOffsetsUpdate = true;
+
     computedNeedsForcedLayout();
     computeStackingContextImpact();
     computeAcceleratedPropertiesState();
@@ -1159,7 +1445,7 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const RenderStyle& una
     BlendingKeyframes blendingKeyframes(AtomString { backingAnimation.name().name });
     if (m_target) {
         if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.name().scopeOrdinal))
-            styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, blendingKeyframes);
+            styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, blendingKeyframes, backingAnimation.timingFunction());
 
         // Ensure resource loads for all the frames.
         for (auto& keyframe : blendingKeyframes) {
@@ -1242,6 +1528,8 @@ void KeyframeEffect::animationTimelineDidChange(const AnimationTimeline* timelin
     updateIsAssociatedWithProgressBasedTimeline();
 
     updateEffectStackMembership();
+
+    m_needsComputedKeyframeOffsetsUpdate = true;
 }
 
 void KeyframeEffect::animationRelevancyDidChange()
@@ -1590,6 +1878,8 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, cons
 
     for (auto property : properties) {
         auto interval = interpolationKeyframes(property, iterationProgress, propertySpecificKeyframeWithZeroOffset, propertySpecificKeyframeWithOneOffset);
+        if (interval.endpoints.isEmpty())
+            continue;
 
         auto* startBlendingKeyframe = dynamicDowncast<BlendingKeyframe>(interval.endpoints.first());
         auto* endBlendingKeyframe = dynamicDowncast<BlendingKeyframe>(interval.endpoints.last());
@@ -1818,6 +2108,9 @@ void KeyframeEffect::animationDidTick()
 {
     invalidate();
     updateAcceleratedActions();
+
+    if (auto* viewTimeline = activeViewTimeline())
+        computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline, animation());
 }
 
 void KeyframeEffect::animationDidChangeTimingProperties()
@@ -1998,7 +2291,7 @@ void KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties()
 #endif
 
     if (m_pendingAcceleratedActions.isEmpty()) {
-        if (getComputedTiming().phase != AnimationEffectPhase::Active)
+        if (!canBeAccelerated() || getComputedTiming().phase != AnimationEffectPhase::Active)
             return;
         m_pendingAcceleratedActions.append(AcceleratedAction::UpdateProperties);
         m_lastRecordedAcceleratedAction = AcceleratedAction::Play;
@@ -2499,12 +2792,15 @@ void KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty()
             UncheckedKeyHashSet<CSSPropertyID> explicitOneProperties;
             auto styleProperties = keyframe.style;
             for (auto propertyReference : styleProperties.get()) {
+                auto computedOffset = keyframe.computedOffset;
+                if (std::isnan(computedOffset))
+                    continue;
                 auto property = propertyReference.id();
                 // All properties may end up being implicit.
                 implicitProperties.add(property);
-                if (!keyframe.computedOffset)
+                if (!computedOffset)
                     explicitZeroProperties.add(property);
-                else if (keyframe.computedOffset == 1)
+                else if (computedOffset == 1)
                     explicitOneProperties.add(property);
             }
             // Let's remove all properties found on the 0% and 100% keyframes from the list of potential implicit properties.
@@ -2881,5 +3177,49 @@ bool KeyframeEffect::isPropertyAdditiveOrCumulative(KeyframeInterpolation::Prope
         return false;
     });
 }
+
+const ViewTimeline* KeyframeEffect::activeViewTimeline()
+{
+    RefPtr animation = this->animation();
+    if (!animation)
+        return nullptr;
+
+    RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(animation->timeline());
+    if (viewTimeline && viewTimeline->currentTime())
+        return viewTimeline.get();
+
+    return nullptr;
+}
+
+void KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics(const TimelineRange& animationAttachmentRange)
+{
+    AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics(animationAttachmentRange);
+    m_needsComputedKeyframeOffsetsUpdate = true;
+}
+
+void KeyframeEffect::updateComputedKeyframeOffsetsIfNeeded()
+{
+    if (!m_needsComputedKeyframeOffsetsUpdate)
+        return;
+
+    // FIXME: also call this when metrics of the view timeline changes.
+
+    RefPtr animation = this->animation();
+    if (!animation)
+        return;
+
+    RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(animation->timeline());
+    if (viewTimeline && !viewTimeline->currentTime())
+        return;
+
+    if (!m_parsedKeyframes.isEmpty())
+        computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline.get(), animation.get());
+
+    m_blendingKeyframes.updatedComputedOffsets([&](auto& specifiedOffset) {
+        return computedOffset(specifiedOffset.name, specifiedOffset.value, viewTimeline.get(), animation.get());
+    });
+
+    m_needsComputedKeyframeOffsetsUpdate = false;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -68,14 +68,16 @@ public:
     static Ref<KeyframeEffect> create(Ref<KeyframeEffect>&&);
     static Ref<KeyframeEffect> create(const Element&, const std::optional<Style::PseudoElementIdentifier>&);
 
+    using KeyframeOffset = std::variant<std::nullptr_t, double, TimelineRangeOffset, String>;
+
     struct BasePropertyIndexedKeyframe {
-        std::variant<std::nullptr_t, Vector<std::optional<double>>, double> offset = Vector<std::optional<double>>();
+        std::variant<std::nullptr_t, Vector<KeyframeOffset>, double, TimelineRangeOffset, String> offset = Vector<KeyframeOffset>();
         std::variant<Vector<String>, String> easing = Vector<String>();
         std::variant<Vector<CompositeOperationOrAuto>, CompositeOperationOrAuto> composite = Vector<CompositeOperationOrAuto>();
     };
 
     struct BaseKeyframe {
-        MarkableDouble offset;
+        KeyframeOffset offset;
         String easing { "linear"_s };
         CompositeOperationOrAuto composite { CompositeOperationOrAuto::Auto };
     };
@@ -281,6 +283,10 @@ private:
     bool ticksContinuouslyWhileActive() const final;
     std::optional<double> progressUntilNextStep(double) const final;
     bool preventsAnimationReadiness() const final;
+    void animationProgressBasedTimelineSourceDidChangeMetrics(const TimelineRange&) final;
+
+    const ViewTimeline* activeViewTimeline();
+    void updateComputedKeyframeOffsetsIfNeeded();
 
     // KeyframeInterpolation
     CompositeOperation compositeOperation() const final { return m_compositeOperation; }
@@ -325,6 +331,7 @@ private:
     bool m_hasReferenceFilter { false };
     bool m_animatesSizeAndSizeDependentTransform { false };
     bool m_isAssociatedWithProgressBasedTimeline { false };
+    bool m_needsComputedKeyframeOffsetsUpdate { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.idl
+++ b/Source/WebCore/animation/KeyframeEffect.idl
@@ -24,6 +24,7 @@
  */
 
 typedef USVString CSSOMString;
+typedef (double? or TimelineRangeOffset or DOMString) KeyframeOffset;
 
 [
     Exposed=Window,
@@ -41,13 +42,13 @@ typedef USVString CSSOMString;
 };
 
 dictionary BasePropertyIndexedKeyframe {
-    (sequence<double?> or double?) offset = [];
+    (sequence<KeyframeOffset> or KeyframeOffset) offset = [];
     (sequence<DOMString> or DOMString) easing = [];
     (sequence<CompositeOperationOrAuto> or CompositeOperationOrAuto) composite = [];
 };
 
 dictionary BaseKeyframe {
-    double? offset = null;
+    KeyframeOffset offset = null;
     DOMString easing = "linear";
     CompositeOperationOrAuto composite = "auto";
 };
@@ -55,8 +56,8 @@ dictionary BaseKeyframe {
 [
     JSGenerateToJSObject
 ] dictionary BaseComputedKeyframe {
-     double? offset = null;
-     double computedOffset;
+     KeyframeOffset offset = null;
+     unrestricted double computedOffset;
      DOMString easing = "linear";
      CompositeOperationOrAuto composite = "auto";
 };

--- a/Source/WebCore/animation/KeyframeInterpolation.cpp
+++ b/Source/WebCore/animation/KeyframeInterpolation.cpp
@@ -45,9 +45,9 @@ const KeyframeInterpolation::KeyframeInterval KeyframeInterpolation::interpolati
 
     for (size_t i = 0; i < numberOfKeyframes(); ++i) {
         auto& keyframe = keyframeAtIndex(i);
-        auto offset = keyframe.offset();
-        if (!keyframe.animatesProperty(property))
+        if (!keyframe.hasResolvedOffset() || !keyframe.animatesProperty(property))
             continue;
+        auto offset = keyframe.offset();
         if (!offset)
             numberOfKeyframesWithZeroOffset++;
         if (offset == 1)

--- a/Source/WebCore/animation/KeyframeInterpolation.h
+++ b/Source/WebCore/animation/KeyframeInterpolation.h
@@ -40,6 +40,7 @@ public:
 
     class Keyframe {
     public:
+        bool hasResolvedOffset() const { return !std::isnan(offset()); }
         virtual double offset() const = 0;
         virtual std::optional<CompositeOperation> compositeOperation() const = 0;
         virtual bool animatesProperty(Property) const = 0;

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -56,8 +56,10 @@ Ref<ScrollTimeline> ScrollTimeline::create(Document& document, ScrollTimelineOpt
     // 3. Set the axis property of timeline to the corresponding value from options.
     timeline->setAxis(options.axis);
 
-    if (timeline->m_source)
+    if (auto source = timeline->m_source.element()) {
+        source->protectedDocument()->updateLayoutIgnorePendingStylesheets();
         timeline->cacheCurrentTime();
+    }
 
     return timeline;
 }

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -66,9 +66,14 @@ public:
     Element* source() const override;
     TimelineRange defaultRange() const final;
 
+    std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const TimelineRange&) const final;
+    std::pair<double, double> offsetIntervalForAttachmentRange(const TimelineRange&) const;
+    std::pair<double, double> offsetIntervalForTimelineRangeName(const SingleTimelineRange::Name) const;
+
 private:
     ScrollTimeline::Data computeTimelineData() const final;
-    std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const TimelineRange&) const final;
+    std::pair<double, double> intervalForTimelineRangeName(const ScrollTimeline::Data&, const SingleTimelineRange::Name) const;
+    template<typename F> double mapOffsetToTimelineRange(const ScrollTimeline::Data&, const SingleTimelineRange::Name, F&&) const;
 
     explicit ViewTimeline(ScrollAxis);
     explicit ViewTimeline(const AtomString&, ScrollAxis, ViewTimelineInsets&&);

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1943,9 +1943,8 @@ const TimelineRange& WebAnimation::range()
 void WebAnimation::progressBasedTimelineSourceDidChangeMetrics()
 {
     ASSERT(m_timeline && m_timeline->isProgressBased());
-    RefPtr effect = m_effect;
-    if (effect && !range().isDefault())
-        effect->animationProgressBasedTimelineSourceDidChangeMetrics();
+    if (RefPtr effect = m_effect)
+        effect->animationProgressBasedTimelineSourceDidChangeMetrics(range());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -37,13 +37,30 @@
 
 namespace WebCore {
 
+void StyleRuleKeyframe::Key::writeToString(StringBuilder& str) const
+{
+    if (rangeName == CSSValueContain)
+        str.append("contain "_s);
+    else if (rangeName == CSSValueCover)
+        str.append("cover "_s);
+    else if (rangeName == CSSValueEntry)
+        str.append("entry "_s);
+    else if (rangeName == CSSValueEntryCrossing)
+        str.append("entry-crossing "_s);
+    else if (rangeName == CSSValueExit)
+        str.append("exit "_s);
+    else if (rangeName == CSSValueExitCrossing)
+        str.append("exit-crossing "_s);
+    str.append(offset * 100, '%');
+}
+
 StyleRuleKeyframe::StyleRuleKeyframe(Ref<StyleProperties>&& properties)
     : StyleRuleBase(StyleRuleType::Keyframe)
     , m_properties(WTFMove(properties))
 {
 }
 
-StyleRuleKeyframe::StyleRuleKeyframe(Vector<double>&& keys, Ref<StyleProperties>&& properties)
+StyleRuleKeyframe::StyleRuleKeyframe(Vector<Key>&& keys, Ref<StyleProperties>&& properties)
     : StyleRuleBase(StyleRuleType::Keyframe)
     , m_properties(WTFMove(properties))
     , m_keys(WTFMove(keys))
@@ -55,9 +72,12 @@ Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Ref<StyleProperties>&& properti
     return adoptRef(*new StyleRuleKeyframe(WTFMove(properties)));
 }
 
-Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Vector<double>&& keys, Ref<StyleProperties>&& properties)
+Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Vector<std::pair<CSSValueID, double>>&& keys, Ref<StyleProperties>&& properties)
 {
-    return adoptRef(*new StyleRuleKeyframe(WTFMove(keys), WTFMove(properties)));
+    auto keyStructs = keys.map([](auto& pair) -> Key {
+        return { pair.first, pair.second };
+    });
+    return adoptRef(*new StyleRuleKeyframe(WTFMove(keyStructs), WTFMove(properties)));
 }
 
 StyleRuleKeyframe::~StyleRuleKeyframe() = default;
@@ -78,7 +98,7 @@ String StyleRuleKeyframe::keyText() const
     for (size_t i = 0; i < m_keys.size(); ++i) {
         if (i)
             keyText.append(',');
-        keyText.append(m_keys[i] * 100, '%');
+        m_keys[i].writeToString(keyText);
     }
     return keyText.toString();
 }
@@ -86,10 +106,12 @@ String StyleRuleKeyframe::keyText() const
 bool StyleRuleKeyframe::setKeyText(const String& keyText)
 {
     ASSERT(!keyText.isNull());
-    auto keys = CSSParser::parseKeyframeKeyList(keyText);
+    auto keys = CSSParser::parseKeyframeKeyList(keyText, strictCSSParserContext());
     if (keys.isEmpty())
         return false;
-    m_keys = WTFMove(keys);
+    m_keys = keys.map([](auto& pair) -> Key {
+        return { pair.first, pair.second };
+    });
     return true;
 }
 

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -38,21 +38,29 @@ class StyleRuleCSSStyleDeclaration;
 class StyleRuleKeyframe final : public StyleRuleBase {
 public:
     static Ref<StyleRuleKeyframe> create(Ref<StyleProperties>&&);
-    static Ref<StyleRuleKeyframe> create(Vector<double>&& keys, Ref<StyleProperties>&&);
+    static Ref<StyleRuleKeyframe> create(Vector<std::pair<CSSValueID, double>>&& keys, Ref<StyleProperties>&&);
     ~StyleRuleKeyframe();
 
     Ref<StyleRuleKeyframe> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
+    struct Key {
+        CSSValueID rangeName;
+        double offset;
+
+        void writeToString(StringBuilder&) const;
+        bool operator==(const Key&) const = default;
+    };
+
     String keyText() const;
     bool setKeyText(const String&);
-    void setKey(double key)
+    void setKey(Key key)
     {
         ASSERT(m_keys.isEmpty());
         m_keys.clear();
         m_keys.append(key);
     }
 
-    const Vector<double>& keys() const { return m_keys; };
+    const Vector<Key>& keys() const { return m_keys; };
 
     const StyleProperties& properties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();
@@ -61,10 +69,10 @@ public:
 
 private:
     explicit StyleRuleKeyframe(Ref<StyleProperties>&&);
-    StyleRuleKeyframe(Vector<double>&&, Ref<StyleProperties>&&);
+    StyleRuleKeyframe(Vector<Key>&&, Ref<StyleProperties>&&);
 
     Ref<StyleProperties> m_properties;
-    Vector<double> m_keys;
+    Vector<Key> m_keys;
 };
 
 class CSSKeyframeRule final : public CSSRule {

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -164,9 +164,9 @@ void CSSParser::parseDeclarationForInspector(const CSSParserContext& context, co
     CSSParserImpl::parseDeclarationListForInspector(string, context, observer);
 }
 
-Vector<double> CSSParser::parseKeyframeKeyList(const String& selector)
+Vector<std::pair<CSSValueID, double>> CSSParser::parseKeyframeKeyList(const String& selector, const CSSParserContext& context)
 {
-    return CSSParserImpl::parseKeyframeKeyList(selector);
+    return CSSParserImpl::parseKeyframeKeyList(selector, context);
 }
 
 }

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -60,7 +60,7 @@ public:
     static RefPtr<StyleRuleBase> parseRule(const CSSParserContext&, StyleSheetContents*, const String&, CSSParserEnum::NestedContext = { });
     
     RefPtr<StyleRuleKeyframe> parseKeyframeRule(const String&);
-    static Vector<double> parseKeyframeKeyList(const String&);
+    static Vector<std::pair<CSSValueID, double>> parseKeyframeKeyList(const String&, const CSSParserContext&);
 
     bool parseSupportsCondition(const String&);
 

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -101,7 +101,7 @@ public:
     static void parseStyleSheet(const String&, const CSSParserContext&, StyleSheetContents&);
     static CSSSelectorList parsePageSelector(CSSParserTokenRange, StyleSheetContents*);
 
-    static Vector<double> parseKeyframeKeyList(const String&);
+    static Vector<std::pair<CSSValueID, double>> parseKeyframeKeyList(const String&, const CSSParserContext&);
 
     bool supportsDeclaration(CSSParserTokenRange&);
     const CSSParserContext& context() const { return m_context; }
@@ -182,8 +182,6 @@ private:
     bool consumeDeclaration(CSSParserTokenRange, StyleRuleType);
     void consumeDeclarationValue(CSSParserTokenRange, CSSPropertyID, IsImportant, StyleRuleType);
     void consumeCustomPropertyValue(CSSParserTokenRange, const AtomString& propertyName, IsImportant);
-
-    static Vector<double> consumeKeyframeKeyList(CSSParserTokenRange);
 
     RefPtr<StyleSheetContents> protectedStyleSheet() const;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
@@ -37,6 +37,64 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
+Vector<std::pair<CSSValueID, double>> consumeKeyframeKeyList(CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    // <keyframe-selector> = from | to | <percentage [0,100]> | <timeline-range-name> <percentage>
+    // https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
+
+    auto consumeAndConvertPercentage = [&](CSSParserTokenRange& range) -> std::optional<double> {
+        // FIXME: We use resolveAsPercentageDeprecated() to deal with calc() and % values.
+        // We will eventually want to return a CSS value that can be kept as-is on a
+        // BlendingKeyframe so that resolution happens when we have the necessary context
+        // when the keyframes are associated with a target element.
+        if (auto percentageValue = consumePercentage(range, context, ValueRange::NonNegative)) {
+            auto resolvedPercentage = percentageValue->resolveAsPercentageDeprecated();
+            if (resolvedPercentage >= 0 && resolvedPercentage <= 100)
+                return resolvedPercentage / 100;
+        }
+        return { };
+    };
+
+    auto timelineRange = [&](CSSParserTokenRange& range, CSSValueID id) -> std::optional<std::pair<CSSValueID, double>> {
+        if (CSSPropertyParserHelpers::isAnimationRangeKeyword(id)) {
+            // "normal" will be considered valid by isAnimationRangeKeyword() but is not valid for a @keyframes rule.
+            if (id == CSSValueNormal)
+                return { };
+            if (auto convertedPercentage = consumeAndConvertPercentage(range))
+                return { { id, *convertedPercentage } };
+        }
+        return { };
+    };
+
+    Vector<std::pair<CSSValueID, double>> result;
+    while (true) {
+        range.consumeWhitespace();
+
+        if (auto tokenValue = consumeIdent(range)) {
+            auto valueId = tokenValue->valueID();
+            if (valueId == CSSValueFrom)
+                result.append({ CSSValueNormal, 0 });
+            else if (valueId == CSSValueTo)
+                result.append({ CSSValueNormal, 1 });
+            else if (auto pair = timelineRange(range, valueId))
+                result.append(*pair);
+            else
+                return { }; // Parser error, invalid value in keyframe selector
+        } else if (auto convertedPercentage = consumeAndConvertPercentage(range))
+            result.append({ CSSValueNormal, *convertedPercentage });
+        else
+            return { }; // Parser error, invalid value in keyframe selector
+
+        if (range.atEnd()) {
+            result.shrinkToFit();
+            return result;
+        }
+
+        if (range.consume().type() != CommaToken)
+            return { }; // Parser error
+    }
+}
+
 RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange& range, const CSSParserContext&)
 {
     // <keyframes-name> = <custom-ident> | <string>

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
@@ -35,6 +35,10 @@ struct CSSParserContext;
 
 namespace CSSPropertyParserHelpers {
 
+// MARK: <keyframe-selector> consuming
+// https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
+Vector<std::pair<CSSValueID, double>> consumeKeyframeKeyList(CSSParserTokenRange&, const CSSParserContext&);
+
 // MARK: <keyframes-name> consuming
 // https://drafts.csswg.org/css-animations/#typedef-keyframes-name
 RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange&, const CSSParserContext&);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
@@ -152,7 +152,7 @@ RefPtr<CSSValue> consumeViewTimelineInset(CSSParserTokenRange& range, const CSSP
     });
 }
 
-static bool isAnimationRangeKeyword(CSSValueID id)
+bool isAnimationRangeKeyword(CSSValueID id)
 {
     return identMatches<CSSValueNormal, CSSValueCover, CSSValueContain, CSSValueEntry, CSSValueExit, CSSValueEntryCrossing, CSSValueExitCrossing>(id);
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
@@ -37,6 +37,8 @@ struct CSSParserContext;
 
 namespace CSSPropertyParserHelpers {
 
+bool isAnimationRangeKeyword(CSSValueID);
+
 // MARK: - Consumer functions
 
 RefPtr<CSSValue> consumeAnimationRange(CSSParserTokenRange&, const CSSParserContext&, SingleTimelineRange::Type);

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -55,6 +55,7 @@ class StyleRuleKeyframes;
 class StyleRulePage;
 class StyleSheet;
 class StyleSheetList;
+class TimingFunction;
 class ViewportStyleResolver;
 
 // MatchOnlyUserAgentRules is used in media queries, where relative units
@@ -95,7 +96,7 @@ public:
     ResolvedStyle styleForElement(Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
     ResolvedStyle styleForElementWithCachedMatchResult(Element&, const ResolutionContext&, const MatchResult&, const RenderStyle& existingRenderStyle);
 
-    void keyframeStylesForAnimation(Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&);
+    void keyframeStylesForAnimation(Element&, const RenderStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&, const TimingFunction*);
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(Element&, const PseudoElementRequest&, const ResolutionContext&);
 
@@ -142,7 +143,7 @@ public:
     static KeyframesRuleMap& userAgentKeyframes();
     static void addUserAgentKeyframeStyle(Ref<StyleRuleKeyframes>&&);
     void addKeyframeStyle(Ref<StyleRuleKeyframes>&&);
-    Vector<Ref<StyleRuleKeyframe>> keyframeRulesForName(const AtomString&) const;
+    Vector<Ref<StyleRuleKeyframe>> keyframeRulesForName(const AtomString&, const TimingFunction*) const;
 
     RefPtr<StyleRuleViewTransition> viewTransitionRule() const;
 


### PR DESCRIPTION
#### 21ebfdcf906c11c01ead1af39be3fa7de873002e
<pre>
[scroll-animations] allow timeline ranges to be used when specifying keyframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=286920">https://bugs.webkit.org/show_bug.cgi?id=286920</a>

Reviewed by Sam Weinig.

The Scroll-driven Animations specification extends the definition of keyframes
to allow for timeline ranges to be used on top of the existing percentage values.
This means that for view timelines, authors can specify specific points within
that timeline&apos;s range as keyframe offsets. For instance, here is an animation
which would animate the opacity from 0 to 1 as the target element enters the
visible range within its scrolling container, and then from 1 to 0 as it leaves
it:

```
@keyframes my-anim {
    cover 0% { opacity: 0 }
    contain 0% { opacity: 1 }
    contain 100% { opacity: 1 }
    cover 100% { opacity: 0 }
}
```

This is a pretty big change since until now, keyframe offsets were either implicit
omitted values or explicit numeric values that could synchronously be computed to
a finite value. With timeline ranges, computed offsets will be NaN until we have
viable metrics for the view timeline&apos;s source and subject and will dynamically
update as the view timeline&apos;s metrics and scroll offset changes.

To that end, we introduce the notion of a `specifiedOffset` on `BlendingKeyframe`
and make the existing `offset` be the computed value. Specified offsets are
represented via the new `BlendingKeyframe::Offset` struct which encompasses the
range name (including `Omitted` and `Normal` values) and the numeric value.
This provides a way to determine whether a specified value was implicit or
explicit.

As for computed values, they are all NaN by default and resolved using the new
`BlendingKeyframes::updatedComputedOffsets()` method which will let the caller
provide a callback to convert each specified offset, leaving the mapping from
the view timeline range to keyframe effects.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/merge-timeline-offset-keyframes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-range-name-offset-in-keyframes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-keyframe-boundary-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-keyframe-boundary-interpolation.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/zero-intrinsic-iteration-duration.tentative-expected.txt:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::animationProgressBasedTimelineSourceDidChangeMetrics):
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::insert):
(WebCore::BlendingKeyframes::copyKeyframes):
(WebCore::zeroPercentKeyframe):
(WebCore::hundredPercentKeyframe):
(WebCore::BlendingKeyframes::fillImplicitKeyframes):
(WebCore::BlendingKeyframes::analyzeKeyframe):
(WebCore::BlendingKeyframes::updatedComputedOffsets):
(WebCore::BlendingKeyframe::BlendingKeyframe):
(WebCore::BlendingKeyframe::usesRangeOffset const):
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::hasKeyframeNotUsingRangeOffset const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::rangeStringToSingleTimelineRangeName):
(WebCore::isTimelineRangeOffsetValid):
(WebCore::rangeStringFromSingleTimelineRangeName):
(WebCore::doubleOrTimelineRangeOffsetFromString):
(WebCore::validateKeyframeOffset):
(WebCore::computedOffset):
(WebCore::computeMissingKeyframeOffsets):
(WebCore::processKeyframeLikeObject):
(WebCore::processIterableKeyframes):
(WebCore::processPropertyIndexedKeyframes):
(WebCore::timelineRangeOffsetFromSpecifiedOffset):
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::processKeyframes):
(WebCore::specifiedOffsetForParsedKeyframe):
(WebCore::KeyframeEffect::updateBlendingKeyframes):
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::animationTimelineDidChange):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::animationDidTick):
(WebCore::KeyframeEffect::applyPendingAcceleratedActionsOrUpdateTimingProperties):
(WebCore::KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty):
(WebCore::KeyframeEffect::activeViewTimeline):
(WebCore::KeyframeEffect::animationProgressBasedTimelineSourceDidChangeMetrics):
(WebCore::KeyframeEffect::updateComputedKeyframeOffsetsIfNeeded):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffect.idl:
* Source/WebCore/animation/KeyframeInterpolation.cpp:
(WebCore::KeyframeInterpolation::interpolationKeyframes const):
* Source/WebCore/animation/KeyframeInterpolation.h:
(WebCore::KeyframeInterpolation::Keyframe::hasResolvedOffset const):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::create):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::create):
(WebCore::ViewTimeline::intervalForTimelineRangeName const):
(WebCore::ViewTimeline::mapOffsetToTimelineRange const):
(WebCore::ViewTimeline::offsetIntervalForTimelineRangeName const):
(WebCore::ViewTimeline::offsetIntervalForAttachmentRange const):
(WebCore::ViewTimeline::intervalForAttachmentRange const):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::progressBasedTimelineSourceDidChangeMetrics):
* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::Key::writeToString const):
(WebCore::StyleRuleKeyframe::StyleRuleKeyframe):
(WebCore::StyleRuleKeyframe::create):
(WebCore::StyleRuleKeyframe::keyText const):
(WebCore::StyleRuleKeyframe::setKeyText):
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/css/CSSKeyframesRule.cpp:
(WebCore::StyleRuleKeyframes::findKeyframeIndex const):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseKeyframeKeyList):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parseKeyframeKeyList):
(WebCore::CSSParserImpl::consumeKeyframeStyleRule):
(WebCore::CSSParserImpl::consumeKeyframeKeyList): Deleted.
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
(WebCore::CSSPropertyParserHelpers::consumeKeyframeKeyList):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp:
(WebCore::CSSPropertyParserHelpers::isAnimationRangeKeyword):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h:
* Source/WebCore/style/StyleResolver.cpp:
(WTF::StyleRuleKeyframeKeyHash::hash):
(WTF::StyleRuleKeyframeKeyHash::equal):
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::isEmptyValue):
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::isDeletedValue):
(WebCore::Style::Resolver::keyframeRulesForName const):
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/289948@main">https://commits.webkit.org/289948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55bca165891c7b679b03a896c0d6c7b5d23be65a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68239 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25954 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6185 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34438 "Found 1 new test failure: editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95271 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15646 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11467 "Found 3 new test failures: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html imported/w3c/web-platform-tests/screen-orientation/lock-basic.html pdf/annotations/radio-buttons-select-second.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77104 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76365 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19172 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8685 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13836 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15662 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->