### PR TITLE
[text-wrap balance] InlineContentConstrainer should populate inline item width cache after performing line layouts.

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-svg-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-svg-expected.html
@@ -1,0 +1,17 @@
+<style>
+a {
+  text-wrap: auto;
+}
+
+div {
+  display: flex;
+}
+
+</style>
+<div>
+    <a>
+        This text passes if the svg is not wrapped to a second line.<svg class="arrow" viewBox="0 0 12 12" width="12" height="12">
+            <path d="m6 9 6-6H0Z"></path>
+        </svg>
+    </a>
+</div>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-svg.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-with-svg.html
@@ -1,0 +1,17 @@
+<style>
+a {
+  text-wrap: balance;
+}
+
+div {
+  display: flex;
+}
+
+</style>
+<div>
+    <a>
+        This text passes if the svg is not wrapped to a second line.<svg class="arrow" viewBox="0 0 12 12" width="12" height="12">
+            <path d="m6 9 6-6H0Z"></path>
+        </svg>
+    </a>
+</div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
@@ -43,6 +43,8 @@ public:
 
 private:
     void initialize();
+    void updateCachedWidths();
+    void checkCanConstrainInlineItems();
 
     std::optional<Vector<LayoutUnit>> balanceRangeWithLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, size_t numberOfLines, bool isFirstChunk);
     std::optional<Vector<LayoutUnit>> balanceRangeWithNoLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, bool isFirstChunk);
@@ -69,6 +71,7 @@ private:
     double m_maximumLineWidth { 0 };
     bool m_cannotConstrainContent { false };
     bool m_hasSingleLineVisibleContent { false };
+    bool m_hasValidInlineItemWidthCache { false };
 
     struct SlidingWidth {
         SlidingWidth(const InlineContentConstrainer&, const InlineItemList&, size_t start, size_t end, bool useFirstLineStyle, bool isFirstLineInChunk);


### PR DESCRIPTION
#### 4fe5fedb57aa0b2e73ceff68013355504e739e25
<pre>
[text-wrap balance] InlineContentConstrainer should populate inline item width cache after performing line layouts.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284665">https://bugs.webkit.org/show_bug.cgi?id=284665</a>
&lt;<a href="https://rdar.apple.com/141532036">rdar://141532036</a>&gt;

Reviewed by Alan Baradlay.

InlineContentConstrainer is caching inline item widths before performing a line layout.
This is incorrect as the the width of inline items like as SVGs are not set until a
line layout has been performed.

This PR updates the InlineContentConstrainer to cache inline item widths exactly once
after performing all line layouts and to calculate item widths explicitly beforehand.

Canonical link: <a href="https://commits.webkit.org/289963@main">https://commits.webkit.org/289963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c608ee06150acdf0e063bc1c1a1d9273967a5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16231 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25984 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48635 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34487 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15703 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77136 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76400 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20796 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19215 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8742 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15719 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->