### PR TITLE
Fix most static analysis errors in Page.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1005,7 +1005,6 @@ page/NavigationTransition.cpp
 page/Navigator.cpp
 page/NavigatorLoginStatus.cpp
 page/OpportunisticTaskScheduler.cpp
-page/Page.cpp
 page/PageConsoleClient.cpp
 page/PageOverlay.cpp
 page/PageOverlayController.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -139,7 +139,6 @@ page/EventSource.cpp
 page/ImageAnalysisQueue.cpp
 page/LocalDOMWindow.cpp
 page/Navigation.cpp
-page/Page.cpp
 page/Quirks.cpp
 page/ScreenOrientation.cpp
 page/ShareDataReader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -556,7 +556,6 @@ page/Location.cpp
 page/Navigation.cpp
 page/Navigator.cpp
 page/OpportunisticTaskScheduler.cpp
-page/Page.cpp
 page/PageColorSampler.cpp
 page/PageConsoleClient.cpp
 page/PageGroup.cpp

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -715,6 +715,7 @@ public:
 
 #if ENABLE(WHEEL_EVENT_LATCHING)
     ScrollLatchingController& scrollLatchingController();
+    Ref<ScrollLatchingController> protectedScrollLatchingController();
     ScrollLatchingController* scrollLatchingControllerIfExists() { return m_scrollLatchingController.get(); }
 #endif // ENABLE(WHEEL_EVENT_LATCHING)
 
@@ -1114,11 +1115,11 @@ public:
     DeviceOrientationUpdateProvider* deviceOrientationUpdateProvider() const { return m_deviceOrientationUpdateProvider.get(); }
 #endif
 
-    WEBCORE_EXPORT void forEachDocument(const Function<void(Document&)>&) const;
+    WEBCORE_EXPORT void forEachDocument(NOESCAPE const Function<void(Document&)>&) const;
     bool findMatchingLocalDocument(const Function<bool(Document&)>&) const;
     void forEachRenderableDocument(const Function<void(Document&)>&) const;
-    void forEachMediaElement(const Function<void(HTMLMediaElement&)>&);
-    static void forEachDocumentFromMainFrame(const Frame&, const Function<void(Document&)>&);
+    void forEachMediaElement(NOESCAPE const Function<void(HTMLMediaElement&)>&);
+    static void forEachDocumentFromMainFrame(const Frame&, NOESCAPE const Function<void(Document&)>&);
     void forEachLocalFrame(const Function<void(LocalFrame&)>&);
     void forEachWindowEventLoop(const Function<void(WindowEventLoop&)>&);
 
@@ -1319,6 +1320,8 @@ private:
 
     void stopKeyboardScrollAnimation();
 
+    Ref<DocumentSyncData> protectedTopDocumentSyncData() const;
+
     enum ShouldHighlightMatches { DoNotHighlightMatches, HighlightMatches };
     enum ShouldMarkMatches { DoNotMarkMatches, MarkMatches };
 
@@ -1350,6 +1353,7 @@ private:
     RenderingUpdateScheduler* existingRenderingUpdateScheduler();
 
     WheelEventTestMonitor& ensureWheelEventTestMonitor();
+    Ref<WheelEventTestMonitor> ensureProtectedWheelEventTestMonitor();
 
 #if ENABLE(IMAGE_ANALYSIS)
     void resetTextRecognitionResults();
@@ -1370,35 +1374,35 @@ private:
     bool hasLocalMainFrame();
 
     struct Internals;
-    UniqueRef<Internals> m_internals;
+    const UniqueRef<Internals> m_internals;
 
     std::optional<PageIdentifier> m_identifier;
-    UniqueRef<Chrome> m_chrome;
-    UniqueRef<DragCaretController> m_dragCaretController;
+    const UniqueRef<Chrome> m_chrome;
+    const UniqueRef<DragCaretController> m_dragCaretController;
 
 #if ENABLE(DRAG_SUPPORT)
-    UniqueRef<DragController> m_dragController;
+    const UniqueRef<DragController> m_dragController;
 #endif
     std::unique_ptr<FocusController> m_focusController;
 #if ENABLE(CONTEXT_MENUS)
-    UniqueRef<ContextMenuController> m_contextMenuController;
+    const UniqueRef<ContextMenuController> m_contextMenuController;
 #endif
     const UniqueRef<InspectorController> m_inspectorController;
-    UniqueRef<PointerCaptureController> m_pointerCaptureController;
+    const UniqueRef<PointerCaptureController> m_pointerCaptureController;
 #if ENABLE(POINTER_LOCK)
-    UniqueRef<PointerLockController> m_pointerLockController;
+    const UniqueRef<PointerLockController> m_pointerLockController;
 #endif
-    UniqueRef<ElementTargetingController> m_elementTargetingController;
+    const UniqueRef<ElementTargetingController> m_elementTargetingController;
     RefPtr<ScrollingCoordinator> m_scrollingCoordinator;
 
     const RefPtr<Settings> m_settings;
-    UniqueRef<CryptoClient> m_cryptoClient;
-    UniqueRef<ProgressTracker> m_progress;
-    UniqueRef<ProcessSyncClient> m_processSyncClient;
+    const UniqueRef<CryptoClient> m_cryptoClient;
+    const UniqueRef<ProgressTracker> m_progress;
+    const UniqueRef<ProcessSyncClient> m_processSyncClient;
 
-    UniqueRef<BackForwardController> m_backForwardController;
+    const UniqueRef<BackForwardController> m_backForwardController;
     UncheckedKeyHashSet<WeakRef<LocalFrame>> m_rootFrames;
-    UniqueRef<EditorClient> m_editorClient;
+    const UniqueRef<EditorClient> m_editorClient;
     Ref<Frame> m_mainFrame;
     String m_mainFrameURLFragment;
 
@@ -1413,10 +1417,10 @@ private:
     RefPtr<SpeechSynthesisClient> m_speechSynthesisClient;
 #endif
 
-    UniqueRef<SpeechRecognitionProvider> m_speechRecognitionProvider;
+    const UniqueRef<SpeechRecognitionProvider> m_speechRecognitionProvider;
 
-    UniqueRef<WebRTCProvider> m_webRTCProvider;
-    Ref<RTCController> m_rtcController;
+    const UniqueRef<WebRTCProvider> m_webRTCProvider;
+    const Ref<RTCController> m_rtcController;
 
     PlatformDisplayID m_displayID { 0 };
     std::optional<FramesPerSecond> m_displayNominalFramesPerSecond;
@@ -1514,10 +1518,10 @@ private:
     std::unique_ptr<AlternativeTextClient> m_alternativeTextClient;
 
     bool m_scriptedAnimationsSuspended { false };
-    UniqueRef<PageConsoleClient> m_consoleClient;
+    const UniqueRef<PageConsoleClient> m_consoleClient;
 
 #if ENABLE(REMOTE_INSPECTOR)
-    Ref<PageDebuggable> m_inspectorDebuggable;
+    const Ref<PageDebuggable> m_inspectorDebuggable;
 #endif
 
     RefPtr<IDBClient::IDBConnectionToServer> m_idbConnectionToServer;
@@ -1529,13 +1533,13 @@ private:
     unsigned m_forbidPromptsDepth { 0 };
     unsigned m_forbidSynchronousLoadsDepth { 0 };
 
-    Ref<SocketProvider> m_socketProvider;
-    Ref<CookieJar> m_cookieJar;
+    const Ref<SocketProvider> m_socketProvider;
+    const Ref<CookieJar> m_cookieJar;
     RefPtr<ApplicationCacheStorage> m_applicationCacheStorage;
-    Ref<CacheStorageProvider> m_cacheStorageProvider;
-    Ref<DatabaseProvider> m_databaseProvider;
-    Ref<PluginInfoProvider> m_pluginInfoProvider;
-    Ref<StorageNamespaceProvider> m_storageNamespaceProvider;
+    const Ref<CacheStorageProvider> m_cacheStorageProvider;
+    const Ref<DatabaseProvider> m_databaseProvider;
+    const Ref<PluginInfoProvider> m_pluginInfoProvider;
+    const Ref<StorageNamespaceProvider> m_storageNamespaceProvider;
     Ref<UserContentProvider> m_userContentProvider;
     WeakPtr<ScreenOrientationManager> m_screenOrientationManager;
     Ref<VisitedLinkStore> m_visitedLinkStore;
@@ -1604,7 +1608,7 @@ private:
     std::unique_ptr<ScrollLatchingController> m_scrollLatchingController;
 #endif
 #if PLATFORM(MAC) && (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION))
-    UniqueRef<ServicesOverlayController> m_servicesOverlayController;
+    const UniqueRef<ServicesOverlayController> m_servicesOverlayController;
 #endif
     std::unique_ptr<ImageOverlayController> m_imageOverlayController;
 
@@ -1624,8 +1628,8 @@ private:
 #endif
 
 #if ENABLE(WEB_AUTHN)
-    UniqueRef<AuthenticatorCoordinator> m_authenticatorCoordinator;
-    UniqueRef<CredentialRequestCoordinator> m_credentialRequestCoordinator;
+    const UniqueRef<AuthenticatorCoordinator> m_authenticatorCoordinator;
+    const UniqueRef<CredentialRequestCoordinator> m_credentialRequestCoordinator;
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
@@ -1668,8 +1672,8 @@ private:
 
     std::optional<std::pair<uint16_t, uint16_t>> m_portsForUpgradingInsecureSchemeForTesting;
 
-    UniqueRef<StorageProvider> m_storageProvider;
-    UniqueRef<ModelPlayerProvider> m_modelPlayerProvider;
+    const UniqueRef<StorageProvider> m_storageProvider;
+    const UniqueRef<ModelPlayerProvider> m_modelPlayerProvider;
 
     WeakPtr<KeyboardScrollingAnimator> m_currentKeyboardScrollingAnimator;
 
@@ -1678,7 +1682,7 @@ private:
 #endif
 
     bool m_isWaitingForLoadToFinish { false };
-    Ref<OpportunisticTaskScheduler> m_opportunisticTaskScheduler;
+    const Ref<OpportunisticTaskScheduler> m_opportunisticTaskScheduler;
 
 #if ENABLE(IMAGE_ANALYSIS)
     using CachedTextRecognitionResult = std::pair<TextRecognitionResult, IntRect>;
@@ -1691,8 +1695,8 @@ private:
 
     ContentSecurityPolicyModeForExtension m_contentSecurityPolicyModeForExtension;
 
-    Ref<BadgeClient> m_badgeClient;
-    Ref<HistoryItemClient> m_historyItemClient;
+    const Ref<BadgeClient> m_badgeClient;
+    const Ref<HistoryItemClient> m_historyItemClient;
 
     HashMap<RegistrableDomain, uint64_t> m_noiseInjectionHashSalts;
 
@@ -1717,7 +1721,7 @@ private:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    UniqueRef<WritingToolsController> m_writingToolsController;
+    const UniqueRef<WritingToolsController> m_writingToolsController;
 #endif
 
     UncheckedKeyHashSet<std::pair<URL, ScriptTelemetryCategory>> m_reportedScriptsWithTelemetry;


### PR DESCRIPTION
#### 507d655beb3dd35fe68bcff7d8f718a8393594b8
<pre>
Fix most static analysis errors in Page.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286935">https://bugs.webkit.org/show_bug.cgi?id=286935</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateValidationMessages):
(WebCore::networkStateChanged):
(WebCore::Page::~Page):
(WebCore::Page::destroyRenderTrees):
(WebCore::Page::scrollingStateTreeAsText):
(WebCore::Page::synchronousScrollingReasonsAsText):
(WebCore::Page::nonFastScrollableRectsForTesting):
(WebCore::Page::touchEventRectsForEventForTesting):
(WebCore::Page::passiveTouchEventListenerRectsForTesting):
(WebCore::Page::updateProcessSyncData):
(WebCore::Page::refreshPlugins):
(WebCore::Page::takeAnyMediaCanStartListener):
(WebCore::Page::setCanStartMedia):
(WebCore::Page::findString):
(WebCore::Page::analyzeImagesForFindInPage):
(WebCore::replaceRanges):
(WebCore::Page::editableElementsInRect const):
(WebCore::Page::setDefersLoading):
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::windowScreenDidChange):
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::setVerticalScrollElasticity):
(WebCore::Page::setIsInWindowInternal):
(WebCore::Page::updateRendering):
(WebCore::Page::finalizeRenderingUpdate):
(WebCore::Page::shouldUpdateAccessibilityRegions const):
(WebCore::Page::userAgentChanged):
(WebCore::Page::setMemoryCacheClientCallsEnabled):
(WebCore::Page::mediaPlaybackExists):
(WebCore::Page::mediaPlaybackIsPaused):
(WebCore::Page::pauseAllMediaPlayback):
(WebCore::Page::suspendAllMediaPlayback):
(WebCore::Page::resumeAllMediaPlayback):
(WebCore::Page::suspendAllMediaBuffering):
(WebCore::Page::resumeAllMediaBuffering):
(WebCore::Page::stopKeyboardScrollAnimation):
(WebCore::Page::protectedTopDocumentSyncData const):
(WebCore::Page::suspendActiveDOMObjectsAndAnimations):
(WebCore::Page::resumeActiveDOMObjectsAndAnimations):
(WebCore::Page::startMonitoringWheelEvents):
(WebCore::Page::ensureProtectedWheelEventTestMonitor):
(WebCore::Page::idbConnection):
(WebCore::Page::outermostFullscreenDocument const):
(WebCore::Page::didChangeMainDocument):
(WebCore::Page::forEachDocumentFromMainFrame):
(WebCore::Page::forEachDocument const):
(WebCore::Page::forEachRenderableDocument const):
(WebCore::Page::forEachMediaElement):
(WebCore::Page::forEachLocalFrame):
(WebCore::Page::forEachWindowEventLoop):
(WebCore::Page::protectedScrollLatchingController):
(WebCore::Page::startApplePayAMSUISession):
(WebCore::Page::setMediaSessionCoordinator):
(WebCore::Page::invalidateMediaSessionCoordinator):
(WebCore::Page::serviceWorkerPage):
(WebCore::Page::forceRepaintAllFrames):
(WebCore::Page::reloadExecutionContextsForOrigin const):
(WebCore::Page::activeImmersiveXRSession const):
(WebCore::Page::setPresentingApplicationAuditToken):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/289762@main">https://commits.webkit.org/289762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35db4aeab2b9a1ae2ac1078e641db894b9293dcc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38612 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67841 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25581 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48209 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33912 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37719 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94626 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15030 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11065 "Found 2 new test failures: ipc/create-media-source-with-invalid-constraints-crash.html swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75925 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20303 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8034 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13714 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20349 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14790 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->