### PR TITLE
Deploy more smart pointers in NavigationState.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -206,7 +206,6 @@ UIProcess/Cocoa/AutomationClient.mm
 UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
 UIProcess/Cocoa/LegacyDownloadClient.mm
 UIProcess/Cocoa/ModelElementControllerCocoa.mm
-UIProcess/Cocoa/NavigationState.mm
 UIProcess/Cocoa/PreferenceObserver.mm
 UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
 UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -312,6 +312,11 @@ WebsitePolicies& PageConfiguration::defaultWebsitePolicies() const
     return m_data.defaultWebsitePolicies.get();
 }
 
+Ref<WebsitePolicies> PageConfiguration::protectedDefaultWebsitePolicies() const
+{
+    return defaultWebsitePolicies();
+}
+
 void PageConfiguration::setDefaultWebsitePolicies(RefPtr<WebsitePolicies>&& policies)
 {
     m_data.defaultWebsitePolicies = WTFMove(policies);

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -171,6 +171,7 @@ public:
     void setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&&);
 
     WebsitePolicies& defaultWebsitePolicies() const;
+    Ref<WebsitePolicies> protectedDefaultWebsitePolicies() const;
     void setDefaultWebsitePolicies(RefPtr<WebsitePolicies>&&);
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -105,6 +105,8 @@ private:
         ~NavigationClient();
 
     private:
+        RefPtr<NavigationState> protectedNavigationState() const { return m_navigationState.get(); }
+
         void didStartProvisionalNavigation(WebPageProxy&, const WebCore::ResourceRequest&, API::Navigation*, API::Object*) override;
         void didStartProvisionalLoadForFrame(WebPageProxy&, WebCore::ResourceRequest&&, FrameInfoData&&) override;
         void didReceiveServerRedirectForProvisionalNavigation(WebPageProxy&, API::Navigation*, API::Object*) override;


### PR DESCRIPTION
#### 701a1c40afe5c50bcee00d61584b74db670f3133
<pre>
Deploy more smart pointers in NavigationState.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=286945">https://bugs.webkit.org/show_bug.cgi?id=286945</a>

Reviewed by Geoffrey Garen.

Deployed more smart pointers as suggested by the safer C++ static analyzer warnings.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::protectedDefaultWebsitePolicies const):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationState):
(WebKit::NavigationState::~NavigationState):
(WebKit::NavigationState::NavigationClient::didChangeBackForwardList):
(WebKit::NavigationState::NavigationClient::willGoToBackForwardListItem):
(WebKit::trySOAuthorization):
(WebKit::tryInterceptNavigation):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
(WebKit::NavigationState::NavigationClient::didStartProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didStartProvisionalLoadForFrame):
(WebKit::NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::willPerformClientRedirect):
(WebKit::NavigationState::NavigationClient::didPerformClientRedirect):
(WebKit::NavigationState::NavigationClient::didCancelClientRedirect):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailProvisionalLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didCommitNavigation):
(WebKit::NavigationState::NavigationClient::didCommitLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFinishDocumentLoad):
(WebKit::NavigationState::NavigationClient::didFinishNavigation):
(WebKit::NavigationState::NavigationClient::didFinishLoadForFrame):
(WebKit::NavigationState::NavigationClient::didBlockLoadToKnownTracker):
(WebKit::NavigationState::NavigationClient::didApplyLinkDecorationFiltering):
(WebKit::NavigationState::NavigationClient::didPromptForStorageAccess):
(WebKit::NavigationState::NavigationClient::didFailNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didSameDocumentNavigation):
(WebKit::NavigationState::NavigationClient::renderingProgressDidChange):
(WebKit::NavigationState::NavigationClient::didReceiveAuthenticationChallenge):
(WebKit::NavigationState::NavigationClient::shouldAllowLegacyTLS):
(WebKit::NavigationState::NavigationClient::didNegotiateModernTLS):
(WebKit::NavigationState::NavigationClient::processDidTerminate):
(WebKit::NavigationState::NavigationClient::processDidBecomeResponsive):
(WebKit::NavigationState::NavigationClient::processDidBecomeUnresponsive):
(WebKit::NavigationState::NavigationClient::legacyWebCryptoMasterKey):
(WebKit::NavigationState::NavigationClient::navigationActionDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::navigationResponseDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::contextMenuDidCreateDownload):
(WebKit::NavigationState::NavigationClient::didStartLoadForQuickLookDocumentInMainFrame):
(WebKit::NavigationState::NavigationClient::didFinishLoadForQuickLookDocumentInMainFrame):
(WebKit::NavigationState::NavigationClient::decidePolicyForSOAuthorizationLoad):
(WebKit::NavigationState::HistoryClient::didNavigateWithNavigationData):
(WebKit::NavigationState::HistoryClient::didPerformClientRedirect):
(WebKit::NavigationState::HistoryClient::didPerformServerRedirect):
(WebKit::NavigationState::HistoryClient::didUpdateHistoryTitle):

Canonical link: <a href="https://commits.webkit.org/289766@main">https://commits.webkit.org/289766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da0ca1422aae6374d927a354373d1fe6e16cc499

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38653 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67860 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25600 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48228 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5756 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37760 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94668 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76711 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75949 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8075 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13716 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15089 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20390 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14831 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->