### PR TITLE
[WebGPU] MTLCounterTimestamps are not always retained for the lifetime of the MTLCommandBuffer

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286956-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286956-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286956.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286956.html
@@ -1,0 +1,13666 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'timestamp-query',
+  ],
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let computePassEncoder0 = commandEncoder0.beginComputePass({});
+let sampler0 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 69.31,
+  compare: 'never',
+  maxAnisotropy: 4,
+});
+try {
+sampler0.label = '\ua98e\u0bdf\u0664\ua608\u4a3b\ua1fa\u4c04';
+} catch {}
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({label: '\u0555\u{1fef4}\ub3da\u3450\u00db\u0484\u0f95\u081a\u9125', colorFormats: ['r32sint']});
+let sampler1 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 98.07,
+});
+await gc();
+let texture0 = device0.createTexture({size: [51, 1, 13], dimension: '3d', format: 'r32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler2 = device0.createSampler({addressModeV: 'repeat', lodMinClamp: 67.44, lodMaxClamp: 81.29, compare: 'equal', maxAnisotropy: 1});
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte170m', transfer: 'gamma22curve'} });
+let buffer0 = device0.createBuffer({
+  size: 10882,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderBundleEncoder0.setVertexBuffer(2, buffer0, 0, 293);
+} catch {}
+let buffer1 = device0.createBuffer({size: 590, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture1 = device0.createTexture({
+  size: {width: 51, height: 1, depthOrArrayLayers: 61},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderBundleEncoder0.setVertexBuffer(2, buffer0, 0);
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+device0.label = '\u{1ff07}\ubc8d\ub51b\u4da8\u0645\u{1faec}';
+} catch {}
+try {
+renderBundleEncoder0.setIndexBuffer(buffer0, 'uint32', 6_368, 1_711);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(3, buffer0, 204, 3_319);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 708, new BigUint64Array(6608), 2792, 108);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer2 = device0.createBuffer({size: 5719, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+let textureView0 = texture0.createView({label: '\u02b8\udbf8\ufcf9\uc762\uaa46\uca56\u9a94\uca25\u082c'});
+await gc();
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 19, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 44, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 131, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder1 = device0.createCommandEncoder({});
+let texture2 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView1 = texture2.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder1 = commandEncoder1.beginComputePass({});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 19, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 44, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 131, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let commandEncoder2 = device0.createCommandEncoder();
+let computePassEncoder2 = commandEncoder2.beginComputePass();
+let renderBundle0 = renderBundleEncoder0.finish({});
+let sampler3 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.08,
+  maxAnisotropy: 3,
+});
+try {
+device0.queue.writeBuffer(buffer2, 628, new BigUint64Array(6137), 770, 316);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let commandEncoder3 = device0.createCommandEncoder({});
+try {
+commandEncoder3.insertDebugMarker('\u{1ffd1}');
+} catch {}
+let sampler4 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 88.02});
+let texture3 = device0.createTexture({
+  size: {width: 25},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder3 = commandEncoder3.beginComputePass({});
+let sampler5 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 7,
+});
+try {
+  await promise1;
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0, veryExplicitBindGroupLayout1]});
+let sampler6 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 61.26});
+let texture4 = device0.createTexture({
+  size: [8],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler7 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', lodMaxClamp: 69.62});
+let promise2 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 19, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 44, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 131, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3472 */
+  offset: 3472,
+  bytesPerRow: 15872,
+  buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  size: [51],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder4 = commandEncoder4.beginComputePass({});
+let sampler8 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 99.99});
+let buffer3 = device0.createBuffer({size: 5272, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let textureView2 = texture0.createView({label: '\u0c80\u{1fbe7}\u1324\u4415\u6986'});
+let computePassEncoder5 = commandEncoder5.beginComputePass({});
+try {
+buffer2.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let commandEncoder6 = device0.createCommandEncoder({});
+try {
+commandEncoder6.pushDebugGroup('\u0101');
+} catch {}
+try {
+commandEncoder6.insertDebugMarker('\u{1fbec}');
+} catch {}
+let texture6 = device0.createTexture({
+  size: {width: 51},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+commandEncoder6.copyBufferToBuffer(buffer1, 76, buffer0, 2316, 8);
+} catch {}
+try {
+commandEncoder6.popDebugGroup();
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({});
+let computePassEncoder6 = commandEncoder6.beginComputePass({});
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 364 */
+  offset: 364,
+  rowsPerImage: 348,
+  buffer: buffer3,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 1509});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'film', transfer: 'unspecified'} });
+try {
+globalThis.someLabel = commandEncoder6.label;
+} catch {}
+let buffer4 = device0.createBuffer({
+  size: 3118,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let querySet1 = device0.createQuerySet({type: 'timestamp', count: 314});
+let textureView3 = texture2.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder7 = commandEncoder8.beginComputePass({});
+let buffer5 = device0.createBuffer({
+  size: 11807,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7744 */
+  offset: 7744,
+  buffer: buffer5,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(300).fill(222), /* required buffer size: 300 */
+{offset: 300}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer1, 4, buffer0, 1520, 0);
+} catch {}
+let buffer6 = device0.createBuffer({size: 14013, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder10 = device0.createCommandEncoder({});
+let texture7 = device0.createTexture({
+  size: {width: 25, height: 1, depthOrArrayLayers: 44},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder8 = commandEncoder9.beginComputePass({});
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 0 */
+  offset: 0,
+  bytesPerRow: 5120,
+  buffer: buffer0,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet1, 220, 0, buffer0, 1024);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({
+  size: [700, 4, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder9 = commandEncoder10.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 62}});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte432', transfer: 'linear'} });
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture9 = device0.createTexture({size: [96, 1820, 1], format: 'rgba8sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let computePassEncoder10 = commandEncoder12.beginComputePass({});
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 155, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 172 */
+  offset: 172,
+  bytesPerRow: 25088,
+  buffer: buffer5,
+}, {width: 11, height: 98, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 52, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let texture10 = device0.createTexture({
+  size: [5600, 34, 1],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint'],
+});
+let textureView4 = texture5.createView({});
+try {
+commandEncoder11.copyBufferToBuffer(buffer3, 472, buffer2, 340, 1080);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 640 */
+  offset: 640,
+  bytesPerRow: 9984,
+  buffer: buffer3,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let textureView5 = texture6.createView({});
+let texture11 = device0.createTexture({
+  size: {width: 24, height: 455, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+device0.queue.writeBuffer(buffer4, 356, new Int16Array(5674), 368, 984);
+} catch {}
+let buffer7 = device0.createBuffer({size: 5558, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder13 = device0.createCommandEncoder({});
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 276 */
+  offset: 276,
+  rowsPerImage: 259,
+  buffer: buffer3,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 160, new BigUint64Array(20559), 1030, 32);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let commandEncoder14 = device0.createCommandEncoder({});
+let computePassEncoder11 = commandEncoder7.beginComputePass({});
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3976 */
+  offset: 3976,
+  bytesPerRow: 5632,
+  buffer: buffer6,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer8 = device0.createBuffer({
+  size: 15261,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView6 = texture5.createView({dimension: '1d', mipLevelCount: 1});
+let sampler9 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', minFilter: 'nearest', mipmapFilter: 'nearest'});
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 164 */
+  offset: 164,
+  bytesPerRow: 28672,
+  buffer: buffer1,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 47, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let texture12 = device0.createTexture({
+  size: [96, 1820, 296],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder12 = commandEncoder11.beginComputePass({timestampWrites: {querySet: querySet1}});
+try {
+commandEncoder13.copyBufferToBuffer(buffer7, 3196, buffer0, 4212, 140);
+} catch {}
+let texture13 = device0.createTexture({
+  label: '\ud8e7\u{1fbe5}\u8250\u3584\uc904\u00f9',
+  size: [1400, 8, 459],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture14 = device0.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder13 = commandEncoder13.beginComputePass({timestampWrites: {querySet: querySet1}});
+try {
+buffer1.unmap();
+} catch {}
+try {
+adapter0.label = '\u6b66\u03b7\u086d\u{1f736}';
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder();
+let textureView7 = texture13.createView({});
+let texture15 = device0.createTexture({
+  size: {width: 192, height: 3640, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView8 = texture1.createView({label: '\u0352\u0c23', baseMipLevel: 0, baseArrayLayer: 16, arrayLayerCount: 1});
+let computePassEncoder14 = commandEncoder15.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 209, endOfPassWriteIndex: 38}});
+let sampler10 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 52.15});
+let textureView9 = texture12.createView({});
+let textureView10 = texture10.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder15 = commandEncoder14.beginComputePass({});
+let texture16 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 722},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView11 = texture0.createView({format: 'r32sint', arrayLayerCount: 1});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView12 = texture1.createView({baseArrayLayer: 12, arrayLayerCount: 8});
+let sampler11 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 32.07,
+  maxAnisotropy: 5,
+});
+try {
+device0.queue.writeBuffer(buffer4, 64, new Int16Array(7351), 592, 244);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView13 = texture6.createView({});
+try {
+commandEncoder16.copyBufferToBuffer(buffer8, 560, buffer4, 256, 120);
+} catch {}
+await gc();
+let commandEncoder17 = device0.createCommandEncoder({});
+let texture17 = device0.createTexture({
+  size: {width: 102, height: 1, depthOrArrayLayers: 18},
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView14 = texture11.createView({dimension: '2d-array'});
+let sampler12 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat'});
+let buffer9 = device0.createBuffer({size: 6642, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture18 = device0.createTexture({
+  size: [192, 3640, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder17.copyBufferToBuffer(buffer3, 720, buffer4, 360, 608);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 3320, new Float32Array(5402), 48, 200);
+} catch {}
+await gc();
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  label: '\u{1f8b0}\u0d7f\uecdc\uf3e6\u2e60\u0d45\u0809\u23c4',
+  size: {width: 1400, height: 8, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder16 = commandEncoder18.beginComputePass();
+let renderPassEncoder0 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -821.9, g: 477.5, b: 977.4, a: 956.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+let buffer10 = device0.createBuffer({
+  size: 10748,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture20 = device0.createTexture({
+  size: [8, 8, 12],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder17 = commandEncoder16.beginComputePass({});
+try {
+adapter0.label = '\ue5c9\u8bd4\u6ffb\u020c\u9ca8\u07c5\ude87\ub3b1\u8ee7';
+} catch {}
+let buffer11 = device0.createBuffer({
+  size: 18211,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder19 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({size: [192, 3640, 1], mipLevelCount: 2, format: 'rgba8sint', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint16', 766, 1_754);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer10, 688);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer2, 984, 1464);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 3168, new Float32Array(4809), 1123, 32);
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder();
+let textureView15 = texture3.createView({});
+let computePassEncoder18 = commandEncoder19.beginComputePass({});
+try {
+renderPassEncoder0.setIndexBuffer(buffer11, 'uint32', 3_284, 19);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer5, 592, 2244);
+} catch {}
+let texture22 = device0.createTexture({
+  size: {width: 51, height: 1, depthOrArrayLayers: 186},
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 352 */
+  offset: 352,
+  bytesPerRow: 768,
+  buffer: buffer8,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 256, new BigUint64Array(2556), 128, 20);
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+let computePassEncoder19 = commandEncoder20.beginComputePass({});
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint16', 3_046, 4_545);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let textureView16 = texture10.createView({mipLevelCount: 1});
+let computePassEncoder20 = commandEncoder21.beginComputePass({label: '\u6140\u0747\u646a\u{1fb57}'});
+let commandEncoder22 = device0.createCommandEncoder({});
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1996 */
+  offset: 1996,
+  buffer: buffer10,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder23 = device0.createCommandEncoder();
+let sampler13 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'not-equal',
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer10, 0);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let textureView17 = texture17.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+let renderPassEncoder1 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: -979.0, g: -681.3, b: 174.6, a: -194.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1340 */
+  offset: 1340,
+  rowsPerImage: 303,
+  buffer: buffer7,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler14 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 61.20, compare: 'less-equal'});
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer10, 0, 714);
+} catch {}
+let buffer12 = device0.createBuffer({
+  size: 1248,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder21 = commandEncoder24.beginComputePass({});
+let sampler15 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 78.08,
+  compare: 'not-equal',
+});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame2});
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 26, hasDynamicOffset: false },
+    },
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 322,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 356,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder25 = device0.createCommandEncoder();
+let texture23 = device0.createTexture({
+  size: [1400, 8, 1],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture24 = device0.createTexture({
+  size: [5600, 34, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder22 = commandEncoder25.beginComputePass({});
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5236 */
+  offset: 5236,
+  buffer: buffer11,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 344, new DataView(new ArrayBuffer(1826)), 789, 336);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({});
+let computePassEncoder23 = commandEncoder22.beginComputePass({});
+let sampler16 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMinClamp: 7.595});
+try {
+renderPassEncoder1.setIndexBuffer(buffer5, 'uint32', 2_660, 3_499);
+} catch {}
+try {
+commandEncoder26.clearBuffer(buffer12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 3, y: 1086, z: 0},
+  aspect: 'all',
+}, new Uint8Array(28).fill(173), /* required buffer size: 28 */
+{offset: 28, bytesPerRow: 78}, {width: 18, height: 933, depthOrArrayLayers: 0});
+} catch {}
+let buffer13 = device0.createBuffer({
+  size: 26361,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture25 = device0.createTexture({size: [12], dimension: '1d', format: 'rgba8sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let computePassEncoder24 = commandEncoder26.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 117}});
+try {
+renderPassEncoder1.setViewport(496.1939486924673, 18.404412277502313, 3679.5822441318364, 8.164237808870901, 0.8823043472908201, 0.9082167255748383);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer11, 'uint32', 4_520, 693);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1644, new Float32Array(12233), 547, 60);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer7, 0, 691);
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'unspecified', transfer: 'bt2020_12bit'} });
+let commandEncoder27 = device0.createCommandEncoder({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, undefined);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 19, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 44, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 131, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView18 = texture18.createView({dimension: '2d-array'});
+let renderPassEncoder2 = commandEncoder28.beginRenderPass({colorAttachments: [{view: textureView16, loadOp: 'load', storeOp: 'store'}], maxDrawCount: 12527436});
+let promise4 = device0.queue.onSubmittedWorkDone();
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+renderPassEncoder1.setBlendConstant({ r: 936.6, g: 213.3, b: -234.3, a: 839.1, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(177, 2, 2687, 0);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2368 */
+  offset: 2368,
+  buffer: buffer0,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({label: '\u{1fe76}\ub5e7'});
+let texture26 = device0.createTexture({size: [2800], dimension: '1d', format: 'rgba8sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let sampler17 = device0.createSampler({addressModeW: 'repeat', compare: 'not-equal'});
+try {
+renderPassEncoder2.setIndexBuffer(buffer11, 'uint32', 6_020, 64);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 164 */
+  offset: 164,
+  bytesPerRow: 12544,
+  buffer: buffer6,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 24, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 44, resource: externalTexture0},
+    {binding: 131, resource: externalTexture0},
+    {binding: 19, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer4, offset: 0, size: 852}},
+    {binding: 59, resource: externalTexture0},
+  ],
+});
+let texture27 = device0.createTexture({
+  size: [24, 455, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], stencilReadOnly: true});
+let sampler18 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 98.38});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer0, 2_976, 564);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u6fb5');
+} catch {}
+let buffer14 = device0.createBuffer({
+  size: 1482,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder30 = device0.createCommandEncoder({});
+let renderPassEncoder3 = commandEncoder27.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: -77.20, g: -933.9, b: 303.5, a: -782.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 344916775,
+});
+let sampler19 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.53,
+  maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder3.setVertexBuffer(0, buffer12);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer7);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(3, buffer13, 7_128);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 19, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer14, offset: 0, size: 732}},
+    {binding: 44, resource: externalTexture0},
+    {binding: 131, resource: externalTexture0},
+    {binding: 59, resource: externalTexture0},
+  ],
+});
+let computePassEncoder25 = commandEncoder29.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 98}});
+let sampler20 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 99.31});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup1, new Uint32Array(865), 65, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer14);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 688, 6_083);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder28.finish();
+let texture28 = device0.createTexture({
+  size: {width: 5600, height: 34, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder4 = commandEncoder30.beginRenderPass({
+  colorAttachments: [{
+  view: textureView10,
+  clearValue: { r: 343.7, g: -581.3, b: 440.4, a: 396.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint16', 6_726, 743);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer10, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup1, new Uint32Array(3582), 179, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3228 */
+  offset: 3228,
+  bytesPerRow: 32256,
+  buffer: buffer6,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 1, y: 201, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 31, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 26, y: 220, z: 174},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'bt2020_12bit'} });
+let computePassEncoder26 = commandEncoder31.beginComputePass();
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 315});
+let sampler21 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.26,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(2670), 18, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer14, 'uint32', 352, 252);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 52, resource: externalTexture0},
+    {binding: 110, resource: {buffer: buffer5, offset: 1792, size: 4948}},
+    {binding: 141, resource: {buffer: buffer14, offset: 512, size: 64}},
+  ],
+});
+let buffer15 = device0.createBuffer({size: 15288, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture29 = device0.createTexture({
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup2, [512]);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup2, new Uint32Array(2720), 917, 1);
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 472 */
+  offset: 472,
+  bytesPerRow: 53248,
+  buffer: buffer7,
+}, {
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 2, y: 53, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 340, new DataView(new ArrayBuffer(518)), 205, 12);
+} catch {}
+let img0 = await imageWithData(2, 6, '#10101010', '#20202020');
+let texture30 = device0.createTexture({
+  size: {width: 5600, height: 34, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler22 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 57.57});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup1, new Uint32Array(586), 176, 0);
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(126);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint16', 2_642, 1_142);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer13, 0, 6_793);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup0, new Uint32Array(4765), 49, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 2_688, 954);
+} catch {}
+try {
+commandEncoder29.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2296 widthInBlocks: 574 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1148 */
+  offset: 1148,
+  bytesPerRow: 11776,
+  buffer: buffer13,
+}, {width: 574, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer16 = device0.createBuffer({size: 4988, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder33 = device0.createCommandEncoder({});
+let textureView19 = texture18.createView({dimension: '2d-array'});
+let texture31 = device0.createTexture({
+  size: [5600, 34, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder27 = commandEncoder33.beginComputePass({timestampWrites: {querySet: querySet1}});
+try {
+renderPassEncoder1.setBlendConstant({ r: 679.7, g: -607.8, b: -248.9, a: 664.7, });
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer7, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(0, buffer10, 2_528, 426);
+} catch {}
+try {
+commandEncoder32.clearBuffer(buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(14).fill(205), /* required buffer size: 14 */
+{offset: 14, bytesPerRow: 55}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'unspecified'} });
+try {
+adapter0.label = '\ub684\udd25\ud592\u1bcc\u1641\uae7f\u12d8\u0f84';
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({label: '\u9eb6\u{1f958}\u{1ff28}\u{1f8c9}\u{1ff52}\u0af8\u{1ff35}\u0897\u012e\u3b3e'});
+let texture32 = device0.createTexture({size: [1400, 8, 1], mipLevelCount: 1, format: 'rgba8sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView20 = texture0.createView({baseArrayLayer: 0});
+let computePassEncoder28 = commandEncoder34.beginComputePass({});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup0, new Uint32Array(272), 36, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 2068, new Int16Array(13907), 6195, 220);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 729, z: 19},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder5 = commandEncoder29.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: -51.26, g: 658.7, b: -283.8, a: 262.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(818), 28, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup2, new Uint32Array(1657), 80, 1);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer13);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 22},
+  aspect: 'all',
+}, new Uint8Array(225).fill(131), /* required buffer size: 225 */
+{offset: 225, bytesPerRow: 0, rowsPerImage: 18}, {width: 0, height: 0, depthOrArrayLayers: 39});
+} catch {}
+try {
+computePassEncoder13.setBindGroup(0, bindGroup0, new Uint32Array(267), 13, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(69);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer13);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3772 */
+  offset: 3772,
+  buffer: buffer11,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 19, resource: externalTexture0},
+    {binding: 59, resource: externalTexture0},
+    {binding: 44, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer10, offset: 256}},
+    {binding: 131, resource: externalTexture0},
+  ],
+});
+let computePassEncoder29 = commandEncoder32.beginComputePass({});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup2, new Uint32Array(2100), 87, 1);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer13, 0, 168);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup0, new Uint32Array(5741), 350, 0);
+} catch {}
+let imageData0 = new ImageData(64, 28);
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 52, resource: {buffer: buffer8, offset: 1024, size: 420}},
+    {binding: 3, resource: {buffer: buffer0, offset: 1024, size: 2288}},
+    {binding: 322, resource: {buffer: buffer0, offset: 256, size: 1096}},
+    {binding: 356, resource: textureView9},
+    {binding: 85, resource: textureView7},
+    {binding: 49, resource: {buffer: buffer14, offset: 512, size: 440}},
+  ],
+});
+let textureView21 = texture23.createView({dimension: '2d-array'});
+let sampler23 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', compare: 'never'});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(342, 3, 200, 3);
+} catch {}
+try {
+renderPassEncoder3.pushDebugGroup('\uef2d');
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 19, resource: externalTexture0},
+    {binding: 131, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer4, offset: 256, size: 548}},
+    {binding: 44, resource: externalTexture0},
+    {binding: 59, resource: externalTexture0},
+  ],
+});
+let texture33 = device0.createTexture({
+  size: [2800, 17, 1],
+  mipLevelCount: 3,
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer17 = device0.createBuffer({size: 667, usage: GPUBufferUsage.INDEX, mappedAtCreation: false});
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView22 = texture27.createView({});
+let computePassEncoder30 = commandEncoder35.beginComputePass({});
+let sampler24 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.41,
+});
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer14, 260);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, undefined, 832_774_062);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 1756, new Int16Array(1715), 58, 564);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 16, y: 10, z: 30},
+  aspect: 'all',
+}, new Uint8Array(426_518).fill(131), /* required buffer size: 426_518 */
+{offset: 50, bytesPerRow: 40, rowsPerImage: 173}, {width: 7, height: 109, depthOrArrayLayers: 62});
+} catch {}
+let textureView23 = texture4.createView({aspect: 'all'});
+let sampler25 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.74,
+  maxAnisotropy: 3,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder5.setIndexBuffer(buffer17, 'uint32', 196, 121);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer10, 'uint16', 2_458, 309);
+} catch {}
+let buffer18 = device0.createBuffer({
+  size: 3117,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup1, new Uint32Array(575), 60, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(1661), 63, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup2, [256]);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer17, 'uint32', 32, 131);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 85, resource: textureView7},
+    {binding: 356, resource: textureView9},
+    {binding: 3, resource: {buffer: buffer5, offset: 1024, size: 4048}},
+    {binding: 49, resource: {buffer: buffer4, offset: 0, size: 588}},
+    {binding: 52, resource: {buffer: buffer0, offset: 3072, size: 1340}},
+    {binding: 322, resource: {buffer: buffer5, offset: 768, size: 2760}},
+  ],
+});
+let renderBundle4 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup0, new Uint32Array(1465), 112, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(256), 1, 0);
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.WRITE, 3664);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let textureView24 = texture31.createView({mipLevelCount: 1});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup5, new Uint32Array(151), 16, 0);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let canvas1 = document.createElement('canvas');
+let textureView25 = texture12.createView({});
+let sampler26 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 95.73, maxAnisotropy: 1});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let imageData1 = new ImageData(108, 104);
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpte170m', transfer: 'gamma28curve'} });
+let textureView26 = texture18.createView({
+  label: '\uf273\u0948\u0b91\u0a5a\ufa10\u9eca\u05e2\u0931\u81fb\uc3c4\u03a4',
+  dimension: '2d-array',
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 961.8, g: 902.8, b: -808.3, a: 731.6, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 104, new BigUint64Array(22053), 886, 96);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 25, y: 1501, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder();
+try {
+computePassEncoder13.setBindGroup(2, bindGroup5, new Uint32Array(166), 12, 0);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 412 widthInBlocks: 103 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1160 */
+  offset: 1160,
+  rowsPerImage: 540,
+  buffer: buffer12,
+}, {width: 103, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 1008, new BigUint64Array(597), 23, 160);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let commandEncoder37 = device0.createCommandEncoder({});
+let computePassEncoder31 = commandEncoder36.beginComputePass();
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup5, new Uint32Array(54), 8, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, undefined, 248_106_079, 186_586_152);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 84, new Float32Array(145), 17, 100);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let commandEncoder38 = device0.createCommandEncoder({});
+let texture34 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture35 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder6 = commandEncoder37.beginRenderPass({colorAttachments: [{view: textureView21, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer10, 2192, buffer13, 404, 3184);
+} catch {}
+try {
+renderPassEncoder3.popDebugGroup();
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 44, resource: externalTexture0},
+    {binding: 59, resource: externalTexture1},
+    {binding: 131, resource: externalTexture0},
+    {binding: 19, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer10, offset: 3328, size: 1476}},
+  ],
+});
+let textureView27 = texture34.createView({});
+let computePassEncoder32 = commandEncoder38.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup6, new Uint32Array(2308), 866, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer12, 128, 328);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let textureView28 = texture35.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder6.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint16', 666, 1_086);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(2, buffer14);
+} catch {}
+let textureView29 = texture7.createView({arrayLayerCount: 1});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(1, bindGroup4, new Uint32Array(1353), 77, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup5);
+} catch {}
+document.body.append(canvas1);
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 85, resource: textureView7},
+    {binding: 49, resource: {buffer: buffer0, offset: 2560, size: 688}},
+    {binding: 3, resource: {buffer: buffer4, offset: 512, size: 1972}},
+    {binding: 52, resource: {buffer: buffer0, offset: 4608, size: 88}},
+    {binding: 322, resource: {buffer: buffer10, offset: 256, size: 1228}},
+    {binding: 356, resource: textureView9},
+  ],
+});
+let texture36 = device0.createTexture({
+  size: {width: 24, height: 455, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer0, 0, 3_613);
+} catch {}
+let buffer19 = device0.createBuffer({size: 1283, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture37 = device0.createTexture({
+  size: [8, 8, 12],
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder1.pushDebugGroup('\ubb86');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 284, new BigUint64Array(1020), 18, 32);
+} catch {}
+let buffer20 = device0.createBuffer({size: 21887, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView30 = texture6.createView({dimension: '1d'});
+let renderPassEncoder7 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView16,
+  clearValue: { r: -222.0, g: 69.87, b: 633.8, a: 622.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup1, new Uint32Array(2515), 55, 0);
+} catch {}
+let sampler27 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise7;
+} catch {}
+let textureView31 = texture4.createView({label: '\u6ff3\ud3a9\u{1fac0}\u7dae\u{1f637}\u1257\u{1f9bc}\u{1f844}\u{1fea0}'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup0);
+} catch {}
+let buffer21 = device0.createBuffer({size: 2655, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder40 = device0.createCommandEncoder({});
+let computePassEncoder33 = commandEncoder40.beginComputePass({});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(1736), 9, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup8, new Uint32Array(3441), 107, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 1028, z: 33},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView32 = texture13.createView({});
+let textureView33 = texture4.createView({});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+let imageData2 = new ImageData(20, 76);
+try {
+computePassEncoder5.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup7, new Uint32Array(1058), 300, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer10, 1_588, 5_167);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: canvas0,
+  origin: { x: 7, y: 32 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 6, y: 139, z: 147},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 21, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise6;
+} catch {}
+try {
+computePassEncoder11.setBindGroup(3, bindGroup6);
+} catch {}
+let textureView34 = texture21.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup5, new Uint32Array(1865), 764, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer17, 'uint16', 6, 43);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer0, 0);
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder({});
+let texture38 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 12},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle5 = renderBundleEncoder5.finish({});
+let sampler28 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 77.54});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup7, new Uint32Array(508), 68, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup8, new Uint32Array(769), 4, 0);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(1560, 1, 348, 6);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE, 8, 72);
+} catch {}
+let texture39 = device0.createTexture({
+  size: [25, 1, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView35 = texture2.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder34 = commandEncoder41.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5, new Uint32Array(4522), 281, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(67);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint32', 2_636, 350);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 19, resource: externalTexture3},
+    {binding: 59, resource: externalTexture0},
+    {binding: 44, resource: externalTexture1},
+    {binding: 47, resource: {buffer: buffer0, offset: 512, size: 680}},
+    {binding: 131, resource: externalTexture2},
+  ],
+});
+let textureView36 = texture39.createView({dimension: '2d-array'});
+let textureView37 = texture23.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+renderPassEncoder7.setBlendConstant({ r: -94.63, g: 302.5, b: -11.51, a: 995.6, });
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer19, 'uint16', 328, 290);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer7, 2_260, 115);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 30, y: 342, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 52, resource: {buffer: buffer10, offset: 768, size: 1436}},
+    {binding: 356, resource: textureView25},
+    {binding: 322, resource: {buffer: buffer5, offset: 2560, size: 1548}},
+    {binding: 85, resource: textureView7},
+    {binding: 3, resource: {buffer: buffer10, offset: 1024}},
+    {binding: 49, resource: {buffer: buffer8, offset: 512, size: 852}},
+  ],
+});
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture40 = device0.createTexture({
+  size: [25, 1, 2],
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder35 = commandEncoder42.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup7);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 47, resource: {buffer: buffer5, offset: 6144, size: 492}},
+    {binding: 19, resource: externalTexture0},
+    {binding: 59, resource: externalTexture2},
+    {binding: 44, resource: externalTexture1},
+    {binding: 131, resource: externalTexture1},
+  ],
+});
+let buffer22 = device0.createBuffer({
+  size: 15589,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder43 = device0.createCommandEncoder();
+let textureView38 = texture39.createView({dimension: '2d-array'});
+let sampler29 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 71.69});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup4, new Uint32Array(1796), 86, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup5, new Uint32Array(522), 54, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer11, 3348, buffer16, 244, 492);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\u08ee');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 24, y: 996, z: 0},
+  aspect: 'all',
+}, new Uint8Array(52).fill(254), /* required buffer size: 52 */
+{offset: 52, bytesPerRow: 223}, {width: 88, height: 104, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder36 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup7, new Uint32Array(7737), 497, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer0, 0, 1_799);
+} catch {}
+let texture41 = device0.createTexture({
+  size: {width: 5600},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView39 = texture33.createView({dimension: '2d-array', format: 'r8snorm', mipLevelCount: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 37, y: 523, z: 127},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture42 = device0.createTexture({
+  size: [25, 1, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder37 = commandEncoder29.beginComputePass();
+let sampler30 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'nearest'});
+try {
+renderPassEncoder7.setViewport(981.5180925527513, 30.04836669446285, 3567.6508630422427, 0.0782795093228465, 0.6832262337153818, 0.8131623021283898);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer13);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup12 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 19, resource: externalTexture1},
+    {binding: 44, resource: externalTexture1},
+    {binding: 131, resource: externalTexture1},
+    {binding: 47, resource: {buffer: buffer4, offset: 0, size: 1364}},
+    {binding: 59, resource: externalTexture0},
+  ],
+});
+let commandEncoder44 = device0.createCommandEncoder();
+let computePassEncoder38 = commandEncoder44.beginComputePass({});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise5;
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 52, resource: externalTexture1},
+    {binding: 110, resource: {buffer: buffer18, offset: 0, size: 740}},
+    {binding: 141, resource: {buffer: buffer18, offset: 1024, size: 188}},
+  ],
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1, veryExplicitBindGroupLayout1]});
+let commandEncoder45 = device0.createCommandEncoder({});
+let textureView40 = texture21.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder39 = commandEncoder45.beginComputePass({});
+let videoFrame7 = new VideoFrame(videoFrame4, {timestamp: 0});
+let buffer23 = device0.createBuffer({
+  size: 13619,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView41 = texture35.createView({mipLevelCount: 1});
+try {
+renderPassEncoder6.setIndexBuffer(buffer23, 'uint32', 124, 3_233);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 456, new DataView(new ArrayBuffer(2767)), 13, 108);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas1);
+await gc();
+try {
+adapter0.label = '\u{1ff5e}\u6150';
+} catch {}
+let textureView42 = texture39.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let textureView43 = texture9.createView({});
+let sampler31 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.42,
+});
+try {
+renderPassEncoder6.setIndexBuffer(buffer17, 'uint16', 556, 11);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer12, 180);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder39.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup7, new Uint32Array(3544), 542, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 240, new DataView(new ArrayBuffer(5762)), 8, 1028);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+canvas1.height = 1200;
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup13, new Uint32Array(1373), 341, 1);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(2, 0, 587, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1, veryExplicitBindGroupLayout4]});
+let sampler32 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+device0.queue.writeBuffer(buffer5, 2084, new DataView(new ArrayBuffer(19491)), 252, 104);
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 26, hasDynamicOffset: false },
+    },
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 322,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 356,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+let textureView44 = texture24.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder40 = commandEncoder46.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 249, endOfPassWriteIndex: 115}});
+let sampler33 = device0.createSampler({addressModeV: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 95.97, maxAnisotropy: 1});
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer7, 0, 562);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise8;
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder();
+let sampler34 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.30,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 916 widthInBlocks: 229 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 740 */
+  offset: 740,
+  bytesPerRow: 48640,
+  rowsPerImage: 361,
+  buffer: buffer11,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 545, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 229, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 47, resource: {buffer: buffer14, offset: 256, size: 524}},
+    {binding: 59, resource: externalTexture2},
+    {binding: 19, resource: externalTexture0},
+    {binding: 131, resource: externalTexture3},
+    {binding: 44, resource: externalTexture3},
+  ],
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let computePassEncoder41 = commandEncoder47.beginComputePass({});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(29, 6, 197, 15);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(271).fill(106), /* required buffer size: 271 */
+{offset: 271}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+await gc();
+let computePassEncoder42 = commandEncoder48.beginComputePass();
+let sampler35 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.11,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder7.setViewport(2462.0354652799606, 3.8382786319787288, 1316.8227611346247, 13.420165054392012, 0.6385560447177122, 0.6399360139856379);
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let textureView45 = texture40.createView({aspect: 'all', arrayLayerCount: 1});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup2, new Uint32Array(1076), 32, 1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 1880, new DataView(new ArrayBuffer(17759)), 5856, 344);
+} catch {}
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 52, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup15 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 41, resource: textureView42}]});
+let textureView46 = texture26.createView({});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(1, bindGroup11, new Uint32Array(2147), 191, 0);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(5, 0, 1093, 4);
+} catch {}
+let bindGroup16 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 41, resource: textureView36}]});
+let commandEncoder49 = device0.createCommandEncoder({});
+let renderPassEncoder8 = commandEncoder49.beginRenderPass({colorAttachments: [{view: textureView29, depthSlice: 23, loadOp: 'load', storeOp: 'store'}]});
+let sampler36 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'nearest', compare: 'greater-equal'});
+try {
+renderPassEncoder4.setStencilReference(171);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, undefined, 0, 729_784_924);
+} catch {}
+try {
+  await promise9;
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({entries: []});
+let commandEncoder50 = device0.createCommandEncoder();
+let texture43 = device0.createTexture({
+  size: {width: 5600, height: 34, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder9 = commandEncoder50.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: -723.1, g: 882.7, b: -746.5, a: -479.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 41, endOfPassWriteIndex: 264},
+});
+try {
+renderPassEncoder9.insertDebugMarker('\u4f64');
+} catch {}
+let textureView47 = texture10.createView({mipLevelCount: 1});
+let sampler37 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.92,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 2, y: 1441, z: 0},
+  aspect: 'all',
+}, new Uint8Array(232).fill(7), /* required buffer size: 232 */
+{offset: 232, bytesPerRow: 61}, {width: 4, height: 152, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView48 = texture34.createView({dimension: '2d-array'});
+let sampler38 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 79.41});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup12, new Uint32Array(605), 60, 0);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 439.7, g: 664.4, b: 154.3, a: 294.9, });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas1);
+let bindGroup17 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 52, resource: externalTexture0},
+    {binding: 110, resource: {buffer: buffer10, offset: 3328, size: 2144}},
+    {binding: 141, resource: {buffer: buffer18, offset: 256, size: 68}},
+  ],
+});
+let buffer24 = device0.createBuffer({
+  size: 547,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView49 = texture13.createView({});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup14, new Uint32Array(2138), 610, 0);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(3, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer24, 'uint32', 24, 124);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(65).fill(111), /* required buffer size: 65 */
+{offset: 65}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas0);
+let commandEncoder51 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer7, 336, 2_039);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 48, new Int16Array(15468), 2865, 20);
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({});
+let computePassEncoder43 = commandEncoder52.beginComputePass({});
+let renderPassEncoder10 = commandEncoder51.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  depthSlice: 2,
+  clearValue: { r: 820.9, g: -811.3, b: 950.9, a: 126.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(2, bindGroup12, new Uint32Array(3802), 70, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(90);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer16, 'uint16', 294, 135);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+document.body.append(img0);
+let bindGroup18 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 44, resource: externalTexture2},
+    {binding: 59, resource: externalTexture2},
+    {binding: 131, resource: externalTexture1},
+    {binding: 47, resource: {buffer: buffer5, offset: 1024, size: 2136}},
+    {binding: 19, resource: externalTexture3},
+  ],
+});
+let buffer25 = device0.createBuffer({
+  size: 4670,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder53 = device0.createCommandEncoder({});
+let texture44 = device0.createTexture({
+  size: {width: 700, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder11 = commandEncoder53.beginRenderPass({colorAttachments: [{view: textureView44, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup2, [256]);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup2, [0]);
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+@group(0) @binding(224) var et0: texture_external;
+
+/* zero global variables used */
+fn fn0() -> array<S0, 1> {
+  var out: array<S0, 1>;
+  out[unconst_u32(66)].f2 ^= vec2i(bitcast<i32>(pack4xU8Clamp(vec4u(unconst_u32(42), unconst_u32(193), unconst_u32(2), unconst_u32(151)))));
+  var vf0: vec2f = atanh(vec2f(unconst_f32(0.1336), unconst_f32(0.03284)));
+  out[unconst_u32(261)] = S0(vec4h(unpack4xI8(unconst_u32(146)))[3], unpack4xI8(unconst_u32(146)).ar, unpack4xI8(unconst_u32(146)).zz, vec2h(unpack4xI8(unconst_u32(146)).zy));
+  return out;
+}
+
+/* used global variables: et0 */
+@must_use 
+fn fn2(a0: array<T3, 1>) -> array<T3, 1> {
+  var out: array<T3, 1>;
+  while bool(cos(vec2f(unconst_f32(0.04130), unconst_f32(-0.1021)))[1]) {
+  var vf7: vec4h = refract(vec4h(unconst_f16(13978.2), unconst_f16(-1178.4), unconst_f16(23570.1), unconst_f16(15645.8)), vec4h(unconst_f16(25532.8), unconst_f16(12396.4), unconst_f16(292.8), unconst_f16(1915.7)), unconst_f16(782.3));
+  out[unconst_u32(93)] = T3(f32(override0));
+  vf7 = bitcast<vec4h>(select(vec2f(unconst_f32(0.1827), unconst_f32(0.09836)), vec2f(unconst_f32(0.07434), unconst_f32(0.01815)), unconst_bool(true)));
+  let vf8: vec3h = sin(vec3h(unconst_f16(474.8), unconst_f16(12707.6), unconst_f16(-4107.8)));
+  _ = override0;
+}
+  var vf9: u32 = pack4x8unorm(vec4f(unconst_f32(0.1927), unconst_f32(0.00758), unconst_f32(0.05117), unconst_f32(0.2624)));
+  let ptr2: ptr<function, u32> = &vf9;
+  let vf10: vec3i = (vec3i(unconst_i32(-77), unconst_i32(30), unconst_i32(34)) / unconst_i32(13));
+  switch i32(all((vec3h(unconst_f16(2282.6), unconst_f16(-1431.9), unconst_f16(477.7)) >= vec3h(unconst_f16(10829.5), unconst_f16(27673.7), unconst_f16(21749.2))))) { 
+  default {
+  out[0].f0 += a0[0].f0;
+  let vf11: vec4h = pow(vec4h(unconst_f16(7.441), unconst_f16(-12316.0), unconst_f16(4152.0), unconst_f16(5700.6)), vec4h(unconst_f16(187.4), unconst_f16(2542.7), unconst_f16(18354.0), unconst_f16(-9333.8)));
+  var vf12: array<T3, 1> = a0;
+  var vf13: T3 = a0[0];
+}
+  }
+  var vf14: vec2u = textureDimensions(et0);
+  return out;
+  _ = override0;
+  _ = et0;
+}
+
+struct T0 {
+  @size(16) f0: array<array<vec2h, 2>>,
+}
+
+struct T2 {
+  @size(8) f0: atomic<u32>,
+}
+
+/* zero global variables used */
+@must_use 
+fn fn5(a0: ptr<private, S1>) -> mat3x3h {
+  var out: mat3x3h;
+  var vf21: f32 = cosh(unconst_f32(0.2620));
+  var vf22: vec3f = ceil(vec3f((vec4f(unconst_f32(0.1101), unconst_f32(0.8208), unconst_f32(0.00661), unconst_f32(0.06211)) >= vec4f(unconst_f32(0.04874), unconst_f32(0.07311), unconst_f32(0.08680), unconst_f32(0.1976))).rgb));
+  out -= mat3x3h(f16((*a0).f1), f16((*a0).f1), f16((*a0).f1), f16((*a0).f1), f16((*a0).f1), f16((*a0).f1), f16((*a0).f1), f16((*a0).f1), f16((*a0).f1));
+  vf22 = bitcast<vec3f>(min(vec4u(unconst_u32(76), unconst_u32(59), unconst_u32(28), unconst_u32(400)), vec4u(unconst_u32(375), unconst_u32(19), unconst_u32(77), unconst_u32(357))).wwx);
+  return out;
+}
+
+override override0: f16;
+
+struct S1 {
+  @location(3) @interpolate(flat, either) f0: vec4i,
+  @location(14) @interpolate(flat, first) f1: f32,
+}
+
+var<workgroup> vw1: T3;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T3 {
+  @size(16) f0: f32,
+}
+
+var<workgroup> vw0: array<mat4x4f, 1>;
+
+var<workgroup> vw4: array<array<atomic<i32>, 2>, 8>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+fn fn3(a0: array<mat2x3f, 1>) -> array<mat2x4h, 1> {
+  var out: array<mat2x4h, 1>;
+  while bool(pack4xU8(vec4u((vec4i(unconst_i32(197), unconst_i32(10), unconst_i32(263), unconst_i32(178)) != bitcast<vec4i>(inverseSqrt(vec3f(unconst_f32(-0.1147), unconst_f32(0.5787), unconst_f32(0.1043))).zzzx))))) {
+  let vf15: vec4f = mix(vec4f(unconst_f32(0.03975), unconst_f32(0.1287), unconst_f32(0.2832), unconst_f32(0.1243)), vec4f(unconst_f32(0.06593), unconst_f32(0.02866), unconst_f32(0.2056), unconst_f32(0.2138)), unconst_f32(0.3966));
+  var vf16: mat2x3f = a0[0];
+  let vf17: vec4f = vf15;
+}
+  var vf18: vec4u = (vec4u(unconst_u32(105), unconst_u32(129), unconst_u32(183), unconst_u32(135)) - vec4u(unconst_u32(282), unconst_u32(708), unconst_u32(77), unconst_u32(225)));
+  out[0] -= mat2x4h(vec4h((vec2u(unconst_u32(293), unconst_u32(62)) == vec2u(unconst_u32(375), unconst_u32(79))).xyyx), vec4h((vec2u(unconst_u32(293), unconst_u32(62)) == vec2u(unconst_u32(375), unconst_u32(79))).grrg));
+  while bool(a0[unconst_u32(17)][unconst_i32(1)].y) {
+  out[unconst_u32(92)] = mat2x4h(f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]), f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]), f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]), f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]), f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]), f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]), f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]), f16(a0[unconst_u32(262)][unconst_u32(450)][unconst_u32(47)]));
+  break;
+}
+  vf18 = vec4u(inverseSqrt(vec3h(unconst_f16(3948.3), unconst_f16(10568.1), unconst_f16(14244.6))).xyxy);
+  out[0] = mat2x4h(f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))), f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))), f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))), f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))), f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))), f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))), f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))), f16(pack4xU8(vec4u((vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(true)))))));
+  var vf19: mat2x3f = a0[0];
+  return out;
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw2: array<atomic<u32>, 15>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+@must_use 
+fn fn4(a0: mat2x3f, a1: S1) -> S0 {
+  var out: S0;
+  out.f0 -= f16(tanh(vec2f(unconst_f32(0.1105), unconst_f32(0.00797))).y);
+  out.f2 = vec2i(reflect(vec3h(unconst_f16(5279.1), unconst_f16(2734.4), unconst_f16(18713.8)), vec3h(countOneBits(vec2u(unconst_u32(114), unconst_u32(19))).yxy)).zz);
+  let vf20: i32 = a1.f0[unconst_u32(24)];
+  return out;
+}
+
+struct S0 {
+  @location(9) f0: f16,
+  @location(5) @interpolate(flat, sample) f1: vec2i,
+  @location(11) @interpolate(flat, sample) f2: vec2i,
+  @location(4) @interpolate(linear) f3: vec2h,
+}
+
+struct T1 {
+  @align(16) @size(128) f0: array<array<atomic<u32>, 1>, 1>,
+  @align(64) @size(832) f1: T0,
+}
+
+/* zero global variables used */
+fn fn1(a0: ptr<storage, array<atomic<u32>>, read_write>) -> T3 {
+  var out: T3;
+  out.f0 *= f32(arrayLength(&(*a0)));
+  let ptr0: ptr<storage, atomic<u32>, read_write> = &(*a0)[unconst_u32(146)];
+  atomicStore(&(*a0)[unconst_u32(120)], unconst_u32(148));
+  out = T3(f32(atomicLoad(&(*ptr0))));
+  let ptr1: ptr<storage, atomic<u32>, read_write> = &(*a0)[unconst_u32(387)];
+  let vf1: u32 = pack4xU8(vec4u(unconst_u32(294), unconst_u32(53), unconst_u32(30), unconst_u32(351)));
+  atomicCompareExchangeWeak(&(*a0)[unconst_u32(57)], unconst_u32(235), unconst_u32(379));
+  switch i32(atomicLoad(&(*ptr0))) { 
+  default {
+  out.f0 = vec3f(sign(vec3i(unconst_i32(159), unconst_i32(146), unconst_i32(139))))[0];
+  let vf2: vec3i = sign(vec3i(unconst_i32(134), unconst_i32(59), unconst_i32(350)));
+}
+  }
+  var vf3: u32 = reverseBits(unconst_u32(335));
+  var vf4: f16 = fma(unconst_f16(6867.8), unconst_f16(16466.1), f16(vf1));
+  var vf5: vec2f = (vec2f(unconst_f32(-0.04498), unconst_f32(0.1981)) / unconst_f32(0.05735));
+  var vf6: vec2<bool> = (vec2<bool>(unconst_bool(true), unconst_bool(false)) | vec2<bool>(unconst_bool(true), unconst_bool(false)));
+  return out;
+}
+
+var<workgroup> vw3: bool;
+
+/* zero global variables used */
+@vertex
+fn vertex0(a0: S0, a1: S1, @location(2) @interpolate(flat, first) a2: vec4f, @location(1) @interpolate(linear, sample) a3: f32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  return out;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute0(@builtin(local_invocation_id) a0: vec3u) {
+  vw0[unconst_u32(325)] = mat4x4f(bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), f32(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), f32(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), f32(atomicLoad(&vw4[7][1])), f32(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])), bitcast<f32>(atomicLoad(&vw4[7][1])));
+  vw1 = T3((*&vw0)[unconst_u32(73)][unconst_i32(1)][2]);
+  _ = fn3(array<mat2x3f, 1>(mat2x3f(bitcast<vec3f>((vec3u(unconst_u32(27), unconst_u32(108), unconst_u32(130)) & vec3u(unconst_u32(292), unconst_u32(187), unconst_u32(414)))), vec3f((vec3u(unconst_u32(27), unconst_u32(108), unconst_u32(130)) & vec3u(unconst_u32(292), unconst_u32(187), unconst_u32(414)))))));
+  let ptr3: ptr<workgroup, atomic<u32>> = &vw2[14];
+  var vf23 = fn3(array<mat2x3f, 1>(mat2x3f(f32(atomicLoad(&vw4[7][unconst_u32(341)])), f32(atomicLoad(&vw4[7][unconst_u32(341)])), bitcast<f32>(atomicLoad(&vw4[7][unconst_u32(341)])), f32(atomicLoad(&vw4[7][unconst_u32(341)])), f32(atomicLoad(&vw4[7][unconst_u32(341)])), bitcast<f32>(atomicLoad(&vw4[7][unconst_u32(341)])))));
+  _ = fn3(array<mat2x3f, 1>(mat2x3f(bitcast<f32>(atomicLoad(&(*&vw2)[14])), f32(atomicLoad(&(*&vw2)[14])), bitcast<f32>(atomicLoad(&(*&vw2)[14])), bitcast<f32>(atomicLoad(&(*&vw2)[14])), bitcast<f32>(atomicLoad(&(*&vw2)[14])), f32(atomicLoad(&(*&vw2)[14])))));
+  vw1.f0 = bitcast<f32>(atomicLoad(&(*&vw4)[7][1]));
+  for (var it0=bitcast<vec3u>(min(vec3i(unconst_i32(100), unconst_i32(125), unconst_i32(75)), vec3i(unconst_i32(164), unconst_i32(127), unconst_i32(5))))[1]; it0<atomicLoad(&(*&vw2)[14]); it0++) {
+  vw1.f0 = vw0[atomicLoad(&(*&vw2)[14])][unconst_i32(1)].r;
+  var vf24: i32 = atomicLoad(&(*&vw4)[unconst_u32(231)][1]);
+  vw0[unconst_u32(148)] = mat4x4f(vec4f(sin(vec3h(unconst_f16(6123.6), unconst_f16(14604.5), unconst_f16(23848.9))).yyxx), vec4f(sin(vec3h(unconst_f16(6123.6), unconst_f16(14604.5), unconst_f16(23848.9))).yxzy), vec4f(sin(vec3h(unconst_f16(6123.6), unconst_f16(14604.5), unconst_f16(23848.9))).bggr), vec4f(sin(vec3h(unconst_f16(6123.6), unconst_f16(14604.5), unconst_f16(23848.9))).rgbb));
+  let ptr4: ptr<workgroup, atomic<i32>> = &vw4[7][unconst_u32(186)];
+  var vf25 = fn3(array<mat2x3f, 1>(mat2x3f((*&vw1).f0, (*&vw1).f0, (*&vw1).f0, (*&vw1).f0, (*&vw1).f0, (*&vw1).f0)));
+  return;
+}
+  vw0[unconst_u32(109)] -= mat4x4f((*&vw0)[unconst_u32(16)][unconst_u32(31)], (*&vw0)[unconst_u32(16)][unconst_u32(31)], (*&vw0)[unconst_u32(16)][unconst_u32(31)], (*&vw0)[unconst_u32(16)][unconst_u32(31)]);
+  atomicCompareExchangeWeak(&vw2[unconst_u32(108)], unconst_u32(206), unconst_u32(6));
+  switch atomicLoad(&vw4[unconst_u32(377)][unconst_u32(71)]) { 
+  default {
+  vw1.f0 *= vec2f((vec2h(unconst_f16(8770.3), unconst_f16(5688.5)) < vec2h(unconst_f16(24236.8), unconst_f16(-4230.0)))).r;
+  break;
+}
+  }
+  var vf26: vec4f = (*&vw0)[0][unconst_u32(288)];
+}`,
+});
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\ue137\ufc59',
+  entries: [
+    {binding: 52, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout9]});
+let commandEncoder54 = device0.createCommandEncoder({});
+let computePassEncoder44 = commandEncoder54.beginComputePass({});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], stencilReadOnly: true});
+let sampler39 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 55.09,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5, new Uint32Array(204), 31, 0);
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder({});
+let computePassEncoder45 = commandEncoder55.beginComputePass();
+try {
+computePassEncoder2.setBindGroup(0, bindGroup18, new Uint32Array(336), 51, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup13, new Uint32Array(50), 3, 1);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer19, 'uint16', 4, 275);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer0);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup2, new Uint32Array(888), 147, 1);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer23, 'uint16', 436, 2_100);
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule0, constants: {}}});
+let imageData3 = new ImageData(80, 36);
+let textureView50 = texture25.createView({});
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup11, new Uint32Array(4379), 774, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer19, 'uint16', 126, 582);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer24, 0, 215);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer17, 'uint16', 196, 108);
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let computePassEncoder46 = commandEncoder56.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 302, endOfPassWriteIndex: 225}});
+let sampler40 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 95.36,
+});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint32', 316, 6_361);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(2, buffer21, 960, 15);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(392).fill(90), /* required buffer size: 392 */
+{offset: 392, rowsPerImage: 19}, {width: 97, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+await gc();
+let recycledExplicitBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let texture45 = device0.createTexture({
+  size: {width: 102},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle6 = renderBundleEncoder6.finish({});
+let arrayBuffer0 = buffer15.getMappedRange(3664, 4);
+let promise10 = device0.queue.onSubmittedWorkDone();
+let buffer26 = device0.createBuffer({
+  size: 25077,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder57 = device0.createCommandEncoder({});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup15, new Uint32Array(3052), 672, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle0]);
+} catch {}
+try {
+computePassEncoder9.pushDebugGroup('\u0e60');
+} catch {}
+let texture46 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 142},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder47 = commandEncoder57.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 137}});
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer14, 0);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture47 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder48 = commandEncoder58.beginComputePass({});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup15, new Uint32Array(1473), 45, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer24, 212, 150);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: canvas1,
+  origin: { x: 16, y: 371 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 3, y: 20, z: 27},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 41, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+try {
+computePassEncoder48.setBindGroup(0, bindGroup12, new Uint32Array(152), 86, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(1993.288110218435, 27.55155377183065, 2003.5356197780513, 0.1806501682826565, 0.956988936058862, 0.9950911689460299);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer16, 'uint16', 1_260, 785);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer25, 216, new Int16Array(9963), 1136, 88);
+} catch {}
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup19 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: []});
+let buffer27 = device0.createBuffer({size: 2661, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture48 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder17.setBindGroup(2, bindGroup4, new Uint32Array(3412), 195, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer7, 1_316, 1_270);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer15, 988, buffer3, 524, 384);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture49 = device0.createTexture({
+  size: [12, 1, 41],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup17, new Uint32Array(2117), 40, 1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup16, new Uint32Array(3494), 257, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer0, 6_544, 54);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 808 */
+  offset: 808,
+  buffer: buffer0,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer28 = device0.createBuffer({
+  size: 20693,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder60 = device0.createCommandEncoder({label: '\ud394\u58bf'});
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer22, 0);
+} catch {}
+let arrayBuffer1 = buffer15.getMappedRange(3672, 44);
+try {
+commandEncoder60.resolveQuerySet(querySet0, 311, 261, buffer26, 5376);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 716, new DataView(new ArrayBuffer(1744)));
+} catch {}
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 95.33,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer16, 'uint32', 2_728, 528);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let commandBuffer1 = commandEncoder50.finish();
+let textureView51 = texture25.createView({baseArrayLayer: 0});
+let textureView52 = texture20.createView({dimension: '2d', mipLevelCount: 1});
+let sampler42 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 7,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(1, 1, 2); };
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(372);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer26, 'uint16', 4_526, 6_658);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer7, 484, 802);
+} catch {}
+try {
+commandEncoder60.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 120 */
+  offset: 120,
+  buffer: buffer10,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline1 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule0, constants: {}}});
+let bindGroup20 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 19, resource: externalTexture3},
+    {binding: 59, resource: externalTexture2},
+    {binding: 47, resource: {buffer: buffer26, offset: 512, size: 2360}},
+    {binding: 44, resource: externalTexture1},
+    {binding: 131, resource: externalTexture0},
+  ],
+});
+let computePassEncoder49 = commandEncoder59.beginComputePass();
+let renderPassEncoder12 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: 673.1, g: 680.0, b: -176.5, a: 727.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer24, 'uint32', 544, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer22, 0, 997);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u{1fc62}');
+} catch {}
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup15, new Uint32Array(2057), 1_065, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup7, new Uint32Array(1271), 112, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer21);
+} catch {}
+try {
+computePassEncoder9.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame4);
+let texture50 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 15},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder42.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle2, renderBundle2, renderBundle6, renderBundle6]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer29 = device0.createBuffer({
+  size: 15227,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder61 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  size: [25, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder50 = commandEncoder61.beginComputePass({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 1, stencilReadOnly: false});
+try {
+renderPassEncoder4.setBlendConstant({ r: 354.8, g: -593.3, b: 451.2, a: -639.1, });
+} catch {}
+try {
+renderPassEncoder8.setViewport(16.195234642014373, 0.3919902835332618, 3.559455022002895, 0.08936283320584842, 0.49161907901334945, 0.88835639103303);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer29, 'uint16', 436, 3_642);
+} catch {}
+let texture52 = device0.createTexture({
+  size: {width: 48},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView53 = texture45.createView({});
+try {
+computePassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup13, new Uint32Array(391), 29, 1);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer17, 'uint16', 666, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture53 = device0.createTexture({
+  size: {width: 12, height: 1, depthOrArrayLayers: 66},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup7, new Uint32Array(4467), 1, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer13, 0, 741);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup20, new Uint32Array(466), 13, 0);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer22);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 173, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(17_552).fill(71), /* required buffer size: 17_552 */
+{offset: 64, bytesPerRow: 1592, rowsPerImage: 2}, {width: 98, height: 1, depthOrArrayLayers: 6});
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+let textureView54 = texture39.createView({dimension: '2d-array', aspect: 'all'});
+try {
+renderPassEncoder10.executeBundles([renderBundle1, renderBundle3]);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 9, y: 323, z: 64},
+  aspect: 'all',
+}, new Uint8Array(1_173_959).fill(26), /* required buffer size: 1_173_959 */
+{offset: 36, bytesPerRow: 147, rowsPerImage: 575}, {width: 32, height: 511, depthOrArrayLayers: 14});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let commandEncoder62 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: {width: 1400},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder13 = commandEncoder62.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 251.8, g: 755.7, b: 993.8, a: -631.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer29, 'uint32', 72, 1_448);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer19, 'uint16', 184, 106);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer21, 0, 932);
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470bg', transfer: 'gamma22curve'} });
+let commandEncoder63 = device0.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder63.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 234}});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame7, colorSpace: 'display-p3'});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup18, new Uint32Array(119), 15, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup11, new Uint32Array(165), 32, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 14},
+  aspect: 'all',
+}, new Uint8Array(1_413).fill(89), /* required buffer size: 1_413 */
+{offset: 153, bytesPerRow: 30, rowsPerImage: 7}, {width: 2, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder({});
+let computePassEncoder52 = commandEncoder64.beginComputePass({});
+let sampler43 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer19, 'uint32', 288, 126);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer7, 0, 605);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 512, new Float32Array(5927), 616, 8);
+} catch {}
+document.body.prepend(img0);
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte432', transfer: 'pq'} });
+try {
+globalThis.someLabel = computePassEncoder28.label;
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup15, new Uint32Array(643), 12, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer29);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup17, [0]);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer26, 'uint16', 2_122, 1_288);
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 52, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder65 = device0.createCommandEncoder({});
+let texture55 = device0.createTexture({
+  size: {width: 192, height: 3640, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder14 = commandEncoder65.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: 210.0, g: 575.8, b: 239.6, a: -47.17, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 359945016,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup11, new Uint32Array(871), 182, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer22, 6_216); };
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer12, 164, 172);
+} catch {}
+let arrayBuffer2 = buffer1.getMappedRange(8, 16);
+let commandEncoder66 = device0.createCommandEncoder({});
+let texture56 = device0.createTexture({
+  size: [102, 1, 393],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture57 = device0.createTexture({
+  size: [12, 1, 57],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView55 = texture17.createView({baseArrayLayer: 10, arrayLayerCount: 2});
+let renderPassEncoder15 = commandEncoder66.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 619.6, g: -799.1, b: 297.1, a: -636.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 128027364,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(1, bindGroup15, new Uint32Array(3002), 29, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer19, 'uint32', 56, 15);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup8, new Uint32Array(7), 0, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer16, 'uint32', 4, 615);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 18, y: 115, z: 69},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture58 = device0.createTexture({
+  size: [25, 1, 122],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup13, new Uint32Array(312), 7, 1);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer28);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+canvas1.height = 61;
+let buffer30 = device0.createBuffer({
+  size: 1707,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView56 = texture58.createView({dimension: '3d'});
+let texture59 = device0.createTexture({
+  size: [102, 1, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle7 = renderBundleEncoder7.finish({});
+let sampler44 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 73.60,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(1, bindGroup18, new Uint32Array(684), 37, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(5, buffer7, 1_044, 862);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u7acb');
+} catch {}
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder();
+let textureView57 = texture1.createView({aspect: 'all', baseMipLevel: 0, baseArrayLayer: 15, arrayLayerCount: 2});
+let computePassEncoder53 = commandEncoder67.beginComputePass();
+try {
+computePassEncoder32.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(2, bindGroup6, new Uint32Array(100), 6, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer28, 'uint16', 15_004, 1_542);
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+let textureView58 = texture56.createView({format: 'rgba32float'});
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer14, 'uint32', 56, 184);
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder24.label;
+} catch {}
+let renderBundle8 = renderBundleEncoder8.finish({});
+let sampler45 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 97.16,
+  lodMaxClamp: 98.72,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup17, new Uint32Array(1547), 235, 1);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(4, buffer12, 0, 169);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 392, new Int16Array(13512), 185, 44);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let imageData4 = new ImageData(256, 60);
+let commandEncoder68 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({
+  size: [24, 455, 1],
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView59 = texture20.createView({dimension: '2d'});
+let computePassEncoder54 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup17, [256]);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer28, 6_096, 782);
+} catch {}
+try {
+  await promise11;
+} catch {}
+await gc();
+let buffer31 = device0.createBuffer({size: 9980, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], sampleCount: 1, stencilReadOnly: true});
+let renderBundle9 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup16, new Uint32Array(925), 111, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup11, new Uint32Array(27), 2, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer19, 'uint32', 40, 135);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture61 = device0.createTexture({
+  size: [51, 1, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder55 = commandEncoder69.beginComputePass({});
+let renderBundle10 = renderBundleEncoder11.finish();
+let externalTexture6 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup11, new Uint32Array(1691), 446, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer26, 'uint32', 2_508, 98);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer10, 0, 3_836);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView60 = texture5.createView({});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: true});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup15, new Uint32Array(2003), 42, 0);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup12, []);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup8, new Uint32Array(204), 21, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(3, buffer7, 0, 1_911);
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame4);
+let buffer32 = device0.createBuffer({
+  size: 6907,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder70 = device0.createCommandEncoder({});
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 84.68,
+});
+try {
+computePassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle10, renderBundle10, renderBundle10, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer5, 'uint32', 2_188, 372);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 19, y: 196, z: 98},
+  aspect: 'all',
+},
+{
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 40});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+var<workgroup> vw5: VertexOutput0;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput0 {
+  @invariant @builtin(position) f0: vec4f,
+  @location(13) f1: vec2f,
+  @location(5) f2: vec2h,
+  @location(15) @interpolate(flat, sample) f3: u32,
+}
+
+var<workgroup> vw11: array<mat4x3f, 1>;
+
+var<workgroup> vw9: array<mat4x3f, 1>;
+
+var<workgroup> vw7: array<array<atomic<u32>, 1>, 13>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw6: mat3x2h;
+
+@group(0) @binding(224) var et1: texture_external;
+
+var<workgroup> vw13: array<atomic<u32>, 1>;
+
+var<workgroup> vw8: VertexOutput0;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw12: VertexOutput0;
+
+/* used global variables: et1 */
+fn fn0(a0: ptr<function, array<array<array<VertexOutput0, 1>, 1>, 1>>, a1: array<f16, 10>) -> array<vec4f, 1> {
+  var out: array<vec4f, 1>;
+  var vf27: f16 = (*a0)[0][unconst_u32(293)][0].f2[(*a0)[0][0][0].f3];
+  let vf28: vec4f = textureLoad(et1, vec2u(unconst_u32(179), unconst_u32(141)));
+  out[unconst_u32(66)] -= vec4f((*a0)[unconst_u32(290)][unconst_u32(317)][0].f2.grgr);
+  (*a0)[unconst_u32(200)][unconst_u32(128)][unconst_u32(255)].f3 = bitcast<vec2u>((*a0)[0][unconst_u32(29)][0].f1).r;
+  let ptr5: ptr<function, array<array<VertexOutput0, 1>, 1>> = &(*a0)[unconst_u32(190)];
+  let vf29: f16 = (*a0)[unconst_u32(57)][unconst_u32(183)][unconst_u32(70)].f2[unconst_u32(33)];
+  var vf30: vec4f = (vec4f(unconst_f32(0.02067), unconst_f32(0.2849), unconst_f32(-0.2143), unconst_f32(0.1019)) / vec4f(unconst_f32(-0.00735), unconst_f32(0.3968), unconst_f32(0.06572), unconst_f32(0.03588)));
+  let ptr6: ptr<function, u32> = &(*a0)[bitcast<u32>((*a0)[unconst_u32(258)][0][unconst_u32(333)].f0[unconst_u32(107)])][0][unconst_u32(154)].f3;
+  let ptr7: ptr<function, array<VertexOutput0, 1>> = &(*a0)[0][0];
+  let ptr8: ptr<function, vec4f> = &(*a0)[0][0][unconst_u32(2)].f0;
+  return out;
+  _ = et1;
+}
+
+struct T0 {
+  @align(16) @size(144) f0: array<u32>,
+}
+
+var<workgroup> vw10: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex1(@location(3) @interpolate(flat) a0: vec4u) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = vec4f(f32((unconst_bool(true) || unconst_bool(false))));
+  let vf31: vec2f = abs(vec2f(unconst_f32(0.1334), unconst_f32(0.02505)));
+  out = vec4f( !vec2<bool>(unconst_bool(true), unconst_bool(false)).yyxx);
+  return out;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex2(@builtin(vertex_index) a0: u32, @location(6) a1: u32, @location(12) a2: f16, @location(2) @interpolate(flat, sample) a3: vec2h, @location(14) a4: vec2f, @location(13) a5: f32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  let vf32: vec3h = asin(vec3h(unconst_f16(7518.4), unconst_f16(5647.5), unconst_f16(6529.4)));
+  out.f1 = vec2f(f32(pack2x16unorm(vec2f(unconst_f32(0.03036), unconst_f32(0.09520)))));
+  var vf33: vec2h = a3;
+  let vf34: vec2f = a4;
+  out = VertexOutput0(vec4f(f32(a2)), vec2f(f32(a2)), vec2h(a2), u32(a2));
+  return out;
+}`,
+});
+let recycledExplicitBindGroupLayout3 = pipeline0.getBindGroupLayout(0);
+let bindGroup21 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: []});
+let renderPassEncoder16 = commandEncoder70.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: 877.0, g: -893.4, b: -594.5, a: 223.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer9, 264); };
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint16', 6_722, 66);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer12);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer29, 'uint32', 212, 5_939);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer13);
+} catch {}
+let texture62 = device0.createTexture({
+  size: [8],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView61 = texture16.createView({});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup17, new Uint32Array(156), 24, 1);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer10, 'uint32', 2_472, 2_890);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer32);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+computePassEncoder37.setBindGroup(2, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder13.setViewport(578.4971508374547, 3.0972436712632208, 135.34751160997905, 0.8951493556821464, 0.12160731188612672, 0.3302233986554911);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer29, 880, 1_048);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6, buffer22, 0, 383);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 10, y: 11, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder({});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup18, new Uint32Array(1630), 803, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer22, 3_060); };
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup16, new Uint32Array(945), 207, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint16', 18, 324);
+} catch {}
+let promise12 = shaderModule0.getCompilationInfo();
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout1]});
+let commandEncoder72 = device0.createCommandEncoder({});
+let computePassEncoder56 = commandEncoder71.beginComputePass({});
+let renderPassEncoder17 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: 549.9, g: -766.4, b: 992.6, a: -839.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder33.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup13, [512]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup15, new Uint32Array(969), 6, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: canvas1,
+  origin: { x: 1, y: 5 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 28, y: 746, z: 51},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 17, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+let renderBundle11 = renderBundleEncoder12.finish({});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(157);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer0);
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 1, y: 79, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.clearBuffer(buffer19, 328, 212);
+} catch {}
+let img1 = await imageWithData(12, 180, '#10101010', '#20202020');
+let textureView62 = texture28.createView({mipLevelCount: 1});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup4, new Uint32Array(2338), 174, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(1); };
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 7, y: 206, z: 77},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture63 = device0.createTexture({
+  size: [51, 1, 89],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView63 = texture22.createView({arrayLayerCount: 1});
+let computePassEncoder57 = commandEncoder73.beginComputePass({});
+let sampler47 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup20, new Uint32Array(2610), 187, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroupsIndirect(buffer13, 3_560); };
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+let imageData5 = new ImageData(40, 140);
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let texture64 = device0.createTexture({
+  label: '\u{1ff78}\u115f\u0ae2\u0c0c\u{1f6aa}',
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup12, new Uint32Array(3281), 866, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer17, 'uint16', 48, 224);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(0, buffer24, 0, 69);
+} catch {}
+let texture65 = device0.createTexture({
+  size: [12],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture66 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup20, new Uint32Array(251), 9, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer10, 2_504, 1_787);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer15, 5228, buffer29, 184, 6648);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 223 widthInBlocks: 223 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1401 */
+  offset: 1178,
+  bytesPerRow: 2304,
+  rowsPerImage: 367,
+  buffer: buffer32,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 2577, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 223, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 37, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {
+      binding: 53,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder74 = device0.createCommandEncoder({});
+let textureView64 = texture61.createView({baseMipLevel: 0});
+let textureView65 = texture49.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundle12 = renderBundleEncoder9.finish({});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.55,
+  maxAnisotropy: 19,
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame7});
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle10, renderBundle10]);
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 131, resource: externalTexture6},
+    {binding: 19, resource: externalTexture5},
+    {binding: 59, resource: externalTexture5},
+    {binding: 44, resource: externalTexture4},
+    {binding: 47, resource: {buffer: buffer30, offset: 256, size: 564}},
+  ],
+});
+let commandEncoder75 = device0.createCommandEncoder({});
+let computePassEncoder58 = commandEncoder29.beginComputePass({});
+let renderPassEncoder18 = commandEncoder75.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: 837.7, g: 527.2, b: 362.6, a: 741.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 123},
+  maxDrawCount: 312044909,
+});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup20, new Uint32Array(75), 7, 0);
+} catch {}
+let commandEncoder76 = device0.createCommandEncoder();
+let texture67 = device0.createTexture({
+  size: [12, 1, 1],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView66 = texture38.createView({dimension: 'cube', baseArrayLayer: 0});
+let computePassEncoder59 = commandEncoder74.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 102}});
+let renderPassEncoder19 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: -136.3, g: -887.6, b: 573.0, a: -268.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 67402291,
+});
+let commandEncoder77 = device0.createCommandEncoder();
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 88.04, g: -921.2, b: 232.9, a: -958.2, });
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 820 */
+  offset: 820,
+  bytesPerRow: 1536,
+  buffer: buffer27,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 4, y: 47, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 47, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder77.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 6,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2752 */
+  offset: 2752,
+  buffer: buffer29,
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer33 = device0.createBuffer({
+  size: 21465,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let computePassEncoder60 = commandEncoder77.beginComputePass({});
+let sampler49 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 47.77,
+  lodMaxClamp: 71.73,
+});
+let arrayBuffer3 = buffer1.getMappedRange(32, 4);
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1067, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(107).fill(179), /* required buffer size: 107 */
+{offset: 107}, {width: 76, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder();
+let texture68 = device0.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView67 = texture39.createView({});
+let renderPassEncoder20 = commandEncoder78.beginRenderPass({
+  colorAttachments: [{
+  view: textureView62,
+  clearValue: { r: -269.4, g: 429.9, b: -715.6, a: 179.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 297, endOfPassWriteIndex: 205},
+});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup8, new Uint32Array(2336), 517, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+let textureView68 = texture37.createView({
+  label: '\u057a\u7698\u4a77\u{1ff5b}\u{1ff09}\u3152\ub824\uf70f\u0d00\u{1fa9f}',
+  dimension: '2d',
+  aspect: 'all',
+});
+let sampler50 = device0.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 56.03, maxAnisotropy: 1});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(1419);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer28, 'uint16', 1_144, 3_900);
+} catch {}
+try {
+commandEncoder79.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6308 */
+  offset: 6308,
+  bytesPerRow: 9728,
+  buffer: buffer32,
+}, {
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 6, y: 59, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 59, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder79.clearBuffer(buffer0, 652, 720);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet1, 74, 10, buffer24, 0);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 47, resource: {buffer: buffer8, offset: 2048, size: 6036}},
+    {binding: 59, resource: externalTexture5},
+    {binding: 44, resource: externalTexture4},
+    {binding: 19, resource: externalTexture3},
+    {binding: 131, resource: externalTexture5},
+  ],
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+let textureView69 = texture39.createView({dimension: '2d-array'});
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup13, [768]);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+commandEncoder80.resolveQuerySet(querySet0, 24, 563, buffer11, 768);
+} catch {}
+let textureView70 = texture42.createView({dimension: '2d-array'});
+let computePassEncoder61 = commandEncoder80.beginComputePass({});
+let sampler51 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.03,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderPassEncoder21 = commandEncoder79.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  depthSlice: 12,
+  clearValue: { r: -910.8, g: 344.1, b: 92.74, a: -546.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder47.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer29, 824, 630);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let imageData6 = new ImageData(8, 116);
+let textureView71 = texture35.createView({mipLevelCount: 1});
+let sampler52 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+  await buffer6.mapAsync(GPUMapMode.WRITE, 3936, 848);
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpte240m', transfer: 'log'} });
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup24 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 110, resource: {buffer: buffer18, offset: 0, size: 984}},
+    {binding: 141, resource: {buffer: buffer14, offset: 0, size: 108}},
+    {binding: 52, resource: externalTexture1},
+  ],
+});
+let buffer34 = device0.createBuffer({size: 24538, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let texture69 = device0.createTexture({
+  size: {width: 2800, height: 17, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder57.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer33, 'uint32', 532, 3_534);
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout12]});
+let commandEncoder81 = device0.createCommandEncoder({});
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup2, [256]);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\ufcbe');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder();
+let arrayBuffer4 = buffer6.getMappedRange(3936, 100);
+let bindGroup25 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 41, resource: textureView69}]});
+let buffer35 = device0.createBuffer({size: 1, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let sampler53 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 99.47,
+});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder82.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 536 */
+  offset: 536,
+  bytesPerRow: 15872,
+  rowsPerImage: 282,
+  buffer: buffer27,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 20, y: 2220, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 312, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder82.insertDebugMarker('\u{1f65c}');
+} catch {}
+let commandBuffer2 = commandEncoder82.finish();
+let textureView72 = texture5.createView({});
+let computePassEncoder62 = commandEncoder81.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup18, []);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder20.setViewport(3173.2481826326425, 28.752741518978183, 1941.2829792563236, 0.5746016473862664, 0.9447439228654875, 0.9740035994035461);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+canvas1.height = 546;
+let buffer36 = device0.createBuffer({
+  size: 8755,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let sampler54 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.34,
+  compare: 'always',
+  maxAnisotropy: 6,
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder45.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(2, bindGroup2, new Uint32Array(1983), 692, 1);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle10, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer19, 'uint16', 32, 12);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer36, 32, 2_185);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let renderPassEncoder22 = commandEncoder7.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: -953.1, g: -904.7, b: -768.7, a: 303.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 109793684,
+});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup24, new Uint32Array(2044), 1_184, 1);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(98, 72);
+try {
+adapter0.label = '\u{1f664}\u96e5\u0ec4\u9297\u{1f908}\u51a6\u63cb\u0c72';
+} catch {}
+let textureView73 = texture68.createView({});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup24, new Uint32Array(164), 23, 1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup24, new Uint32Array(2073), 490, 1);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(601);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer32);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 0, new Int16Array(12536), 2263, 0);
+} catch {}
+let promise14 = device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0, entryPoint: 'compute0'}});
+document.body.append(canvas1);
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [{binding: 224, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let bindGroup26 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 141, resource: {buffer: buffer23, offset: 768, size: 4716}},
+    {binding: 110, resource: {buffer: buffer28, offset: 3328, size: 8440}},
+    {binding: 52, resource: externalTexture7},
+  ],
+});
+let buffer37 = device0.createBuffer({size: 1963, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder83 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroupsIndirect(buffer8, 4_120); };
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer7, 344, buffer35, 0, 0);
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture70 = device0.createTexture({
+  size: [2800, 17, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer26, 'uint16', 8_384, 569);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer24);
+} catch {}
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 68 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5636 */
+  offset: 5636,
+  buffer: buffer36,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder63 = commandEncoder83.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer4, 36); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer21, 104);
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({
+  size: [24, 455, 226],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView74 = texture10.createView({label: '\u0b45\u0a9e\udfab\ucb1a', dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder12.setIndexBuffer(buffer23, 'uint32', 1_484, 3_894);
+} catch {}
+let bindGroup27 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 41, resource: textureView54}]});
+let querySet3 = device0.createQuerySet({type: 'timestamp', count: 284});
+let computePassEncoder64 = commandEncoder84.beginComputePass({});
+let renderPassEncoder23 = commandEncoder85.beginRenderPass({
+  colorAttachments: [{view: textureView47, loadOp: 'clear', storeOp: 'store'}],
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 252},
+});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer24, 'uint16', 98, 151);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 5348 widthInBlocks: 1337 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 956 */
+  offset: 956,
+  bytesPerRow: 22528,
+  buffer: buffer3,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 253, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 1337, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 2732 widthInBlocks: 683 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 224 */
+  offset: 224,
+  bytesPerRow: 12800,
+  buffer: buffer26,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 192, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 683, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder();
+let computePassEncoder65 = commandEncoder12.beginComputePass({});
+let renderPassEncoder24 = commandEncoder86.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: -44.29, g: 180.0, b: -384.7, a: -996.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet3, beginningOfPassWriteIndex: 4294967295, endOfPassWriteIndex: 58},
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer4, 1_160); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer24, 104);
+} catch {}
+let arrayBuffer5 = buffer6.getMappedRange(4040, 24);
+let gpuCanvasContext2 = offscreenCanvas0.getContext('webgpu');
+let recycledExplicitBindGroupLayout4 = pipeline0.getBindGroupLayout(0);
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture72 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView75 = texture3.createView({aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup21, new Uint32Array(4434), 16, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer17, 'uint32', 100, 133);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 257, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let commandEncoder88 = device0.createCommandEncoder({});
+let textureView76 = texture36.createView({mipLevelCount: 1});
+let renderPassEncoder25 = commandEncoder87.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: 656.3, g: -612.5, b: 13.07, a: 293.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], stencilReadOnly: true});
+let renderBundle13 = renderBundleEncoder13.finish({});
+let sampler55 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less',
+  maxAnisotropy: 17,
+});
+try {
+commandEncoder88.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 474, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView77 = texture39.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder66 = commandEncoder88.beginComputePass({});
+let sampler56 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 68.62,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup13, [0]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroupsIndirect(buffer33, 6_236); };
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(203);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint32', 232, 7);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer7, 0, 872);
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.WRITE, 496, 276);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 485, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let texture73 = gpuCanvasContext2.getCurrentTexture();
+let textureView78 = texture58.createView({});
+let computePassEncoder67 = commandEncoder89.beginComputePass({});
+let sampler57 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 79.32});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer14, 'uint16', 256, 19);
+} catch {}
+let computePassEncoder68 = commandEncoder33.beginComputePass();
+try {
+computePassEncoder45.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(3, bindGroup19, new Uint32Array(289), 32, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer32, 1_284); };
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer24, 'uint32', 28, 362);
+} catch {}
+try {
+texture58.label = '\u77b8\u5d42\ua330\u0002';
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 141, resource: {buffer: buffer18, offset: 1024, size: 436}},
+    {binding: 52, resource: externalTexture2},
+    {binding: 110, resource: {buffer: buffer22, offset: 1024, size: 2972}},
+  ],
+});
+try {
+renderPassEncoder25.executeBundles([renderBundle1, renderBundle3, renderBundle7, renderBundle13, renderBundle1, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer28, 'uint32', 5_496, 3_582);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(2, buffer14);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let videoFrame11 = new VideoFrame(videoFrame7, {timestamp: 0});
+let bindGroup29 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 52, resource: externalTexture7},
+    {binding: 141, resource: {buffer: buffer23, offset: 3840, size: 2212}},
+    {binding: 110, resource: {buffer: buffer28, offset: 7680, size: 3364}},
+  ],
+});
+let texture74 = gpuCanvasContext2.getCurrentTexture();
+let textureView79 = texture60.createView({});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup16, new Uint32Array(1391), 99, 0);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -915.2, g: -717.1, b: 61.82, a: 569.2, });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 6, y: 547, z: 86},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img2 = await imageWithData(163, 67, '#10101010', '#20202020');
+let buffer38 = device0.createBuffer({
+  size: 12489,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup8, new Uint32Array(177), 3, 0);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup14, new Uint32Array(2312), 226, 0);
+} catch {}
+let arrayBuffer6 = buffer1.getMappedRange(40, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 13},
+  aspect: 'all',
+}, new Uint8Array(447).fill(83), /* required buffer size: 447 */
+{offset: 297, bytesPerRow: 25, rowsPerImage: 2}, {width: 0, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline0.getBindGroupLayout(0);
+let bindGroup30 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 110, resource: {buffer: buffer23, offset: 512, size: 4776}},
+    {binding: 52, resource: externalTexture4},
+    {binding: 141, resource: {buffer: buffer23, offset: 12288, size: 208}},
+  ],
+});
+let buffer39 = device0.createBuffer({size: 42, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder90 = device0.createCommandEncoder({});
+let texture75 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder69 = commandEncoder90.beginComputePass();
+try {
+computePassEncoder40.setBindGroup(0, bindGroup29, new Uint32Array(35), 2, 1);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer29, 'uint32', 6_248, 8_721);
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({
+  label: '\u339c\u09a5\ud4c3\u0fdf\u55ba\u0600',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule0, constants: {}},
+});
+let buffer40 = device0.createBuffer({
+  size: 252,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup25, new Uint32Array(252), 51, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup8, new Uint32Array(10000), 196, 0);
+} catch {}
+let arrayBuffer7 = buffer1.getMappedRange(48, 0);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+let texture76 = device0.createTexture({
+  size: [48, 910, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture77 = gpuCanvasContext0.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer22, 1_596); };
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline1);
+} catch {}
+try {
+  await buffer39.mapAsync(GPUMapMode.WRITE, 0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 100, new DataView(new ArrayBuffer(12136)), 148, 80);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 8, y: 195, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let querySet4 = device0.createQuerySet({type: 'timestamp', count: 392});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup24, new Uint32Array(432), 27, 1);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline2);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 7600, new Int16Array(28455), 71, 592);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder91 = device0.createCommandEncoder();
+try {
+computePassEncoder32.setBindGroup(2, bindGroup27, new Uint32Array(992), 13, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint32', 732, 431);
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 112 */
+  offset: 112,
+  bytesPerRow: 768,
+  buffer: buffer7,
+}, {
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let imageData7 = new ImageData(4, 92);
+let bindGroup31 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [
+    {binding: 59, resource: externalTexture7},
+    {binding: 131, resource: externalTexture8},
+    {binding: 44, resource: externalTexture0},
+    {binding: 19, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer22, offset: 3584, size: 788}},
+  ],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroups(1, 1, 2); };
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup5, new Uint32Array(2231), 145, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer34, 'uint16', 1_874, 4_105);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer28);
+} catch {}
+let arrayBuffer8 = buffer6.getMappedRange(4216, 8);
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 124 widthInBlocks: 31 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 132 */
+  offset: 132,
+  bytesPerRow: 3584,
+  buffer: buffer25,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder70 = commandEncoder92.beginComputePass({});
+try {
+computePassEncoder35.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer14, 0, 288);
+} catch {}
+let buffer41 = device0.createBuffer({
+  size: 801,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView80 = texture39.createView({});
+let computePassEncoder71 = commandEncoder91.beginComputePass({});
+try {
+computePassEncoder69.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup17, new Uint32Array(1761), 238, 1);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({});
+let textureView81 = texture30.createView({dimension: '2d-array'});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup11, []);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2660 */
+  offset: 2660,
+  buffer: buffer26,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 131, resource: externalTexture8},
+    {binding: 59, resource: externalTexture6},
+    {binding: 44, resource: externalTexture4},
+    {binding: 19, resource: externalTexture6},
+    {binding: 47, resource: {buffer: buffer4, offset: 0, size: 896}},
+  ],
+});
+let texture78 = device0.createTexture({
+  size: [12, 1, 79],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup9, new Uint32Array(1415), 14, 0);
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup13, new Uint32Array(113), 1, 1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle8]);
+} catch {}
+try {
+  await promise12;
+} catch {}
+document.body.append(img1);
+let bindGroup33 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 131, resource: externalTexture6},
+    {binding: 19, resource: externalTexture7},
+    {binding: 44, resource: externalTexture1},
+    {binding: 47, resource: {buffer: buffer0, offset: 7936, size: 540}},
+    {binding: 59, resource: externalTexture2},
+  ],
+});
+let buffer42 = device0.createBuffer({
+  size: 17285,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder94 = device0.createCommandEncoder({});
+let textureView82 = texture12.createView({dimension: '3d'});
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup32, new Uint32Array(1423), 68, 0);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 548 */
+  offset: 548,
+  buffer: buffer30,
+}, {
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let buffer43 = device0.createBuffer({
+  size: 707,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView83 = texture75.createView({baseMipLevel: 0});
+let computePassEncoder72 = commandEncoder93.beginComputePass({timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 285, endOfPassWriteIndex: 58}});
+let renderPassEncoder26 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  depthSlice: 11,
+  clearValue: { r: -340.3, g: 918.1, b: 498.1, a: -995.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder72.setPipeline(pipeline0);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet0, 45, 785, buffer8, 1024);
+} catch {}
+let computePassEncoder73 = commandEncoder18.beginComputePass({});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup26, [1024]);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup20);
+} catch {}
+let arrayBuffer9 = buffer6.getMappedRange(4280, 80);
+let recycledExplicitBindGroupLayout6 = pipeline1.getBindGroupLayout(0);
+let bindGroup34 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 322, resource: {buffer: buffer8, offset: 1024, size: 2080}},
+    {binding: 356, resource: textureView82},
+    {binding: 3, resource: {buffer: buffer22, offset: 768, size: 3904}},
+    {binding: 85, resource: textureView32},
+    {binding: 52, resource: {buffer: buffer5, offset: 3840, size: 2052}},
+    {binding: 49, resource: {buffer: buffer26, offset: 2048, size: 13904}},
+  ],
+});
+let commandEncoder95 = device0.createCommandEncoder();
+let computePassEncoder74 = commandEncoder95.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 22, endOfPassWriteIndex: 107}});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup30, [0]);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(1, bindGroup24, new Uint32Array(550), 181, 1);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5, new Uint32Array(156), 0, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer23, 'uint32', 3_864, 296);
+} catch {}
+let computePassEncoder75 = commandEncoder21.beginComputePass();
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.93,
+  lodMaxClamp: 82.41,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({});
+let sampler59 = device0.createSampler({addressModeV: 'repeat', magFilter: 'nearest', lodMinClamp: 98.59, lodMaxClamp: 98.80});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup14, new Uint32Array(105), 45, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer21, 256, buffer43, 68, 32);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 8, new Float32Array(11663), 274, 748);
+} catch {}
+document.body.prepend(canvas0);
+let imageData8 = new ImageData(92, 16);
+let commandEncoder97 = device0.createCommandEncoder({});
+let textureView84 = texture75.createView({aspect: 'all', format: 'rg32uint'});
+let computePassEncoder76 = commandEncoder97.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 27, endOfPassWriteIndex: 300}});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup20, new Uint32Array(1550), 355, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle2, renderBundle7, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(6, buffer36, 0, 3_182);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+  bytesPerRow: 27136,
+  buffer: buffer30,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 17, y: 351, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 29, depthOrArrayLayers: 0});
+} catch {}
+let textureView85 = texture6.createView({});
+let computePassEncoder77 = commandEncoder96.beginComputePass({});
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: imageData8,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 35, y: 108, z: 79},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 13, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let img3 = await imageWithData(186, 109, '#10101010', '#20202020');
+let imageData9 = new ImageData(20, 36);
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 52, resource: externalTexture8},
+    {binding: 141, resource: {buffer: buffer23, offset: 2304, size: 588}},
+    {binding: 110, resource: {buffer: buffer14, offset: 0, size: 872}},
+  ],
+});
+let commandEncoder98 = device0.createCommandEncoder({});
+let textureView86 = texture39.createView({aspect: 'all'});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup35, [1536]);
+} catch {}
+try {
+computePassEncoder51.setBindGroup(3, bindGroup21, new Uint32Array(1981), 286, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup22, new Uint32Array(2733), 436, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle0]);
+} catch {}
+try {
+commandEncoder98.copyBufferToBuffer(buffer23, 1328, buffer3, 656, 372);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 5, y: 10 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 15, y: 664, z: 20},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let buffer44 = device0.createBuffer({
+  size: 214,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture79 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 66},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView87 = texture41.createView({arrayLayerCount: 1});
+let computePassEncoder78 = commandEncoder98.beginComputePass({timestampWrites: {querySet: querySet3, endOfPassWriteIndex: 36}});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], stencilReadOnly: true});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(3, bindGroup17, new Uint32Array(9), 0, 1);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 149.9, g: 606.3, b: 314.0, a: -326.4, });
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer24, 0, 334);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup34, new Uint32Array(2838), 403, 0);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer10, 'uint32', 380, 3_155);
+} catch {}
+document.body.prepend(img0);
+let bindGroup36 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 52, resource: externalTexture7},
+    {binding: 141, resource: {buffer: buffer26, offset: 2816, size: 272}},
+    {binding: 110, resource: {buffer: buffer0, offset: 1024, size: 1852}},
+  ],
+});
+let commandEncoder99 = device0.createCommandEncoder({});
+let texture80 = device0.createTexture({
+  size: [51, 1, 173],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder27 = commandEncoder99.beginRenderPass({
+  colorAttachments: [{view: textureView29, depthSlice: 5, loadOp: 'load', storeOp: 'discard'}],
+  timestampWrites: {querySet: querySet1},
+});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(0, bindGroup2, new Uint32Array(2272), 351, 1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup15, new Uint32Array(119), 9, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+computePassEncoder31.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(1, bindGroup24, new Uint32Array(761), 363, 1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer24, 'uint32', 20, 86);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder({});
+try {
+computePassEncoder61.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 388 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 248 */
+  offset: 248,
+  buffer: buffer27,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 788, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 97, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView88 = texture64.createView({});
+let computePassEncoder79 = commandEncoder100.beginComputePass({timestampWrites: {querySet: querySet4}});
+try {
+renderPassEncoder11.setStencilReference(625);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer30, 'uint32', 208, 354);
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 47, resource: {buffer: buffer14, offset: 256, size: 724}},
+    {binding: 131, resource: externalTexture0},
+    {binding: 59, resource: externalTexture4},
+    {binding: 19, resource: externalTexture4},
+    {binding: 44, resource: externalTexture7},
+  ],
+});
+let buffer45 = device0.createBuffer({
+  size: 4204,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView89 = texture3.createView({format: 'r32sint'});
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup22, new Uint32Array(256), 38, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle1]);
+} catch {}
+let texture81 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView90 = texture71.createView({dimension: '3d'});
+try {
+computePassEncoder79.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup22, new Uint32Array(1215), 3, 0);
+} catch {}
+let arrayBuffer10 = buffer6.getMappedRange(4224, 24);
+let bindGroup38 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 51, resource: {buffer: buffer41, offset: 0, size: 324}}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroupsIndirect(buffer43, 8); };
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer41, 'uint32', 68, 25);
+} catch {}
+try {
+computePassEncoder24.pushDebugGroup('\u2dad');
+} catch {}
+let videoFrame12 = videoFrame9.clone();
+let commandEncoder101 = device0.createCommandEncoder();
+let sampler60 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup22, new Uint32Array(279), 53, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, undefined);
+} catch {}
+try {
+commandEncoder101.copyBufferToTexture({
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 340 */
+  offset: 340,
+  buffer: buffer45,
+}, {
+  texture: texture33,
+  mipLevel: 2,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder();
+let computePassEncoder80 = commandEncoder102.beginComputePass({});
+try {
+renderPassEncoder6.setScissorRect(330, 0, 4, 2);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer7, 0, 162);
+} catch {}
+try {
+commandEncoder101.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 880 */
+  offset: 880,
+  buffer: buffer45,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer46 = device0.createBuffer({
+  size: 35143,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder103 = device0.createCommandEncoder({});
+let texture82 = device0.createTexture({
+  size: {width: 192},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler61 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder77.setBindGroup(3, bindGroup12, new Uint32Array(1421), 111, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroupsIndirect(buffer38, 460); };
+} catch {}
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer42, 'uint16', 4_590, 436);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer30);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer24, 112, buffer21, 20, 56);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageData10 = new ImageData(8, 20);
+let recycledExplicitBindGroupLayout7 = pipeline2.getBindGroupLayout(0);
+let buffer47 = device0.createBuffer({
+  size: 939,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let texture83 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 8},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder28 = commandEncoder101.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -836.9, g: -499.5, b: 209.4, a: 651.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 292},
+  maxDrawCount: 57159403,
+});
+let sampler62 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.84,
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer8, 512); };
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer21, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder103.copyBufferToTexture({
+  /* bytesInLastRow: 2500 widthInBlocks: 625 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2376 */
+  offset: 2376,
+  buffer: buffer46,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 85, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 625, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 2, y: 186, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 1, y: 92, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 411, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(119).fill(141), /* required buffer size: 119 */
+{offset: 119}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let bindGroup39 = device0.createBindGroup({layout: veryExplicitBindGroupLayout15, entries: [{binding: 113, resource: textureView36}]});
+let commandBuffer3 = commandEncoder55.finish();
+let renderPassEncoder29 = commandEncoder104.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -537.4, g: 226.2, b: -674.2, a: -416.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 317183475,
+});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder103.copyBufferToTexture({
+  /* bytesInLastRow: 1572 widthInBlocks: 393 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3656 */
+  offset: 3656,
+  bytesPerRow: 12800,
+  buffer: buffer46,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 2834, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 393, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let buffer48 = device0.createBuffer({size: 1676, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX, mappedAtCreation: false});
+let commandEncoder105 = device0.createCommandEncoder({});
+let computePassEncoder81 = commandEncoder103.beginComputePass({});
+let renderPassEncoder30 = commandEncoder14.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -93.60, g: -313.5, b: 267.9, a: -319.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup30, new Uint32Array(831), 167, 1);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer16, 'uint16', 1_660, 74);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer32, 224, 544);
+} catch {}
+try {
+computePassEncoder24.popDebugGroup();
+} catch {}
+document.body.prepend(img1);
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer49 = device0.createBuffer({
+  size: 6785,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder106 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder56.finish();
+let renderPassEncoder31 = commandEncoder105.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: 314.4, g: 706.4, b: 760.2, a: 15.13, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder30.setIndexBuffer(buffer5, 'uint32', 1_072, 430);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: canvas1,
+  origin: { x: 29, y: 288 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 171, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 34, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture84 = device0.createTexture({size: [51], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let textureView91 = texture71.createView({});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder78.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(3, bindGroup6, new Uint32Array(141), 14, 0);
+} catch {}
+try {
+computePassEncoder49.dispatchWorkgroups(1, 1);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup26, new Uint32Array(940), 485, 1);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer48, 'uint16', 196, 6);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer13, 0, 2_841);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 612, new DataView(new ArrayBuffer(2596)), 97, 1544);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let computePassEncoder82 = commandEncoder106.beginComputePass({});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.57,
+});
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup33, new Uint32Array(890), 25, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer16, 'uint16', 512, 368);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 22, y: 35, z: 23},
+  aspect: 'all',
+}, new Uint8Array(327_595).fill(3), /* required buffer size: 327_595 */
+{offset: 88, bytesPerRow: 51, rowsPerImage: 138}, {width: 9, height: 74, depthOrArrayLayers: 47});
+} catch {}
+let bindGroup40 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: []});
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout6]});
+let commandEncoder107 = device0.createCommandEncoder({});
+try {
+computePassEncoder68.setBindGroup(2, bindGroup17, new Uint32Array(1466), 436, 1);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 53, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+buffer38.label = '\u8751\u0c05\u00ed\ub2bc\u0fd8';
+} catch {}
+let veryExplicitBindGroupLayout17 = device0.createBindGroupLayout({entries: []});
+let bindGroup41 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 44, resource: externalTexture6},
+    {binding: 19, resource: externalTexture9},
+    {binding: 47, resource: {buffer: buffer23, offset: 512, size: 1484}},
+    {binding: 131, resource: externalTexture7},
+    {binding: 59, resource: externalTexture1},
+  ],
+});
+let computePassEncoder83 = commandEncoder107.beginComputePass({});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer0, 'uint16', 256, 636);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer46, 8_132, 7_394);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2028 */
+  offset: 2028,
+  buffer: buffer36,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer13, 6_584); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup33);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: -727.2, g: -317.3, b: 531.6, a: -517.7, });
+} catch {}
+try {
+renderPassEncoder19.setViewport(1092.4000239331524, 19.408265460957683, 1646.8865083930439, 13.122243226275039, 0.6347347446003176, 0.7607113616762632);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer33, 'uint32', 5_836, 363);
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({});
+let computePassEncoder84 = commandEncoder59.beginComputePass({});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame0});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup36, new Uint32Array(444), 58, 1);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 207.9, g: 689.1, b: -642.3, a: -8.651, });
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+let buffer50 = device0.createBuffer({
+  size: 41255,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder109 = device0.createCommandEncoder();
+let sampler64 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'repeat', lodMaxClamp: 67.70});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup24, [0]);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup25, new Uint32Array(272), 77, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(3, buffer13);
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+/* zero global variables used */
+fn fn1(a0: ptr<storage, array<u32>, read>, a1: array<FragmentOutput0, 4>, a2: ptr<storage, array<array<array<array<vec2u, 1>, 1>, 1>>, read>, a3: array<array<array<vec2h, 1>, 1>, 42>) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  _ = fn0();
+  let ptr10: ptr<storage, array<vec2u, 1>, read> = &(*a2)[unconst_u32(183)][unconst_u32(82)][0];
+  out.f0 = (*a2)[unconst_u32(381)][unconst_u32(192)][unconst_u32(138)][0].rrrg;
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(flat) f0: vec4u,
+  @location(1) f1: u32,
+}
+
+@group(0) @binding(41) var st0: texture_storage_2d_array<r32uint, read>;
+
+struct T3 {
+  @align(8) @size(544) f0: array<atomic<u32>>,
+}
+
+var<private> vp0: mat3x2f = mat3x2f(0.07928, 0.00624, 0.00477, 0.1047, 0.04484, 0.1023);
+
+/* zero global variables used */
+@must_use 
+fn fn3(a0: FragmentOutput0) -> vec4h {
+  var out: vec4h;
+  let vf52: vec3<bool> = (vec3h(f16((unconst_u32(85) >> pack4xU8(a0.f0)))) != vec3h(unpack4xI8(unconst_u32(136)).agb));
+  _ = fn0();
+  for (var it1=u32(sin(vec4f(unconst_f32(0.5019), unconst_f32(0.2657), unconst_f32(0.1581), unconst_f32(-0.4677))).w); it1<u32(vf52[unconst_u32(433)]); it1++) {
+  vp0 = mat3x2f(vec2f(a0.f0.rb), bitcast<vec2f>(a0.f0.xw), vec2f(a0.f0.gb));
+  var vf53 = fn0();
+  vp0 += mat3x2f(bitcast<vec2f>((vec2u(unconst_u32(207), unconst_u32(402)) << vec2u(unconst_u32(45), unconst_u32(22)))), vec2f((vec2u(unconst_u32(207), unconst_u32(402)) << vec2u(unconst_u32(45), unconst_u32(22)))), vec2f((vec2u(unconst_u32(207), unconst_u32(402)) << vec2u(unconst_u32(45), unconst_u32(22)))));
+}
+  var vf54: FragmentOutput0 = a0;
+  vp0 = mat3x2f(vec2f(smoothstep(vec3h(unconst_f16(16985.9), unconst_f16(9040.7), unconst_f16(-753.4)), vec3h(unconst_f16(2422.4), unconst_f16(-7276.7), unconst_f16(4754.2)), vec3h(unconst_f16(17804.3), unconst_f16(3671.0), unconst_f16(15267.4))).rr), vec2f(smoothstep(vec3h(unconst_f16(16985.9), unconst_f16(9040.7), unconst_f16(-753.4)), vec3h(unconst_f16(2422.4), unconst_f16(-7276.7), unconst_f16(4754.2)), vec3h(unconst_f16(17804.3), unconst_f16(3671.0), unconst_f16(15267.4))).yy), vec2f(smoothstep(vec3h(unconst_f16(16985.9), unconst_f16(9040.7), unconst_f16(-753.4)), vec3h(unconst_f16(2422.4), unconst_f16(-7276.7), unconst_f16(4754.2)), vec3h(unconst_f16(17804.3), unconst_f16(3671.0), unconst_f16(15267.4))).yz));
+  while bool(a0.f1) {
+  var vf55: vec3f = atanh(vec3f(unconst_f32(0.00240), unconst_f32(0.05647), unconst_f32(0.2005)));
+  var vf56 = fn0();
+  _ = fn0();
+  vf55 = vec3f(degrees(vec3h(unconst_f16(1410.8), unconst_f16(1155.1), unconst_f16(224.7))));
+  break;
+}
+  let vf57: vec2i = reverseBits(countOneBits(vec4i(unconst_i32(219), unconst_i32(313), unconst_i32(28), unconst_i32(161))).gb);
+  vf54 = FragmentOutput0(vec4u((vec3h(unconst_f16(262.3), unconst_f16(94.84), unconst_f16(-2956.7)) != vec3h(unconst_f16(9145.1), unconst_f16(4524.9), unconst_f16(9305.2))).bbbg), vec3u((vec3h(unconst_f16(262.3), unconst_f16(94.84), unconst_f16(-2956.7)) != vec3h(unconst_f16(9145.1), unconst_f16(4524.9), unconst_f16(9305.2))))[1]);
+  vp0 = mat3x2f(radians(f32(firstTrailingBit(unconst_i32(100)))), radians(f32(firstTrailingBit(unconst_i32(100)))), radians(f32(firstTrailingBit(unconst_i32(100)))), radians(f32(firstTrailingBit(unconst_i32(100)))), radians(f32(firstTrailingBit(unconst_i32(100)))), radians(f32(firstTrailingBit(unconst_i32(100)))));
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw15: array<atomic<i32>, 1>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(64) f0: i32,
+  @size(244) f1: array<array<atomic<i32>, 1>>,
+}
+
+struct T1 {
+  @align(64) @size(64) f0: array<atomic<i32>, 1>,
+}
+
+/* zero global variables used */
+fn fn5(a0: FragmentOutput0, a1: ptr<storage, array<mat4x4h, 1>, read_write>) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f1 &= pack4xI8(vec4i(unconst_i32(346), unconst_i32(247), unconst_i32(88), unconst_i32(25)));
+  out.f1 -= bitcast<u32>(unpack4x8snorm(unconst_u32(16)).b);
+  let vf62: vec2f = unpack2x16float(unconst_u32(8));
+  let vf63: f32 = vp0[unconst_u32(338)][unconst_u32(194)];
+  out.f1 = a0.f0[unconst_u32(218)];
+  let vf64: vec4f = unpack4x8snorm(pack2x16unorm(vf62));
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T2 {
+  @align(32) @size(32) f0: mat4x2h,
+  @size(192) f1: array<mat4x4f>,
+}
+
+var<workgroup> vw14: vec4<bool>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T4 {
+  @size(60) f0: array<u32>,
+}
+
+/* zero global variables used */
+@must_use 
+fn fn0() -> T5 {
+  var out: T5;
+  out.f0 &= countLeadingZeros(vec2u(unconst_u32(191), unconst_u32(87)));
+  out.f0 = vec2u(u32(dot(vec4i(unconst_i32(-49), unconst_i32(231), unconst_i32(151), unconst_i32(66)), vec4i(unconst_i32(240), unconst_i32(46), unconst_i32(240), unconst_i32(179)))));
+  var vf35: vec4h = acosh(vec4h(f16(vp0[unconst_u32(460)][unconst_u32(137)])));
+  {
+  loop {
+  let vf36: vec4u = unpack4xU8(unconst_u32(510));
+  return out;
+  break;
+}
+  out.f0 = vec2u(unpack2x16float(u32(vp0[unconst_i32(1)].g)));
+  out.f0 = bitcast<vec2u>(step(vec4h(unconst_f16(13955.3), unconst_f16(16140.3), unconst_f16(429.5), unconst_f16(22535.2)), vec4h(unconst_f16(5071.6), unconst_f16(10760.4), unconst_f16(36547.5), unconst_f16(12033.3))));
+  vp0 -= mat3x2f(ldexp(vec2f(unconst_f32(0.1742), unconst_f32(0.2547)), extractBits(bitcast<vec3i>(faceForward(vec4f(unconst_f32(-0.2292), unconst_f32(0.3358), unconst_f32(0.1382), unconst_f32(0.2145)), vec4f(unconst_f32(0.04507), unconst_f32(0.2098), unconst_f32(0.03304), unconst_f32(0.04156)), vec4f(unconst_f32(-0.1386), unconst_f32(0.01177), unconst_f32(0.00760), unconst_f32(0.07708))).abg), unconst_u32(229), unconst_u32(307)).gg), ldexp(vec2f(unconst_f32(0.1742), unconst_f32(0.2547)), extractBits(bitcast<vec3i>(faceForward(vec4f(unconst_f32(-0.2292), unconst_f32(0.3358), unconst_f32(0.1382), unconst_f32(0.2145)), vec4f(unconst_f32(0.04507), unconst_f32(0.2098), unconst_f32(0.03304), unconst_f32(0.04156)), vec4f(unconst_f32(-0.1386), unconst_f32(0.01177), unconst_f32(0.00760), unconst_f32(0.07708))).abg), unconst_u32(229), unconst_u32(307)).gg), ldexp(vec2f(unconst_f32(0.1742), unconst_f32(0.2547)), extractBits(bitcast<vec3i>(faceForward(vec4f(unconst_f32(-0.2292), unconst_f32(0.3358), unconst_f32(0.1382), unconst_f32(0.2145)), vec4f(unconst_f32(0.04507), unconst_f32(0.2098), unconst_f32(0.03304), unconst_f32(0.04156)), vec4f(unconst_f32(-0.1386), unconst_f32(0.01177), unconst_f32(0.00760), unconst_f32(0.07708))).abg), unconst_u32(229), unconst_u32(307)).gg));
+  vp0 -= mat3x2f(faceForward(vec4f(unconst_f32(0.1691), unconst_f32(0.03432), unconst_f32(0.09125), unconst_f32(0.7437)), vec4f(unconst_f32(0.3817), unconst_f32(0.05206), unconst_f32(0.01983), unconst_f32(-0.5813)), vec4f(unconst_f32(0.08068), unconst_f32(-0.4556), unconst_f32(0.4222), unconst_f32(0.06549))).bb, faceForward(vec4f(unconst_f32(0.1691), unconst_f32(0.03432), unconst_f32(0.09125), unconst_f32(0.7437)), vec4f(unconst_f32(0.3817), unconst_f32(0.05206), unconst_f32(0.01983), unconst_f32(-0.5813)), vec4f(unconst_f32(0.08068), unconst_f32(-0.4556), unconst_f32(0.4222), unconst_f32(0.06549))).xw, faceForward(vec4f(unconst_f32(0.1691), unconst_f32(0.03432), unconst_f32(0.09125), unconst_f32(0.7437)), vec4f(unconst_f32(0.3817), unconst_f32(0.05206), unconst_f32(0.01983), unconst_f32(-0.5813)), vec4f(unconst_f32(0.08068), unconst_f32(-0.4556), unconst_f32(0.4222), unconst_f32(0.06549))).bb);
+}
+  let ptr9: ptr<private, mat3x2f> = &vp0;
+  vp0 = mat3x2f(f32(dot(vec4i(unconst_i32(11), unconst_i32(93), unconst_i32(-64), unconst_i32(99)), vec4i(dot(vec4i(unconst_i32(41), unconst_i32(97), unconst_i32(552), unconst_i32(37)), bitcast<vec4i>((*ptr9)[unconst_u32(187)].rrgg))))), bitcast<f32>(dot(vec4i(unconst_i32(11), unconst_i32(93), unconst_i32(-64), unconst_i32(99)), vec4i(dot(vec4i(unconst_i32(41), unconst_i32(97), unconst_i32(552), unconst_i32(37)), bitcast<vec4i>((*ptr9)[unconst_u32(187)].rrgg))))), f32(dot(vec4i(unconst_i32(11), unconst_i32(93), unconst_i32(-64), unconst_i32(99)), vec4i(dot(vec4i(unconst_i32(41), unconst_i32(97), unconst_i32(552), unconst_i32(37)), bitcast<vec4i>((*ptr9)[unconst_u32(187)].rrgg))))), f32(dot(vec4i(unconst_i32(11), unconst_i32(93), unconst_i32(-64), unconst_i32(99)), vec4i(dot(vec4i(unconst_i32(41), unconst_i32(97), unconst_i32(552), unconst_i32(37)), bitcast<vec4i>((*ptr9)[unconst_u32(187)].rrgg))))), f32(dot(vec4i(unconst_i32(11), unconst_i32(93), unconst_i32(-64), unconst_i32(99)), vec4i(dot(vec4i(unconst_i32(41), unconst_i32(97), unconst_i32(552), unconst_i32(37)), bitcast<vec4i>((*ptr9)[unconst_u32(187)].rrgg))))), bitcast<f32>(dot(vec4i(unconst_i32(11), unconst_i32(93), unconst_i32(-64), unconst_i32(99)), vec4i(dot(vec4i(unconst_i32(41), unconst_i32(97), unconst_i32(552), unconst_i32(37)), bitcast<vec4i>((*ptr9)[unconst_u32(187)].rrgg))))));
+  if bool(reverseBits(vec3u(unconst_u32(47), unconst_u32(64), unconst_u32(127))).r) {
+  var vf37: vec2i = countOneBits(vec2i(unconst_i32(112), unconst_i32(654)));
+  var vf38: vec4h =  -vec4h(unconst_f16(3513.2), unconst_f16(-3741.9), unconst_f16(7853.4), unconst_f16(30988.5));
+  vp0 = mat3x2f(bitcast<f32>(firstTrailingBit(unconst_u32(247))), f32(firstTrailingBit(unconst_u32(247))), bitcast<f32>(firstTrailingBit(unconst_u32(247))), bitcast<f32>(firstTrailingBit(unconst_u32(247))), f32(firstTrailingBit(unconst_u32(247))), bitcast<f32>(firstTrailingBit(unconst_u32(247))));
+  out.f0 >>=  ~vec3u(unconst_u32(318), unconst_u32(20), unconst_u32(100)).rg;
+  vf38 = vec4h(f16(vf37[unconst_u32(202)]));
+  switch i32(vf38[pack2x16snorm(transpose(mat2x4f(unconst_f32(0.04207), unconst_f32(0.6199), unconst_f32(0.1515), unconst_f32(0.00466), unconst_f32(0.01600), unconst_f32(0.3082), unconst_f32(0.02669), unconst_f32(-0.01929)))[unconst_i32(0)])]) { 
+  default {
+  var vf39: u32 = pack4xI8(vec4i(unconst_i32(142), unconst_i32(-49), unconst_i32(427), unconst_i32(203)));
+  break;
+}
+  }
+  let vf40: vec3u = (vec3u(unconst_u32(189), unconst_u32(123), unconst_u32(45)) / unconst_u32(263));
+}
+  out.f0 = bitcast<vec2u>(vp0[unconst_i32(0)]);
+  let vf41: vec4h = cos(vec4h(unconst_f16(11137.8), unconst_f16(8369.9), unconst_f16(-2045.0), unconst_f16(5824.3)));
+  var vf42: vec3h = cos(vec3h(unconst_f16(-9123.0), unconst_f16(10622.0), unconst_f16(26222.8)));
+  switch bitcast<i32>(transpose(mat2x3f(unconst_f32(0.1325), unconst_f32(0.3782), unconst_f32(0.1217), unconst_f32(0.2228), unconst_f32(0.01937), unconst_f32(0.08235)))[unconst_i32(0)][1]) { 
+  default {
+  var vf43: vec2h = cosh(vec2h(unconst_f16(17947.7), unconst_f16(6121.7)));
+  switch bitcast<vec4i>((unconst_u32(70) % vec4u(unconst_u32(10), unconst_u32(162), unconst_u32(49), unconst_u32(82)))).x { 
+  default {
+  out.f0 = vec2u((vec3i(unconst_i32(1), unconst_i32(155), unconst_i32(196)) > vec3i(unconst_i32(21), unconst_i32(38), unconst_i32(121))).bb);
+  vp0 -= mat3x2f((vec4f(unconst_f32(0.04714), unconst_f32(0.1448), unconst_f32(0.09031), unconst_f32(0.1085)) * unconst_f32(0.4823)).zz, (vec4f(unconst_f32(0.04714), unconst_f32(0.1448), unconst_f32(0.09031), unconst_f32(0.1085)) * unconst_f32(0.4823)).xx, (vec4f(unconst_f32(0.04714), unconst_f32(0.1448), unconst_f32(0.09031), unconst_f32(0.1085)) * unconst_f32(0.4823)).bg);
+}
+  }
+  var vf44: vec2h = inverseSqrt(vec2h(unconst_f16(-16889.2), unconst_f16(2283.8)));
+  vp0 += mat3x2f(vec2f(sign(vec3h(unconst_f16(12099.9), unconst_f16(471.9), unconst_f16(717.5))).rr), vec2f(sign(vec3h(unconst_f16(12099.9), unconst_f16(471.9), unconst_f16(717.5))).bb), vec2f(sign(vec3h(unconst_f16(12099.9), unconst_f16(471.9), unconst_f16(717.5))).xy));
+  return out;
+}
+  }
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+fn fn4(a0: vec2i, a1: array<vec4f, 14>) -> vec2f {
+  var out: vec2f;
+  vw14 = vec4<bool>(a1[13]);
+  out = unpack2x16float(pack2x16unorm(vec2f(unconst_f32(1.000), unconst_f32(0.01584))));
+  var vf58: f32 = vp0[unconst_u32(92)][min(u32((unconst_bool(true) || unconst_bool(true))), unconst_u32(50))];
+  var vf59 = fn0();
+  vw14 = vec4<bool>(unpack4xU8(pack4xU8Clamp(vec4u(asinh(vec4h(unconst_f16(-4917.7), unconst_f16(36660.9), unconst_f16(7192.0), unconst_f16(4742.4)))))));
+  let ptr11: ptr<function, vec2u> = &vf59.f0;
+  var vf60: f16 = atan(unconst_f16(38142.8));
+  vp0 -= mat3x2f(vec2f(max(vec4u(unconst_u32(140), unconst_u32(24), unconst_u32(188), unconst_u32(76)), vec4u(unconst_u32(131), unconst_u32(159), unconst_u32(69), unconst_u32(301))).bb), bitcast<vec2f>(max(vec4u(unconst_u32(140), unconst_u32(24), unconst_u32(188), unconst_u32(76)), vec4u(unconst_u32(131), unconst_u32(159), unconst_u32(69), unconst_u32(301))).ga), vec2f(max(vec4u(unconst_u32(140), unconst_u32(24), unconst_u32(188), unconst_u32(76)), vec4u(unconst_u32(131), unconst_u32(159), unconst_u32(69), unconst_u32(301))).xx));
+  out = vec2f(bitcast<f32>(sign(unconst_i32(-97))));
+  var vf61 = fn0();
+  vp0 = mat3x2f(f32(atomicLoad(&vw15[unconst_u32(90)])), bitcast<f32>(atomicLoad(&vw15[unconst_u32(90)])), bitcast<f32>(atomicLoad(&vw15[unconst_u32(90)])), f32(atomicLoad(&vw15[unconst_u32(90)])), f32(atomicLoad(&vw15[unconst_u32(90)])), f32(atomicLoad(&vw15[unconst_u32(90)])));
+  return out;
+}
+
+alias vec3b = vec3<bool>;
+
+struct T5 {
+  @size(88) f0: vec2u,
+}
+
+/* zero global variables used */
+@must_use 
+fn fn2() -> f32 {
+  var out: f32;
+  vp0 = mat3x2f(bitcast<vec2f>(atan2(vec4h(unconst_f16(13570.7), unconst_f16(21970.9), unconst_f16(3894.4), unconst_f16(9785.3)), vec4h(unconst_f16(5594.6), unconst_f16(25327.4), unconst_f16(8744.2), unconst_f16(9307.0)))), bitcast<vec2f>(atan2(vec4h(unconst_f16(13570.7), unconst_f16(21970.9), unconst_f16(3894.4), unconst_f16(9785.3)), vec4h(unconst_f16(5594.6), unconst_f16(25327.4), unconst_f16(8744.2), unconst_f16(9307.0)))), bitcast<vec2f>(atan2(vec4h(unconst_f16(13570.7), unconst_f16(21970.9), unconst_f16(3894.4), unconst_f16(9785.3)), vec4h(unconst_f16(5594.6), unconst_f16(25327.4), unconst_f16(8744.2), unconst_f16(9307.0)))));
+  let vf45: vec3u = (vec3u(unconst_u32(305), unconst_u32(47), unconst_u32(107)) & vec3u(unconst_u32(176), unconst_u32(85), unconst_u32(151)));
+  var vf46: vec2f = tan(vec2f(unconst_f32(-0.02686), unconst_f32(0.1122)));
+  let vf47: vec4f = inverseSqrt(vec4f(unconst_f32(0.01316), unconst_f32(0.06161), unconst_f32(0.2003), unconst_f32(0.1391)));
+  vf46 *= vec2f(f32((unconst_f32(0.05227) <= unconst_f32(0.6863))));
+  vf46 -= tan(vec2f(unconst_f32(0.2007), unconst_f32(0.09655)));
+  let vf48: vec4i = (vec4i(unconst_i32(26), unconst_i32(25), unconst_i32(115), unconst_i32(89)) % vec4i(bitcast<i32>(degrees(unconst_f32(0.08782)))));
+  var vf49: vec3u = vf45;
+  vf46 -= vp0[unconst_i32(0)];
+  let vf50: u32 = (unconst_u32(286) % u32(fract(unconst_f16(-9401.7))));
+  vf46 -= vec2f(vf46[unconst_u32(234)]);
+  let vf51: vec2<bool> =  !vec2<bool>(bool(vf45[unconst_u32(79)]));
+  vf46 = bitcast<vec2f>(atan2(vec4h(unconst_f16(-34099.5), unconst_f16(7898.7), unconst_f16(4964.7), unconst_f16(4011.5)), vec4h(unconst_f16(-4369.6), unconst_f16(16859.5), unconst_f16(26130.5), unconst_f16(20937.5))));
+  out += bitcast<f32>(firstTrailingBit(unconst_i32(242)));
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment0(@builtin(position) a0: vec4f, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf65: vec2f = vp0[unconst_u32(443)];
+  var vf66 = fn3(FragmentOutput0(unpack4xU8(pack2x16snorm(unpack2x16snorm(a1))), pack2x16snorm(unpack2x16snorm(a1))));
+  let vf67: vec4u = reverseBits(vec4u(unconst_u32(216), unconst_u32(233), unconst_u32(92), unconst_u32(56)));
+  let vf68: vec4u = (vec4u(unconst_u32(232), unconst_u32(575), unconst_u32(287), unconst_u32(1)) / vec4u(unconst_u32(7), unconst_u32(158), unconst_u32(93), unconst_u32(201)));
+  _ = fn0();
+  if bool(vf67[unconst_u32(112)]) {
+  out.f1 &= u32(a0[a1]);
+  let vf69: f32 = distance(vec3f(unconst_f32(0.1944), unconst_f32(-0.4086), unconst_f32(0.01186)), vec3f(fma(vec3h(unconst_f16(8286.1), unconst_f16(11855.5), unconst_f16(5086.9)), vec3h(unconst_f16(26211.8), unconst_f16(28531.8), unconst_f16(3273.2)), vec3h(unconst_f16(119.3), unconst_f16(102.7), unconst_f16(8680.4)))));
+  _ = fn3(FragmentOutput0(reverseBits(vec4u(unconst_u32(176), unconst_u32(134), unconst_u32(216), unconst_u32(43))), reverseBits(vec4u(unconst_u32(176), unconst_u32(134), unconst_u32(216), unconst_u32(43)))[2]));
+  var vf70: i32 = clamp(unconst_i32(53), unconst_i32(182), unconst_i32(154));
+  out = FragmentOutput0(unpack4xU8(u32((unconst_f16(24574.1) >= unconst_f16(23556.1)))), u32((unconst_f16(24574.1) >= unconst_f16(23556.1))));
+  var vf71: vec2h = fma(vec2h(abs(vec3f(unconst_f32(0.01501), unconst_f32(0.01149), unconst_f32(0.1873))).zy), vec2h(unconst_f16(2166.5), unconst_f16(13099.2)), vec2h(unconst_f16(5129.5), unconst_f16(7970.1)));
+}
+  out.f1 -= vec2u((vec2h(unconst_f16(3187.8), unconst_f16(16394.5)) <= vec2h(unconst_f16(22775.9), unconst_f16(497.2))))[0];
+  var vf72: u32 = insertBits(unconst_u32(100), unconst_u32(41), unconst_u32(8), unconst_u32(406));
+  let vf73: vec3u = (vec3u(unconst_u32(169), unconst_u32(107), unconst_u32(145)) >> vec3u(unconst_u32(100), unconst_u32(320), unconst_u32(227)));
+  _ = fn0();
+  var vf74: vec4h = normalize(vec4h(unconst_f16(8562.7), unconst_f16(38.71), unconst_f16(13784.2), unconst_f16(7708.3)));
+  return out;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 2, 1)
+fn compute1() {
+  vp0 = mat3x2f(f32(reverseBits(u32(atomicLoad(&vw15[0])))), bitcast<f32>(reverseBits(u32(atomicLoad(&vw15[0])))), f32(reverseBits(u32(atomicLoad(&vw15[0])))), f32(reverseBits(u32(atomicLoad(&vw15[0])))), bitcast<f32>(reverseBits(u32(atomicLoad(&vw15[0])))), bitcast<f32>(reverseBits(u32(atomicLoad(&vw15[0])))));
+}
+
+/* used global variables: st0 */
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  let ptr12: ptr<workgroup, array<atomic<i32>, 1>> = &(*&vw15);
+  let ptr13: ptr<workgroup, atomic<i32>> = &vw15[unconst_u32(43)];
+  vp0 = mat3x2f(tan(vec4f(unconst_f32(0.04492), unconst_f32(0.1932), unconst_f32(0.4088), unconst_f32(0.06223))).zz, tan(vec4f(unconst_f32(0.04492), unconst_f32(0.1932), unconst_f32(0.4088), unconst_f32(0.06223))).yx, tan(vec4f(unconst_f32(0.04492), unconst_f32(0.1932), unconst_f32(0.4088), unconst_f32(0.06223))).ab);
+  while (unconst_f32(0.03491) < unconst_f32(0.3081)) {
+  vp0 = mat3x2f(f32(pack2x16float(vec2f(unconst_f32(0.1656), unconst_f32(0.5552)))), bitcast<f32>(pack2x16float(vec2f(unconst_f32(0.1656), unconst_f32(0.5552)))), bitcast<f32>(pack2x16float(vec2f(unconst_f32(0.1656), unconst_f32(0.5552)))), f32(pack2x16float(vec2f(unconst_f32(0.1656), unconst_f32(0.5552)))), bitcast<f32>(pack2x16float(vec2f(unconst_f32(0.1656), unconst_f32(0.5552)))), f32(pack2x16float(vec2f(unconst_f32(0.1656), unconst_f32(0.5552)))));
+  _ = fn4(vec2i(atomicLoad(&vw15[0])), array<vec4f, 14>(vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1)))), vec4f(pow(vec4h(unconst_f16(16177.7), unconst_f16(4708.0), unconst_f16(10518.8), unconst_f16(888.1)), vec4h(unconst_f16(9525.8), unconst_f16(674.4), unconst_f16(18935.2), unconst_f16(2427.1))))));
+  vp0 += mat3x2f(bitcast<f32>(atomicExchange(&vw15[0], unconst_i32(163))), f32(atomicExchange(&vw15[0], unconst_i32(163))), bitcast<f32>(atomicExchange(&vw15[0], unconst_i32(163))), bitcast<f32>(atomicExchange(&vw15[0], unconst_i32(163))), bitcast<f32>(atomicExchange(&vw15[0], unconst_i32(163))), f32(atomicExchange(&vw15[0], unconst_i32(163))));
+}
+  atomicAnd(&vw15[unconst_u32(44)], unconst_i32(160));
+  let ptr14: ptr<workgroup, atomic<i32>> = &vw15[unconst_u32(136)];
+  vp0 += mat3x2f(bitcast<vec2f>(textureDimensions(st0)), vec2f(textureDimensions(st0)), bitcast<vec2f>(textureDimensions(st0)));
+  vw14 = vec4<bool>(bool(atomicExchange(&(*ptr12)[unconst_u32(207)], i32(vw14[u32(atomicLoad(&vw15[0]))]))));
+  _ = st0;
+}`,
+});
+try {
+computePassEncoder62.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer46, 'uint32', 30_460, 662);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer24);
+} catch {}
+try {
+commandEncoder109.resolveQuerySet(querySet0, 408, 34, buffer23, 512);
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder({});
+try {
+computePassEncoder60.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup26, [1024]);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup5, new Uint32Array(1155), 353, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer19, 'uint32', 276, 135);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1036 */
+  offset: 1036,
+  bytesPerRow: 9984,
+  buffer: buffer37,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas2 = document.createElement('canvas');
+let computePassEncoder85 = commandEncoder109.beginComputePass({timestampWrites: {querySet: querySet4, endOfPassWriteIndex: 362}});
+try {
+computePassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 856 */
+  offset: 856,
+  rowsPerImage: 41,
+  buffer: buffer26,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet4, 126, 72, buffer12, 0);
+} catch {}
+try {
+adapter0.label = '\ufebc\u4dbd\u{1fada}\u{1fb46}\u0bb0';
+} catch {}
+let veryExplicitBindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let texture85 = device0.createTexture({
+  size: {width: 2800, height: 17, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer47, 'uint16', 50, 267);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 60 */
+  offset: 60,
+  bytesPerRow: 11520,
+  buffer: buffer18,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 169, depthOrArrayLayers: 0});
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+let pipeline3 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  multisample: {mask: 0x167fa53c},
+  fragment: {module: shaderModule2, constants: {}, targets: [{format: 'rgba8uint'}]},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 96, shaderLocation: 3},
+          {format: 'sint16x4', offset: 184, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 440, shaderLocation: 9},
+          {format: 'float32', offset: 24, shaderLocation: 14},
+          {format: 'float32', offset: 100, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 240, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 456, shaderLocation: 1},
+          {format: 'sint32x4', offset: 164, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+let buffer51 = device0.createBuffer({
+  size: 9639,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture86 = device0.createTexture({
+  size: {width: 25, height: 1, depthOrArrayLayers: 46},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView92 = texture40.createView({aspect: 'all', format: 'rgba8sint', arrayLayerCount: 1});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer10, 'uint16', 124, 719);
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 1040 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 272 */
+  offset: 272,
+  buffer: buffer48,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 121, y: 4, z: 0},
+  aspect: 'all',
+}, {width: 130, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 1, y: 63 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 11, y: 463, z: 35},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 17, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer5 = commandEncoder52.finish();
+let textureView93 = texture38.createView({dimension: 'cube', baseArrayLayer: 1});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(0, bindGroup16, new Uint32Array(2023), 336, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup24, new Uint32Array(1704), 324, 1);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer23, 'uint32', 16, 560);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer22);
+} catch {}
+let computePassEncoder86 = commandEncoder110.beginComputePass({timestampWrites: {querySet: querySet4}});
+let renderPassEncoder32 = commandEncoder108.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: -155.7, g: -551.9, b: -675.6, a: -809.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler65 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.58,
+});
+try {
+computePassEncoder86.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup14, new Uint32Array(370), 28, 0);
+} catch {}
+await gc();
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup40, new Uint32Array(377), 76, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 19, resource: externalTexture8},
+    {binding: 44, resource: externalTexture3},
+    {binding: 131, resource: externalTexture9},
+    {binding: 59, resource: externalTexture10},
+    {binding: 47, resource: {buffer: buffer41, offset: 0, size: 508}},
+  ],
+});
+let textureView94 = texture59.createView({dimension: '2d-array', aspect: 'all'});
+let renderBundle15 = renderBundleEncoder15.finish({});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder76.setBindGroup(2, bindGroup26, new Uint32Array(272), 112, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroupsIndirect(buffer9, 748); };
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup9, new Uint32Array(619), 91, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer24, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(121).fill(42), /* required buffer size: 121 */
+{offset: 121}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 3 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 12, y: 675, z: 39},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas2.getContext('webgpu');
+} catch {}
+let textureView95 = texture26.createView({arrayLayerCount: 1});
+let sampler66 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+computePassEncoder51.pushDebugGroup('\u7a77');
+} catch {}
+try {
+computePassEncoder51.popDebugGroup();
+} catch {}
+let veryExplicitBindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 52,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 26, hasDynamicOffset: false },
+    },
+    {
+      binding: 85,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 322,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 356,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let texture87 = device0.createTexture({
+  size: {width: 700, height: 4, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView96 = texture31.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup35, new Uint32Array(534), 40, 1);
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle8, renderBundle8, renderBundle8, renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer46, 'uint16', 5_684, 1_342);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer21, 260, buffer18, 492, 116);
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet2, 141, 4, buffer44, 0);
+} catch {}
+let texture88 = device0.createTexture({
+  size: [96, 1820, 434],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder66.setPipeline(pipeline0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let buffer52 = device0.createBuffer({
+  size: 11452,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture89 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler67 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.60,
+  lodMaxClamp: 93.41,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup26, new Uint32Array(4994), 227, 1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup39, new Uint32Array(1766), 587, 0);
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder13.finish();
+let textureView97 = texture33.createView({mipLevelCount: 1});
+let texture90 = device0.createTexture({
+  size: {width: 700, height: 4, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView98 = texture40.createView({dimension: '2d', baseMipLevel: 0});
+let computePassEncoder87 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder83.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer34, 'uint16', 6_080, 78);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer10, 0, 3_017);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+adapter0.label = '\ua6b4\u{1fb84}\u9a78\u97ee\u0f52\u8520\u0523\u{1f803}';
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder();
+let computePassEncoder88 = commandEncoder112.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroupsIndirect(buffer43, 360); };
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({});
+let texture91 = device0.createTexture({
+  size: {width: 12, height: 1, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder89 = commandEncoder113.beginComputePass({timestampWrites: {querySet: querySet3, endOfPassWriteIndex: 57}});
+let sampler68 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 58.35,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder114 = device0.createCommandEncoder({});
+let sampler69 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 9.544});
+try {
+computePassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup17, new Uint32Array(2190), 7, 1);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer23, 'uint16', 1_254, 2_271);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, undefined);
+} catch {}
+try {
+commandEncoder114.copyBufferToBuffer(buffer10, 4560, buffer3, 1692, 952);
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(querySet4, 4, 75, buffer25, 768);
+} catch {}
+await gc();
+let imageBitmap2 = await createImageBitmap(imageData8);
+let textureView99 = texture18.createView({format: 'etc2-rgb8unorm-srgb'});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup22, new Uint32Array(60), 10, 0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer44, 'uint32', 48, 72);
+} catch {}
+try {
+adapter0.label = '\u02ca\u{1fd02}\u{1fb93}\ud48b\u{1f63b}\u30ea\u7b63\u3ef0\u0ce1\u038d';
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [
+    {binding: 19, resource: externalTexture0},
+    {binding: 44, resource: externalTexture4},
+    {binding: 59, resource: externalTexture8},
+    {binding: 131, resource: externalTexture3},
+    {binding: 47, resource: {buffer: buffer29, offset: 512, size: 2200}},
+  ],
+});
+let texture92 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView100 = texture62.createView({mipLevelCount: 1});
+let sampler70 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 79.95,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup35, [0]);
+} catch {}
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder12.setViewport(5004.279355112527, 4.458389569069665, 193.03177691460084, 23.287252933469716, 0.6133120103855297, 0.8971088636989719);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer49, 'uint16', 18, 370);
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer38, 552, 324);
+} catch {}
+try {
+commandEncoder114.resolveQuerySet(querySet2, 8, 1, buffer44, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 59, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer5, offset: 1280, size: 3048}},
+    {binding: 19, resource: externalTexture6},
+    {binding: 44, resource: externalTexture3},
+    {binding: 131, resource: externalTexture5},
+  ],
+});
+let texture93 = device0.createTexture({
+  size: [48],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup2, [0]);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup13, [1024]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 156, new Float32Array(2204), 288, 52);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise15;
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder88.label;
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup0, new Uint32Array(428), 7, 0);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 16},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let textureView101 = texture9.createView({});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup38, new Uint32Array(1349), 465, 0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(605.5852888096485, 3.660779165175893, 792.8495348675528, 2.074182268681728, 0.6533155065001948, 0.6913371307530455);
+} catch {}
+let texture94 = device0.createTexture({size: {width: 12}, dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder90 = commandEncoder114.beginComputePass();
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.91,
+  maxAnisotropy: 8,
+});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder77.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer38, 'uint16', 726, 942);
+} catch {}
+try {
+commandEncoder115.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1348 */
+  offset: 1348,
+  bytesPerRow: 43264,
+  buffer: buffer20,
+}, {
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder115.resolveQuerySet(querySet3, 4, 21, buffer24, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 47, resource: {buffer: buffer5, offset: 1024, size: 1984}},
+    {binding: 44, resource: externalTexture11},
+    {binding: 131, resource: externalTexture7},
+    {binding: 19, resource: externalTexture11},
+    {binding: 59, resource: externalTexture5},
+  ],
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let texture95 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder91 = commandEncoder115.beginComputePass({});
+let sampler72 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.03,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 1632 widthInBlocks: 408 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 416 */
+  offset: 416,
+  bytesPerRow: 15104,
+  buffer: buffer25,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 76, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 408, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1132 */
+  offset: 1132,
+  buffer: buffer12,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder117 = device0.createCommandEncoder({});
+let computePassEncoder92 = commandEncoder117.beginComputePass({});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup28, [0]);
+} catch {}
+let computePassEncoder93 = commandEncoder116.beginComputePass({});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], stencilReadOnly: false});
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer51, 'uint32', 340, 1_119);
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 600 */
+  offset: 600,
+  buffer: buffer37,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 39, y: 31, z: 65},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+let renderPassEncoder33 = commandEncoder44.beginRenderPass({
+  colorAttachments: [{
+  view: textureView76,
+  clearValue: { r: -129.8, g: -448.0, b: -713.1, a: 24.21, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler73 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 6.166,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder88.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer40, 56, 23);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder();
+let querySet5 = device0.createQuerySet({type: 'timestamp', count: 1152});
+let textureView102 = texture69.createView({dimension: '2d-array'});
+let sampler74 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 94.30,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 560 */
+  offset: 560,
+  bytesPerRow: 16896,
+  buffer: buffer21,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 11, y: 39, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder31.insertDebugMarker('\uda9e');
+} catch {}
+let videoFrame13 = new VideoFrame(canvas2, {timestamp: 0});
+let commandEncoder120 = device0.createCommandEncoder({});
+let texture96 = device0.createTexture({
+  size: [51, 1, 580],
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame9});
+try {
+computePassEncoder87.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer30, 156);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup28, [0]);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder118.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 424 */
+  offset: 424,
+  bytesPerRow: 2304,
+  buffer: buffer7,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 0, y: 77, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 569, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder({});
+try {
+computePassEncoder61.setBindGroup(2, bindGroup39, new Uint32Array(722), 26, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(3, buffer49, 0);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer17, 'uint16', 114, 64);
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas1);
+let bindGroup46 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 131, resource: externalTexture1},
+    {binding: 47, resource: {buffer: buffer14, offset: 0, size: 680}},
+    {binding: 59, resource: externalTexture2},
+    {binding: 44, resource: externalTexture10},
+    {binding: 19, resource: externalTexture10},
+  ],
+});
+let buffer53 = device0.createBuffer({
+  size: 5201,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture97 = device0.createTexture({
+  size: [102, 1, 19],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView103 = texture91.createView({dimension: '2d-array', arrayLayerCount: 1});
+let renderBundle16 = renderBundleEncoder16.finish();
+let sampler75 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 50.50, compare: 'equal'});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup20, new Uint32Array(2102), 106, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(2, bindGroup25, new Uint32Array(378), 99, 0);
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2808 */
+  offset: 2808,
+  rowsPerImage: 342,
+  buffer: buffer26,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\u6982');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 2, y: 1311, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u0505\u0e87\u{1f8a3}\u0919\u794c';
+} catch {}
+let recycledExplicitBindGroupLayout8 = pipeline0.getBindGroupLayout(0);
+let bindGroup47 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 44, resource: externalTexture9},
+    {binding: 59, resource: externalTexture10},
+    {binding: 19, resource: externalTexture9},
+    {binding: 47, resource: {buffer: buffer23, offset: 1024, size: 7616}},
+    {binding: 131, resource: externalTexture7},
+  ],
+});
+let commandEncoder122 = device0.createCommandEncoder({});
+let commandBuffer7 = commandEncoder120.finish();
+let computePassEncoder94 = commandEncoder118.beginComputePass({});
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup17, [0]);
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 131, resource: externalTexture7},
+    {binding: 19, resource: externalTexture5},
+    {binding: 59, resource: externalTexture0},
+    {binding: 44, resource: externalTexture10},
+    {binding: 47, resource: {buffer: buffer31, offset: 0, size: 4920}},
+  ],
+});
+let buffer54 = device0.createBuffer({
+  size: 145,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder123 = device0.createCommandEncoder({});
+let textureView104 = texture61.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+computePassEncoder93.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup38, new Uint32Array(2842), 946, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer24, 'uint16', 68, 135);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer18, 1484, 1168);
+} catch {}
+try {
+externalTexture5.label = '\u5975\u{1f893}';
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 59, resource: externalTexture3},
+    {binding: 131, resource: externalTexture12},
+    {binding: 47, resource: {buffer: buffer46, offset: 2560, size: 424}},
+    {binding: 44, resource: externalTexture1},
+    {binding: 19, resource: externalTexture2},
+  ],
+});
+let commandEncoder124 = device0.createCommandEncoder({});
+let computePassEncoder95 = commandEncoder123.beginComputePass({});
+let sampler76 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMinClamp: 31.47, maxAnisotropy: 1});
+try {
+computePassEncoder64.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer13, 0, 11_389);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer1, 0, buffer51, 40, 56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(816).fill(223), /* required buffer size: 816 */
+{offset: 816}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  size: [25, 1, 172],
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture99 = device0.createTexture({
+  size: [25, 1, 38],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder96 = commandEncoder119.beginComputePass();
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer24);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: imageData2,
+  origin: { x: 2, y: 16 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1, y: 667, z: 83},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+let imageData11 = new ImageData(36, 4);
+let texture100 = device0.createTexture({
+  label: '\ue8dc\u5ecc\u0f7f\u{1ff31}\u77ca\u5ef0\u737b\u439d',
+  size: [700, 4, 71],
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView105 = texture76.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup17, new Uint32Array(6296), 2_966, 1);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(2, buffer54, 16, 37);
+} catch {}
+try {
+commandEncoder122.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1459 */
+  offset: 1459,
+  buffer: buffer29,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 52, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 110,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 141,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+  ],
+});
+let texture101 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture102 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint'],
+});
+let renderPassEncoder34 = commandEncoder125.beginRenderPass({
+  colorAttachments: [{view: textureView44, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet2,
+  timestampWrites: {querySet: querySet5, beginningOfPassWriteIndex: 681},
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup24, [0]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer46, 'uint32', 3_808, 333);
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'timestamp', count: 75});
+let texture103 = device0.createTexture({
+  size: {width: 51, height: 1, depthOrArrayLayers: 39},
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup34, new Uint32Array(408), 26, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer29, 4_940); };
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer38, 'uint16', 9_470, 90);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer53);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup28, [0]);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer49, 184, 1_703);
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32', offset: 908, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 156, shaderLocation: 2},
+          {format: 'float16x2', offset: 72, shaderLocation: 9},
+          {format: 'sint32x2', offset: 668, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 196, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 1012, shaderLocation: 14},
+          {format: 'float16x4', offset: 80, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 1100,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x4', offset: 184, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+await gc();
+let texture104 = device0.createTexture({
+  size: {width: 25, height: 1, depthOrArrayLayers: 136},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView106 = texture25.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder97 = commandEncoder126.beginComputePass({});
+let renderBundle17 = renderBundleEncoder17.finish();
+try {
+renderPassEncoder27.executeBundles([renderBundle0, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer34, 'uint32', 624, 1_142);
+} catch {}
+let arrayBuffer11 = buffer15.getMappedRange(3720, 252);
+try {
+  await promise19;
+} catch {}
+let textureView107 = texture100.createView({baseMipLevel: 0});
+try {
+renderPassEncoder25.setIndexBuffer(buffer47, 'uint32', 132, 19);
+} catch {}
+try {
+commandEncoder124.copyBufferToTexture({
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1476 */
+  offset: 1476,
+  bytesPerRow: 13056,
+  buffer: buffer32,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 65, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 27, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture98,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: imageData7,
+  origin: { x: 0, y: 6 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 2, y: 682, z: 103},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise17;
+} catch {}
+offscreenCanvas0.height = 741;
+let commandEncoder127 = device0.createCommandEncoder({});
+let texture105 = device0.createTexture({
+  size: [24, 455, 1],
+  sampleCount: 4,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder98 = commandEncoder127.beginComputePass({});
+let renderPassEncoder35 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{
+  view: textureView44,
+  clearValue: { r: -725.4, g: -820.9, b: -949.3, a: 571.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet6, beginningOfPassWriteIndex: 62, endOfPassWriteIndex: 42},
+  maxDrawCount: 420833853,
+});
+try {
+computePassEncoder89.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup2, new Uint32Array(3955), 62, 1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 260, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 44, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+override override10 = 0.07520;
+
+override override3: u32 = 475;
+
+@id(17947) override override4: f16;
+
+struct T7 {
+  @size(96) f0: array<T0, 1>,
+}
+
+@id(27645) override override7: f32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T6 {
+  @size(64) f0: T0,
+  @align(32) @size(1152) f1: array<u32>,
+}
+
+struct T8 {
+  f0: array<atomic<i32>>,
+}
+
+override override5 = 0.02793;
+
+struct T4 {
+  @align(8) @size(104) f0: atomic<u32>,
+}
+
+struct T9 {
+  @size(1952) f0: array<u32>,
+}
+
+override override11 = true;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+fn fn1(a0: array<array<array<array<vec2u, 1>, 1>, 1>, 1>, a1: ptr<function, mat4x4f>) {
+  let vf78: vec2u = a0[unconst_u32(142)][0][unconst_u32(58)][0];
+  var vf79 = fn0(FragmentOutput1(vec2i(i32(vw16[38][0])), vec4f(f32(vw16[38][0]))));
+  _ = override9;
+  _ = override5;
+}
+
+@group(0) @binding(224) var et2: texture_external;
+
+@id(41508) override override12: bool;
+
+override override9: f16 = 27610.2;
+
+struct T5 {
+  @align(64) @size(2880) f0: T3,
+}
+
+var<workgroup> vw16: array<array<f16, 1>, 39>;
+
+@id(41706) override override8: u32;
+
+@id(56084) override override2: i32;
+
+struct T0 {
+  @align(8) @size(8) f0: atomic<u32>,
+}
+
+struct T2 {
+  @align(32) @size(32) f0: array<u32>,
+}
+
+struct T3 {
+  @size(768) f0: array<T0>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(59150) override override1: f16 = 2523.9;
+
+struct T1 {
+  @size(532) f0: array<array<array<i32, 1>, 1>>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(21050) override override6 = 0.1538;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* zero global variables used */
+fn fn0(a0: FragmentOutput1) -> array<FragmentOutput1, 1> {
+  var out: array<FragmentOutput1, 1>;
+  vw16[unconst_u32(280)][unconst_u32(137)] *= override9;
+  vw16[unconst_u32(112)][unconst_u32(133)] -= f16(a0.f1[3]);
+  while bool(fract(unconst_f16(4491.4))) {
+  let vf75: i32 = a0.f0[unconst_u32(92)];
+  let ptr15: ptr<workgroup, array<f16, 1>> = &(*&vw16)[38];
+  out[unconst_u32(56)].f1 = vec4f(reflect(vec2h(unconst_f16(3306.4), unconst_f16(15003.4)), vec2h(unconst_f16(12717.5), unconst_f16(27334.9))).yxyy);
+  var vf76: vec2h = pow(vec2h(unconst_f16(4897.2), unconst_f16(8047.4)), vec2h(unconst_f16(16519.3), unconst_f16(10149.3)));
+  vw16[unconst_u32(2)][unconst_u32(574)] -= atan(vec3h(unconst_f16(4728.5), unconst_f16(3612.2), unconst_f16(2892.9))).g;
+  vf76 += vec2h(vw16[unconst_u32(42)][0]);
+  break;
+}
+  out[unconst_u32(46)].f0 = vec2i(i32(ldexp(unconst_f16(11593.5), unconst_i32(112))));
+  for (var it2=u32(normalize(vec4h((*&vw16)[38][unconst_u32(650)])).w); it2<u32(vw16[unconst_u32(13)][0]); it2++) {
+  var vf77: u32 = pack4xI8(vec4i(unconst_i32(47), unconst_i32(13), unconst_i32(221), unconst_i32(99)));
+  vw16[unconst_u32(204)][bitcast<u32>(override5)] = vw16[38][0];
+  _ = override5;
+}
+  return out;
+  _ = override9;
+  _ = override5;
+}
+
+struct FragmentOutput1 {
+  @location(1) f0: vec2i,
+  @location(0) f1: vec4f,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex3(@location(14) a0: vec2f) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out -= vec4f(f32(override3));
+  let vf80: vec4h = tanh(vec4h(unconst_f16(7907.6), unconst_f16(4593.0), unconst_f16(3552.8), unconst_f16(2824.1)));
+  out -= vec4f(f32(override9));
+  out += vec4f(f32(vf80[vec3u(cross(vec3f(unconst_f32(0.1764), unconst_f32(0.1132), unconst_f32(0.1292)), vec3f(override5))).r]));
+  out -= vec4f(f32(length(vec4h(unconst_f16(4216.8), unconst_f16(3989.5), unconst_f16(3237.3), unconst_f16(3153.5)))));
+  var vf81: u32 = dot(vec3u(unconst_u32(119), unconst_u32(246), unconst_u32(10)), vec3u( !vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true))));
+  out *= vec4f(f32(length(vec4h(unconst_f16(1662.6), unconst_f16(13763.4), unconst_f16(6929.7), unconst_f16(2842.5)))));
+  vf81 *= bitcast<u32>(override7);
+  return out;
+  _ = override9;
+  _ = override7;
+  _ = override5;
+  _ = override3;
+}
+
+/* used global variables: et2 */
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  out.f1 = vec4f(f32(dot(vec4u(unconst_u32(239), unconst_u32(643), unconst_u32(124), unconst_u32(9)), bitcast<vec4u>(radians(vec2f(unconst_f32(0.2252), unconst_f32(0.07049))).grgg))));
+  out.f1 = vec4f(extractBits(vec4i(unconst_i32(23), unconst_i32(197), unconst_i32(4), unconst_i32(24)), countTrailingZeros(vec3u(sin(vec3f(unconst_f32(0.5545), unconst_f32(0.05370), unconst_f32(0.03692))))[2]), unconst_u32(48)));
+  var vf82: u32 = dot(vec4u(unconst_u32(304), unconst_u32(92), unconst_u32(118), unconst_u32(117)), vec4u(unconst_u32(91), unconst_u32(30), unconst_u32(63), unconst_u32(84)));
+  vf82 = textureDimensions(et2)[1];
+  var vf83: vec4h = exp2(vec4h(unconst_f16(3165.6), unconst_f16(11263.0), unconst_f16(733.2), unconst_f16(18435.6)));
+  var vf84: u32 = override3;
+  {
+  out.f1 = vec4f(f32(override2));
+  out.f0 ^= vec2i(i32(distance(vec2f(unconst_f32(0.04109), unconst_f32(-0.3371)), vec2f(unconst_f32(0.09276), unconst_f32(0.1869)))));
+  var vf85: vec3f = cos(ceil(vec4f(unconst_f32(0.1155), unconst_f32(0.02175), unconst_f32(0.1143), unconst_f32(0.1845))).aar);
+  while any(unconst_bool(false)) {
+  out.f0 = vec2i(i32(acos(unconst_f32(0.4501))));
+  out = FragmentOutput1((vec3i(atan2(vec4f(unconst_f32(0.1345), unconst_f32(0.09332), unconst_f32(0.3777), unconst_f32(0.2953)), vec4f(unconst_f32(0.02535), unconst_f32(-0.2176), unconst_f32(0.1725), unconst_f32(0.01457))).yzx) ^ vec3i(unconst_i32(16), unconst_i32(83), unconst_i32(352))).zy, bitcast<vec4f>((vec3i(atan2(vec4f(unconst_f32(0.1345), unconst_f32(0.09332), unconst_f32(0.3777), unconst_f32(0.2953)), vec4f(unconst_f32(0.02535), unconst_f32(-0.2176), unconst_f32(0.1725), unconst_f32(0.01457))).yzx) ^ vec3i(unconst_i32(16), unconst_i32(83), unconst_i32(352))).yzxz));
+  var vf86: u32 = (unconst_u32(123) << unconst_u32(127));
+  var vf87: vec2f = unpack2x16snorm(unconst_u32(33));
+}
+  let vf88: vec4h = asinh(vec4h(unconst_f16(39729.2), unconst_f16(12453.3), unconst_f16(24711.8), unconst_f16(463.7)));
+  out.f1 *= vec4f(f32(any(bool(override3))));
+  _ = override3;
+  _ = override2;
+}
+  return out;
+  _ = override2;
+  _ = override3;
+  _ = et2;
+}`,
+});
+let textureView108 = texture53.createView({label: '\u0f26\u0572\u{1f6e5}', baseArrayLayer: 6, arrayLayerCount: 4});
+let renderPassEncoder36 = commandEncoder122.beginRenderPass({
+  colorAttachments: [{
+  view: textureView104,
+  clearValue: { r: 340.2, g: -754.1, b: -32.70, a: 480.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler77 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 90.48});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup37);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup47, new Uint32Array(5050), 106, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture106 = device0.createTexture({
+  size: [102],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler78 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 93.83,
+});
+try {
+computePassEncoder74.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder22.setViewport(43.035345846069795, 73.22579401409813, 4.959662264894595, 48.28580009592271, 0.18929043431574333, 0.643598533967332);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet4, 58, 116, buffer0, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: canvas2,
+  origin: { x: 113, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 35, z: 42},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 28, height: 19, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 51, resource: {buffer: buffer42, offset: 4096, size: 144}}],
+});
+let commandBuffer8 = commandEncoder2.finish();
+let textureView109 = texture24.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder76.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle10]);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+let buffer55 = device0.createBuffer({
+  size: 3989,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let querySet7 = device0.createQuerySet({type: 'timestamp', count: 67});
+let computePassEncoder99 = commandEncoder124.beginComputePass({});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(1, bindGroup8, new Uint32Array(690), 85, 0);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer8]);
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 47, resource: {buffer: buffer23, offset: 4352, size: 2116}},
+    {binding: 131, resource: externalTexture3},
+    {binding: 59, resource: externalTexture3},
+    {binding: 44, resource: externalTexture2},
+    {binding: 19, resource: externalTexture6},
+  ],
+});
+let buffer56 = device0.createBuffer({
+  size: 7321,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture107 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView110 = texture107.createView({dimension: '2d-array'});
+try {
+computePassEncoder90.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder34.setScissorRect(105, 5, 1053, 8);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer24, 'uint32', 76, 13);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(16).fill(247), /* required buffer size: 16 */
+{offset: 16}, {width: 283, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 59, resource: externalTexture10},
+    {binding: 44, resource: externalTexture3},
+    {binding: 131, resource: externalTexture6},
+    {binding: 47, resource: {buffer: buffer28, offset: 512, size: 8308}},
+    {binding: 19, resource: externalTexture4},
+  ],
+});
+let commandEncoder128 = device0.createCommandEncoder({});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup17, [0]);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(2, bindGroup39, new Uint32Array(3010), 73, 0);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 700, height: 4, depthOrArrayLayers: 71}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 49, y: 1, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline5 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule3,
+  constants: {56_084: 1},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'constant'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 88,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 4, shaderLocation: 2},
+          {format: 'sint32x2', offset: 0, shaderLocation: 5},
+          {format: 'sint32x4', offset: 8, shaderLocation: 11},
+          {format: 'sint32x4', offset: 0, shaderLocation: 3},
+          {format: 'float32x2', offset: 8, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 4},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 9},
+          {format: 'float32', offset: 28, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+let commandEncoder129 = device0.createCommandEncoder();
+let texture108 = device0.createTexture({
+  size: [8, 8, 769],
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView111 = texture98.createView({baseArrayLayer: 0});
+let renderPassEncoder37 = commandEncoder129.beginRenderPass({
+  colorAttachments: [{
+  view: textureView104,
+  clearValue: { r: 953.8, g: -17.29, b: -37.44, a: -959.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 222607638,
+});
+let sampler79 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.86,
+});
+try {
+computePassEncoder95.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer30, 'uint16', 316, 58);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(canvas1);
+let texture109 = device0.createTexture({
+  label: '\uacb9\u0ab1\u0662',
+  size: {width: 1400},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView112 = texture26.createView({});
+let computePassEncoder100 = commandEncoder128.beginComputePass({});
+try {
+buffer54.unmap();
+} catch {}
+try {
+  await buffer39.mapAsync(GPUMapMode.WRITE, 0, 0);
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule2, constants: {}, targets: [{format: 'rgba8uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex3',
+    constants: {27_645: 1},
+    buffers: [{arrayStride: 1032, attributes: [{format: 'unorm16x2', offset: 20, shaderLocation: 14}]}],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroup53 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 41, resource: textureView77}]});
+let buffer57 = device0.createBuffer({size: 13553, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView113 = texture14.createView({baseMipLevel: 0});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle6]);
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 888 */
+  offset: 888,
+  bytesPerRow: 4608,
+  buffer: buffer18,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 357, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 1900, new Int16Array(12591), 487, 688);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+document.body.prepend(canvas2);
+let imageData12 = new ImageData(64, 4);
+let commandEncoder130 = device0.createCommandEncoder({});
+let texture110 = device0.createTexture({
+  size: [2800, 17, 1],
+  mipLevelCount: 5,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup5, new Uint32Array(1506), 4, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer0, 'uint16', 856, 717);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup48);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer10, 'uint16', 2_146, 1_453);
+} catch {}
+let arrayBuffer12 = buffer6.getMappedRange(4496, 48);
+try {
+commandEncoder9.resolveQuerySet(querySet6, 21, 1, buffer54, 0);
+} catch {}
+let commandBuffer9 = commandEncoder130.finish();
+let textureView114 = texture38.createView({dimension: 'cube', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder101 = commandEncoder9.beginComputePass({timestampWrites: {querySet: querySet7, endOfPassWriteIndex: 34}});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer10, 'uint32', 676, 166);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer55, 'uint32', 596, 0);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer21);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 100, new DataView(new ArrayBuffer(5752)), 408, 792);
+} catch {}
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup4, new Uint32Array(1919), 252, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup13, new Uint32Array(2373), 205, 1);
+} catch {}
+try {
+renderPassEncoder32.setViewport(600.323844342656, 2.2154238840061904, 414.90692297785586, 1.1067093232809613, 0.2739671962019866, 0.50806569246114);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(7, buffer33, 1_036, 1_391);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup54 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: []});
+let buffer58 = device0.createBuffer({
+  size: 1579,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture111 = device0.createTexture({
+  size: [12, 1, 60],
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView115 = texture41.createView({label: '\u{1fa5b}\u6a15\u{1ff36}\u445b\u4f9f\u9bda\u6e25\u{1fc95}\ue313'});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup45, new Uint32Array(4807), 90, 0);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u74af');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({});
+let texture112 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 31},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder102 = commandEncoder131.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(0, bindGroup41, new Uint32Array(1081), 112, 0);
+} catch {}
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer49, 'uint32', 1_432, 199);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer47, 248, 15);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 131, resource: externalTexture7},
+    {binding: 47, resource: {buffer: buffer53, offset: 256, size: 1244}},
+    {binding: 44, resource: externalTexture4},
+    {binding: 19, resource: externalTexture3},
+    {binding: 59, resource: externalTexture7},
+  ],
+});
+let textureView116 = texture65.createView({label: '\u0e4b\u53b2\u6ca5\u0208', format: 'rgb10a2uint', arrayLayerCount: 1});
+let computePassEncoder103 = commandEncoder93.beginComputePass({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], stencilReadOnly: true});
+let sampler80 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 98.70, maxAnisotropy: 1});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup4, new Uint32Array(945), 37, 0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer29, 'uint16', 3_820, 762);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer50, 'uint32', 8_112, 3_505);
+} catch {}
+let pipeline7 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule2, entryPoint: 'compute2', constants: {}}});
+let bindGroup56 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 19, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer0, offset: 4608, size: 3164}},
+    {binding: 44, resource: externalTexture7},
+    {binding: 59, resource: externalTexture11},
+    {binding: 131, resource: externalTexture3},
+  ],
+});
+let commandEncoder132 = device0.createCommandEncoder();
+let textureView117 = texture106.createView({dimension: '1d'});
+try {
+computePassEncoder101.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(4, buffer54, 0, 30);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+try {
+commandEncoder132.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 30},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 124, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder104 = commandEncoder132.beginComputePass();
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup17, [512]);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: 526.2, g: 740.1, b: -839.5, a: 680.8, });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas2);
+let commandEncoder133 = device0.createCommandEncoder({label: '\u450e\u{1fc12}'});
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+override override16: f32;
+
+/* zero global variables used */
+fn fn0(a0: mat2x4h) -> VertexOutput1 {
+  var out: VertexOutput1;
+  for (var it3=override19; it3<pack4x8unorm(vec4f(unconst_f32(0.1511), unconst_f32(0.2280), unconst_f32(0.06641), unconst_f32(0.05694))); it3++) {
+  let vf89: vec2i = firstTrailingBit(vec2i(i32(pack4xU8Clamp(vec4u(unconst_u32(127), unconst_u32(276), unconst_u32(229), unconst_u32(174))))));
+  let vf90: vec4<bool> = (vec4u(unconst_u32(416), unconst_u32(503), unconst_u32(511), unconst_u32(9)) >= vec4u(unconst_u32(111), unconst_u32(140), unconst_u32(26), unconst_u32(214)));
+  let vf91: u32 = override13;
+  break;
+  _ = override13;
+}
+  let vf92: u32 = pack2x16float(vec2f(unconst_f32(0.1240), unconst_f32(0.04453)));
+  var vf93: mat3x4h = (unconst_f16(16502.3) * mat3x4h());
+  out.f4 -= vec2h((vec2u(unconst_u32(141), unconst_u32(82)) ^ vec2u(unconst_u32(333), unconst_u32(55))));
+  if bool(sign(vec4h(unconst_f16(7621.3), unconst_f16(181.2), unconst_f16(-6469.5), unconst_f16(9187.3))).x) {
+  let vf94: vec2h = acos(vec2h(unconst_f16(223.3), unconst_f16(8434.6)));
+  out.f9 &= vec3u(round(vec3f(unconst_f32(0.00213), unconst_f32(-0.03865), unconst_f32(-0.3377)))).g;
+  var vf95: vec4i = firstTrailingBit(vec4i(unconst_i32(358), unconst_i32(608), unconst_i32(105), unconst_i32(487)));
+  var vf96: vec2h = degrees(vec2h(unconst_f16(10756.7), unconst_f16(3329.9)));
+  var vf97: vec4<bool> = (vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(false)) | vec4<bool>(bool(override19)));
+  let vf98: u32 = pack2x16snorm(vec2f(unconst_f32(0.00201), unconst_f32(0.5478)));
+  _ = override19;
+}
+  out.f17 = unpack4x8unorm(vf92);
+  var vf99: vec4h = sign(vec4h(unconst_f16(5579.2), unconst_f16(25460.6), unconst_f16(6474.4), unconst_f16(23636.5)));
+  var vf100: vec3h = cosh(vec3h((vec2i(unconst_i32(3), unconst_i32(111)) | vec2i(unconst_i32(10), unconst_i32(388))).ggr));
+  let vf101: f16 = max(vf93[unconst_i32(0)][1], unconst_f16(3345.9));
+  loop {
+  out.f9 ^= pack4xU8(countOneBits(vec4u(unconst_u32(136), unconst_u32(152), unconst_u32(216), unconst_u32(112))));
+  out.f9 = u32((unconst_i32(5) >> vec4u(a0[unconst_i32(1)])[1]));
+  break;
+}
+  var vf102: i32 = dot4I8Packed(unconst_u32(231), unconst_u32(86));
+  var vf103: vec3<bool> = (vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false)) & vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(false)));
+  let vf104: f16 = vf93[unconst_u32(134)][unconst_u32(430)];
+  return out;
+  _ = override13;
+  _ = override19;
+}
+
+/* zero global variables used */
+fn fn3() -> T1 {
+  var out: T1;
+  out.f0[unconst_u32(154)][unconst_u32(107)][unconst_u32(488)][unconst_u32(84)] -= vec4i(i32(override18));
+  _ = fn0(mat2x4h(bitcast<vec4h>((vec2i(unconst_i32(142), unconst_i32(9)) & vec2i(unconst_i32(91), unconst_i32(233)))), bitcast<vec4h>((vec2i(unconst_i32(142), unconst_i32(9)) & vec2i(unconst_i32(91), unconst_i32(233))))));
+  if bool(cosh(vec4f(unconst_f32(-0.1274), unconst_f32(0.2837), unconst_f32(0.2738), unconst_f32(0.00219))).z) {
+  var vf117 = fn0(mat2x4h(vec4h( ~vec3u(unconst_u32(74), unconst_u32(98), unconst_u32(17)).xyzx), vec4h( ~vec3u(unconst_u32(74), unconst_u32(98), unconst_u32(17)).zxyz)));
+  let ptr16: ptr<function, vec4f> = &vf117.f17;
+  let ptr17: ptr<function, f16> = &vf117.f10;
+  fn1();
+  _ = override17;
+  _ = override19;
+  _ = override13;
+}
+  let vf118: vec4h = sqrt(vec4h(unconst_f16(16092.3), unconst_f16(35340.1), unconst_f16(1156.3), unconst_f16(40965.0)));
+  _ = fn2();
+  {
+  out.f0[unconst_u32(25)][unconst_u32(225)][unconst_u32(121)][unconst_u32(94)] = bitcast<vec4i>(unpack2x16float(unconst_u32(223)).yyxx);
+  out = T1(array<array<array<array<vec4i, 1>, 1>, 1>, 1>(array<array<array<vec4i, 1>, 1>, 1>(array<array<vec4i, 1>, 1>(array<vec4i, 1>(vec4i((vec3i(unconst_i32(-850), unconst_i32(47), unconst_i32(61)) < vec3i(i32(override19))).grbb))))));
+  out.f0[unconst_u32(912)][unconst_u32(235)][unconst_u32(128)][0] &= unpack4xI8(pack4x8unorm(vec4f(unconst_f32(0.1257), unconst_f32(0.1473), unconst_f32(0.04484), unconst_f32(0.1394))));
+  fn0(mat2x4h(vec4h(extractBits(vec4u(unconst_u32(897), unconst_u32(137), unconst_u32(129), unconst_u32(354)), unconst_u32(563), unconst_u32(137))), vec4h(extractBits(vec4u(unconst_u32(897), unconst_u32(137), unconst_u32(129), unconst_u32(354)), unconst_u32(563), unconst_u32(137)))));
+  _ = override19;
+  _ = override13;
+}
+  out.f0[unconst_u32(78)][unconst_u32(47)][unconst_u32(167)][unconst_u32(177)] ^= unpack4xI8((unconst_u32(86) >> unconst_u32(161)));
+  out.f0[unconst_u32(232)][unconst_u32(402)][unconst_u32(79)][unconst_u32(65)] *= vec4i(vf118);
+  var vf119: vec2f = unpack2x16snorm(bitcast<u32>(min(bitcast<vec2i>(sqrt(vec4f(unconst_f32(0.1390), unconst_f32(-0.08291), unconst_f32(0.1579), unconst_f32(0.01972))).yz), vec2i(unconst_i32(216), unconst_i32(504))).g));
+  var vf120 = fn2();
+  out.f0[unconst_u32(62)][unconst_u32(213)][unconst_u32(379)][u32(override16)] ^= vec4i(i32(override16));
+  let ptr18: ptr<function, vec2f> = &vf119;
+  return out;
+  _ = override13;
+  _ = override16;
+  _ = override17;
+  _ = override19;
+  _ = override14;
+  _ = override18;
+}
+
+override override17: u32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(59101) override override15: f32;
+
+/* zero global variables used */
+@must_use 
+fn fn5(a0: ptr<function, array<array<mat2x2f, 1>, 1>>, a1: T1) -> array<mat4x2h, 1> {
+  var out: array<mat4x2h, 1>;
+  var vf126: vec4i = a1.f0[0][unconst_u32(47)][unconst_u32(28)][0];
+  var vf127: f32 = (*a0)[unconst_u32(59)][0][unconst_u32(158)][unconst_u32(38)];
+  var vf128: i32 = a1.f0[unconst_u32(103)][0][0][unconst_u32(146)][unconst_u32(781)];
+  (*a0)[0][unconst_u32(89)] = mat2x2f(bitcast<f32>(a1.f0[unconst_u32(17)][0][unconst_u32(247)][0][unconst_u32(67)]), f32(a1.f0[unconst_u32(17)][0][unconst_u32(247)][0][unconst_u32(67)]), f32(a1.f0[unconst_u32(17)][0][unconst_u32(247)][0][unconst_u32(67)]), f32(a1.f0[unconst_u32(17)][0][unconst_u32(247)][0][unconst_u32(67)]));
+  let vf129: vec4i = a1.f0[unconst_u32(175)][0][0][unconst_u32(11)];
+  let ptr20: ptr<function, mat2x2f> = &(*a0)[0][unconst_u32(34)];
+  let vf130: array<vec4i, 1> = a1.f0[0][unconst_u32(221)][0];
+  return out;
+}
+
+/* zero global variables used */
+fn fn1() {
+  var vf105 = fn0(mat2x4h(atan2(vec4h(unconst_f16(20775.5), unconst_f16(1529.3), unconst_f16(10225.3), unconst_f16(332.1)), vec4h(unconst_f16(5003.3), unconst_f16(5315.4), unconst_f16(2097.3), unconst_f16(8582.0))), atan2(vec4h(unconst_f16(20775.5), unconst_f16(1529.3), unconst_f16(10225.3), unconst_f16(332.1)), vec4h(unconst_f16(5003.3), unconst_f16(5315.4), unconst_f16(2097.3), unconst_f16(8582.0)))));
+  fn0(mat2x4h(vec4h(fract(vec3f(atan(vec4h(unconst_f16(9736.9), unconst_f16(37310.5), unconst_f16(8793.5), unconst_f16(17347.6))).xyy)).gbgr), vec4h(fract(vec3f(atan(vec4h(unconst_f16(9736.9), unconst_f16(37310.5), unconst_f16(8793.5), unconst_f16(17347.6))).xyy)).grrb)));
+  let vf106: f32 = vf105.f8[unconst_u32(102)];
+  var vf107: f32 = vf105.f15[unconst_u32(53)];
+  vf107 *= bitcast<f32>(vf105.f4);
+  let vf108: i32 = vf105.f7[unconst_u32(37)];
+  loop {
+  var vf109 = fn0(mat2x4h(pow(vec4h(unconst_f16(7474.0), unconst_f16(-4725.5), unconst_f16(37598.0), unconst_f16(-10030.3)), vec4h(unconst_f16(37775.7), unconst_f16(6492.0), unconst_f16(-1421.2), unconst_f16(7707.9))), pow(vec4h(unconst_f16(7474.0), unconst_f16(-4725.5), unconst_f16(37598.0), unconst_f16(-10030.3)), vec4h(unconst_f16(37775.7), unconst_f16(6492.0), unconst_f16(-1421.2), unconst_f16(7707.9)))));
+  vf109 = VertexOutput1(vec2h(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))), i32(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))[1]), pack2x16float(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))), vec2i(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))), step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371))), pack2x16snorm(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))), f16(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371))).y), step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371))), bitcast<vec4i>(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371))).xxxy), bitcast<vec2i>(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))), step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371))).yyyx, step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371))).ggrg, vec2i(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))), step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371))).yyxy, vec2i(step(vec2f(unconst_f32(0.5439), unconst_f32(0.02259)), vec2f(unconst_f32(0.2149), unconst_f32(0.07371)))).g);
+  break;
+  _ = override19;
+  _ = override13;
+}
+  for (var it4=bitcast<vec2u>(firstLeadingBit(vec2i(unconst_i32(255), unconst_i32(172))))[0]; it4<u32(any((vec2f(vf105.f11[unconst_u32(76)]) == vec2f(vf105.f12.bb)))); it4++) {
+  if bool(pack4x8unorm(vec4f(unconst_f32(0.1382), unconst_f32(0.1961), unconst_f32(0.06345), unconst_f32(-0.5391)))) {
+  fn0(mat2x4h(f16(atan(unconst_f32(0.1606))), f16(atan(unconst_f32(0.1606))), f16(atan(unconst_f32(0.1606))), f16(atan(unconst_f32(0.1606))), f16(atan(unconst_f32(0.1606))), f16(atan(unconst_f32(0.1606))), f16(atan(unconst_f32(0.1606))), f16(atan(unconst_f32(0.1606)))));
+  _ = override19;
+  _ = override13;
+}
+  fn0(mat2x4h(bitcast<vec4h>(unpack2x16float(unconst_u32(60))), bitcast<vec4h>(unpack2x16float(unconst_u32(60)))));
+  let vf110: vec2h = faceForward(vec2h(unconst_f16(4063.6), unconst_f16(1300.9)), bitcast<vec2h>(pack4xU8(vec4u(unconst_u32(33), unconst_u32(509), unconst_u32(36), unconst_u32(111)))), vec2h(unconst_f16(1397.4), unconst_f16(4363.1)));
+  var vf111: vec4h = max(vec4h(unconst_f16(30289.1), unconst_f16(15184.1), unconst_f16(3345.9), unconst_f16(31852.3)), vec4h(unconst_f16(5729.4), unconst_f16(7243.9), unconst_f16(23.80), unconst_f16(7687.3)));
+  vf111 = bitcast<vec4h>(unpack2x16float(unconst_u32(104)));
+  var vf112 = fn0(mat2x4h(saturate(unconst_f16(1699.6)), saturate(unconst_f16(1699.6)), saturate(unconst_f16(1699.6)), saturate(unconst_f16(1699.6)), saturate(unconst_f16(1699.6)), saturate(unconst_f16(1699.6)), saturate(unconst_f16(1699.6)), saturate(unconst_f16(1699.6))));
+  vf112 = VertexOutput1(fract(vec2h(vf112.f7)), bitcast<i32>(fract(vec2h(vf112.f7))), bitcast<u32>(fract(vec2h(vf112.f7))), vec2i(fract(vec2h(vf112.f7))), vec2f(fract(vec2h(vf112.f7))), bitcast<u32>(fract(vec2h(vf112.f7))), fract(vec2h(vf112.f7))[1], vec2f(fract(vec2h(vf112.f7))), vec4i(fract(vec2h(vf112.f7)).grgg), vec2i(fract(vec2h(vf112.f7))), vec4f(fract(vec2h(vf112.f7)).grrg), vec4f(fract(vec2h(vf112.f7)).xxyx), vec2i(fract(vec2h(vf112.f7))), vec4f(fract(vec2h(vf112.f7)).grgg), bitcast<i32>(fract(vec2h(vf112.f7))));
+  break;
+  _ = override19;
+  _ = override13;
+}
+  var vf113: f16 = atanh(unconst_f16(-14490.5));
+  fn0(mat2x4h(f16((unconst_bool(false) && unconst_bool(false))), f16((unconst_bool(false) && unconst_bool(false))), f16((unconst_bool(false) && unconst_bool(false))), f16((unconst_bool(false) && unconst_bool(false))), f16((unconst_bool(false) && unconst_bool(false))), f16((unconst_bool(false) && unconst_bool(false))), f16((unconst_bool(false) && unconst_bool(false))), f16((unconst_bool(false) && unconst_bool(false)))));
+  vf113 += f16(vf105.f14[3]);
+  vf105 = VertexOutput1(bitcast<vec2h>(override17), i32(override17), override17, vec2i(bitcast<i32>(override17)), unpack2x16unorm(override17), override17, f16(override17), vec2f(f32(override17)), unpack4xI8(override17), vec2i(bitcast<i32>(override17)), vec4f(bitcast<f32>(override17)), vec4f(bitcast<f32>(override17)), vec2i(bitcast<i32>(override17)), unpack4x8snorm(override17), bitcast<i32>(override17));
+  return;
+  _ = override13;
+  _ = override17;
+  _ = override19;
+}
+
+/* zero global variables used */
+fn fn4() -> VertexOutput1 {
+  var out: VertexOutput1;
+  _ = fn2();
+  var vf121: vec4i = unpack4xI8(unconst_u32(86));
+  var vf122: i32 = vf121[unconst_u32(56)];
+  fn0(mat2x4h(f16(vf122), f16(vf122), f16(vf122), f16(vf122), f16(vf122), f16(vf122), f16(vf122), f16(vf122)));
+  var vf123 = fn0(mat2x4h(vec4h(countOneBits(vec3i(unconst_i32(29), unconst_i32(-379), unconst_i32(151))).zzzz), vec4h(countOneBits(vec3i(unconst_i32(29), unconst_i32(-379), unconst_i32(151))).zyxx)));
+  let ptr19: ptr<function, vec2f> = &vf123.f8;
+  out.f13 = vf123.f16;
+  var vf124 = fn2();
+  vf121 = vec4i(vf121[unconst_u32(44)]);
+  out.f15 = vec4f(cos(vec4h(unconst_f16(7449.3), unconst_f16(11447.4), unconst_f16(10900.5), unconst_f16(9449.3))));
+  var vf125 = fn0(mat2x4h(bitcast<vec4h>(vf123.f13), bitcast<vec4h>(vf123.f13)));
+  out.f11 = vec2f(vf125.f12.zz);
+  return out;
+  _ = override18;
+  _ = override14;
+  _ = override13;
+  _ = override19;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@id(17064) override override19: u32 = 171;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+/* zero global variables used */
+fn fn7(a0: ptr<function, mat2x3h>) -> T1 {
+  var out: T1;
+  (*a0) += mat2x3h(vec3h(transpose(mat4x4f())[unconst_i32(1)].wyy), vec3h(transpose(mat4x4f())[unconst_i32(2)].yyw));
+  return out;
+}
+
+/* zero global variables used */
+fn fn8(a0: T1, a1: ptr<private, VertexOutput1>) {
+  let ptr21: ptr<private, f16> = &(*a1).f10;
+  (*a1).f8 = bitcast<vec2f>(a0.f0[unconst_u32(195)][unconst_u32(168)][unconst_u32(51)][0].xw);
+  let vf133: vec4i = a0.f0[unconst_u32(8)][unconst_u32(23)][0][bitcast<u32>((*a1).f18)];
+}
+
+@id(11106) override override18: u32 = 7;
+
+struct VertexOutput1 {
+  @location(10) @interpolate(linear, either) f4: vec2h,
+  @location(14) @interpolate(flat, sample) f5: i32,
+  @location(7) @interpolate(flat, either) f6: u32,
+  @location(1) f7: vec2i,
+  @location(0) @interpolate(perspective, centroid) f8: vec2f,
+  @location(6) @interpolate(flat, sample) f9: u32,
+  @location(9) @interpolate(flat, sample) f10: f16,
+  @location(11) f11: vec2f,
+  @location(5) f12: vec4i,
+  @location(15) f13: vec2i,
+  @location(12) f14: vec4f,
+  @location(13) @interpolate(linear, centroid) f15: vec4f,
+  @location(8) f16: vec2i,
+  @builtin(position) f17: vec4f,
+  @location(4) f18: i32,
+}
+
+@id(17018) override override14 = false;
+
+struct T1 {
+  f0: array<array<array<array<vec4i, 1>, 1>, 1>, 1>,
+}
+
+override override13: u32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+fn fn6(a0: VertexOutput1) -> vec2i {
+  var out: vec2i;
+  var vf131 = fn2();
+  var vf132: i32 = sign(unconst_i32(53));
+  fn0(mat2x4h(length(unconst_f16(5630.9)), length(unconst_f16(5630.9)), length(unconst_f16(5630.9)), length(unconst_f16(5630.9)), length(unconst_f16(5630.9)), length(unconst_f16(5630.9)), length(unconst_f16(5630.9)), length(unconst_f16(5630.9))));
+  while bool(a0.f15[unconst_u32(250)]) {
+  out &= vec2i(i32(a0.f9));
+}
+  return out;
+  _ = override13;
+  _ = override19;
+  _ = override14;
+  _ = override18;
+}
+
+struct T0 {
+  @align(16) @size(16) f0: array<atomic<u32>, 1>,
+}
+
+/* zero global variables used */
+@must_use 
+fn fn2() -> array<mat3x2h, 1> {
+  var out: array<mat3x2h, 1>;
+  out[unconst_u32(66)] = mat3x2h(f16(override14), f16(override14), f16(override14), f16(override14), f16(override14), f16(override14));
+  out[unconst_u32(639)] = mat3x2h(floor(vec2h(unconst_f16(435.0), unconst_f16(5621.2))), floor(vec2h(unconst_f16(435.0), unconst_f16(5621.2))), floor(vec2h(unconst_f16(435.0), unconst_f16(5621.2))));
+  out[unconst_u32(157)] = mat3x2h(vec2h((vec2u(unconst_u32(37), unconst_u32(5)) <= vec2u(unconst_u32(111), unconst_u32(182)))), vec2h((vec2u(unconst_u32(37), unconst_u32(5)) <= vec2u(unconst_u32(111), unconst_u32(182)))), vec2h((vec2u(unconst_u32(37), unconst_u32(5)) <= vec2u(unconst_u32(111), unconst_u32(182)))));
+  let vf114: vec2h = saturate(vec2h(unconst_f16(7003.5), unconst_f16(10637.9)));
+  let vf115: u32 = override18;
+  let vf116: vec4h = trunc(vec4h(unconst_f16(9178.8), unconst_f16(16307.0), unconst_f16(4806.2), unconst_f16(38836.2)));
+  return out;
+  _ = override14;
+  _ = override18;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex4(@location(13) a0: vec4i) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f8 = ldexp(vec2f(unconst_f32(0.07138), unconst_f32(0.01457)), vec2i(unconst_i32(118), unconst_i32(370)));
+  var vf134: vec4f = unpack4x8unorm(unconst_u32(113));
+  var vf135: vec4f = unpack4x8unorm(unconst_u32(219));
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment2() -> @location(200) vec4f {
+  var out: vec4f;
+  out += vec4f(override16);
+  var vf136 = fn6(VertexOutput1(bitcast<vec2h>(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149)), u32(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), vec2i(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), vec2f(bitcast<f32>(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149)))), u32(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), f16(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), vec2f(bitcast<f32>(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149)))), vec4i(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), vec2i(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), vec4f(bitcast<f32>(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149)))), vec4f(bitcast<f32>(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149)))), vec2i(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))), vec4f(f32(insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149)))), insertBits(bitcast<i32>(unpack4x8unorm(unconst_u32(143))[0]), unconst_i32(13), unconst_u32(61), unconst_u32(149))));
+  fn4();
+  loop {
+  out -= vec4f(cross(vec3h(unconst_f16(10551.0), unconst_f16(6421.7), unconst_f16(29305.3)), vec3h(f16(pack2x16unorm(vec2f(unconst_f32(0.2386), unconst_f32(0.3134)))))).xyxy);
+  break;
+}
+  if bool(override18) {
+  if bool(unpack2x16unorm(unconst_u32(211))[1]) {
+  var vf137: vec3i = extractBits(vec3i(bitcast<i32>(override17)), unconst_u32(266), unconst_u32(13));
+  _ = override17;
+}
+  _ = override17;
+}
+  var vf138 = fn4();
+  return out;
+  _ = override19;
+  _ = override16;
+  _ = override17;
+  _ = override13;
+  _ = override18;
+  _ = override14;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(4, 1, 1)
+fn compute3() {
+  let vf139: vec2<bool> =  !vec2<bool>(bool(atan2(vec3f((vec3i(unconst_i32(6), unconst_i32(77), unconst_i32(178)) == vec3i(unconst_i32(66), unconst_i32(469), unconst_i32(39)))).g, unconst_f32(0.1253))));
+  var vf140: vec3i = (vec3i(unconst_i32(166), unconst_i32(33), unconst_i32(3)) ^ vec3i(unconst_i32(14), unconst_i32(175), unconst_i32(135)));
+  let vf141: u32 = override17;
+  var vf142: i32 = firstLeadingBit(unconst_i32(17));
+  var vf143: u32 = override17;
+  fn1();
+  let vf144: vec2<bool> = (vec2f(unconst_f32(0.2640), unconst_f32(0.1757)) < vec2f(unconst_f32(0.2598), unconst_f32(0.01920)));
+  vf140 = vec3i((vec4u(unconst_u32(7), unconst_u32(19), unconst_u32(268), unconst_u32(179)) >= unpack4xU8(override19)).bbb);
+  fn1();
+  vf140 = vec3i(bitcast<i32>(vf141));
+  _ = fn2();
+  fn0(mat2x4h(f16(vf141), f16(vf141), f16(vf141), f16(vf141), f16(vf141), f16(vf141), f16(vf141), f16(vf141)));
+  fn0(mat2x4h(smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3)), smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3)), smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3)), smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3)), smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3)), smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3)), smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3)), smoothstep(unconst_f16(3398.3), unconst_f16(4755.1), unconst_f16(3630.3))));
+  _ = override14;
+  _ = override13;
+  _ = override18;
+  _ = override17;
+  _ = override19;
+}`,
+});
+let bindGroup57 = device0.createBindGroup({
+  label: '\u0165\ua2d8\ub03d\ubdbe\u{1fbc5}\ucaec',
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 52, resource: externalTexture11},
+    {binding: 141, resource: {buffer: buffer43, offset: 0, size: 112}},
+    {binding: 110, resource: {buffer: buffer53, offset: 512, size: 752}},
+  ],
+});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout19]});
+let commandEncoder134 = device0.createCommandEncoder();
+let texture113 = device0.createTexture({
+  size: {width: 25, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder38 = commandEncoder133.beginRenderPass({
+  colorAttachments: [{
+  view: textureView96,
+  clearValue: { r: 160.1, g: 136.4, b: 542.5, a: 403.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  timestampWrites: {querySet: querySet6, endOfPassWriteIndex: 42},
+  maxDrawCount: 93339768,
+});
+let sampler81 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+});
+try {
+renderPassEncoder34.setStencilReference(546);
+} catch {}
+let arrayBuffer13 = buffer6.getMappedRange(4464, 0);
+try {
+  await promise22;
+} catch {}
+let bindGroup58 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 224, resource: externalTexture5}]});
+let commandEncoder135 = device0.createCommandEncoder({});
+let textureView118 = texture13.createView({});
+let texture114 = device0.createTexture({
+  size: [8, 8, 12],
+  sampleCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder105 = commandEncoder135.beginComputePass();
+let renderPassEncoder39 = commandEncoder134.beginRenderPass({colorAttachments: [{view: textureView92, loadOp: 'load', storeOp: 'store'}]});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup27, new Uint32Array(5104), 80, 0);
+} catch {}
+try {
+  await promise20;
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* zero global variables used */
+@must_use 
+fn fn2(a0: FragmentOutput2) -> vec4u {
+  var out: vec4u;
+  if bool(override26) {
+  let vf158: i32 = max(unconst_i32(178), unconst_i32(-19));
+  let vf159: f32 = smoothstep(unconst_f32(0.00835), cosh(vec4f(bitcast<f32>(override27))).y, unconst_f32(-0.1427));
+  _ = override27;
+}
+  let vf160: f16 = sin(unconst_f16(4766.6));
+  out *= unpack4xU8(u32(sin(unconst_f16(11205.4))));
+  out <<= unpack4xU8(u32(vf160));
+  var vf161: bool = all(unconst_bool(false));
+  let vf162: vec3f = tanh(vec3f(unconst_f32(0.3591), unconst_f32(0.3151), unconst_f32(0.1893)));
+  return out;
+  _ = override26;
+  _ = override27;
+}
+
+override override20: f16;
+
+override override21: f16 = 10297.1;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(11551) override override28: bool;
+
+/* zero global variables used */
+fn fn1(a0: ptr<uniform, mat3x4h>, a1: u32) -> array<array<FragmentOutput2, 1>, 1> {
+  var out: array<array<FragmentOutput2, 1>, 1>;
+  var vf148: vec4h = exp2(vec4h(unconst_f16(29013.6), unconst_f16(6745.6), unconst_f16(18513.2), unconst_f16(5900.3)));
+  let vf149: i32 = override26;
+  {
+  out[u32(exp(vec4f(unconst_f32(0.01275), unconst_f32(0.08083), unconst_f32(0.02139), unconst_f32(0.2901)))[3])][0].f0 = vec2f(degrees(unconst_f32(0.04541)));
+  if bool(insertBits(vec4u(unconst_u32(75), unconst_u32(66), unconst_u32(7), unconst_u32(234)), vec4u(unconst_u32(104), unconst_u32(13), unconst_u32(132), unconst_u32(143)), u32(fma(unconst_f32(0.1455), unconst_f32(0.00891), unconst_f32(0.2195))), unconst_u32(27))[3]) {
+  var vf150: f16 = override21;
+  var vf151: vec4u = (unconst_u32(569) + vec4u(unconst_u32(180), unconst_u32(137), unconst_u32(212), unconst_u32(361)));
+  _ = override21;
+}
+  out[unconst_u32(154)][unconst_u32(378)].f2 *= insertBits(vec4u(unconst_u32(124), unconst_u32(128), unconst_u32(167), unconst_u32(2)), vec4u(unconst_u32(467), unconst_u32(170), unconst_u32(2), unconst_u32(426)), unconst_u32(84), unconst_u32(416));
+  out[unconst_u32(15)][unconst_u32(460)] = FragmentOutput2(vec2f(f32(override28)), u32(override28), vec4u(u32(override28)));
+  var vf152: f32 = degrees(unconst_f32(-0.02302));
+  var vf153: vec4u = insertBits(vec4u(unconst_u32(318), unconst_u32(11), unconst_u32(141), unconst_u32(30)), vec4u(unconst_u32(226), unconst_u32(212), unconst_u32(330), unconst_u32(273)), unconst_u32(547), unconst_u32(45));
+  return out;
+  _ = override28;
+  _ = override21;
+}
+  let vf154: vec3f = floor(vec3f(unconst_f32(0.4716), unconst_f32(0.1661), unconst_f32(0.1295)));
+  vf148 += (*a0)[unconst_i32(1)];
+  var vf155: u32 =  ~unconst_u32(16);
+  loop {
+  var vf156: u32 = a1;
+  out[0][unconst_u32(182)].f2 = vec4u(sign(vec2h(unconst_f16(74.84), unconst_f16(4821.0))).rggg);
+  var vf157: bool = override28;
+  break;
+  _ = override28;
+}
+  return out;
+  _ = override28;
+  _ = override21;
+  _ = override26;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* zero global variables used */
+fn fn3(a0: ptr<workgroup, array<atomic<u32>, 1>>) {
+  var vf163: bool = override28;
+  let vf164: vec4<bool> = (vec4h(unconst_f16(424.6), unconst_f16(24407.9), unconst_f16(-31384.2), unconst_f16(23190.0)) <= vec4h(unconst_f16(14517.8), unconst_f16(3983.3), unconst_f16(7021.1), unconst_f16(-4574.6)));
+  if bool(override27) {
+  var vf165: vec4i = (vec4i(unconst_i32(171), unconst_i32(291), unconst_i32(22), unconst_i32(333)) << vec4u(unconst_u32(126), unconst_u32(142), unconst_u32(34), unconst_u32(2)));
+}
+  atomicOr(&(*a0)[unconst_u32(55)], unconst_u32(110));
+  vf163 = bool(atomicLoad(&(*a0)[0]));
+  atomicSub(&(*a0)[unconst_u32(108)], unconst_u32(1));
+  _ = override28;
+  _ = override27;
+}
+
+override override26: i32;
+
+override override24: f32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+@id(8953) override override23: u32 = 197;
+
+/* zero global variables used */
+fn fn0(a0: ptr<storage, atomic<i32>, read_write>) -> array<mat4x3f, 1> {
+  var out: array<mat4x3f, 1>;
+  out[unconst_u32(42)] -= mat4x3f(bitcast<vec3f>(unpack4xI8(unconst_u32(157)).aga), vec3f(unpack4xI8(unconst_u32(157)).zxy), bitcast<vec3f>(unpack4xI8(unconst_u32(157)).yyy), bitcast<vec3f>(unpack4xI8(unconst_u32(157)).rrr));
+  let vf145: vec4h = round(vec4h(unconst_f16(7598.0), unconst_f16(10570.9), unconst_f16(3015.0), unconst_f16(13680.6)));
+  switch i32(cross(asinh(vf145.zww), vec3h(unconst_f16(545.9), unconst_f16(925.4), unconst_f16(12874.5)))[2]) { 
+  default {
+  atomicMax(&(*a0), unconst_i32(173));
+  atomicCompareExchangeWeak(&(*a0), unconst_i32(11), unconst_i32(222));
+  var vf146: bool = (bool(atomicLoad(&(*a0))) || unconst_bool(true));
+  out[u32(vf146)] = mat4x3f(bitcast<vec3f>(countLeadingZeros(vec2i(unconst_i32(-214), unconst_i32(79))).grr), vec3f(countLeadingZeros(vec2i(unconst_i32(-214), unconst_i32(79))).yxy), vec3f(countLeadingZeros(vec2i(unconst_i32(-214), unconst_i32(79))).xxy), bitcast<vec3f>(countLeadingZeros(vec2i(unconst_i32(-214), unconst_i32(79))).ggg));
+  break;
+}
+  }
+  atomicCompareExchangeWeak(&(*a0), unconst_i32(126), unconst_i32(98));
+  var vf147: vec3h = cos(vec3h(unconst_f16(961.6), unconst_f16(4937.5), unconst_f16(8985.8)));
+  return out;
+}
+
+struct T0 {
+  @align(32) @size(1088) f0: array<atomic<u32>>,
+}
+
+override override22 = false;
+
+override override25 = true;
+
+@id(35989) override override27: u32;
+
+struct FragmentOutput2 {
+  @location(6) @interpolate(perspective) f0: vec2f,
+  @location(3) f1: u32,
+  @location(0) f2: vec4u,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+@fragment
+fn fragment3() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  var vf166: bool = override22;
+  vf166 = bool(ceil(vec2h(unconst_f16(5110.5), unconst_f16(6563.5))).x);
+  return out;
+  _ = override22;
+}`,
+});
+let bindGroup59 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 59, resource: externalTexture3},
+    {binding: 131, resource: externalTexture10},
+    {binding: 44, resource: externalTexture8},
+    {binding: 47, resource: {buffer: buffer29, offset: 6400, size: 1760}},
+    {binding: 19, resource: externalTexture6},
+  ],
+});
+let commandEncoder136 = device0.createCommandEncoder();
+let texture115 = device0.createTexture({
+  size: {width: 51, height: 1, depthOrArrayLayers: 54},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture13 = device0.importExternalTexture({label: '\uf6a5\udc27\u05a2\u33e7\u7c68\u61b0\u{1f6ca}\u0c18\u0c91', source: videoFrame11});
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup40, new Uint32Array(177), 6, 0);
+} catch {}
+try {
+commandEncoder136.copyTextureToTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup32, new Uint32Array(1482), 63, 0);
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 358});
+let computePassEncoder106 = commandEncoder136.beginComputePass({});
+try {
+computePassEncoder98.setBindGroup(1, bindGroup18, new Uint32Array(2470), 458, 0);
+} catch {}
+let bindGroup60 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 19, resource: externalTexture12},
+    {binding: 131, resource: externalTexture12},
+    {binding: 44, resource: externalTexture10},
+    {binding: 47, resource: {buffer: buffer25, offset: 0, size: 1212}},
+    {binding: 59, resource: externalTexture9},
+  ],
+});
+let commandEncoder137 = device0.createCommandEncoder({});
+let texture116 = device0.createTexture({
+  size: [700, 4, 1],
+  mipLevelCount: 7,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView119 = texture51.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder40 = commandEncoder137.beginRenderPass({colorAttachments: [{view: textureView29, depthSlice: 10, loadOp: 'load', storeOp: 'store'}]});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer46, 'uint32', 1_316, 4_451);
+} catch {}
+try {
+  await promise24;
+} catch {}
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let texture117 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder80.setBindGroup(3, bindGroup39, new Uint32Array(3736), 258, 0);
+} catch {}
+try {
+computePassEncoder97.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup27, new Uint32Array(925), 16, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle10, renderBundle10, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer11, 'uint32', 972, 4_371);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer40, 0, 18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(233_834).fill(143), /* required buffer size: 233_834 */
+{offset: 338, bytesPerRow: 138, rowsPerImage: 94}, {width: 5, height: 0, depthOrArrayLayers: 19});
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [
+    {binding: 131, resource: externalTexture10},
+    {binding: 47, resource: {buffer: buffer0, offset: 2048, size: 2460}},
+    {binding: 19, resource: externalTexture5},
+    {binding: 59, resource: externalTexture2},
+    {binding: 44, resource: externalTexture0},
+  ],
+});
+let buffer59 = device0.createBuffer({size: 3530, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup26, [6144]);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer33, 'uint16', 10_632, 1_408);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+try {
+  await buffer27.mapAsync(GPUMapMode.WRITE, 176, 172);
+} catch {}
+let textureView120 = texture14.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder83); computePassEncoder83.dispatchWorkgroupsIndirect(buffer33, 3_200); };
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 2148, new DataView(new ArrayBuffer(870)), 119, 52);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(137).fill(11), /* required buffer size: 137 */
+{offset: 137}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule2, entryPoint: 'compute1', constants: {}}});
+let texture118 = device0.createTexture({
+  size: [51],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder83.end();
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer33, 'uint32', 5_108, 8_571);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 260 */
+  offset: 260,
+  bytesPerRow: 67072,
+  buffer: buffer55,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 42, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 71, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder107.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 183 */
+  offset: 183,
+  bytesPerRow: 2048,
+  buffer: buffer29,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder1.pushDebugGroup('\u0fa7');
+} catch {}
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup62 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 47, resource: {buffer: buffer43, offset: 0, size: 420}},
+    {binding: 19, resource: externalTexture12},
+    {binding: 131, resource: externalTexture3},
+    {binding: 59, resource: externalTexture8},
+    {binding: 44, resource: externalTexture0},
+  ],
+});
+let commandEncoder138 = device0.createCommandEncoder({});
+let computePassEncoder107 = commandEncoder138.beginComputePass({timestampWrites: {querySet: querySet3, beginningOfPassWriteIndex: 157}});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+let sampler82 = device0.createSampler({
+  label: '\u0973\u0c5c\u9ca1\u{1fd54}\u407a\u{1fa03}\u{1fc05}',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle13, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer16, 'uint32', 1_368, 52);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+renderPassEncoder1.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({
+  layout: pipelineLayout11,
+  compute: {module: shaderModule4, constants: {override17: 1, override13: 1}},
+});
+let commandEncoder139 = device0.createCommandEncoder({});
+let textureView121 = texture28.createView({baseMipLevel: 1, mipLevelCount: 1});
+let computePassEncoder108 = commandEncoder107.beginComputePass({});
+let renderBundle20 = renderBundleEncoder21.finish({});
+let sampler83 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 96.57});
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup23, new Uint32Array(833), 54, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(1, buffer32, 384, 2_051);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let computePassEncoder109 = commandEncoder139.beginComputePass();
+let sampler84 = device0.createSampler({
+  label: '\ue55d\uc8cc\u0cfc\uf747\ufe1e\u8eda\u{1f88e}\u2f85\u020f',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.13,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup47, new Uint32Array(6019), 2_622, 0);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder17.setViewport(4079.268422215495, 30.295711056978632, 615.4533707775785, 1.5951916911875972, 0.07246021213501952, 0.27577989684861315);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup61, new Uint32Array(2499), 310, 0);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 348, new Float32Array(3264), 186, 88);
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder({});
+let texture119 = device0.createTexture({
+  size: [12, 1, 11],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder110 = commandEncoder140.beginComputePass({timestampWrites: {querySet: querySet7, beginningOfPassWriteIndex: 27}});
+let renderBundle21 = renderBundleEncoder20.finish({});
+try {
+computePassEncoder9.setPipeline(pipeline2);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 0, new BigUint64Array(259), 72, 4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: imageData0,
+  origin: { x: 16, y: 3 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 26, y: 144, z: 97},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 12, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+let commandEncoder141 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'timestamp', count: 31});
+let texture120 = device0.createTexture({
+  size: {width: 1400, height: 8, depthOrArrayLayers: 386},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup2, [0]);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder25.beginOcclusionQuery(234);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer22, 0, 268);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer60 = device0.createBuffer({
+  size: 14691,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture121 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 485},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler85 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 98.31,
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup44, new Uint32Array(418), 169, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer56, 1_696); };
+} catch {}
+try {
+computePassEncoder99.end();
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup53, new Uint32Array(2578), 73, 0);
+} catch {}
+let buffer61 = device0.createBuffer({
+  size: 1825,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture122 = device0.createTexture({
+  size: [24],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView122 = texture35.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder41 = commandEncoder141.beginRenderPass({
+  label: '\u7f36\ub3a4\u{1fc98}\u058b\u{1fe0f}\u{1f8c2}\u09d6',
+  colorAttachments: [{view: textureView62, loadOp: 'load', storeOp: 'discard'}],
+});
+let sampler86 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  compare: 'greater',
+});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup49, []);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle3, renderBundle3]);
+} catch {}
+try {
+commandEncoder26.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder();
+let computePassEncoder111 = commandEncoder142.beginComputePass({});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup27, new Uint32Array(1420), 210, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer49, 'uint32', 1_020, 2_597);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer6, 936, buffer33, 672, 3216);
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas0);
+let imageData13 = new ImageData(60, 36);
+let bindGroup63 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [
+    {binding: 44, resource: externalTexture7},
+    {binding: 47, resource: {buffer: buffer22, offset: 768, size: 5352}},
+    {binding: 131, resource: externalTexture13},
+    {binding: 59, resource: externalTexture5},
+    {binding: 19, resource: externalTexture6},
+  ],
+});
+let textureView123 = texture82.createView({aspect: 'all', format: 'r32sint'});
+let renderPassEncoder42 = commandEncoder124.beginRenderPass({
+  colorAttachments: [{
+  view: textureView62,
+  clearValue: { r: -113.0, g: 454.7, b: 958.9, a: -432.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet5, beginningOfPassWriteIndex: 1121},
+  maxDrawCount: 140001855,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(3, bindGroup21, new Uint32Array(5053), 699, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder61); computePassEncoder61.dispatchWorkgroupsIndirect(buffer56, 1_372); };
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 508 */
+  offset: 508,
+  bytesPerRow: 26880,
+  buffer: buffer12,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let sampler87 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 70.01,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder102.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer33, 8_700, 1_019);
+} catch {}
+let buffer62 = device0.createBuffer({size: 638, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder85.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup43, new Uint32Array(130), 4, 0);
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2772 */
+  offset: 2772,
+  bytesPerRow: 50432,
+  buffer: buffer18,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 246, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 35, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let commandEncoder143 = device0.createCommandEncoder();
+let textureView124 = texture111.createView({});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['r32sint']});
+let sampler88 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder102.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup32, []);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 700, height: 4, depthOrArrayLayers: 71}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder68.setBindGroup(0, bindGroup40, new Uint32Array(3216), 57, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup51);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer32, 2348, buffer0, 692, 2064);
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule2, entryPoint: 'compute1'}});
+let pipeline11 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  multisample: {mask: 0x8c59012},
+  fragment: {
+  module: shaderModule2,
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 628,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 144, shaderLocation: 5},
+          {format: 'sint32x2', offset: 404, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 136, shaderLocation: 2},
+          {format: 'float32x3', offset: 28, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 56, shaderLocation: 4},
+          {format: 'float32x2', offset: 340, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 70, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 136,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 8, shaderLocation: 11}],
+      },
+    ],
+  },
+});
+let texture123 = device0.createTexture({
+  size: [25, 1, 256],
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup50);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(1, bindGroup4, new Uint32Array(37), 23, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer49, 'uint16', 1_308, 77);
+} catch {}
+try {
+commandEncoder143.clearBuffer(buffer0, 420, 980);
+} catch {}
+document.body.append(canvas2);
+let imageBitmap3 = await createImageBitmap(videoFrame12);
+try {
+adapter0.label = '\ud9be\u6144\u353d\u{1fcdd}\ub15d\u03e4';
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder({});
+let computePassEncoder112 = commandEncoder143.beginComputePass();
+try {
+computePassEncoder105.setBindGroup(1, bindGroup30, [256]);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup17, new Uint32Array(1718), 25, 1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 0, y: 133 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 240, z: 111},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 9, height: 22, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(89, 243);
+try {
+adapter0.label = '\udcd7\u642c\u64b5\u0461\u{1ffbe}\uaa41\u{1f657}\u{1fb8b}\u{1f881}\u{1fab5}\u07d6';
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder({});
+let texture124 = device0.createTexture({
+  size: {width: 8},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder43 = commandEncoder144.beginRenderPass({colorAttachments: [{view: textureView22, loadOp: 'load', storeOp: 'store'}], maxDrawCount: 129318721});
+try {
+computePassEncoder0.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(330);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer21, 0, 205);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer43, 92, buffer36, 504, 16);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 128,
+        attributes: [
+          {format: 'snorm16x2', offset: 28, shaderLocation: 2},
+          {format: 'float32', offset: 4, shaderLocation: 4},
+          {format: 'sint8x2', offset: 12, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 1},
+          {format: 'sint32x4', offset: 0, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 30, shaderLocation: 14},
+          {format: 'sint32x3', offset: 52, shaderLocation: 5},
+          {format: 'float32', offset: 20, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let commandEncoder146 = device0.createCommandEncoder();
+let computePassEncoder113 = commandEncoder26.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroupsIndirect(buffer40, 60); };
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder146.copyBufferToBuffer(buffer26, 3572, buffer37, 20, 508);
+} catch {}
+let bindGroup64 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 41, resource: textureView36}]});
+let buffer63 = device0.createBuffer({
+  size: 3793,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder147 = device0.createCommandEncoder({});
+let texture125 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 11},
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder114 = commandEncoder147.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 332, endOfPassWriteIndex: 68}});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup44, new Uint32Array(400), 88, 0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup37, new Uint32Array(441), 51, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle8, renderBundle10, renderBundle8]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 4, y: 87, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'timestamp', count: 67});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(41);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 11}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas1.getContext('webgpu');
+await gc();
+let img4 = await imageWithData(12, 42, '#10101010', '#20202020');
+let bindGroup65 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 19, resource: externalTexture11},
+    {binding: 59, resource: externalTexture5},
+    {binding: 47, resource: {buffer: buffer28, offset: 9472, size: 1224}},
+    {binding: 44, resource: externalTexture11},
+    {binding: 131, resource: externalTexture1},
+  ],
+});
+let buffer64 = device0.createBuffer({
+  size: 23061,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture126 = device0.createTexture({
+  size: {width: 700},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder115 = commandEncoder146.beginComputePass({});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: imageData8,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 0, y: 231, z: 98},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let computePassEncoder116 = commandEncoder43.beginComputePass({timestampWrites: {querySet: querySet3, beginningOfPassWriteIndex: 166, endOfPassWriteIndex: 254}});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], depthReadOnly: true});
+try {
+computePassEncoder109.setBindGroup(1, bindGroup8, new Uint32Array(773), 89, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup13, new Uint32Array(389), 66, 1);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer19, 'uint16', 192, 78);
+} catch {}
+await gc();
+let buffer65 = device0.createBuffer({
+  size: 10242,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let textureView125 = texture108.createView({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup37, new Uint32Array(1104), 79, 0);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer14, 'uint32', 108, 427);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer0, 824);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder({});
+let textureView126 = texture101.createView({dimension: '3d'});
+let computePassEncoder117 = commandEncoder150.beginComputePass({timestampWrites: {querySet: querySet5, beginningOfPassWriteIndex: 547}});
+let renderBundle23 = renderBundleEncoder23.finish({});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer0, 'uint32', 6_888, 753);
+} catch {}
+let arrayBuffer14 = buffer27.getMappedRange(176, 8);
+try {
+buffer64.unmap();
+} catch {}
+let texture127 = device0.createTexture({
+  size: [102, 1, 14],
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView127 = texture72.createView({});
+let computePassEncoder118 = commandEncoder145.beginComputePass({timestampWrites: {querySet: querySet5, beginningOfPassWriteIndex: 396}});
+let renderPassEncoder44 = commandEncoder149.beginRenderPass({
+  colorAttachments: [{view: textureView47, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 227354704,
+});
+try {
+computePassEncoder96.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle10]);
+} catch {}
+try {
+commandEncoder148.copyBufferToBuffer(buffer64, 3308, buffer21, 736, 76);
+} catch {}
+let commandEncoder151 = device0.createCommandEncoder();
+let texture128 = device0.createTexture({size: [51, 1, 61], format: 'rgba8unorm-srgb', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let computePassEncoder119 = commandEncoder151.beginComputePass();
+try {
+computePassEncoder21.setBindGroup(1, bindGroup13, new Uint32Array(2389), 714, 1);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup31, new Uint32Array(418), 39, 0);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(4, buffer29);
+} catch {}
+let buffer66 = device0.createBuffer({
+  size: 9435,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder152 = device0.createCommandEncoder({});
+let textureView128 = texture92.createView({});
+try {
+computePassEncoder107.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer19, 'uint16', 116, 170);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+canvas1.width = 666;
+let imageBitmap4 = await createImageBitmap(img3);
+let bindGroup66 = device0.createBindGroup({layout: veryExplicitBindGroupLayout10, entries: []});
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let sampler89 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 74.41,
+});
+try {
+computePassEncoder106.setBindGroup(1, bindGroup47, []);
+} catch {}
+try {
+computePassEncoder96.setBindGroup(1, bindGroup36, new Uint32Array(364), 2, 1);
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+let texture129 = device0.createTexture({
+  size: {width: 51},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView129 = texture53.createView({dimension: '2d', format: 'rgba8sint', baseArrayLayer: 5});
+let computePassEncoder120 = commandEncoder152.beginComputePass({});
+let renderPassEncoder45 = commandEncoder148.beginRenderPass({
+  colorAttachments: [{view: textureView37, loadOp: 'clear', storeOp: 'discard'}],
+  timestampWrites: {querySet: querySet7, endOfPassWriteIndex: 16},
+  maxDrawCount: 216329204,
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(1, bindGroup31, new Uint32Array(617), 203, 0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup27, new Uint32Array(3206), 2_695, 0);
+} catch {}
+try {
+buffer66.unmap();
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.WRITE);
+} catch {}
+let sampler90 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup51, new Uint32Array(930), 34, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle16, renderBundle22, renderBundle0, renderBundle2, renderBundle7, renderBundle0]);
+} catch {}
+let buffer67 = device0.createBuffer({size: 16718, usage: GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint'], stencilReadOnly: true});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup48);
+} catch {}
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup2, [0]);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer28, 'uint16', 5_964, 3_285);
+} catch {}
+try {
+adapter0.label = '\u81c0\u0bc8\u0bf6\u002e\u09bd\u06d9\u0fb5\u344a';
+} catch {}
+let buffer68 = device0.createBuffer({size: 50086, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let computePassEncoder121 = commandEncoder35.beginComputePass({});
+let renderBundle24 = renderBundleEncoder24.finish({});
+try {
+computePassEncoder113.setPipeline(pipeline0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 760, new DataView(new ArrayBuffer(5362)), 398, 24);
+} catch {}
+try {
+  await promise21;
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder({});
+let sampler91 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 55.45});
+try {
+{ clearResourceUsages(device0, computePassEncoder108); computePassEncoder108.dispatchWorkgroups(1); };
+} catch {}
+try {
+  await promise25;
+} catch {}
+let computePassEncoder122 = commandEncoder153.beginComputePass();
+try {
+computePassEncoder69.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup56, new Uint32Array(676), 16, 0);
+} catch {}
+try {
+renderPassEncoder39.setViewport(8.442765763891739, 0.22093678861879373, 6.886420490709532, 0.351729032645744, 0.8589656342140672, 0.9083212092979314);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+let bindGroup67 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 224, resource: externalTexture3}]});
+let texture130 = device0.createTexture({
+  size: {width: 2800},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder95.setBindGroup(0, bindGroup8, new Uint32Array(2193), 58, 0);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer54, 0, 4);
+} catch {}
+let bindGroup68 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 59, resource: externalTexture7},
+    {binding: 44, resource: externalTexture5},
+    {binding: 47, resource: {buffer: buffer18, offset: 0, size: 740}},
+    {binding: 19, resource: externalTexture6},
+    {binding: 131, resource: externalTexture7},
+  ],
+});
+let textureView130 = texture126.createView({aspect: 'all'});
+let sampler92 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+});
+try {
+computePassEncoder77.setBindGroup(1, bindGroup51, new Uint32Array(202), 21, 0);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline9);
+} catch {}
+try {
+computePassEncoder104.setPipeline(pipeline8);
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let bindGroup69 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 51, resource: {buffer: buffer42, offset: 2048, size: 216}}],
+});
+let buffer69 = device0.createBuffer({size: 12257, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder154 = device0.createCommandEncoder({});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint32', 1_720, 1_353);
+} catch {}
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 532 */
+  offset: 532,
+  buffer: buffer62,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer43, 88, new DataView(new ArrayBuffer(9280)), 44, 352);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [
+    {binding: 110, resource: {buffer: buffer29, offset: 768, size: 760}},
+    {binding: 52, resource: externalTexture7},
+    {binding: 141, resource: {buffer: buffer22, offset: 4608, size: 96}},
+  ],
+});
+let buffer70 = device0.createBuffer({
+  size: 9501,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView131 = texture129.createView({format: 'rgba8uint'});
+let computePassEncoder123 = commandEncoder154.beginComputePass();
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup13, [256]);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup48, new Uint32Array(2014), 153, 0);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer55, 'uint16', 1_402, 12);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 131, resource: externalTexture9},
+    {binding: 19, resource: externalTexture10},
+    {binding: 59, resource: externalTexture2},
+    {binding: 44, resource: externalTexture8},
+    {binding: 47, resource: {buffer: buffer64, offset: 10496, size: 7260}},
+  ],
+});
+let commandEncoder155 = device0.createCommandEncoder({});
+let texture131 = device0.createTexture({
+  size: {width: 8, height: 8, depthOrArrayLayers: 85},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView132 = texture36.createView({aspect: 'all', mipLevelCount: 1});
+let computePassEncoder124 = commandEncoder58.beginComputePass({});
+let renderPassEncoder46 = commandEncoder155.beginRenderPass({
+  colorAttachments: [{
+  view: textureView132,
+  clearValue: { r: 886.2, g: -130.2, b: 839.9, a: -927.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler93 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 95.63,
+});
+try {
+computePassEncoder90.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup36, new Uint32Array(6646), 2_193, 1);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer12, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(25).fill(99), /* required buffer size: 25 */
+{offset: 25}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(canvas1);
+let imageData14 = new ImageData(12, 100);
+let autogeneratedBindGroupLayout0 = pipeline5.getBindGroupLayout(0);
+try {
+computePassEncoder97.setPipeline(pipeline8);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline10);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup72 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 52, resource: externalTexture10},
+    {binding: 141, resource: {buffer: buffer30, offset: 0, size: 460}},
+    {binding: 110, resource: {buffer: buffer30, offset: 512, size: 728}},
+  ],
+});
+let commandEncoder156 = device0.createCommandEncoder();
+let textureView133 = texture72.createView({baseArrayLayer: 0});
+let computePassEncoder125 = commandEncoder156.beginComputePass({});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(1314), 252, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer63, 'uint16', 390, 1_056);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout9 = pipeline3.getBindGroupLayout(1);
+let buffer71 = device0.createBuffer({size: 34712, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let sampler94 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.65,
+});
+try {
+computePassEncoder112.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup5, new Uint32Array(2209), 148, 0);
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule4, constants: {override17: 1, override13: 1}}});
+let texture132 = device0.createTexture({
+  size: {width: 96, height: 1820, depthOrArrayLayers: 434},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView134 = texture125.createView({aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder125.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle6, renderBundle13]);
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+let textureView135 = texture25.createView({});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(6, buffer62);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer55, 216, buffer32, 656, 60);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+document.body.append(img4);
+let buffer72 = device0.createBuffer({size: 43288, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let computePassEncoder126 = commandEncoder3.beginComputePass({timestampWrites: {querySet: querySet10, endOfPassWriteIndex: 54}});
+let sampler95 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 79.60,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder119.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup17, new Uint32Array(373), 6, 1);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer16, 'uint32', 392, 972);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(4, buffer29);
+} catch {}
+let bindGroup73 = device0.createBindGroup({layout: autogeneratedBindGroupLayout0, entries: [{binding: 224, resource: externalTexture2}]});
+let texture133 = device0.createTexture({
+  size: [12, 1, 1],
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder118.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup65, new Uint32Array(283), 19, 0);
+} catch {}
+let imageData15 = new ImageData(12, 140);
+let buffer73 = device0.createBuffer({
+  size: 4078,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder157 = device0.createCommandEncoder({});
+let sampler96 = device0.createSampler({addressModeV: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'linear'});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 96, height: 1820, depthOrArrayLayers: 296}
+*/
+{
+  source: imageData12,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 13, y: 325, z: 152},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer74 = device0.createBuffer({size: 18386, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder158 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  size: [700, 4, 1],
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder127 = commandEncoder158.beginComputePass({timestampWrites: {querySet: querySet7, beginningOfPassWriteIndex: 12, endOfPassWriteIndex: 66}});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup2, new Uint32Array(752), 166, 1);
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(6, buffer55, 0, 711);
+} catch {}
+try {
+commandEncoder157.copyBufferToTexture({
+  /* bytesInLastRow: 824 widthInBlocks: 103 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1488 */
+  offset: 1488,
+  bytesPerRow: 12032,
+  buffer: buffer46,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 166, y: 1, z: 1},
+  aspect: 'all',
+}, {width: 103, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder157.copyTextureToTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 856, new Float32Array(4054), 322, 28);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderPassEncoder47 = commandEncoder157.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 7,
+  clearValue: { r: -720.6, g: 674.9, b: -399.3, a: 281.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler97 = device0.createSampler({addressModeW: 'repeat', lodMaxClamp: 80.55});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+try {
+  await promise26;
+} catch {}
+let imageData16 = new ImageData(12, 56);
+let buffer75 = device0.createBuffer({size: 3891, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture135 = device0.createTexture({size: [24], dimension: '1d', format: 'rgb10a2uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup26, new Uint32Array(3627), 1_363, 1);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline1);
+} catch {}
+await gc();
+let sampler98 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMinClamp: 28.86, compare: 'less'});
+try {
+computePassEncoder121.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(2, buffer53, 0);
+} catch {}
+let videoFrame14 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let commandEncoder159 = device0.createCommandEncoder({});
+let computePassEncoder128 = commandEncoder159.beginComputePass();
+try {
+computePassEncoder65.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle13]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 342, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(46).fill(143), /* required buffer size: 46 */
+{offset: 46, bytesPerRow: 403}, {width: 92, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise23;
+} catch {}
+let textureView136 = texture75.createView({});
+let texture136 = device0.createTexture({
+  size: {width: 700, height: 4, depthOrArrayLayers: 13},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView137 = texture132.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let sampler99 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 3.689,
+  lodMaxClamp: 5.785,
+  compare: 'equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroupsIndirect(buffer56, 240); };
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup62, new Uint32Array(644), 168, 0);
+} catch {}
+await gc();
+let buffer76 = device0.createBuffer({size: 5472, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder115.setPipeline(pipeline0);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 11}
+*/
+{
+  source: imageData2,
+  origin: { x: 3, y: 5 },
+  flipY: true,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+try {
+externalTexture6.label = '\ued2d\uce10\u0c86\ubc4b\u1c1b\ua253\u4b1e';
+} catch {}
+let textureView138 = texture56.createView({});
+let sampler100 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder61.end();
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5156 */
+  offset: 5156,
+  bytesPerRow: 26880,
+  rowsPerImage: 415,
+  buffer: buffer74,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer75, 492, new Float32Array(40248), 17777, 380);
+} catch {}
+let buffer77 = device0.createBuffer({
+  size: 5433,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder160 = device0.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder160.beginComputePass({
+  label: '\u0436\u3006\u5478\u{1fcf2}\u0f42\u063f\u91d7\uc98d\u3b04\ucae3\u0607',
+  timestampWrites: {querySet: querySet9, beginningOfPassWriteIndex: 18},
+});
+let renderPassEncoder48 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 2,
+  clearValue: { r: 908.6, g: -464.5, b: 38.38, a: -908.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+  timestampWrites: {querySet: querySet7, beginningOfPassWriteIndex: 31, endOfPassWriteIndex: 3},
+  maxDrawCount: 47677609,
+});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup40, new Uint32Array(3219), 11, 0);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setViewport(4286.200410563862, 6.677558496511649, 447.4354113598497, 9.42248168849351, 0.09592806626293482, 0.6044917172718856);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(1, buffer12, 64);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 68, new Float32Array(5282), 294, 56);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let buffer78 = device0.createBuffer({
+  size: 13542,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup71);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(4, buffer74, 0, 18_070);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer47, 'uint16', 26, 27);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 36, new Float32Array(21672), 10, 80);
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 19, resource: externalTexture6},
+    {binding: 47, resource: {buffer: buffer22, offset: 256, size: 1020}},
+    {binding: 59, resource: externalTexture6},
+    {binding: 44, resource: externalTexture5},
+    {binding: 131, resource: externalTexture12},
+  ],
+});
+let buffer79 = device0.createBuffer({size: 6476, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundle25 = renderBundleEncoder25.finish({});
+try {
+computePassEncoder75.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup62);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(324);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(5, buffer74);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(130).fill(64), /* required buffer size: 130 */
+{offset: 130}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline14 = device0.createComputePipeline({
+  layout: pipelineLayout9,
+  compute: {module: shaderModule4, entryPoint: 'compute3', constants: {override13: 1, 11_106: 1, override17: 1}},
+});
+try {
+  await promise27;
+} catch {}
+let commandEncoder161 = device0.createCommandEncoder();
+let textureView139 = texture119.createView({});
+let sampler101 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 74.96,
+  compare: 'less-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup26, new Uint32Array(66), 0, 1);
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle12, renderBundle7, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer5, 'uint16', 3_056, 1_407);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(1, buffer53);
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(112).fill(96), /* required buffer size: 112 */
+{offset: 112}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 25, height: 1, depthOrArrayLayers: 256}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 84},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = device0.createComputePipeline({layout: pipelineLayout16, compute: {module: shaderModule0}});
+try {
+adapter0.label = '\u0ee6\u0460\u0ea5\u697a\u{1ff94}\u0e9c\u0a35\u4986\u{1f63f}';
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp2 = array(array(modf(f16(2647.7)), modf(f16(9820.9)), modf(f16(8444.6)), modf(f16(1681.4)), modf(f16(-31134.6)), modf(f16(8655.5)), modf(f16(-6615.8)), modf(f16(1037.7)), modf(f16(6324.6))));
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput3 {
+  @location(14) f26: vec4h,
+  @location(2) f27: f16,
+  @location(12) @interpolate(perspective, either) f28: f32,
+  @location(4) @interpolate(flat, either) f29: u32,
+  @location(13) f30: i32,
+  @location(6) f31: vec2i,
+  @location(0) @interpolate(flat, either) f32: vec4i,
+  @invariant @builtin(position) f33: vec4f,
+  @location(11) f34: vec2i,
+  @location(1) @interpolate(flat, either) f35: vec4f,
+  @location(5) f36: vec2u,
+  @location(3) @interpolate(flat, first) f37: vec4u,
+  @location(7) f38: vec2h,
+  @location(10) f39: vec4f,
+  @location(9) f40: vec2i,
+  @location(8) f41: vec2h,
+  @location(15) f42: vec4h,
+}
+
+/* zero global variables used */
+@must_use 
+fn fn4(a0: bool) -> array<array<vec2h, 25>, 1> {
+  var out: array<array<vec2h, 25>, 1>;
+  out[bitcast<u32>(asinh(vec2h(unconst_f16(8296.9), unconst_f16(-2872.3))))][unconst_u32(793)] *= vec2h(firstLeadingBit(vec2u(unconst_u32(95), unconst_u32(18))));
+  vp1 = modf(vec2f(f32(round(unconst_f16(28.08)))));
+  let ptr33 = &vp1;
+  return out;
+}
+
+struct T1 {
+  @size(124) f0: atomic<u32>,
+  @size(176) f1: array<u32>,
+}
+
+var<workgroup> vw18: array<f16, 6>;
+
+struct VertexOutput2 {
+  @location(10) f19: vec4f,
+  @location(6) f20: vec4u,
+  @location(7) @interpolate(linear) f21: f32,
+  @location(2) @interpolate(flat, first) f22: f16,
+  @location(13) f23: u32,
+  @location(11) @interpolate(linear) f24: f16,
+  @invariant @builtin(position) f25: vec4f,
+}
+
+struct T0 {
+  @size(112) f0: array<u32>,
+}
+
+/* zero global variables used */
+fn fn2() {
+  var vf170 = fn1();
+  let vf171: vec2h = (*&vw17)[unconst_u32(110)];
+  let ptr31: ptr<workgroup, f16> = &(*&vw18)[unconst_u32(21)];
+  vp1 = modf(vec2f(f32((unconst_bool(true) || bool(vp2[0][8].fract)))));
+  {
+  let ptr32: ptr<workgroup, f16> = &(*&vw18)[5];
+  vw17 -= mat3x2h(vp2[0][8].fract, vp2[0][8].fract, vp2[0][8].fract, vp2[0][8].fract, vp2[0][8].fract, vp2[0][8].fract);
+  var vf172 = fn1();
+  var vf173: f16 = vw17[unconst_u32(52)][unconst_u32(34)];
+  var vf174: array<f16, 6> = workgroupUniformLoad(&vw18);
+  vf173 = f16(countLeadingZeros(vec3i(unconst_i32(413), unconst_i32(98), unconst_i32(276))).b);
+  return;
+}
+  loop {
+  _ = fn1();
+  _ = fn1();
+  _ = fn1();
+  var vf175: vec2h = asinh(vec2h(unconst_f16(-21044.5), unconst_f16(5546.3)));
+  let vf176: vec2f = saturate(vec2f(unconst_f32(0.3988), unconst_f32(0.01553)));
+  vw17 = mat3x2h(vec2h(saturate(vec4f(unconst_f32(0.00578), unconst_f32(0.1738), unconst_f32(0.1272), unconst_f32(0.06751))).xy), vec2h(saturate(vec4f(unconst_f32(0.00578), unconst_f32(0.1738), unconst_f32(0.1272), unconst_f32(0.06751))).bb), vec2h(saturate(vec4f(unconst_f32(0.00578), unconst_f32(0.1738), unconst_f32(0.1272), unconst_f32(0.06751))).ba));
+  break;
+}
+  vp1 = modf(vec2f(bitcast<f32>(pack4x8snorm(vec4f(unconst_f32(0.1444), unconst_f32(0.07044), unconst_f32(0.01040), unconst_f32(0.1651))))));
+  _ = fn1();
+  vw17 = mat3x2h((*&vw18)[5], (*&vw18)[5], (*&vw18)[5], (*&vw18)[5], (*&vw18)[5], (*&vw18)[5]);
+  _ = fn1();
+  vw18[unconst_u32(48)] = vw18[unconst_u32(2)];
+  return;
+}
+
+var<workgroup> vw17: mat3x2h;
+
+/* zero global variables used */
+@must_use 
+fn fn3(a0: ptr<uniform, mat4x3h>) -> i32 {
+  var out: i32;
+  var vf177: vec4f = trunc(vec4f(unconst_f32(0.04514), unconst_f32(0.2446), unconst_f32(0.06187), unconst_f32(0.06527)));
+  out &= i32(reflect(vec2f(unconst_f32(0.09447), unconst_f32(0.1379)), vec2f(unconst_f32(0.01700), unconst_f32(0.04331))).g);
+  var vf178: vec2u = abs(vec2u(unconst_u32(124), unconst_u32(158)));
+  var vf179: f16 = (*a0)[unconst_u32(5)][unconst_u32(42)];
+  while bool((vec2i(unconst_i32(297), unconst_i32(142)) << vec2u(unconst_u32(200), unconst_u32(264))).x) {
+  var vf180: vec2f = degrees(vec2f(unconst_f32(0.2072), unconst_f32(0.08339)));
+  out &= i32(abs(vec3h(unconst_f16(8359.9), unconst_f16(6651.9), unconst_f16(2232.8))).z);
+  let vf181: u32 = pack4x8snorm(vec4f(unconst_f32(0.4041), unconst_f32(0.3055), unconst_f32(0.1640), unconst_f32(0.01199)));
+  let vf182: f16 = ceil((*a0)[unconst_i32(2)][2]);
+  var vf183: u32 = pack4x8snorm(vec4f(unconst_f32(0.02603), unconst_f32(0.3189), unconst_f32(0.01619), unconst_f32(0.2446)));
+  break;
+}
+  var vf184: vec4f = trunc(vec4f(unconst_f32(0.1318), unconst_f32(0.00525), unconst_f32(-0.3796), unconst_f32(0.1966)));
+  vf179 = vec2h(reflect(vec2f(unconst_f32(0.4410), unconst_f32(0.3450)), unpack4x8snorm(unconst_u32(8)).wz))[1];
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput3 {
+  @location(5) @interpolate(flat) f0: vec2f,
+  @location(4) f1: vec2i,
+  @location(0) f2: vec4u,
+}
+
+/* zero global variables used */
+fn fn0(a0: ptr<function, array<array<array<f16, 3>, 1>, 1>>, a1: FragmentOutput3) -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f21 -= f32(vp2[vec2u(a1.f1)[0]][unconst_u32(205)].fract);
+  let ptr22: ptr<private, f16> = &vp2[unconst_u32(77)][unconst_u32(42)].fract;
+  let vf167: f32 = distance(vec2f(unconst_f32(0.2990), unconst_f32(0.1419)), vec2f(unconst_f32(0.2621), unconst_f32(0.09963)));
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp1 = modf(vec2f(-0.1100, 0.3420));
+
+/* zero global variables used */
+@must_use 
+fn fn1() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  let ptr23: ptr<workgroup, mat3x2h> = &(*&vw17);
+  let ptr24: ptr<workgroup, array<f16, 6>> = &(*&vw18);
+  let ptr25: ptr<private, f16> = &vp2[unconst_u32(88)][8].fract;
+  out.f2 = vec4u((*&vw17)[unconst_i32(1)].xxxy);
+  let ptr26: ptr<private, vec2f> = &vp1.fract;
+  let ptr27: ptr<workgroup, f16> = &(*ptr24)[unconst_u32(154)];
+  var vf168: f16 = vw17[unconst_u32(131)][unconst_u32(161)];
+  vp2[0][unconst_u32(47)] = modf(vw17[unconst_u32(33)][unconst_u32(314)]);
+  var vf169: vec3f = round(vec3f(unconst_f32(0.3111), unconst_f32(0.1859), unconst_f32(0.2885)));
+  let ptr28: ptr<workgroup, mat3x2h> = &vw17;
+  let ptr29: ptr<private, f16> = &(*ptr25);
+  let ptr30: ptr<workgroup, mat3x2h> = &vw17;
+  vf169 = vec3f(f32((*ptr24)[5]));
+  return out;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex5(@builtin(instance_index) a0: u32, @location(11) @interpolate(flat, first) a1: vec4i, @location(1) a2: vec2u, @location(12) a3: u32, @location(14) a4: vec2f, @builtin(vertex_index) a5: u32) -> VertexOutput2 {
+  var out: VertexOutput2;
+  switch i32(vp2[0][unconst_u32(29)].fract) { 
+  default {
+  for (var it5=u32(asinh(vec3h(unconst_f16(-2218.1), unconst_f16(15679.9), unconst_f16(30115.8))).y); it5<a2[unconst_u32(246)]; it5++) {
+  let vf185: vec2u = a2;
+  break;
+}
+  break;
+}
+  }
+  let vf186: u32 = pack2x16snorm(vec2f(unconst_f32(-0.03176), unconst_f32(0.6982)));
+  let ptr34 = &vp2[u32(floor(unconst_f32(0.6386)))];
+  let ptr35 = &(*ptr34)[8];
+  var vf187: vec2f = unpack2x16float(unconst_u32(4));
+  vp2[unconst_u32(17)][unconst_u32(370)].whole = vp2[0][8].whole;
+  out.f25 = vec4f(f32(vp2[unconst_u32(203)][unconst_u32(31)].whole));
+  var vf188: vec2f = cos(vec2f(unconst_f32(0.3874), unconst_f32(0.3504)));
+  let ptr36 = &(*ptr34)[8];
+  for (var it6=a3; it6<u32(vp2[0][8].whole); it6++) {
+  var vf189 = fn4(bool(vp2[unconst_u32(289)][unconst_u32(147)].fract));
+  break;
+}
+  return out;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex6() -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f42 -= bitcast<vec4h>(unpack2x16snorm(unconst_u32(637)));
+  out.f42 = vec4h(f16(min(unconst_f32(0.05750), unconst_f32(0.1697))));
+  _ = fn4(bool(vp2[0][unconst_u32(126)].fract));
+  let ptr37 = &vp2;
+  out.f27 = (*ptr37)[0][unconst_u32(181)].whole;
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment4(@location(12) @interpolate(linear) a0: f32, @location(10) @interpolate(perspective, first) a1: vec4f, @location(11) a2: vec2i, @location(9) @interpolate(flat) a3: vec2i) -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  var vf190 = fn4(bool(unpack2x16float(unconst_u32(107)).y));
+  if bool(countLeadingZeros(unconst_u32(97))) {
+  let ptr38 = &vp2[unconst_u32(13)][8];
+}
+  return out;
+}`,
+});
+let bindGroup75 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 41, resource: textureView42}]});
+let buffer80 = device0.createBuffer({
+  size: 12604,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder129.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer17, 'uint16', 168, 184);
+} catch {}
+try {
+commandEncoder161.copyBufferToTexture({
+  /* bytesInLastRow: 380 widthInBlocks: 95 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4616 */
+  offset: 4616,
+  bytesPerRow: 29440,
+  buffer: buffer26,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 61, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 95, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder161.copyTextureToBuffer({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 7, y: 64, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 68 */
+  offset: 68,
+  bytesPerRow: 3584,
+  buffer: buffer21,
+}, {width: 11, height: 48, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder44.pushDebugGroup('\u{1f66f}');
+} catch {}
+try {
+renderPassEncoder44.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 25, height: 1, depthOrArrayLayers: 256}
+*/
+{
+  source: imageData3,
+  origin: { x: 3, y: 6 },
+  flipY: true,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 29},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 110, resource: {buffer: buffer18, offset: 256, size: 692}},
+    {binding: 141, resource: {buffer: buffer31, offset: 512, size: 6880}},
+    {binding: 52, resource: externalTexture7},
+  ],
+});
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout2, recycledExplicitBindGroupLayout2]});
+let buffer81 = device0.createBuffer({size: 5201, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let textureView140 = texture92.createView({dimension: '2d-array'});
+try {
+{ clearResourceUsages(device0, computePassEncoder97); computePassEncoder97.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder108); computePassEncoder108.dispatchWorkgroupsIndirect(buffer30, 372); };
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder161.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1152 */
+  offset: 1152,
+  bytesPerRow: 17664,
+  buffer: buffer11,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder161.insertDebugMarker('\ubcee');
+} catch {}
+try {
+adapter0.label = '\u47e9\u{1fe02}\ue52e\ue964\u{1fcff}\u060d';
+} catch {}
+let recycledExplicitBindGroupLayout10 = pipeline14.getBindGroupLayout(0);
+let commandEncoder162 = device0.createCommandEncoder();
+let textureView141 = texture136.createView({baseArrayLayer: 0});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup28, new Uint32Array(2230), 644, 1);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(4, buffer32, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let commandEncoder163 = device0.createCommandEncoder({});
+let texture137 = device0.createTexture({
+  size: [1400, 8, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder130 = commandEncoder162.beginComputePass({timestampWrites: {querySet: querySet5}});
+try {
+computePassEncoder79.setBindGroup(0, bindGroup49, []);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(0, bindGroup62, new Uint32Array(906), 17, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup46, new Uint32Array(917), 176, 0);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer24);
+} catch {}
+try {
+commandEncoder161.resolveQuerySet(querySet5, 1, 7, buffer47, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 0, new Int16Array(4367), 418, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let bindGroup77 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 41, resource: textureView38}]});
+let commandEncoder164 = device0.createCommandEncoder();
+let querySet11 = device0.createQuerySet({label: '\ub457\ud146\u2d20\u0d90\u{1f6b2}', type: 'timestamp', count: 1876});
+let textureView142 = texture105.createView({});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], depthReadOnly: true, stencilReadOnly: true});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder90); computePassEncoder90.dispatchWorkgroupsIndirect(buffer33, 4_448); };
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline5);
+} catch {}
+let arrayBuffer15 = buffer6.getMappedRange(4472, 0);
+let bindGroup78 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 52, resource: externalTexture10},
+    {binding: 110, resource: {buffer: buffer69, offset: 1536, size: 744}},
+    {binding: 141, resource: {buffer: buffer12, offset: 256}},
+  ],
+});
+let querySet12 = device0.createQuerySet({type: 'timestamp', count: 11});
+let textureView143 = texture6.createView({dimension: '1d'});
+let img5 = await imageWithData(26, 40, '#10101010', '#20202020');
+let bindGroup79 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout9,
+  entries: [
+    {binding: 44, resource: externalTexture4},
+    {binding: 19, resource: externalTexture3},
+    {binding: 47, resource: {buffer: buffer12, offset: 0}},
+    {binding: 131, resource: externalTexture1},
+    {binding: 59, resource: externalTexture3},
+  ],
+});
+let buffer82 = device0.createBuffer({
+  size: 8279,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder165 = device0.createCommandEncoder({});
+let texture138 = device0.createTexture({
+  size: {width: 700, height: 4, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint']});
+let sampler102 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  compare: 'less-equal',
+});
+try {
+computePassEncoder130.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup20, new Uint32Array(2748), 2_311, 0);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer50, 'uint16', 4_108, 5_337);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(4, undefined, 59_941_626);
+} catch {}
+try {
+commandEncoder163.copyBufferToTexture({
+  /* bytesInLastRow: 588 widthInBlocks: 147 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2328 */
+  offset: 2328,
+  rowsPerImage: 12,
+  buffer: buffer52,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 147, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder();
+let texture139 = device0.createTexture({
+  size: {width: 102},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let texture140 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer30, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup70, [5632]);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup29, new Uint32Array(2013), 341, 1);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline5);
+} catch {}
+let computePassEncoder131 = commandEncoder163.beginComputePass({timestampWrites: {querySet: querySet7, endOfPassWriteIndex: 38}});
+let sampler103 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMinClamp: 58.22, lodMaxClamp: 94.62});
+try {
+{ clearResourceUsages(device0, computePassEncoder112); computePassEncoder112.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup73);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup73, new Uint32Array(2958), 586, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer44, 'uint16', 54, 34);
+} catch {}
+let commandEncoder167 = device0.createCommandEncoder({});
+let textureView144 = texture68.createView({mipLevelCount: 1});
+let renderPassEncoder49 = commandEncoder167.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: -914.9, g: 909.6, b: -979.0, a: 762.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+});
+let sampler104 = device0.createSampler({addressModeV: 'repeat'});
+try {
+computePassEncoder117.setBindGroup(3, bindGroup27, new Uint32Array(131), 33, 0);
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup24, new Uint32Array(3068), 538, 1);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(0, 264, 1, 147_518_592, 1_392_566_813);
+} catch {}
+try {
+commandEncoder165.copyBufferToBuffer(buffer8, 3372, buffer32, 1368, 2048);
+} catch {}
+try {
+commandEncoder161.copyTextureToBuffer({
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1084 widthInBlocks: 271 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1944 */
+  offset: 1944,
+  buffer: buffer37,
+}, {width: 271, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(2_220).fill(179), /* required buffer size: 2_220 */
+{offset: 114, bytesPerRow: 27, rowsPerImage: 39}, {width: 1, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let recycledExplicitBindGroupLayout11 = pipeline14.getBindGroupLayout(0);
+let bindGroup80 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 52, resource: externalTexture8},
+    {binding: 141, resource: {buffer: buffer30, offset: 256, size: 576}},
+    {binding: 110, resource: {buffer: buffer4, offset: 1280, size: 712}},
+  ],
+});
+let texture141 = device0.createTexture({
+  size: {width: 96, height: 1820, depthOrArrayLayers: 898},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView145 = texture101.createView({});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup47, new Uint32Array(3789), 490, 0);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle1, renderBundle16]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer49, 'uint32', 1_116, 64);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(4, buffer30, 184);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexedIndirect(buffer66, 1_852);
+} catch {}
+try {
+renderBundleEncoder26.drawIndirect(buffer71, 6_624);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder166.copyTextureToBuffer({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 1637, y: 3, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2188 widthInBlocks: 547 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1532 */
+  offset: 1532,
+  bytesPerRow: 5120,
+  buffer: buffer70,
+}, {width: 547, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder166.insertDebugMarker('\u3b7f');
+} catch {}
+document.body.prepend(canvas0);
+let texture142 = device0.createTexture({
+  size: [12, 1, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder132 = commandEncoder164.beginComputePass({timestampWrites: {querySet: querySet12}});
+let renderBundle26 = renderBundleEncoder28.finish({});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer42, 'uint32', 2_772, 1_044);
+} catch {}
+try {
+renderBundleEncoder26.drawIndexed(0, 2, 0, 90_818_124, 813_907_933);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer16 = buffer1.getMappedRange(64, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 402, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(26).fill(171), /* required buffer size: 26 */
+{offset: 26, bytesPerRow: 1081, rowsPerImage: 52}, {width: 270, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+override override29 = -0.09463;
+
+struct VertexOutput5 {
+  @location(14) f48: vec2h,
+  @location(6) @interpolate(perspective, either) f49: vec2f,
+  @builtin(position) f50: vec4f,
+  @location(12) @interpolate(perspective, centroid) f51: f32,
+  @location(5) @interpolate(flat, sample) f52: i32,
+  @location(15) @interpolate(flat, sample) f53: f32,
+  @location(9) @interpolate(flat, center) f54: vec2u,
+}
+
+struct S2 {
+  @location(1) f0: vec4i,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* used global variables: et5 */
+fn fn2() -> S2 {
+  var out: S2;
+  out.f0 -= bitcast<vec4i>(normalize(exp(vec3f(f32((unconst_f32(0.2969) <= unconst_f32(0.2051))))).rgbr));
+  let vf205: u32 = pack4xI8Clamp(bitcast<vec4i>(textureDimensions(et5).yxyy));
+  fn0();
+  var vf206: vec4i = unpack4xI8(unconst_u32(10));
+  var vf207: u32 = pack2x16float(vec2f(unconst_f32(0.3383), unconst_f32(0.2331)));
+  out.f0 -= vec4i(i32(all(unconst_bool(false))));
+  out.f0 = vec4i(i32(atan2(unconst_f16(10818.6), unconst_f16(5577.0))));
+  out = S2(bitcast<vec4i>(ldexp(vec3f(unconst_f32(0.3133), unconst_f32(0.2090), unconst_f32(0.06456)), vec3i(i32((unconst_f32(0.04865) <= unconst_f32(0.1888))))).rbrr));
+  out.f0 *= vec4i(ldexp(vec3f(unconst_f32(0.05978), unconst_f32(0.1308), unconst_f32(-0.2196)), vec3i(unconst_i32(-34), unconst_i32(-150), unconst_i32(32))).zyyx);
+  var vf208 = fn0();
+  let ptr40: ptr<function, f32> = &vf208[unconst_u32(135)].f1;
+  var vf209 = fn0();
+  vf207 ^= pack4xI8(vf209[unconst_u32(119)].f0);
+  var vf210 = fn0();
+  return out;
+  _ = override29;
+  _ = et5;
+}
+
+alias vec3b = vec3<bool>;
+
+/* zero global variables used */
+fn fn3(a0: VertexOutput4) {
+  switch i32(override29) { 
+  default {
+}
+  }
+  return;
+  _ = override29;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+fn fn4(a0: S2, a1: vec4f) -> T0 {
+  var out: T0;
+  var vf211 = fn0();
+  vf211[1].f1 -= f32(vf211[unconst_u32(251)].f0.r);
+  out = T0(array<i32, 1>(bitcast<vec3i>(exp2(vec3f(unconst_f32(0.2502), unconst_f32(0.1137), unconst_f32(-0.1634))))[0]));
+  var vf212: f16 = distance(vec2h(unconst_f16(4505.6), unconst_f16(8087.3)), vec2h(unconst_f16(1586.2), unconst_f16(1664.9)));
+  vf212 = vec2h((vec2f(unconst_f32(0.2376), unconst_f32(0.1422)) > vec2f(unconst_f32(0.3096), unconst_f32(0.08396)))).r;
+  vf211[1].f0 = firstTrailingBit(vec3i(unconst_i32(221), unconst_i32(9), unconst_i32(327))).gbbb;
+  vf212 -= f16(vf211[unconst_u32(418)].f0[1]);
+  _ = fn0();
+  let ptr41: ptr<function, f32> = &vf211[1].f1;
+  let ptr42: ptr<function, f32> = &vf211[1].f1;
+  _ = fn0();
+  _ = fn0();
+  return out;
+  _ = override29;
+}
+
+struct T0 {
+  f0: array<i32, 1>,
+}
+
+struct VertexOutput4 {
+  @location(8) f43: vec4u,
+  @location(5) @interpolate(linear, either) f44: f32,
+  @invariant @builtin(position) f45: vec4f,
+  @location(1) @interpolate(linear, center) f46: vec2f,
+  @location(15) f47: vec4f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(224) var et5: texture_external;
+
+/* used global variables: et5 */
+fn fn1() -> S2 {
+  var out: S2;
+  out.f0 |= vec4i(log(vec3h(unconst_f16(-14236.6), unconst_f16(5388.7), unconst_f16(5869.0))).zyyx);
+  var vf195 = fn0();
+  var vf196 = fn0();
+  out = S2(unpack4xI8(countTrailingZeros(unconst_u32(68))));
+  fn0();
+  _ = fn0();
+  loop {
+  var vf197: f32 = override29;
+  var vf198: i32 = reverseBits(unconst_i32(54));
+  vf197 += bitcast<vec3f>(((vec3u(unconst_u32(54), unconst_u32(107), unconst_u32(225)) & vec3u(unconst_u32(63), unconst_u32(15), unconst_u32(196))) & vec3u(cross(vec3h(f16(vf198)), vec3h(unconst_f16(4259.8), unconst_f16(-5853.4), unconst_f16(2118.9))))))[1];
+  fn0();
+  vf198 = i32(cross(vec3h(unconst_f16(20397.8), unconst_f16(5495.9), unconst_f16(13407.9)), vec3h(unconst_f16(14779.1), unconst_f16(6203.0), unconst_f16(2401.0)))[0]);
+  break;
+  _ = override29;
+}
+  var vf199: u32 = pack4xU8Clamp(vec4u(unconst_u32(100), unconst_u32(227), unconst_u32(234), unconst_u32(201)));
+  if bool(vf195[1].f0[unconst_u32(75)]) {
+  var vf200: vec2f = unpack2x16unorm(unconst_u32(15));
+  var vf201: vec2i = insertBits(vec2i(unconst_i32(32), unconst_i32(-142)), vec2i(unconst_i32(6), unconst_i32(35)), unconst_u32(77), unconst_u32(252));
+  var vf202 = fn0();
+  out.f0 = vec4i(vf202[unconst_u32(354)].f0[unconst_u32(35)]);
+  var vf203: vec2i = insertBits(vec2i(bitcast<i32>(vf200[vec4u(textureLoad(et5, vec2u(unconst_u32(158), unconst_u32(216))))[1]])), vec2i(unconst_i32(186), unconst_i32(277)), unconst_u32(5), unconst_u32(87));
+  _ = override29;
+  _ = et5;
+}
+  vf195[unconst_u32(179)] = FragmentOutput4(bitcast<vec4i>(textureDimensions(et5).rggg), vec2f(textureDimensions(et5))[0]);
+  let vf204: bool = all(unconst_bool(false));
+  return out;
+  _ = override29;
+  _ = et5;
+}
+
+/* zero global variables used */
+fn fn0() -> array<FragmentOutput4, 2> {
+  var out: array<FragmentOutput4, 2>;
+  out[unconst_u32(445)].f0 -= vec4i(refract(vec3h(unconst_f16(2292.9), unconst_f16(8412.2), unconst_f16(9685.0)), step(vec4h(unconst_f16(6627.9), unconst_f16(10482.0), unconst_f16(1302.3), unconst_f16(5311.5)), refract(vec3h(unconst_f16(3160.0), unconst_f16(4427.4), unconst_f16(714.6)), vec3h(unconst_f16(-6674.9), unconst_f16(4836.8), unconst_f16(229.4)), vec3h(mix(vec3f(length(unconst_f32(0.02828))), vec3f(unconst_f32(0.07087), unconst_f32(0.2080), unconst_f32(0.3468)), unconst_f32(0.1502)))[2]).bbbb).grb, unconst_f16(15027.2)).grbg);
+  out[unconst_u32(261)].f0 = bitcast<vec4i>(inverseSqrt(vec3f(unconst_f32(0.2000), unconst_f32(0.1557), unconst_f32(-0.02962))).bbbg);
+  out[unconst_u32(55)].f1 *= bitcast<f32>(dot4I8Packed(unconst_u32(229), unconst_u32(484)));
+  out[1] = FragmentOutput4(vec4i(step(vec4h(unconst_f16(39087.0), unconst_f16(7099.5), unconst_f16(12800.7), unconst_f16(1419.3)), vec4h(unconst_f16(2662.8), unconst_f16(8527.6), unconst_f16(18736.2), unconst_f16(27291.3)))), vec4f(step(vec4h(unconst_f16(39087.0), unconst_f16(7099.5), unconst_f16(12800.7), unconst_f16(1419.3)), vec4h(unconst_f16(2662.8), unconst_f16(8527.6), unconst_f16(18736.2), unconst_f16(27291.3)))).r);
+  var vf191: u32 = pack2x16snorm(vec2f(unconst_f32(0.00852), unconst_f32(0.1045)));
+  var vf192: vec4h = step(vec4h(unconst_f16(983.0), unconst_f16(6049.6), unconst_f16(5566.7), unconst_f16(9011.4)), vec4h(unconst_f16(38.71), unconst_f16(2991.4), unconst_f16(14769.9), unconst_f16(3327.8)));
+  let vf193: i32 = dot4I8Packed(pack2x16snorm(inverseSqrt(vec3f(unconst_f32(0.08704), unconst_f32(0.03003), unconst_f32(0.2032))).yy), unconst_u32(163));
+  var vf194: vec3h = refract(vec3h(unconst_f16(19960.6), unconst_f16(3183.1), unconst_f16(4029.8)), vec3h(unconst_f16(9143.7), unconst_f16(5383.7), unconst_f16(13502.2)), unconst_f16(1521.0));
+  vf191 >>= bitcast<u32>(extractBits(unconst_i32(13), unconst_u32(253), unconst_u32(9)));
+  vf191 = u32(fma(vec3h(unconst_f16(14050.8), unconst_f16(-11596.7), unconst_f16(-2919.3)), vec3h(unconst_f16(626.7), unconst_f16(611.5), unconst_f16(5715.1)), vec3h(unconst_f16(1404.4), unconst_f16(6657.0), unconst_f16(1951.8))).g);
+  vf192 -= vec4h(f16(override29));
+  let ptr39: ptr<function, vec4h> = &vf192;
+  return out;
+  _ = override29;
+}
+
+struct FragmentOutput4 {
+  @location(0) @interpolate(flat) f0: vec4i,
+  @location(2) f1: f32,
+}
+
+/* used global variables: et5 */
+@vertex
+fn vertex7(@location(11) @interpolate(perspective, center) a0: f16, @location(7) a1: f16, @location(8) a2: f32, @location(2) a3: f32, a4: S2, @location(3) a5: vec2u, @builtin(instance_index) a6: u32, @location(15) a7: f32, @location(10) @interpolate(perspective) a8: vec2f) -> VertexOutput4 {
+  var out: VertexOutput4;
+  out.f46 = vec2f(ceil(unconst_f32(0.05191)));
+  for (var it7=bitcast<u32>(a8[unconst_u32(314)]); it7<textureDimensions(et5)[0]; it7++) {
+  var vf213: f16 = sinh(unconst_f16(8229.3));
+  out.f47 -= atan2(vec2f(unconst_f32(0.02701), unconst_f32(0.08008)), vec2f(unconst_f32(0.3892), unconst_f32(0.04852))).gggg;
+  out.f47 += vec4f(a4.f0);
+  _ = fn1();
+  out.f46 *= vec2f(max(unconst_f32(0.03563), unconst_f32(-0.00167)));
+  var vf214 = fn1();
+  _ = override29;
+  _ = et5;
+}
+  var vf215 = fn1();
+  var vf216 = fn1();
+  _ = fn1();
+  vf215.f0 -= vf216.f0;
+  while bool(a4.f0[0]) {
+  out.f44 = f32(a0);
+  out.f46 *= vec2f((vec2h(unconst_f16(9301.9), unconst_f16(10869.1)) / vec2h(unconst_f16(300.7), unconst_f16(9672.0))));
+}
+  var vf217 = fn1();
+  return out;
+  _ = override29;
+  _ = et5;
+}
+
+/* used global variables: et5 */
+@vertex @must_use
+fn vertex8(@location(13) @interpolate(flat, either) a0: vec4f, @location(0) @interpolate(perspective) a1: vec2f, @location(9) a2: vec4h, @location(4) a3: f16) -> VertexOutput5 {
+  var out: VertexOutput5;
+  var vf218: vec2f = a1;
+  var vf219: vec4f = textureLoad(et5, vec2u(unconst_u32(167), unconst_u32(38)));
+  out.f50 = vec4f(f32(a3));
+  let vf220: vec2u = textureDimensions(et5);
+  out.f50 -= vec4f(override29);
+  out.f54 = vec2u(vf218);
+  loop {
+  var vf221: u32 = pack2x16float(vec2f(unconst_f32(0.1700), unconst_f32(0.1733)));
+  _ = fn0();
+  let vf222: vec2u = textureDimensions(et5);
+  fn0();
+  break;
+  _ = override29;
+  _ = et5;
+}
+  let vf223: f32 = tanh(unconst_f32(-0.1737));
+  out.f52 *= clamp(vec2i(unconst_i32(166), unconst_i32(396)), vec2i(unconst_i32(594), unconst_i32(473)), vec2i(unconst_i32(159), unconst_i32(239)))[0];
+  var vf224 = fn1();
+  let ptr43: ptr<function, S2> = &vf224;
+  out.f49 = vec2f(vf223);
+  var vf225: bool = all(unconst_bool(false));
+  return out;
+  _ = override29;
+  _ = et5;
+}
+
+/* used global variables: et5 */
+@fragment
+fn fragment5(@location(8) a0: vec4u) -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  let vf226: vec3h = log2(vec3h(unconst_f16(10056.6), unconst_f16(-1513.7), unconst_f16(10472.6)));
+  _ = fn2();
+  fn3(VertexOutput4(vec4u(log2(vec3h(unconst_f16(5399.0), unconst_f16(12303.7), unconst_f16(6623.6))).bggr), f32(log2(vec3h(unconst_f16(5399.0), unconst_f16(12303.7), unconst_f16(6623.6)))[0]), vec4f(log2(vec3h(unconst_f16(5399.0), unconst_f16(12303.7), unconst_f16(6623.6))).zxxz), vec2f(log2(vec3h(unconst_f16(5399.0), unconst_f16(12303.7), unconst_f16(6623.6))).yy), vec4f(log2(vec3h(unconst_f16(5399.0), unconst_f16(12303.7), unconst_f16(6623.6))).rgrb)));
+  out.f0 += vec4i(log2(vec3h(unconst_f16(202.9), unconst_f16(8356.7), unconst_f16(8794.1))).bbrr);
+  fn3(VertexOutput4(unpack4xU8(u32(vf226[unconst_u32(176)])), f32(vf226[unconst_u32(176)]), vec4f(f32(vf226[unconst_u32(176)])), vec2f(f32(vf226[unconst_u32(176)])), vec4f(f32(vf226[unconst_u32(176)]))));
+  fn3(VertexOutput4(vec4u(cosh(saturate(vec4h(unconst_f16(1822.0), unconst_f16(10482.3), unconst_f16(9994.7), unconst_f16(16580.0))).zyx).xyzz), f32(cosh(saturate(vec4h(unconst_f16(1822.0), unconst_f16(10482.3), unconst_f16(9994.7), unconst_f16(16580.0))).zyx)[1]), vec4f(cosh(saturate(vec4h(unconst_f16(1822.0), unconst_f16(10482.3), unconst_f16(9994.7), unconst_f16(16580.0))).zyx).gbbr), vec2f(cosh(saturate(vec4h(unconst_f16(1822.0), unconst_f16(10482.3), unconst_f16(9994.7), unconst_f16(16580.0))).zyx).zy), vec4f(cosh(saturate(vec4h(unconst_f16(1822.0), unconst_f16(10482.3), unconst_f16(9994.7), unconst_f16(16580.0))).zyx).yyzz)));
+  _ = fn0();
+  out.f1 = vec2f(textureDimensions(et5))[0];
+  out.f1 += f32(insertBits(vec4i(unconst_i32(-242), unconst_i32(140), unconst_i32(119), unconst_i32(238)), vec4i(unconst_i32(162), unconst_i32(157), unconst_i32(151), unconst_i32(-66)), u32(vf226[unconst_u32(109)]), unconst_u32(139)).y);
+  fn0();
+  out.f0 *= vec4i(saturate(vec4h(unconst_f16(3285.5), unconst_f16(5066.7), unconst_f16(16882.9), unconst_f16(2649.4))));
+  var vf227: vec3h = vf226;
+  return out;
+  _ = override29;
+  _ = et5;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(3, 2, 4)
+fn compute4(@builtin(local_invocation_id) a0: vec3u) {
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 3, 2)
+fn compute5() {
+  var vf228 = fn4(S2(vec4i(i32(round(f16(any(bool(max(vec4h(unconst_f16(33515.0), unconst_f16(40476.2), unconst_f16(34308.4), unconst_f16(2061.1)), vec4h(unconst_f16(11184.2), unconst_f16(1184.5), unconst_f16(29000.0), unconst_f16(7110.4)))[1]))))))), vec4f((vec2i(unconst_i32(6), unconst_i32(196)) <= vec2i(unconst_i32(202), unconst_i32(609))).xyyy));
+  while bool(exp2(vec3f(unconst_f32(0.05213), unconst_f32(0.03795), unconst_f32(0.07220))).y) {
+  _ = fn4(S2(vec4i(i32(override29))), vec4f(f32((unconst_bool(false) || unconst_bool(false)))));
+  while (unconst_bool(true) || unconst_bool(true)) {
+  break;
+}
+  var vf229 = fn4(S2(vec4i(tanh(vec3h(unconst_f16(18391.1), unconst_f16(1271.2), unconst_f16(3176.8))).rbrb)), vec4f(bitcast<f32>(pack4xU8Clamp(vec4u(unconst_u32(91), unconst_u32(582), unconst_u32(171), unconst_u32(27))))));
+  let vf230: vec3h = reflect(vec3h(mix(vec2f(unconst_f32(0.2360), unconst_f32(0.04347)), vec2f(unconst_f32(1.000), unconst_f32(0.2981)), unconst_f32(0.2516)).xyy), vec3h(unconst_f16(1903.0), unconst_f16(4389.0), unconst_f16(2957.5)));
+  break;
+  _ = override29;
+}
+  let vf231: vec2h = asin(vec2h(unconst_f16(1956.9), unconst_f16(8633.2)));
+  vf228.f0[unconst_u32(8)] *= bitcast<i32>(unpack2x16snorm(unconst_u32(190)).r);
+  var vf232: vec4u = countOneBits(vec4u(unconst_u32(61), unconst_u32(55), unconst_u32(57), unconst_u32(149)));
+  _ = override29;
+}`,
+});
+let buffer83 = device0.createBuffer({size: 9938, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder168 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({type: 'timestamp', count: 17});
+let sampler105 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 87.50});
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroupsIndirect(buffer51, 424); };
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup68, []);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer54, 0);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte240m', transfer: 'smpte170m'} });
+let recycledExplicitBindGroupLayout12 = pipeline14.getBindGroupLayout(0);
+let bindGroup81 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [
+    {binding: 47, resource: {buffer: buffer25, offset: 0, size: 840}},
+    {binding: 131, resource: externalTexture13},
+    {binding: 19, resource: externalTexture3},
+    {binding: 59, resource: externalTexture9},
+    {binding: 44, resource: externalTexture1},
+  ],
+});
+let commandEncoder169 = device0.createCommandEncoder();
+let textureView146 = texture7.createView({baseMipLevel: 0});
+let renderBundle27 = renderBundleEncoder27.finish({});
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer10, 0);
+} catch {}
+try {
+renderBundleEncoder26.setIndexBuffer(buffer65, 'uint16', 1_016, 3_821);
+} catch {}
+try {
+computePassEncoder94.pushDebugGroup('\u0dd0');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 25, height: 1, depthOrArrayLayers: 256}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpteSt4281', transfer: 'iec61966-2-1'} });
+let commandEncoder170 = device0.createCommandEncoder({});
+let textureView147 = texture119.createView({aspect: 'all'});
+let textureView148 = texture55.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder98.setBindGroup(0, bindGroup4, new Uint32Array(1876), 127, 0);
+} catch {}
+try {
+computePassEncoder97.end();
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle2, renderBundle16, renderBundle7, renderBundle0, renderBundle0, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer38, 'uint32', 3_372, 380);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer12, 0);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(7, buffer33, 0, 18_495);
+} catch {}
+try {
+commandEncoder170.copyBufferToTexture({
+  /* bytesInLastRow: 7276 widthInBlocks: 1819 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2204 */
+  offset: 2204,
+  bytesPerRow: 7424,
+  buffer: buffer82,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 218, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 1819, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 191,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder171 = device0.createCommandEncoder({});
+let texture143 = device0.createTexture({
+  size: {width: 8},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder50 = commandEncoder170.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  depthSlice: 14,
+  clearValue: { r: 410.9, g: -530.1, b: 636.6, a: -657.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: false});
+try {
+renderBundleEncoder29.setIndexBuffer(buffer17, 'uint32', 52, 74);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(6, buffer46, 0);
+} catch {}
+let bindGroup82 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 19, resource: externalTexture9},
+    {binding: 131, resource: externalTexture5},
+    {binding: 44, resource: externalTexture12},
+    {binding: 47, resource: {buffer: buffer57, offset: 1536, size: 1648}},
+    {binding: 59, resource: externalTexture11},
+  ],
+});
+let texture144 = device0.createTexture({
+  size: [25],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView149 = texture123.createView({dimension: '2d', baseArrayLayer: 48});
+let computePassEncoder133 = commandEncoder165.beginComputePass({timestampWrites: {querySet: querySet12, beginningOfPassWriteIndex: 5, endOfPassWriteIndex: 8}});
+let renderPassEncoder51 = commandEncoder166.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 0,
+  clearValue: { r: 630.1, g: 849.8, b: 947.5, a: 648.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder31.setIndexBuffer(buffer30, 'uint32', 124, 21);
+} catch {}
+try {
+renderBundleEncoder29.setIndexBuffer(buffer33, 'uint32', 8_536, 1_357);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(0, buffer32, 264, 140);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let querySet14 = device0.createQuerySet({type: 'timestamp', count: 507});
+let textureView150 = texture118.createView({});
+let renderPassEncoder52 = commandEncoder168.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 9,
+  clearValue: { r: 126.3, g: 540.6, b: 140.5, a: 843.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder119.setBindGroup(1, bindGroup64);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder108); computePassEncoder108.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder47.executeBundles([renderBundle27]);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder29.setVertexBuffer(0, buffer82, 0, 1_562);
+} catch {}
+try {
+commandEncoder161.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 948 */
+  offset: 948,
+  bytesPerRow: 5120,
+  rowsPerImage: 949,
+  buffer: buffer63,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 7, y: 547, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 888, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder169.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer84 = device0.createBuffer({
+  size: 1076,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder172 = device0.createCommandEncoder();
+let computePassEncoder134 = commandEncoder172.beginComputePass({});
+let renderPassEncoder53 = commandEncoder169.beginRenderPass({
+  colorAttachments: [{
+  view: textureView29,
+  depthSlice: 11,
+  clearValue: { r: 837.1, g: 587.7, b: -37.90, a: -326.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle28 = renderBundleEncoder26.finish();
+try {
+computePassEncoder106.setBindGroup(0, bindGroup63);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(0, bindGroup37, new Uint32Array(632), 182, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle5, renderBundle22, renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(2, bindGroup32, new Uint32Array(492), 176, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let veryExplicitBindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture145 = device0.createTexture({
+  size: {width: 700, height: 4, depthOrArrayLayers: 245},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView151 = texture70.createView({dimension: '2d-array'});
+let computePassEncoder135 = commandEncoder126.beginComputePass({});
+let sampler106 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder133.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer47, 'uint16', 378, 90);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(7, buffer12, 0, 83);
+} catch {}
+try {
+commandEncoder161.copyTextureToTexture({
+  texture: texture142,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+document.body.append(canvas1);
+let textureView152 = texture87.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder136 = commandEncoder171.beginComputePass({});
+let renderBundle29 = renderBundleEncoder29.finish({});
+try {
+computePassEncoder119.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder104); computePassEncoder104.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(489);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer26, 'uint32', 2_576, 149);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder161.resolveQuerySet(querySet11, 348, 403, buffer66, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 1096, new Float32Array(21072), 3374, 16);
+} catch {}
+let pipeline16 = device0.createRenderPipeline({
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment3',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    constants: {27_645: 1, override9: 1, override3: 1},
+    buffers: [
+      {
+        arrayStride: 520,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 8, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder173 = device0.createCommandEncoder();
+let textureView153 = texture60.createView({dimension: '2d-array'});
+let computePassEncoder137 = commandEncoder161.beginComputePass({timestampWrites: {querySet: querySet4, endOfPassWriteIndex: 15}});
+let renderPassEncoder54 = commandEncoder173.beginRenderPass({colorAttachments: [{view: textureView121, loadOp: 'load', storeOp: 'store'}]});
+let sampler107 = device0.createSampler({addressModeW: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 87.84});
+try {
+computePassEncoder123.setBindGroup(1, bindGroup36, [5376]);
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: 925.5, g: -670.4, b: 993.2, a: 736.8, });
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer53, 0, 2_089);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout1 = pipeline7.getBindGroupLayout(0);
+let bindGroup83 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 51, resource: {buffer: buffer22, offset: 3328, size: 3720}}],
+});
+let buffer85 = device0.createBuffer({size: 3204, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture146 = device0.createTexture({
+  size: [5600],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer73, 'uint32', 2_144, 234);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(7, buffer40, 4);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture147 = gpuCanvasContext0.getCurrentTexture();
+let textureView154 = texture33.createView({label: '\u0ab4\u821c\u{1fd65}\u42d7\u1552\ucac6\u3be5\u08a2\u5923\u088d\u08e8', mipLevelCount: 1});
+let renderPassEncoder55 = commandEncoder23.beginRenderPass({colorAttachments: [{view: textureView47, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup56, new Uint32Array(9755), 99, 0);
+} catch {}
+try {
+  await buffer83.mapAsync(GPUMapMode.WRITE, 1312, 1948);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 121, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(199).fill(211), /* required buffer size: 199 */
+{offset: 199, rowsPerImage: 100}, {width: 718, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = device0.createComputePipeline({
+  layout: 'auto',
+  compute: {module: shaderModule4, constants: {override13: 1, override17: 1, 17_018: 1}},
+});
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u0621\u0464\ude4a',
+  entries: [
+    {
+      binding: 133,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder174 = device0.createCommandEncoder();
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 277});
+let textureView155 = texture69.createView({format: 'rgb10a2uint'});
+let sampler108 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 90.99});
+try {
+computePassEncoder134.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(1815);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer30, 'uint16', 668, 39);
+} catch {}
+document.body.append(canvas1);
+let bindGroup84 = device0.createBindGroup({
+  label: '\ude0d\u00dc\u50b8\u{1fb35}',
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 59, resource: externalTexture11},
+    {binding: 44, resource: externalTexture0},
+    {binding: 47, resource: {buffer: buffer64, offset: 2816, size: 3720}},
+    {binding: 19, resource: externalTexture3},
+    {binding: 131, resource: externalTexture13},
+  ],
+});
+let commandEncoder175 = device0.createCommandEncoder();
+let texture148 = device0.createTexture({
+  size: {width: 2800, height: 17, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder138 = commandEncoder174.beginComputePass({timestampWrites: {querySet: querySet7}});
+let sampler109 = device0.createSampler({addressModeV: 'repeat', magFilter: 'nearest', mipmapFilter: 'linear', lodMaxClamp: 51.92});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup70, new Uint32Array(611), 198, 1);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle1, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer40, 'uint32', 32, 67);
+} catch {}
+let arrayBuffer17 = buffer15.getMappedRange(136, 24);
+try {
+commandEncoder175.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3716 */
+  offset: 3716,
+  buffer: buffer3,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 0, y: 223, z: 0},
+  aspect: 'all',
+}, new Uint8Array(487).fill(106), /* required buffer size: 487 */
+{offset: 487, bytesPerRow: 67}, {width: 14, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 25, height: 1, depthOrArrayLayers: 256}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 33},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let bindGroup85 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [{binding: 191, resource: {buffer: buffer25, offset: 2816, size: 388}}],
+});
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer86 = device0.createBuffer({size: 3897, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView156 = texture88.createView({mipLevelCount: 1});
+let computePassEncoder139 = commandEncoder175.beginComputePass({});
+let sampler110 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 94.18,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder70); computePassEncoder70.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer52, 1208, new BigUint64Array(3106), 332, 68);
+} catch {}
+let textureView157 = texture33.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder136.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder55.end();
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(3, buffer21, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 3952, new Float32Array(2639), 12, 0);
+} catch {}
+let img6 = await imageWithData(9, 105, '#10101010', '#20202020');
+let imageData17 = new ImageData(32, 4);
+let commandEncoder176 = device0.createCommandEncoder({});
+let textureView158 = texture55.createView({dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder140 = commandEncoder23.beginComputePass({});
+let renderPassEncoder56 = commandEncoder176.beginRenderPass({
+  colorAttachments: [{view: textureView37, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet15,
+  timestampWrites: {querySet: querySet7},
+  maxDrawCount: 540918897,
+});
+let sampler111 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.60,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+computePassEncoder108.end();
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle10, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer28, 'uint16', 3_076, 2_664);
+} catch {}
+try {
+commandEncoder107.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3700 */
+  offset: 3700,
+  bytesPerRow: 37376,
+  buffer: buffer70,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 19, y: 200, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 529, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer87 = device0.createBuffer({
+  size: 1317,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandBuffer10 = commandEncoder107.finish();
+let textureView159 = texture121.createView({mipLevelCount: 1});
+let sampler112 = device0.createSampler({addressModeU: 'repeat', minFilter: 'linear', mipmapFilter: 'nearest', lodMaxClamp: 87.24});
+try {
+{ clearResourceUsages(device0, computePassEncoder114); computePassEncoder114.dispatchWorkgroupsIndirect(buffer22, 3_304); };
+} catch {}
+try {
+computePassEncoder140.setPipeline(pipeline7);
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'bt470m', transfer: 'smpte170m'} });
+let bindGroup86 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 52, resource: externalTexture13},
+    {binding: 110, resource: {buffer: buffer57, offset: 0, size: 3712}},
+    {binding: 141, resource: {buffer: buffer57, offset: 1024, size: 940}},
+  ],
+});
+let texture149 = device0.createTexture({size: [51], dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup22, new Uint32Array(346), 93, 0);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer40, 'uint32', 16, 71);
+} catch {}
+let imageBitmap5 = await createImageBitmap(videoFrame4);
+let buffer88 = device0.createBuffer({
+  size: 2444,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+computePassEncoder94.setBindGroup(2, bindGroup76, new Uint32Array(1737), 304, 1);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup62);
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(76);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle29, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder52.setVertexBuffer(1, buffer70);
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder();
+let computePassEncoder141 = commandEncoder177.beginComputePass({timestampWrites: {querySet: querySet13, beginningOfPassWriteIndex: 12, endOfPassWriteIndex: 9}});
+try {
+computePassEncoder96.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline1);
+} catch {}
+let commandEncoder178 = device0.createCommandEncoder();
+let querySet16 = device0.createQuerySet({type: 'timestamp', count: 998});
+let textureView160 = texture65.createView({baseArrayLayer: 0});
+let computePassEncoder142 = commandEncoder178.beginComputePass({timestampWrites: {querySet: querySet3, beginningOfPassWriteIndex: 265, endOfPassWriteIndex: 49}});
+try {
+{ clearResourceUsages(device0, computePassEncoder52); computePassEncoder52.dispatchWorkgroupsIndirect(buffer4, 8); };
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup2, [0]);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle10, renderBundle29]);
+} catch {}
+let buffer89 = device0.createBuffer({size: 9566, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 1247});
+let sampler113 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'nearest'});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup50);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer89, 'uint32', 7_088, 562);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let commandEncoder179 = device0.createCommandEncoder({});
+let renderPassEncoder57 = commandEncoder179.beginRenderPass({
+  colorAttachments: [{
+  view: textureView37,
+  clearValue: { r: 437.6, g: 736.6, b: 367.6, a: 142.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet13, beginningOfPassWriteIndex: 14},
+});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup9, new Uint32Array(447), 22, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 700, height: 4, depthOrArrayLayers: 71}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 165, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer90 = device0.createBuffer({size: 25097, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder180 = device0.createCommandEncoder({});
+let computePassEncoder143 = commandEncoder180.beginComputePass({});
+let sampler114 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.60,
+  lodMaxClamp: 96.11,
+});
+try {
+computePassEncoder143.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer47, 'uint32', 396, 57);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer51, 708, 284);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(11_274).fill(221), /* required buffer size: 11_274 */
+{offset: 74, bytesPerRow: 25, rowsPerImage: 64}, {width: 2, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder();
+let computePassEncoder144 = commandEncoder181.beginComputePass({});
+try {
+computePassEncoder114.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup18, []);
+} catch {}
+try {
+renderPassEncoder54.setBlendConstant({ r: 670.6, g: 729.7, b: 723.5, a: -209.6, });
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer0, 'uint16', 1_906, 2_748);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+computePassEncoder94.popDebugGroup();
+} catch {}
+let gpuCanvasContext4 = canvas3.getContext('webgpu');
+let autogeneratedBindGroupLayout2 = pipeline5.getBindGroupLayout(0);
+let bindGroup87 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout11,
+  entries: [
+    {binding: 131, resource: externalTexture10},
+    {binding: 47, resource: {buffer: buffer4, offset: 512, size: 496}},
+    {binding: 19, resource: externalTexture7},
+    {binding: 59, resource: externalTexture9},
+    {binding: 44, resource: externalTexture3},
+  ],
+});
+let computePassEncoder145 = commandEncoder147.beginComputePass({timestampWrites: {querySet: querySet4}});
+try {
+computePassEncoder128.setBindGroup(1, bindGroup45);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle29]);
+} catch {}
+try {
+externalTexture0.label = '\u{1fc36}\u00e1';
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 59, resource: externalTexture2},
+    {binding: 19, resource: externalTexture13},
+    {binding: 47, resource: {buffer: buffer8, offset: 256, size: 4484}},
+    {binding: 44, resource: externalTexture2},
+    {binding: 131, resource: externalTexture14},
+  ],
+});
+try {
+computePassEncoder145.setPipeline(pipeline8);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder182 = device0.createCommandEncoder({});
+try {
+computePassEncoder94.setBindGroup(0, bindGroup5, new Uint32Array(4589), 1_403, 0);
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 472, new Int16Array(8935), 2160, 160);
+} catch {}
+let computePassEncoder146 = commandEncoder182.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup80, [0]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder54); computePassEncoder54.dispatchWorkgroupsIndirect(buffer33, 5_036); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer24, 'uint16', 24, 341);
+} catch {}
+let texture150 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup19, new Uint32Array(3310), 1_178, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder84); computePassEncoder84.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline10);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 11}
+*/
+{
+  source: imageData10,
+  origin: { x: 1, y: 4 },
+  flipY: false,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup89 = device0.createBindGroup({layout: autogeneratedBindGroupLayout2, entries: [{binding: 224, resource: externalTexture11}]});
+let pipelineLayout21 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout9, veryExplicitBindGroupLayout12]});
+let commandEncoder183 = device0.createCommandEncoder({});
+let texture151 = device0.createTexture({
+  size: [25, 1, 22],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture152 = device0.createTexture({
+  size: {width: 25, height: 1, depthOrArrayLayers: 207},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView161 = texture49.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 5});
+let computePassEncoder147 = commandEncoder63.beginComputePass({});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(0, buffer24, 28, 197);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline18 = device0.createRenderPipeline({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule2,
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 24,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 0, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 2},
+          {format: 'float32x4', offset: 0, shaderLocation: 14},
+          {format: 'sint8x4', offset: 0, shaderLocation: 3},
+          {format: 'sint8x4', offset: 4, shaderLocation: 5},
+          {format: 'sint32x4', offset: 0, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: false},
+});
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({entries: []});
+let computePassEncoder148 = commandEncoder183.beginComputePass({});
+let sampler115 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'nearest', minFilter: 'linear', lodMaxClamp: 92.60});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup86, new Uint32Array(1537), 216, 1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4, renderBundle8]);
+} catch {}
+try {
+adapter0.label = '\u062c\uec25\ud8ff';
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 49, resource: {buffer: buffer43, offset: 0, size: 216}},
+    {binding: 356, resource: textureView63},
+    {binding: 3, resource: {buffer: buffer60, offset: 0, size: 5328}},
+    {binding: 322, resource: {buffer: buffer50, offset: 4864, size: 11456}},
+    {binding: 85, resource: textureView32},
+    {binding: 52, resource: {buffer: buffer54, offset: 0, size: 32}},
+  ],
+});
+let commandEncoder184 = device0.createCommandEncoder({});
+let renderPassEncoder58 = commandEncoder184.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 0,
+  clearValue: { r: -294.7, g: 984.1, b: 606.6, a: 731.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet16, beginningOfPassWriteIndex: 600, endOfPassWriteIndex: 567},
+});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup84);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder106); computePassEncoder106.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+computePassEncoder115.insertDebugMarker('\u88c4');
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 812, new DataView(new ArrayBuffer(33229)), 4423, 864);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 700, height: 4, depthOrArrayLayers: 71}
+*/
+{
+  source: img2,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 129, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder16.label = '\u638d\u03b9\u0c48\u527e\u{1f6fc}\u62b6\u5d4e';
+} catch {}
+let texture153 = device0.createTexture({
+  size: {width: 48, height: 910, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder53.executeBundles([renderBundle2, renderBundle16, renderBundle22, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer24, 'uint16', 52, 143);
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder({label: '\u0272\u4f59\u{1fcc8}\u7ea2\u{1f9da}\u{1fac4}\u{1ff56}'});
+let textureView162 = texture10.createView({dimension: '2d-array', mipLevelCount: 1});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder147.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(1, bindGroup43, new Uint32Array(206), 93, 0);
+} catch {}
+try {
+commandEncoder64.copyBufferToBuffer(buffer6, 492, buffer38, 3836, 3844);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 492 widthInBlocks: 123 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 880 */
+  offset: 880,
+  buffer: buffer50,
+}, {
+  texture: texture148,
+  mipLevel: 1,
+  origin: {x: 217, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 123, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 3328, new DataView(new ArrayBuffer(19719)), 3687, 8060);
+} catch {}
+await gc();
+let textureView163 = texture107.createView({dimension: '2d-array', format: 'rgba8unorm-srgb', baseMipLevel: 0});
+let renderPassEncoder59 = commandEncoder185.beginRenderPass({colorAttachments: [{view: textureView103, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder116.setBindGroup(1, bindGroup89, new Uint32Array(13), 2, 0);
+} catch {}
+let arrayBuffer18 = buffer1.getMappedRange(24, 0);
+try {
+device0.queue.writeBuffer(buffer13, 4008, new DataView(new ArrayBuffer(1021)), 165, 52);
+} catch {}
+let imageData18 = new ImageData(12, 36);
+let bindGroup91 = device0.createBindGroup({layout: veryExplicitBindGroupLayout23, entries: [{binding: 41, resource: textureView38}]});
+let textureView164 = texture96.createView({});
+try {
+computePassEncoder148.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup48, new Uint32Array(3966), 51, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle16]);
+} catch {}
+let bindGroup92 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 19, resource: externalTexture10},
+    {binding: 59, resource: externalTexture2},
+    {binding: 47, resource: {buffer: buffer30, offset: 256, size: 468}},
+    {binding: 131, resource: externalTexture15},
+    {binding: 44, resource: externalTexture1},
+  ],
+});
+let textureView165 = texture29.createView({});
+let computePassEncoder149 = commandEncoder64.beginComputePass({timestampWrites: {querySet: querySet10, endOfPassWriteIndex: 34}});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup31, new Uint32Array(2509), 632, 0);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup1, new Uint32Array(1361), 232, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+document.body.prepend(img3);
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'film', transfer: 'linear'} });
+let bindGroup93 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 141, resource: {buffer: buffer22, offset: 512, size: 2500}},
+    {binding: 110, resource: {buffer: buffer14, offset: 0, size: 696}},
+    {binding: 52, resource: externalTexture1},
+  ],
+});
+let buffer91 = device0.createBuffer({
+  size: 31688,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView166 = texture105.createView({aspect: 'all'});
+let sampler116 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup43, new Uint32Array(771), 89, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer78, 'uint16', 2_610, 805);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 2,
+  origin: {x: 108, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(252).fill(236), /* required buffer size: 252 */
+{offset: 252}, {width: 133, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+let videoFrame19 = videoFrame0.clone();
+let sampler117 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 67.34,
+  lodMaxClamp: 98.77,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup29, [1792]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder82); computePassEncoder82.dispatchWorkgroupsIndirect(buffer60, 720); };
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 868, new Float32Array(11812), 837, 200);
+} catch {}
+let veryExplicitBindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 19, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 44, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 47,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 59, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 131, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let bindGroup94 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 59, resource: externalTexture8},
+    {binding: 19, resource: externalTexture6},
+    {binding: 44, resource: externalTexture5},
+    {binding: 131, resource: externalTexture15},
+    {binding: 47, resource: {buffer: buffer43, offset: 0, size: 452}},
+  ],
+});
+let commandEncoder186 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder42); computePassEncoder42.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(2, buffer46, 2_520, 3_451);
+} catch {}
+try {
+commandEncoder186.insertDebugMarker('\ub948');
+} catch {}
+let pipeline19 = device0.createComputePipeline({layout: pipelineLayout8, compute: {module: shaderModule0}});
+let bindGroup95 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [{binding: 2, resource: {buffer: buffer91, offset: 0, size: 7996}}],
+});
+let computePassEncoder150 = commandEncoder186.beginComputePass({timestampWrites: {querySet: querySet13, beginningOfPassWriteIndex: 0}});
+try {
+computePassEncoder150.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer41, 'uint32', 40, 48);
+} catch {}
+let commandEncoder187 = device0.createCommandEncoder({});
+let querySet18 = device0.createQuerySet({type: 'timestamp', count: 553});
+try {
+computePassEncoder56.setBindGroup(2, bindGroup54);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup12, new Uint32Array(833), 183, 0);
+} catch {}
+try {
+renderPassEncoder49.beginOcclusionQuery(60);
+} catch {}
+try {
+commandEncoder187.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 868 */
+  offset: 868,
+  bytesPerRow: 1280,
+  rowsPerImage: 1226,
+  buffer: buffer21,
+}, {
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 10},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer65, 1364, new DataView(new ArrayBuffer(5386)), 812, 1956);
+} catch {}
+let buffer92 = device0.createBuffer({
+  size: 7276,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder188 = device0.createCommandEncoder({});
+let textureView167 = texture2.createView({mipLevelCount: 1});
+try {
+computePassEncoder105.setBindGroup(3, bindGroup34, []);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(0, bindGroup89, new Uint32Array(921), 285, 0);
+} catch {}
+try {
+computePassEncoder84.dispatchWorkgroups(2, 2, 1);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(116);
+} catch {}
+try {
+renderPassEncoder49.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer47, 'uint16', 10, 108);
+} catch {}
+try {
+buffer82.unmap();
+} catch {}
+try {
+commandEncoder187.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'smpteSt4281'} });
+try {
+globalThis.someLabel = externalTexture8.label;
+} catch {}
+let bindGroup96 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout24,
+  entries: [{binding: 133, resource: {buffer: buffer26, offset: 512, size: 4488}}],
+});
+let commandEncoder189 = device0.createCommandEncoder();
+let texture154 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder151 = commandEncoder188.beginComputePass({});
+let sampler118 = device0.createSampler({addressModeU: 'mirror-repeat'});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame13, colorSpace: 'display-p3'});
+try {
+computePassEncoder74.setBindGroup(1, bindGroup16, new Uint32Array(5005), 879, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup24, new Uint32Array(73), 2, 1);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, undefined, 112_119_992, 278_506_074);
+} catch {}
+let bindGroup97 = device0.createBindGroup({layout: veryExplicitBindGroupLayout25, entries: []});
+try {
+computePassEncoder78.setBindGroup(0, bindGroup1, new Uint32Array(361), 76, 0);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(16);
+} catch {}
+try {
+renderPassEncoder50.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer28, 'uint16', 2_884, 241);
+} catch {}
+try {
+buffer90.unmap();
+} catch {}
+try {
+globalThis.someLabel = commandEncoder87.label;
+} catch {}
+let commandEncoder190 = device0.createCommandEncoder({});
+let textureView168 = texture75.createView({});
+let texture155 = device0.createTexture({
+  size: {width: 25, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder152 = commandEncoder187.beginComputePass({});
+let renderPassEncoder60 = commandEncoder190.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 1,
+  clearValue: { r: -927.1, g: -511.1, b: 564.4, a: 171.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet15,
+  maxDrawCount: 65283592,
+});
+try {
+computePassEncoder152.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(3, bindGroup87, new Uint32Array(2690), 195, 0);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(2, buffer29, 0, 763);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder189.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 1117, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 176 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4512 */
+  offset: 4512,
+  bytesPerRow: 39168,
+  rowsPerImage: 200,
+  buffer: buffer32,
+}, {width: 44, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture156 = device0.createTexture({
+  label: '\u5695\u{1f93c}\u{1fac0}\ud8c3',
+  size: [5600],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder61 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView109,
+  clearValue: { r: 692.7, g: -962.0, b: -287.9, a: 338.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 445850383,
+});
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup28, [0]);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.setViewport(795.7380093353968, 17.00500730418102, 3659.9363507609146, 4.1455358607424175, 0.3111585454582547, 0.8582695110303208);
+} catch {}
+try {
+commandEncoder189.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2104 */
+  offset: 2104,
+  buffer: buffer73,
+}, {
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 59, y: 1, z: 6},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise28;
+} catch {}
+let veryExplicitBindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 133,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup98 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 44, resource: externalTexture6},
+    {binding: 19, resource: externalTexture5},
+    {binding: 131, resource: externalTexture2},
+    {binding: 59, resource: externalTexture4},
+    {binding: 47, resource: {buffer: buffer5, offset: 512, size: 6920}},
+  ],
+});
+let renderPassEncoder62 = commandEncoder189.beginRenderPass({colorAttachments: [{view: textureView164, depthSlice: 123, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler119 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup45, new Uint32Array(371), 22, 0);
+} catch {}
+let buffer93 = device0.createBuffer({
+  size: 1237,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let sampler120 = device0.createSampler({addressModeU: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 99.70});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup80, [0]);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(0, bindGroup33, new Uint32Array(56), 4, 0);
+} catch {}
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 25, height: 1, depthOrArrayLayers: 256}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 32},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer94 = device0.createBuffer({size: 7419, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], depthReadOnly: true});
+try {
+computePassEncoder141.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder144); computePassEncoder144.dispatchWorkgroupsIndirect(buffer22, 1_696); };
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer13, 0, 1_008);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 4384, new BigUint64Array(31760), 7206, 656);
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 450});
+let computePassEncoder153 = commandEncoder192.beginComputePass();
+let renderBundle30 = renderBundleEncoder30.finish();
+try {
+computePassEncoder130.setBindGroup(1, bindGroup96);
+} catch {}
+try {
+computePassEncoder94.setBindGroup(0, bindGroup43, new Uint32Array(2133), 122, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroupsIndirect(buffer46, 15_756); };
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle10, renderBundle4, renderBundle30, renderBundle10, renderBundle10]);
+} catch {}
+let arrayBuffer19 = buffer1.getMappedRange(72, 0);
+try {
+buffer78.unmap();
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let commandEncoder193 = device0.createCommandEncoder({});
+try {
+computePassEncoder153.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle29]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer50, 'uint32', 700, 7_636);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer95 = device0.createBuffer({size: 5139, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let renderPassEncoder63 = commandEncoder193.beginRenderPass({
+  colorAttachments: [{
+  view: textureView164,
+  depthSlice: 575,
+  clearValue: { r: 334.7, g: -336.6, b: 201.1, a: -146.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder56.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer10, 0);
+} catch {}
+try {
+computePassEncoder34.insertDebugMarker('\u65be');
+} catch {}
+let imageBitmap6 = await createImageBitmap(img0);
+let bindGroup99 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [{binding: 191, resource: {buffer: buffer85, offset: 0}}],
+});
+let sampler121 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.58,
+  compare: 'greater',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup11, new Uint32Array(266), 15, 0);
+} catch {}
+try {
+computePassEncoder84.end();
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer88, 'uint32', 432, 618);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer87, 0, 49);
+} catch {}
+let commandEncoder194 = device0.createCommandEncoder({});
+let textureView169 = texture127.createView({dimension: '2d-array', mipLevelCount: 2, arrayLayerCount: 6});
+let computePassEncoder154 = commandEncoder59.beginComputePass({});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup84, new Uint32Array(3080), 352, 0);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer30, 0, 412);
+} catch {}
+try {
+commandEncoder194.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 112 */
+  offset: 112,
+  buffer: buffer10,
+}, {
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder194.copyTextureToBuffer({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3032 */
+  offset: 3032,
+  bytesPerRow: 5120,
+  buffer: buffer23,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2800, height: 17, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 0, y: 7 },
+  flipY: false,
+}, {
+  texture: texture148,
+  mipLevel: 0,
+  origin: {x: 289, y: 4, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -73,6 +73,7 @@ public:
 private:
     CommandBuffer(id<MTLCommandBuffer>, Device&, id<MTLSharedEvent>, uint64_t sharedEventSignalValue, CommandEncoder&);
     CommandBuffer(Device&);
+    void retainTimestampsForOneUpdateLoop();
 
     id<MTLCommandBuffer> m_commandBuffer { nil };
     id<MTLCommandBuffer> m_cachedCommandBuffer { nil };

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -281,6 +281,7 @@ private:
     NSMapTable<id<MTLCommandBuffer>, id<MTLCounterSampleBuffer>>* m_sampleCounterBuffers;
     NSMapTable<id<MTLCommandBuffer>, NSMutableArray<id<MTLBuffer>>*>* m_resolvedSampleCounterBuffers;
     id<MTLSharedEvent> m_resolveTimestampsSharedEvent { nil };
+    uint64_t m_commandEncoderId { 0 };
     bool m_supressAllErrors { false };
     const uint32_t m_maxVerticesPerDrawCall { 0 };
 } SWIFT_SHARED_REFERENCE(refDevice, derefDevice);

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -94,8 +94,9 @@ public:
 
     // This can be called on a background thread.
     void scheduleWork(Instance::WorkItem&&);
-    uint32_t WARN_UNUSED_RETURN retainEncoder(CommandEncoder&);
-    void releaseEncoder(uint32_t);
+    uint64_t WARN_UNUSED_RETURN retainCounterSampleBuffer(CommandEncoder&);
+    void releaseCounterSampleBuffer(uint64_t);
+    void retainTimestampsForOneUpdate(NSMutableSet<id<MTLCounterSampleBuffer>> *);
 private:
     Queue(id<MTLCommandQueue>, Adapter&, Device&);
     Queue(Adapter&, Device&);
@@ -123,7 +124,7 @@ private:
     HashMap<uint64_t, OnSubmittedWorkScheduledCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkScheduledCallbacks;
     using OnSubmittedWorkDoneCallbacks = Vector<WTF::Function<void(WGPUQueueWorkDoneStatus)>>;
     HashMap<uint64_t, OnSubmittedWorkDoneCallbacks, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_onSubmittedWorkDoneCallbacks;
-    HashMap<uint32_t, RefPtr<CommandEncoder>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_retainedEncoders;
+    NSMutableDictionary<NSNumber*, NSMutableSet<id<MTLCounterSampleBuffer>>*>* m_retainedCounterSampleBuffers;
     NSMutableOrderedSet<id<MTLCommandBuffer>> *m_createdNotCommittedBuffers { nil };
     NSMapTable<id<MTLCommandBuffer>, id<MTLCommandEncoder>> *m_openCommandEncoders;
     const ThreadSafeWeakPtr<Instance> m_instance;


### PR DESCRIPTION
#### e0a82ddfa60ac8ac327d645c214d092c792d0937
<pre>
[WebGPU] MTLCounterTimestamps are not always retained for the lifetime of the MTLCommandBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=286956">https://bugs.webkit.org/show_bug.cgi?id=286956</a>
<a href="https://rdar.apple.com/144077005">rdar://144077005</a>

Reviewed by Tadeu Zagallo.

To workaround <a href="https://rdar.apple.com/143905417">rdar://143905417</a> we must retain MTLCounterSampleBuffer
instances until the MTLCommandBuffer&apos;s dealloc method runs.

Prior attempt largely ensured this but missed the case when the MTLCommandBuffer
is retained after CommandEncoder&apos;s destructor already ran.

Address this by manually retaining the MTLCounterSampleBuffer from
CommandEncoder&apos;s destructor.

* LayoutTests/fast/webgpu/nocrash/fuzz-286956-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-286956.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::retainEncoderForOneUpdateLoop):
(WebGPU::CommandBuffer::~CommandBuffer):
(WebGPU::CommandBuffer::makeInvalid):
(WebGPU::CommandBuffer::makeInvalidDueToCommit):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::retainTimestampsForOneUpdateLoop):
(WebGPU::CommandEncoder::~CommandEncoder):
(WebGPU::CommandEncoder::discardCommandBuffer):
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::retainTimestampsForOneUpdate):
Manually retain the MTLCounterSampleBuffer until -[MTLCommandBuffer dealloc] runs.

Canonical link: <a href="https://commits.webkit.org/289905@main">https://commits.webkit.org/289905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/826765e821e4f5a4d26848962d9fb7834d243caf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39075 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68133 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25856 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79887 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48502 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6066 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34300 "Found 2 new test failures: accessibility/negative-tabindex-does-not-expose-label.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38183 "Hash 826765e8 for PR 39933 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95121 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15496 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11361 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77000 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76247 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20640 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19056 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8533 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15512 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20818 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->