### PR TITLE
Invalid WTF::URLs should not convert to NSURLs

### DIFF
--- a/LayoutTests/platform/mac-wk1/fast/loader/redirect-to-invalid-url-using-meta-refresh-disallowed-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/loader/redirect-to-invalid-url-using-meta-refresh-disallowed-expected.txt
@@ -1,6 +1,6 @@
 main frame - didFinishDocumentLoadForFrame
 main frame - didHandleOnloadEventsForFrame
-main frame - willPerformClientRedirectToURL: http://A=a%25B=b
+main frame - willPerformClientRedirectToURL: (null)
 main frame - didFinishLoadForFrame
 main frame - didCancelClientRedirectForFrame
 Tests that we do not redirect to an invalid URL initiated by <meta http-equiv="refresh">. This test PASSED if you see an entry in the dumped frame load callbacks of the form: "willPerformClientRedirectToURL: http://A=a%B=b" followed by "didCancelClientRedirectForFrame".

--- a/LayoutTests/platform/mac-wk1/fast/loader/window-open-to-invalid-url-disallowed-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/loader/window-open-to-invalid-url-disallowed-expected.txt
@@ -1,5 +1,5 @@
 main frame - didFinishDocumentLoadForFrame
-main frame - willPerformClientRedirectToURL: http://A=a%25B=b
+main frame - willPerformClientRedirectToURL: (null)
 main frame - didHandleOnloadEventsForFrame
 main frame - didFinishLoadForFrame
 main frame - didCancelClientRedirectForFrame

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -29,6 +29,7 @@
 #include <CoreFoundation/CFURL.h>
 #include <wtf/URLParser.h>
 #include <wtf/cf/CFURLExtras.h>
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #include <wtf/text/CString.h>
 
 namespace WTF {
@@ -42,15 +43,6 @@ URL::URL(CFURLRef url)
         *this = URLParser(bytesAsString(url)).result();
 }
 
-#if !USE(FOUNDATION)
-
-RetainPtr<CFURLRef> URL::emptyCFURL()
-{
-    return nullptr;
-}
-
-#endif
-
 RetainPtr<CFURLRef> URL::createCFURL() const
 {
     if (isNull())
@@ -58,6 +50,9 @@ RetainPtr<CFURLRef> URL::createCFURL() const
 
     if (isEmpty())
         return emptyCFURL();
+
+    if (!isValid() && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull))
+        return nullptr;
 
     RetainPtr<CFURLRef> result;
     if (LIKELY(m_string.is8Bit() && m_string.containsOnlyASCII())) {
@@ -69,13 +64,15 @@ RetainPtr<CFURLRef> URL::createCFURL() const
         result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, utf8Span.data(), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
     }
 
-    if (protocolIsInHTTPFamily() && !isSameOrigin(result.get(), *this))
+    // This additional check is only needed for invalid URLs, for which we've already returned null with new SDKs.
+    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull)
+        && protocolIsInHTTPFamily()
+        && !isSameOrigin(result.get(), *this))
         return nullptr;
 
     return result;
 }
 
-#if !PLATFORM(WIN)
 String URL::fileSystemPath() const
 {
     auto cfURL = createCFURL();
@@ -84,6 +81,5 @@ String URL::fileSystemPath() const
 
     return adoptCF(CFURLCopyFileSystemPath(cfURL.get(), kCFURLPOSIXPathStyle)).get();
 }
-#endif
 
 }

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -308,6 +308,8 @@ NSURL *URLByRemovingUserInfo(NSURL *URL)
 
 NSData *originalURLData(NSURL *URL)
 {
+    if (!URL)
+        return nil;
     auto data = bridge_cast(bytesAsCFData(bridge_cast(URL)));
     if (auto baseURL = bridge_cast(CFURLGetBaseURL(bridge_cast(URL))))
         return originalURLData(URLWithData(data.get(), baseURL));

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -43,6 +43,7 @@ enum class SDKAlignedBehavior {
     BrowsingContextControllerSPIAccessRemoved,
     ContextMenuTriggersLinkActivationNavigationType,
     ConvertsInvalidURLsToBlank,
+    ConvertsInvalidURLsToNull,
     DataURLFragmentRemoval,
     DecidesPolicyBeforeLoadingQuickLookPreview,
     DefaultsToExcludingBackgroundsWhenPrinting,

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -346,7 +346,7 @@ void ResourceRequest::doUpdatePlatformRequest()
 void ResourceRequest::doUpdatePlatformHTTPBody()
 {
     if (isNull()) {
-        ASSERT(!m_nsRequest);
+        m_nsRequest = nil;
         return;
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -237,6 +237,8 @@ std::optional<IPC::AsyncReplyID> WebPageProxy::grantAccessToCurrentPasteboardDat
 void WebPageProxy::beginSafeBrowsingCheck(const URL& url, bool forMainFrameNavigation, WebFramePolicyListenerProxy& listener)
 {
 #if HAVE(SAFE_BROWSING)
+    if (!url.isValid())
+        return listener.didReceiveSafeBrowsingResults({ });
     SSBLookupContext *context = [SSBLookupContext sharedLookupContext];
     if (!context)
         return listener.didReceiveSafeBrowsingResults({ });

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -271,8 +271,8 @@ TEST(WTF_URLExtras, URLExtras_Space)
     // Selected ideographic space, which looks like the ASCII space, which is not allowed unescaped.
 
     // Code path similar to the one used when typing in a URL.
-    EXPECT_STREQ("http://site.com%20othersite.org", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
-    EXPECT_STREQ("http://site.com%20othersite.org", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
+    EXPECT_STREQ("", originalDataAsString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
+    EXPECT_STREQ("", userVisibleString(WTF::URLWithUserTypedString(@"http://site.com\xE3\x80\x80othersite.org", nil)));
 
     // Code paths similar to the ones used for URLs found in webpages or HTTP responses.
     EXPECT_STREQ("http://site.com\xE3\x80\x80othersite.org", originalDataAsString(literalURL("http://site.com\xE3\x80\x80othersite.org")));
@@ -300,19 +300,19 @@ TEST(WTF_URLExtras, URLExtras_ParsingError)
     EXPECT_TRUE(encodedHostName == nil);
 
     WTF::URL url2 { utf16String(u"http://\u2267\u222E\uFE63\u0661\u06F1") };
-    EXPECT_STREQ([[url2 absoluteString] UTF8String], "http://%E2%89%A7%E2%88%AE%EF%B9%A3%D9%A1%DB%B1");
+    EXPECT_NULL([url2 absoluteString]);
 
     std::array<UChar, 2> utf16 { 0xC2, 0xB6 };
     WTF::URL url3 { String(utf16) };
     EXPECT_FALSE(url3.string().is8Bit());
     EXPECT_FALSE(url3.isValid());
-    EXPECT_STREQ([[url3 absoluteString] UTF8String], "%C3%82%C2%B6");
+    EXPECT_NULL([url3 absoluteString]);
     
     std::array<LChar, 2> latin1 { 0xC2, 0xB6 };
     WTF::URL url4 { String(latin1) };
     EXPECT_FALSE(url4.isValid());
     EXPECT_TRUE(url4.string().is8Bit());
-    EXPECT_STREQ([[url4 absoluteString] UTF8String], "%C3%82%C2%B6");
+    EXPECT_NULL([url4 absoluteString]);
 
     std::array<char, 100> buffer = { };
     WTF::URL url5 { "file:///A%C3%A7%C3%A3o.html"_str };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAlternateHTMLString.mm
@@ -118,9 +118,8 @@ TEST(WKWebView, LoadAlternateHTMLStringFromProvisionalLoadErrorBackToBack)
 
         isDone = false;
         TestWebKitAPI::Util::run(&isDone);
-        // In success, we should only start 2 provisional loads: 1 for the second loadRequest, and 1 for the _loadAlternateHTMLString.
-        // The second loadRequest cancels the first one before its provisional load starts.
-        EXPECT_EQ(2, provisionalLoadCount);
+        // We should only start 1 provisional load for the _loadAlternateHTMLString.
+        EXPECT_EQ(1, provisionalLoadCount);
     }
 }
 
@@ -210,7 +209,7 @@ TEST(WebKit, LoadHTMLStringWithInvalidBaseURL)
 
     [webView loadHTMLString:@"test" baseURL:[NSURL URLWithString:@"invalid"]];
     TestWebKitAPI::Util::run(&didFinishNavigation);
-    EXPECT_WK_STREQ([webView URL].absoluteString, "invalid");
+    EXPECT_WK_STREQ([webView URL].absoluteString, "");
 
     EXPECT_FALSE(didCrash);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadInvalidURLRequest.mm
@@ -57,7 +57,7 @@ static NSURL *literalURL(const char* literal)
 {
     EXPECT_WK_STREQ(error.domain, @"WebKitErrorDomain");
     EXPECT_EQ(error.code, 101);
-    EXPECT_TRUE([error.userInfo[@"NSErrorFailingURLKey"] isEqual:literalURL(literal)]);
+    EXPECT_NULL(error.userInfo[@"NSErrorFailingURLKey"]);
 
     didFailProvisionalLoad = true;
     didFinishTest = true;
@@ -111,11 +111,7 @@ TEST(WebKit, LoadInvalidURLRequestNonASCII)
     delegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *error) {
         EXPECT_WK_STREQ(error.domain, @"WebKitErrorDomain");
         EXPECT_EQ(error.code, WebKitErrorCannotShowURL);
-#if HAVE(WK_SECURE_CODING_NSURLREQUEST)
-        EXPECT_WK_STREQ([error.userInfo[@"NSErrorFailingURLKey"] absoluteString], "http://%C3%83%C2%A2%C3%82%C2%80%C3%82%C2%80");
-#else
-        EXPECT_WK_STREQ([error.userInfo[@"NSErrorFailingURLKey"] absoluteString], "http://%C3%A2%C2%80%C2%80");
-#endif
+        EXPECT_WK_STREQ([error.userInfo[@"NSErrorFailingURLKey"] absoluteString], "");
         done = true;
     };
     auto webView = adoptNS([WKWebView new]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NavigationAction.mm
@@ -209,7 +209,7 @@ TEST(WKNavigationAction, BlobRequestBody)
         if ([action.request.URL.absoluteString isEqualToString:@"about:blank"])
             completionHandler(WKNavigationActionPolicyAllow);
         else {
-            EXPECT_WK_STREQ(action.request.URL.absoluteString, "/formAction");
+            EXPECT_WK_STREQ(action.request.URL.absoluteString, "");
             completionHandler(WKNavigationActionPolicyCancel);
             done = true;
         }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
@@ -59,7 +59,7 @@ TEST(_WKActivatedElementInfo, InfoForLink)
     [webView _requestActivatedElementAtPosition:CGPointMake(50, 50) completionBlock: ^(_WKActivatedElementInfo *elementInfo) {
 
         EXPECT_TRUE(elementInfo.type == _WKActivatedElementTypeLink);
-        EXPECT_WK_STREQ(elementInfo.URL.absoluteString, "testURL.test");
+        EXPECT_WK_STREQ(elementInfo.URL.absoluteString, "");
         EXPECT_WK_STREQ(elementInfo.title, "HitTestLinkTitle");
         EXPECT_WK_STREQ(elementInfo.ID, @"testID");
         EXPECT_NOT_NULL(elementInfo.image);


### PR DESCRIPTION
#### 2404832a74ce484dc64a981d5d2ef659db3ccbef
<pre>
Invalid WTF::URLs should not convert to NSURLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=286926">https://bugs.webkit.org/show_bug.cgi?id=286926</a>

Reviewed by John Wilander.

Creating valid NSURLs from invalid WTF::URLs has long been a source
of issues that we find more targeted fixes for.  We do this over and
over again in different places.  This will fix all of them.

A sprinkling of little fixes is needed to keep some of the failures
the same as they were before, but this also intends to change some
of the URLs accessed after putting them into WebKit when WebKit
thinks they are not valid.

To mitigate the binary compatibility effects of this change, I did
the important changes behind a linkedOnOrAfterSDKWithBehavior check.

* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL const):
(WTF::URL::fileSystemPath const):
(WTF::URL::emptyCFURL): Deleted.

Canonical link: <a href="https://commits.webkit.org/289946@main">https://commits.webkit.org/289946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64b99764c957c84cdfbf72fd27e86edf5b08949

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93451 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16196 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91495 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80046 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6202 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38355 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81292 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95293 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87269 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15668 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76383 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19193 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13834 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15684 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109762 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15425 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26392 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->