### PR TITLE
Trusted Types policy name CSP logic incorrectly handles multiple directives

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
@@ -17,7 +17,7 @@ CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the fol
 CONSOLE MESSAGE: Refused to connect to http://localhost:8800/common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 
 PASS Trusted Type violation report: creating a forbidden policy.
-FAIL Trusted Type violation report: creating a report-only-forbidden policy. assert_true: expected true got false
+PASS Trusted Type violation report: creating a report-only-forbidden policy.
 PASS Trusted Type violation report: creating a forbidden-but-not-reported policy.
 PASS Trusted Type violation report: sample for SVGScriptElement href assignment
 PASS Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
@@ -17,7 +17,7 @@ CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the fol
 CONSOLE MESSAGE: Refused to connect to http://web-platform.test:8800/common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 
 PASS Trusted Type violation report: creating a forbidden policy.
-FAIL Trusted Type violation report: creating a report-only-forbidden policy. assert_true: expected true got false
+PASS Trusted Type violation report: creating a report-only-forbidden policy.
 PASS Trusted Type violation report: creating a forbidden-but-not-reported policy.
 PASS Trusted Type violation report: sample for SVGScriptElement href assignment
 PASS Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
@@ -17,7 +17,7 @@ CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the fol
 CONSOLE MESSAGE: Refused to connect to http://web-platform.test:8800/common/blank.html because it does not appear in the connect-src directive of the Content Security Policy.
 
 PASS Trusted Type violation report: creating a forbidden policy.
-FAIL Trusted Type violation report: creating a report-only-forbidden policy. assert_true: expected true got false
+PASS Trusted Type violation report: creating a report-only-forbidden policy.
 PASS Trusted Type violation report: creating a forbidden-but-not-reported policy.
 PASS Trusted Type violation report: sample for SVGScriptElement href assignment
 PASS Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -79,8 +79,6 @@ bool ContentSecurityPolicyTrustedTypesDirective::allows(const String& value, boo
         details = AllowTrustedTypePolicy::DisallowedName;
     else if (!(m_allowAny || m_list.contains(value)))
         details = AllowTrustedTypePolicy::DisallowedName;
-    else
-        details = AllowTrustedTypePolicy::Allowed;
 
     return details == AllowTrustedTypePolicy::Allowed;
 }


### PR DESCRIPTION
#### dd5c487fbeadfcf2d28a1c5d65b128ca508c7b35
<pre>
Trusted Types policy name CSP logic incorrectly handles multiple directives
<a href="https://bugs.webkit.org/show_bug.cgi?id=286917">https://bugs.webkit.org/show_bug.cgi?id=286917</a>

Reviewed by Tim Nguyen.

Previously the violation disposition could get incorrectly moved back to &quot;Allowed&quot; by a later
CSP header. This patch updates the logic to correct this.

Now once a header disallows a policy name it stays disallowed.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt:
* LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowTrustedTypesPolicy const):
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
(WebCore::ContentSecurityPolicyTrustedTypesDirective::allows const):

Canonical link: <a href="https://commits.webkit.org/289865@main">https://commits.webkit.org/289865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8660031878b898114a6490010c7e8c055cf02e19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39010 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68087 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25805 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79822 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48457 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34231 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95059 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15430 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75679 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76195 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20588 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18998 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8457 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20747 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15190 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->