### PR TITLE
[iOS] [Visual Bidi Selection] Text sometimes becomes unselected after releasing selection handles

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7-expected.txt
@@ -1,0 +1,13 @@
+هذه جملة باللغة الإنجليزية: The quick brown fox jumped over the lazy dog.
+
+Verifies that the selection remains visually consistent when selecting the entire first line in the paragraph below. To manually run the test, select the text highlighted in red, from right to left
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS isVisuallyContiguous is true
+PASS selectionBounds.width is >= lineBounds.width
+PASS selectionBounds.height is >= lineBounds.height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    font-size: 18px;
+    font-family: system-ui;
+}
+
+div.overlay {
+    position: fixed;
+    background-color: tomato;
+    opacity: 0.15;
+    pointer-events: none;
+}
+
+p[dir="rtl"] {
+    max-width: 350px;
+    border: 1px solid tomato;
+    padding: 12px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection remains visually consistent when selecting the entire first line in the paragraph below. To manually run the test, select the text highlighted in red, from right to left");
+
+    lineBounds = (() => {
+        const range = document.createRange();
+        range.selectNodeContents(document.querySelector("p[dir='rtl']"));
+        const clientRects = range.getClientRects();
+        const firstRect = clientRects[0];
+        const secondRect = clientRects[1];
+        const x = Math.min(firstRect.left, secondRect.left);
+        const y = Math.min(firstRect.top, secondRect.top);
+        const maxX = Math.max(firstRect.left + firstRect.width, secondRect.left + secondRect.width);
+        const maxY = Math.max(firstRect.top + firstRect.height, secondRect.top + secondRect.height);
+        return {
+            top: Math.round(y),
+            left: Math.round(x),
+            width: Math.round(maxX - x),
+            height: Math.round(maxY - y)
+        };
+    })();
+
+    let overlay = document.querySelector("div.overlay");
+    overlay.style.top = `${lineBounds.top}px`;
+    overlay.style.left = `${lineBounds.left}px`;
+    overlay.style.width = `${lineBounds.width}px`;
+    overlay.style.height = `${lineBounds.height}px`;
+
+    await UIHelper.longPressAtPoint(lineBounds.left + lineBounds.width - 5, lineBounds.top + 5);
+    await UIHelper.waitForSelectionToAppear();
+
+    const endHandlePoint = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(endHandlePoint.x, endHandlePoint.y)
+        .move(endHandlePoint.x - lineBounds.width, endHandlePoint.y, 0.5)
+        .end()
+        .takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    isVisuallyContiguous = await UIHelper.isSelectionVisuallyContiguous();
+    selectionBounds = await UIHelper.selectionBounds();
+
+    shouldBeTrue("isVisuallyContiguous");
+    shouldBeGreaterThanOrEqual("selectionBounds.width", "lineBounds.width");
+    shouldBeGreaterThanOrEqual("selectionBounds.height", "lineBounds.height");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p dir="rtl">هذه جملة باللغة الإنجليزية: The quick brown fox jumped over the lazy dog.</p>
+    <div class="overlay"></div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1036,8 +1036,8 @@ window.UIHelper = class UIHelper {
         for (const rect of rects) {
             minTop = Math.min(minTop, rect.top);
             minLeft = Math.min(minLeft, rect.left);
-            maxTop = Math.max(maxTop, rect.left + rect.width);
-            maxLeft = Math.max(maxLeft, rect.top + rect.height);
+            maxTop = Math.max(maxTop, rect.top + rect.height);
+            maxLeft = Math.max(maxLeft, rect.left + rect.width);
         }
 
         return { left: minLeft, top: minTop, width: maxLeft - minLeft, height: maxTop - minTop };

--- a/Source/WebCore/platform/ios/SelectionGeometry.h
+++ b/Source/WebCore/platform/ios/SelectionGeometry.h
@@ -56,6 +56,7 @@ public:
     int logicalWidth() const { return m_isHorizontal ? rect().width() : rect().height(); }
     int logicalTop() const { return m_isHorizontal ? rect().y() : rect().x(); }
     int logicalHeight() const { return m_isHorizontal ? rect().height() : rect().width(); }
+    int logicalLeftExtent() const { return logicalLeft() + logicalWidth(); }
 
     TextDirection direction() const { return m_direction; }
     int minX() const { return m_minX; }


### PR DESCRIPTION
#### 14147705667fe75a38cb4cbef3b094039e26a7a8
<pre>
[iOS] [Visual Bidi Selection] Text sometimes becomes unselected after releasing selection handles
<a href="https://bugs.webkit.org/show_bug.cgi?id=286936">https://bugs.webkit.org/show_bug.cgi?id=286936</a>
<a href="https://rdar.apple.com/142407933">rdar://142407933</a>

Reviewed by Megan Gardner.

Make a couple of minor adjustments to selection geometry coalescing logic on iOS, to mitigate the
case where an RTL selection rect that&apos;s adjacent to an LTR selection rect for a fully selected LTR
text run results in a coalesced selection rect that only contains the RTL part. To illustrate this
scenario, consider the following selection rects (`▦` indicates regions covered by the selection
highlight and `S` and `E` denote the start of the RTL run and the end of the LTR run, respectively:

▦▦▦▦▦▦▦▦▦▦|▦▦▦▦▦▦▦▦▦▦|
    ltr   E   rtl    S

...when we attempt to make the selection visually contiguous, this currently results in the entire
LTR portion appearing unselected (even though it&apos;s still logically selected), since we fill in the
gap from `S` to `E`:

——————————|▦▦▦▦▦▦▦▦▦▦|
    ltr   E   rtl    S

To fix this, we adjust logic used to coalesce overlapping selection rects, such that perfectly-
adjacent selections are coalesced (even if they don&apos;t technically intersect). This results in the
following coalesced rect:

|▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦|
E   ltr       rtl    S

Note that, with this change, we need to also adjust `collectSelectionGeometriesInternal`, so that
we avoid (incorrectly) expanding the width of LTR selection rects to become adjacent to the end of
neighboring RTL selection rects, which would otherwise result in adjacent LTR and RTL text bounds
being coalesced, even if there should be a visual gap in between them.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7.html: Added.

Add a layout test to exercise the scenario above.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async selectionBounds):

Drive-by fix: the width and height are flipped in this (recently-added) helper method.

* Source/WebCore/platform/ios/SelectionGeometry.h:
(WebCore::SelectionGeometry::logicalLeftExtent const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::usesVisuallyContiguousBidiTextSelection):
(WebCore::adjustTextDirectionForCoalescedGeometries):
(WebCore::RenderObject::collectSelectionGeometriesInternal):

If the visual bidi selection setting is enabled, avoid expanding selection rect widths eagerly here,
in favor of stitching them together in `collectSelectionGeometries`, if the endpoints are adjacent.
See above for mor edetails.

(WebCore::canCoalesceGeometries):
(WebCore::RenderObject::collectSelectionGeometries):

Canonical link: <a href="https://commits.webkit.org/289751@main">https://commits.webkit.org/289751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee71c6e713aca87f3d8731c917839565e15e1100

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5734 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15040 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15295 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75364 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/75931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18673 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20310 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15058 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14800 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->