### PR TITLE
[WebGPU] beginOcclusionQuery validation is incorrect for 'queryIndex < this.[[occlusion_query_set]].count.'

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286933-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286933-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286933.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286933.html
@@ -1,0 +1,92 @@
+<!-- webkit-test-runner [ enableMetalDebugDevice=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+    try {
+        let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+// START
+promise0 = adapter0.requestDevice();
+device0 = await promise0;
+texture10 = device0.createTexture({
+  size : {width : 8001, depthOrArrayLayers : 60},
+  format : 'rg16sint',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT});
+textureView8 = texture10.createView(
+    {dimension : '2d', });
+querySet0 = device0.createQuerySet({type : 'occlusion', count : 0});
+commandEncoder47 = device0.createCommandEncoder();
+renderPassEncoder17 = commandEncoder47.beginRenderPass({
+  colorAttachments : [ {
+    view : textureView8,
+    clearValue : {
+      r : 797.1,
+      g : 641.7,
+      b : 397.6,
+      a : 543.7},
+    loadOp : 'clear',
+    storeOp : 'store'} ],
+  occlusionQuerySet : querySet0});
+try {
+  renderPassEncoder17.beginOcclusionQuery(0)} catch {
+}
+// END
+        await device0.queue.onSubmittedWorkDone();
+    } catch {}
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -202,22 +202,23 @@ void RenderPassEncoder::beginOcclusionQuery(uint32_t queryIndex)
 {
     RETURN_IF_FINISHED();
 
+    auto initialQueryIndex = queryIndex;
     queryIndex *= sizeof(uint64_t);
     if (m_occlusionQueryActive || m_queryBufferIndicesToClear.contains(queryIndex)) {
         makeInvalid(@"beginOcclusionQuery validation failure");
         return;
     }
+    if (initialQueryIndex >= m_visibilityResultBufferSize / sizeof(uint64_t)) {
+        makeInvalid(@"beginOcclusionQuery validation failure");
+        return;
+    }
+
     m_occlusionQueryActive = true;
     m_visibilityResultBufferOffset = queryIndex;
     m_queryBufferIndicesToClear.add(m_visibilityResultBufferOffset);
 
-
     if (occlusionQueryIsDestroyed())
         return;
-    if (!m_visibilityResultBufferSize || queryIndex >= m_visibilityResultBufferSize) {
-        makeInvalid(@"beginOcclusionQuery validation failure");
-        return;
-    }
 
     if (m_queryBufferUtilizedIndices.contains(queryIndex))
         return;


### PR DESCRIPTION
#### 20ad90c434666ab8d8d0f83ef0ecc9718e5cd131
<pre>
[WebGPU] beginOcclusionQuery validation is incorrect for &apos;queryIndex &lt; this.[[occlusion_query_set]].count.&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=286933#">https://bugs.webkit.org/show_bug.cgi?id=286933#</a>
<a href="https://rdar.apple.com/144077088">rdar://144077088</a>

Reviewed by Tadeu Zagallo.

Section 17.2.3 of the WebGPU specification <a href="https://www.w3.org/TR/webgpu/#render-pass-encoder-queries">https://www.w3.org/TR/webgpu/#render-pass-encoder-queries</a>
says:

    queryIndex &lt; this.[[occlusion_query_set]].count.

which was previously implemented as &apos;queryIndex * 8 &lt; bufferSize&apos;.

However, for a QuerySet with 0 elements, it has a buffer size of 1 since
Device::safeCreateBuffer is implemented as:

    [m_device newBufferWithLength:std::max&lt;NSUInteger&gt;(1, length) options:resourceOptions];

and when passing queryIndex=0 to beginOcclusionQuery, we note:

    0 * 8 &lt; 1 -&gt; true

however, as the query set has zero elements, that is incorrect. The new logic will test:
    0 &lt; 1 / 8 =&gt; 0 &lt; 0 -&gt; false

as desired.

* LayoutTests/fast/webgpu/nocrash/fuzz-286933-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-286933.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::beginOcclusionQuery):

Canonical link: <a href="https://commits.webkit.org/289856@main">https://commits.webkit.org/289856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82c0e2c2dff90a4d1be58f1371a37e1c3920e867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38915 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68032 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79740 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34155 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38023 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94963 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15335 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76888 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75596 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18735 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20525 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8362 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15353 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->