### PR TITLE
Add networking support for InstallEvent.addRoutes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6431,7 +6431,6 @@ imported/w3c/web-platform-tests/workers/modules/shared-worker-options-credential
 imported/w3c/web-platform-tests/xhr/send-after-setting-document-domain.htm [ Skip ]
 
 imported/w3c/web-platform-tests/service-workers/service-worker/static-router-race-network-and-fetch-handler.https.html [ Failure ]
-imported/w3c/web-platform-tests/service-workers/service-worker/static-router-request-method.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/tentative/static-router/static-router-resource-timing.https.html [ Failure ]
 

--- a/LayoutTests/http/wpt/service-workers/service-worker-add-routes-too-late-worker.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-add-routes-too-late-worker.js
@@ -1,0 +1,17 @@
+let installEvent;
+oninstall = e => {
+   installEvent = e;
+}
+
+onmessage = async e => {
+    let result = "KO";
+    try {
+        await installEvent.addRoutes([{
+            condition: {urlPattern: new URLPattern({pathname: 'direct.txt', port: 80})},
+            source: 'network'
+        }]);
+    } catch (e) {
+       result = "OK";
+    }
+    e.source.postMessage(result);
+}

--- a/LayoutTests/http/wpt/service-workers/service-worker-add-routes-too-late.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-add-routes-too-late.js
@@ -1,0 +1,17 @@
+let installEvent;
+oninstall = e => {
+   installEvent = e;
+}
+
+onmessage = async e => {
+    let result = "KO";
+    try {
+        installEvent.addRoutes([{
+            condition: {urlPattern: new URLPattern({pathname: '/**/direct.txt'})},
+            source: 'network'
+        }]);
+    } catch (e) {
+       result = "OK";
+    }
+    e.source.postMessage(result);
+}

--- a/LayoutTests/http/wpt/service-workers/service-worker-add-routes-worker.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-add-routes-worker.js
@@ -1,0 +1,27 @@
+var installEvent;
+var resolveInstallEvent;
+oninstall = e => {
+   installEvent = e;
+   installEvent.waitUntil(new Promise(resolve => resolveInstallEvent = resolve));
+}
+
+onmessage = e => {
+  if (e.data == "finish") {
+    resolveInstallEvent();
+    return;
+  }
+  try {
+    const routes = [];
+    for (let i = 0; i < e.data; i++) {
+        routes.push({
+            condition: {urlPattern: new URLPattern({pathname: 'direct.txt' + i})},
+            source: 'network'
+        });
+    }
+    const promise = installEvent.addRoutes(routes);
+    installEvent.waitUntil(promise);
+    promise.then(() => e.source.postMessage("OK"), (error) => e.source.postMessage(error.toString()));
+  } catch(exception) {
+    e.source.postMessage(exception);
+  }
+}

--- a/LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Try to register too many routes in one call
+PASS Try to register too many routes incrementally
+PASS add route when not installing
+

--- a/LayoutTests/http/wpt/service-workers/service-worker-routes.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-routes.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+
+promise_test(async test => {
+    let registration = await navigator.serviceWorker.getRegistration("1");
+    if (registration)
+        await registration.unregister();
+    registration = await navigator.serviceWorker.register("service-worker-add-routes-worker.js", { scope: "1" });
+    const worker = registration.installing;
+    await waitForState(worker, "installing");
+
+    worker.postMessage(257);
+    const result = await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data));
+    worker.postMessage("finish");
+
+    assert_equals(result, "TypeError: Too many routes are registered");
+    await waitForState(worker, "redundant");
+}, "Try to register too many routes in one call");
+
+promise_test(async test => {
+    let registration = await navigator.serviceWorker.getRegistration("2");
+    if (registration)
+        await registration.unregister();
+    registration = await navigator.serviceWorker.register("service-worker-add-routes-worker.js", { scope: "2" });
+    const worker = registration.installing;
+    await waitForState(worker, "installing");
+
+    let counter = 0;
+    let result;
+    for (; counter < 1024; counter++) {
+       worker.postMessage(1);
+       result = await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data));
+       if (result != "OK")
+           break;
+    }
+    worker.postMessage("finish");
+
+    assert_equals(result, "TypeError: Too many routes are registered");
+    assert_equals(counter, 256);
+    await waitForState(worker, "redundant");
+}, "Try to register too many routes incrementally");
+
+promise_test(async (test) => {
+    let registration = await navigator.serviceWorker.getRegistration("3");
+    if (registration)
+        await registration.unregister();
+    registration = await navigator.serviceWorker.register("service-worker-add-routes-too-late-worker.js", { scope : "3" });
+    const worker = registration.installing;
+
+    await waitForState(worker, "activated");
+
+    worker.postMessage("addRoutes");
+    assert_equals(await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data)), "OK");
+}, "add route when not installing");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/service-worker-too-many-routes.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-too-many-routes.js
@@ -1,0 +1,11 @@
+oninstall = e => {
+   const routes = [];
+   for (let i = 0; i < 1024; ++i) {
+       routes.push({
+           condition: {urlPattern: new URLPattern({pathname: '/**/direct.txt'})},
+           source: 'network'
+       });
+   }
+   // FIXME: Remove waitUntil call.
+   e.waitUntil(e.addRoutes(routes));
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-fetch-event.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-fetch-event.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Main resource matched the rule with fetch-event source assert_equals: expected 0 but got 1
+PASS Main resource matched the rule with fetch-event source
 PASS Subresource load matched the rule fetch-event source
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-main-resource.https-expected.txt
@@ -6,6 +6,6 @@ PASS Main resource load not matched with the condition
 FAIL Main resource load matched with the cache source assert_equals: expected 0 but got 1
 FAIL Main resource fallback to the network when there is no cache entry assert_equals: expected 0 but got 1
 FAIL Main resource load matched with the cache source, with specifying the cache name assert_equals: expected 0 but got 1
-PASS Main resource load should not match the condition with not
-FAIL Main resource load should match the condition without not assert_equals: expected 0 but got 1
+FAIL Main resource load should not match the condition with not assert_equals: expected 1 but got 0
+PASS Main resource load should match the condition without not
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-mutiple-conditions.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-mutiple-conditions.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Multiple conditions work with `and` operation assert_true: expected true got false
-FAIL Multiple conditions including requestDestination work with `and` operation assert_true: expected true got false
+PASS Multiple conditions work with `and` operation
+PASS Multiple conditions including requestDestination work with `and` operation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-request-destination.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-request-destination.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Subreosurce load matched with the requestMethod script condition assert_equals: expected (boolean) true but got (undefined) undefined
+PASS Subreosurce load matched with the requestMethod script condition
 PASS Subreosurce load not matched with the requestMethod script condition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-request-method.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-request-method.https-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Subresource load matched with the requestMethod GET condition assert_equals: expected "Network with GET request" but got "nlgjk"
-FAIL Subresource load matched with the requestMethod POST condition assert_equals: expected "Network with POST request" but got "mdfhk"
-FAIL Subresource load matched with the requestMethod PUT condition assert_equals: expected "Network with PUT request" but got "vmhwc"
-FAIL Subresource load matched with the requestMethod DELETE condition assert_equals: expected "Network with DELETE request" but got "mtvce"
+PASS Subresource load matched with the requestMethod GET condition
+PASS Subresource load matched with the requestMethod POST condition
+PASS Subresource load matched with the requestMethod PUT condition
+PASS Subresource load matched with the requestMethod DELETE condition
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt
@@ -1,20 +1,20 @@
 
 PASS Subresource load not matched with URLPattern condition
-FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "svhgd"
+FAIL Subresource load matched with URLPattern condition assert_equals: expected "Network\n" but got "bodyh"
 FAIL Subresource cross origin load matched with URLPattern condition via constructed object assert_equals: expected 0 but got 2
-FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "tztxb"
+FAIL Subresource load matched with ignoreCase URLPattern condition assert_equals: expected "Network\n" but got "lmsjn"
 PASS Subresource load matched without ignoreCase URLPattern condition
-FAIL Subresource load matched with URLPattern condition via URLPatternCompatible assert_equals: expected "Network\n" but got "qhmva"
+FAIL Subresource load matched with URLPattern condition via URLPatternCompatible assert_equals: expected "Network\n" but got "ccrmz"
 FAIL Subresource cross origin load not matched with URLPattern condition via URLPatternCompatible assert_equals: expected 1 but got 2
-FAIL Subresource load matched with URLPattern condition via string assert_equals: expected "Network\n" but got "jxftd"
+FAIL Subresource load matched with URLPattern condition via string assert_equals: expected "Network\n" but got "hkqxk"
 FAIL Subresource cross origin load not matched with URLPattern condition via string assert_equals: expected 1 but got 2
-FAIL Subresource load matched with RequestMode condition assert_equals: expected "matched,with,non-url,conditions\n" but got "mwcmj"
-FAIL Subresource load matched with the nested `or` condition assert_equals: expected "Network\n" but got "wyaqu"
-FAIL Subresource load matched with the next `or` condition assert_equals: expected "Network\n" but got "gejtc"
-PASS Subresource load not matched with `or` condition
+FAIL Subresource load matched with RequestMode condition assert_equals: expected "matched,with,non-url,conditions\n" but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
+PASS Subresource load matched with the nested `or` condition
+PASS Subresource load matched with the next `or` condition
+FAIL Subresource load not matched with `or` condition assert_equals: expected "ftazh" but got "{\"error\": {\"code\": 404, \"message\": \"404\"}}"
 FAIL Subresource load matched with the cache source rule assert_equals: expected "From cache" but got ""
-FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "jayau"
+FAIL Subresource load did not match with the cache and fallback to the network assert_equals: expected "Network\n" but got "fhlly"
 FAIL Subresource load matched with the cache source, with specifying the cache name assert_equals: expected "From cache" but got ""
 PASS Subresource load should not match with the not condition
-FAIL Subresource load should match with a file other than not assert_equals: expected "Network\n" but got "aqnyr"
+FAIL Subresource load should match with a file other than not assert_equals: expected "Network\n" but got "boywr"
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -374,6 +374,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/fetch/FetchLoader.h
     Modules/fetch/FetchLoaderClient.h
     Modules/fetch/FetchRequestCredentials.h
+    Modules/fetch/FetchRequestDestination.h
+    Modules/fetch/FetchRequestMode.h
     Modules/fetch/RequestPriority.h
 
     Modules/filesystemaccess/FileSystemDirectoryHandle.h
@@ -2815,6 +2817,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     workers/service/ServiceWorkerRegistrationData.h
     workers/service/ServiceWorkerRegistrationKey.h
     workers/service/ServiceWorkerRegistrationOptions.h
+    workers/service/ServiceWorkerRoute.h
     workers/service/ServiceWorkerTypes.h
     workers/service/ServiceWorkerUpdateViaCache.h
 

--- a/Source/WebCore/workers/service/ServiceWorkerRoute.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRoute.h
@@ -50,8 +50,8 @@ struct ServiceWorkerRoutePattern {
     Component username;
     Component password;
     Component hostname;
-    Component pathname;
     Component port;
+    Component pathname;
     Component search;
     Component hash;
 };
@@ -82,7 +82,8 @@ struct ServiceWorkerRoute {
     ServiceWorkerRoute isolatedCopy() &&;
 };
 
-std::optional<ExceptionData> validateServiceWorkerRoute(ServiceWorkerRoute&, size_t maxRouteConditionDepth);
+size_t computeServiceWorkerRouteConditionCount(const ServiceWorkerRoute&);
+std::optional<ExceptionData> validateServiceWorkerRoute(ServiceWorkerRoute&);
 bool matchRouterCondition(const ServiceWorkerRouteCondition&, const FetchOptions&, const ResourceRequest&, bool isServiceWorkerRunning);
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -945,6 +945,28 @@ OptionSet<AdvancedPrivacyProtections> SWServer::advancedPrivacyProtectionsFromCl
     return result;
 }
 
+void SWServer::addRoutes(ServiceWorkerRegistrationIdentifier identifier, Vector<ServiceWorkerRoute>&& routes, CompletionHandler<void(Expected<void, ExceptionData>&&)>&& callback)
+{
+    RefPtr registration = getRegistration(identifier);
+    if (!registration) {
+        callback(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "No registration found"_s }));
+        return;
+    }
+
+    RefPtr installingWorker = registration->installingWorker();
+    if (!installingWorker) {
+        callback(makeUnexpected(ExceptionData { ExceptionCode::TypeError, "Service worker is not installing"_s }));
+        return;
+    }
+
+    if (auto exception = installingWorker->addRoutes(WTFMove(routes))) {
+        callback(makeUnexpected(WTFMove(*exception)));
+        return;
+    }
+
+    callback({ });
+}
+
 void SWServer::installContextData(const ServiceWorkerContextData& data)
 {
     ASSERT_WITH_MESSAGE(!data.loadedFromDisk, "Workers we just read from disk should only be launched as needed");

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -82,6 +82,7 @@ struct RetrieveRecordsOptions;
 struct ServiceWorkerClientQueryOptions;
 struct ServiceWorkerContextData;
 struct ServiceWorkerRegistrationData;
+struct ServiceWorkerRoute;
 struct WorkerFetchResult;
 
 class SWServer : public RefCountedAndCanMakeWeakPtr<SWServer> {
@@ -307,6 +308,8 @@ public:
 #if ENABLE(CONTENT_EXTENSIONS)
     WEBCORE_EXPORT void reportNetworkUsageToAllWorkerClients(ServiceWorkerIdentifier, size_t bytesTransferredOverNetworkDelta);
 #endif
+
+    WEBCORE_EXPORT void addRoutes(ServiceWorkerRegistrationIdentifier, Vector<ServiceWorkerRoute>&&, CompletionHandler<void(Expected<void, ExceptionData>&&)>&&);
 
 private:
     SWServer(SWServerDelegate&, UniqueRef<SWOriginStore>&&, bool processTerminationDelayEnabled, String&& registrationDatabaseDirectory, PAL::SessionID, bool shouldRunServiceWorkersOnMainThreadForTesting, bool hasServiceWorkerEntitlement, std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue, ServiceWorkerIsInspectable);

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -28,12 +28,14 @@
 #include "ClientOrigin.h"
 #include "ContentSecurityPolicyResponseHeaders.h"
 #include "CrossOriginEmbedderPolicy.h"
+#include "ExceptionData.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "ServiceWorkerClientData.h"
 #include "ServiceWorkerContextData.h"
 #include "ServiceWorkerData.h"
 #include "ServiceWorkerIdentifier.h"
 #include "ServiceWorkerRegistrationKey.h"
+#include "ServiceWorkerRoute.h"
 #include "ServiceWorkerTypes.h"
 #include "Site.h"
 #include "Timer.h"
@@ -52,6 +54,7 @@ class SWServerToContextConnection;
 struct ServiceWorkerClientQueryOptions;
 struct ServiceWorkerContextData;
 struct ServiceWorkerJobDataIdentifier;
+struct ServiceWorkerRoute;
 enum class WorkerThreadMode : bool;
 enum class WorkerType : bool;
 
@@ -126,7 +129,7 @@ public:
     WEBCORE_EXPORT SWServerToContextConnection* contextConnection();
     String userAgent() const;
 
-    bool shouldSkipFetchEvent() const { return m_shouldSkipHandleFetch; }
+    WEBCORE_EXPORT RouterSource getRouterSource(const FetchOptions&, const ResourceRequest&) const;
     
     WEBCORE_EXPORT SWServerRegistration* registration() const;
 
@@ -153,6 +156,8 @@ public:
 
     void needsRunning() { m_lastNeedRunningTime = ApproximateTime::now(); }
     bool isIdle(Seconds) const;
+
+    std::optional<ExceptionData> addRoutes(Vector<ServiceWorkerRoute>&&);
 
 private:
     SWServerWorker(SWServer&, SWServerRegistration&, const URL&, const ScriptBuffer&, const CertificateInfo&, const ContentSecurityPolicyResponseHeaders&, const CrossOriginEmbedderPolicy&, String&& referrerPolicy, WorkerType, ServiceWorkerIdentifier, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&&);
@@ -195,6 +200,7 @@ private:
     bool m_isInspected { false };
     bool m_isActivateEventFired { false };
     ApproximateTime m_lastNeedRunningTime;
+    Vector<ServiceWorkerRoute> m_routes;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -60,6 +60,7 @@ struct ClientOrigin;
 struct ExceptionData;
 struct MessageWithMessagePorts;
 struct ServiceWorkerClientData;
+struct ServiceWorkerRoute;
 }
 
 namespace WebKit {
@@ -167,6 +168,7 @@ private:
     void removeCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, Vector<WebCore::CookieChangeSubscription>&&, ExceptionOrVoidCallback&&);
     using ExceptionOrCookieChangeSubscriptionsCallback = CompletionHandler<void(Expected<Vector<WebCore::CookieChangeSubscription>, WebCore::ExceptionData>&&)>;
     void cookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier, ExceptionOrCookieChangeSubscriptionsCallback&&);
+    void addRoutes(WebCore::ServiceWorkerRegistrationIdentifier, Vector<WebCore::ServiceWorkerRoute>&&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&);
 
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -73,6 +73,8 @@ messages -> WebSWServerConnection {
     [EnabledBy=CookieStoreManagerEnabled] RemoveCookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier identifier, Vector<WebCore::CookieChangeSubscription> subscriptions) -> (std::optional<WebCore::ExceptionData> result)
     [EnabledBy=CookieStoreManagerEnabled] CookieChangeSubscriptions(WebCore::ServiceWorkerRegistrationIdentifier identifier) -> (Expected<Vector<WebCore::CookieChangeSubscription>, WebCore::ExceptionData> result)
 
+    AddRoutes(WebCore::ServiceWorkerRegistrationIdentifier identifier, Vector<WebCore::ServiceWorkerRoute> subscriptions) -> (Expected<void, WebCore::ExceptionData> result)
+
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     GetNotifications(URL registrationURL, String tag) -> (Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData> result)
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5538,6 +5538,48 @@ struct WebCore::ServiceWorkerJobData {
     [Validator='( type == WebCore::ServiceWorkerJobType::Register && registrationOptions->has_value()) || (type != WebCore::ServiceWorkerJobType::Register && !registrationOptions->has_value() )'] std::optional<WebCore::ServiceWorkerRegistrationOptions> registrationOptions;
 };
 
+struct WebCore::RouterSourceDict {
+    String cacheName;
+}
+
+enum class WebCore::RouterSourceEnum : uint8_t {
+    Cache,
+    FetchEvent,
+    Network
+};
+
+enum class WebCore::RunningStatus : bool
+
+header: <WebCore/ServiceWorkerRoute.h>
+[CustomHeader] struct WebCore::ServiceWorkerRoutePattern {
+    String protocol;
+    String username;
+    String password;
+    String hostname;
+    String port;
+    String pathname;
+    String search;
+    String hash;
+}
+
+header: <WebCore/ServiceWorkerRoute.h>
+[CustomHeader] struct WebCore::ServiceWorkerRouteCondition {
+    std::optional<WebCore::ServiceWorkerRoutePattern> urlPattern;
+    String requestMethod;
+    std::optional<WebCore::FetchRequestMode> requestMode;
+    std::optional<WebCore::FetchRequestDestination> requestDestination;
+    std::optional<WebCore::RunningStatus> runningStatus;
+
+    Vector<WebCore::ServiceWorkerRouteCondition> orConditions;
+    std::unique_ptr<WebCore::ServiceWorkerRouteCondition> notCondition;
+
+};
+
+struct WebCore::ServiceWorkerRoute {
+    WebCore::ServiceWorkerRouteCondition condition;
+    std::variant<WebCore::RouterSourceDict, WebCore::RouterSourceEnum> source;
+};
+
 struct WebCore::EventInit {
     bool bubbles;
     bool cancelable;

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -499,8 +499,13 @@ void WebSWClientConnection::cookieChangeSubscriptions(WebCore::ServiceWorkerRegi
 
 Ref<WebSWClientConnection::AddRoutePromise> WebSWClientConnection::addRoutes(ServiceWorkerRegistrationIdentifier identifier, Vector<ServiceWorkerRoute>&& routes)
 {
-    // FIXM:Implement this.
-    return AddRoutePromise::createAndReject(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "not yet implemented"_s });
+    struct PromiseConverter {
+        static auto convertError(IPC::Error)
+        {
+            return makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::TypeError, "Internal error"_s });
+        }
+    };
+    return WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendWithPromisedReply<PromiseConverter>(Messages::WebSWServerConnection::AddRoutes { identifier, routes });
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 1027096740b02a13e6372b2d59b6c1ac7e03aa7c
<pre>
Add networking support for InstallEvent.addRoutes
<a href="https://rdar.apple.com/144085570">rdar://144085570</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286924">https://bugs.webkit.org/show_bug.cgi?id=286924</a>

Reviewed by Chris Dumez.

We store the routes in SWServerWorker and validate them.
We add checks in WebSWClientConnection to use routes in case of fetch event.
We only support fetch or networking for now, and not going to the cache storage.

We implement a better handling of maximum service worker route count check by limiting the total number of conditions.
We also fix an error in ServiceWorkerRouteCondition where port and pathname were interchanged.

Covered by added tests and rebased tests.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/service-workers/service-worker-add-routes-too-late-worker.js: Added.
(onmessage.async e):
* LayoutTests/http/wpt/service-workers/service-worker-add-routes-too-late.js: Added.
(onmessage.async e):
* LayoutTests/http/wpt/service-workers/service-worker-add-routes-worker.js: Added.
(onmessage.e.catch):
* LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/service-worker-routes.html: Added.
* LayoutTests/http/wpt/service-workers/service-worker-too-many-routes.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-mutiple-conditions.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-request-destination.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-request-method.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/static-router-subresource.https-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/workers/service/ServiceWorkerRoute.cpp:
(WebCore::computeServiceWorkerRouteConditionCount):
(WebCore::validateServiceWorkerRouteCondition):
(WebCore::validateServiceWorkerRoute):
(WebCore::matchURLPatternComponent):
(WebCore::ServiceWorkerRoutePattern::isolatedCopy):
* Source/WebCore/workers/service/ServiceWorkerRoute.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::addRoutes):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::addRoutes):
(WebCore::SWServerWorker::getRouterSource const):
* Source/WebCore/workers/service/server/SWServerWorker.h:
(WebCore::SWServerWorker::shouldSkipFetchEvent const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::addRoutes):

Canonical link: <a href="https://commits.webkit.org/291835@main">https://commits.webkit.org/291835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/575edf877c993a21b8ed2782d574dbfcee01475f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44545 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71743 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29094 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2579 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43861 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101067 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80751 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20001 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14232 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21054 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26232 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->