### PR TITLE
Introduce NullTerminated / reduce use of const char*

### DIFF
--- a/Source/JavaScriptCore/API/JSBase.cpp
+++ b/Source/JavaScriptCore/API/JSBase.cpp
@@ -207,7 +207,7 @@ JSObjectRef JSGetMemoryUsageStatistics(JSContextRef ctx)
     auto typeCounts = vm.heap.objectTypeCounts();
     JSObject* objectTypeCounts = constructEmptyObject(globalObject);
     for (auto& it : *typeCounts)
-        objectTypeCounts->putDirect(vm, Identifier::fromLatin1(vm, it.key), jsNumber(it.value));
+        objectTypeCounts->putDirect(vm, Identifier::fromString(vm, it.key), jsNumber(it.value));
 
     JSObject* object = constructEmptyObject(globalObject);
     object->putDirect(vm, Identifier::fromString(vm, "heapSize"_s), jsNumber(vm.heap.size()));

--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -51,14 +51,14 @@ OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass*
     , callAsConstructor(definition->callAsConstructor)
     , hasInstance(definition->hasInstance)
     , convertToType(definition->convertToType)
-    , m_className(String::fromUTF8(definition->className))
+    , m_className(String::fromUTF8(unsafeNullTerminated(definition->className)))
 {
     JSC::initialize();
 
     if (const JSStaticValue* staticValue = definition->staticValues) {
         m_staticValues = makeUnique<OpaqueJSClassStaticValuesTable>();
         while (staticValue->name) {
-            String valueName = String::fromUTF8(staticValue->name);
+            String valueName = String::fromUTF8(unsafeNullTerminated(staticValue->name));
             if (!valueName.isNull())
                 m_staticValues->set(valueName.impl(), makeUnique<StaticValueEntry>(staticValue->getProperty, staticValue->setProperty, staticValue->attributes, valueName));
             ++staticValue;
@@ -68,7 +68,7 @@ OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass*
     if (const JSStaticFunction* staticFunction = definition->staticFunctions) {
         m_staticFunctions = makeUnique<OpaqueJSClassStaticFunctionsTable>();
         while (staticFunction->name) {
-            String functionName = String::fromUTF8(staticFunction->name);
+            String functionName = String::fromUTF8(unsafeNullTerminated(staticFunction->name));
             if (!functionName.isNull())
                 m_staticFunctions->set(functionName.impl(), makeUnique<StaticFunctionEntry>(staticFunction->callAsFunction, staticFunction->attributes));
             ++staticFunction;

--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1282,7 +1282,7 @@ static StructHandlers* createStructHandlerMap()
             return;
         {
             auto type = adoptSystem<char[]>(method_copyArgumentType(method, 2));
-            structHandlers->add(StringImpl::createFromCString(type.get()), (StructTagHandler) { selector, 0 });
+            structHandlers->add(StringImpl::createFromCString(unsafeNullTerminated(type.get())), (StructTagHandler) { selector, 0 });
         }
     });
 

--- a/Source/JavaScriptCore/API/glib/JSCClass.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCClass.cpp
@@ -554,7 +554,7 @@ static GRefPtr<JSCValue> jscClassCreateConstructor(JSCClass* jscClass, const cha
     JSC::JSGlobalObject* globalObject = toJS(priv->context);
     Ref vm = globalObject->vm();
     JSC::JSLockHolder locker(vm);
-    auto* functionObject = JSC::JSCCallbackFunction::create(vm, globalObject, String::fromUTF8(name),
+    auto* functionObject = JSC::JSCCallbackFunction::create(vm, globalObject, String::fromUTF8(unsafeNullTerminated(name)),
         JSC::JSCCallbackFunction::Type::Constructor, jscClass, WTFMove(closure), returnType, WTFMove(parameters));
     auto context = jscContextGetOrCreate(priv->context);
     auto constructor = jscContextGetOrCreateValue(context.get(), toRef(functionObject));
@@ -699,7 +699,7 @@ static void jscClassAddMethod(JSCClass* jscClass, const char* name, GCallback ca
     JSC::JSGlobalObject* globalObject = toJS(priv->context);
     Ref vm = globalObject->vm();
     JSC::JSLockHolder locker(vm);
-    auto* functionObject = toRef(JSC::JSCCallbackFunction::create(vm, globalObject, String::fromUTF8(name),
+    auto* functionObject = toRef(JSC::JSCCallbackFunction::create(vm, globalObject, String::fromUTF8(unsafeNullTerminated(name)),
         JSC::JSCCallbackFunction::Type::Method, jscClass, WTFMove(closure), returnType, WTFMove(parameters)));
     auto context = jscContextGetOrCreate(priv->context);
     auto method = jscContextGetOrCreateValue(context.get(), functionObject);

--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -1069,7 +1069,7 @@ void jsc_value_object_define_property_data(JSCValue* value, const char* property
         return;
     }
 
-    auto name = OpaqueJSString::tryCreate(String::fromUTF8(propertyName));
+    auto name = OpaqueJSString::tryCreate(String::fromUTF8(unsafeNullTerminated(propertyName)));
     if (!name)
         return;
 
@@ -1102,7 +1102,7 @@ static void jscValueObjectDefinePropertyAccessor(JSCValue* value, const char* pr
         return;
     }
 
-    auto name = OpaqueJSString::tryCreate(String::fromUTF8(propertyName));
+    auto name = OpaqueJSString::tryCreate(String::fromUTF8(unsafeNullTerminated(propertyName)));
     if (!name)
         return;
 
@@ -1182,7 +1182,7 @@ static GRefPtr<JSCValue> jscValueFunctionCreate(JSCContext* context, const char*
     JSC::JSGlobalObject* globalObject = toJS(jscContextGetJSContext(context));
     Ref vm = globalObject->vm();
     JSC::JSLockHolder locker(vm);
-    auto* functionObject = toRef(JSC::JSCCallbackFunction::create(vm, globalObject, name ? String::fromUTF8(name) : "anonymous"_s,
+    auto* functionObject = toRef(JSC::JSCCallbackFunction::create(vm, globalObject, name ? String::fromUTF8(unsafeNullTerminated(name)) : "anonymous"_s,
         JSC::JSCCallbackFunction::Type::Function, nullptr, WTFMove(closure), returnType, WTFMove(parameters)));
     return jscContextGetOrCreateValue(context, functionObject);
 }
@@ -2091,7 +2091,7 @@ JSCValue* jsc_value_new_from_json(JSCContext* context, const char* json)
 
     JSValueRef exception = nullptr;
     JSC::JSValue jsValue;
-    String jsonString = String::fromUTF8(json);
+    String jsonString = String::fromUTF8(unsafeNullTerminated(json));
     if (jsonString.is8Bit()) {
         JSC::LiteralParser<LChar, JSC::JSONReviverMode::Disabled> jsonParser(globalObject, jsonString.span8(), JSC::StrictJSON);
         jsValue = jsonParser.tryLiteralParse();

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -77,7 +77,7 @@ String Value::generateCompilerConstructionSite()
     stackTrace.forEach([&] (unsigned, void*, const char* cName) {
         if (printed > 10)
             return;
-        auto name = String::fromUTF8(cName);
+        auto name = String::fromUTF8(unsafeNullTerminated(cName));
         if (name.contains("JSC::Wasm::OMGIRGenerator::emit"_s)
             || name.contains("JSC::Wasm::OMGIRGenerator::add"_s)
             || name.contains("JSC::Wasm::OMGIRGenerator::create"_s)

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -175,7 +175,7 @@ void testX86LeaAddAdd()
                 return strstr(disassembly, "lea 0x64(%rdi,%rsi,1), %rax")
                     || strstr(disassembly, "lea 0x64(%rsi,%rdi,1), %rax");
             },
-            "Expected to find something like lea 0x64(%rdi,%rsi,1), %rax but didn't!");
+            "Expected to find something like lea 0x64(%rdi,%rsi,1), %rax but didn't!"_s);
     }
 }
 
@@ -226,7 +226,7 @@ void testX86LeaAddShlLeftScale1()
                 return strstr(disassembly, "lea (%rdi,%rsi,1), %rax")
                     || strstr(disassembly, "lea (%rsi,%rdi,1), %rax");
             },
-            "Expected to find something like lea (%rdi,%rsi,1), %rax but didn't!");
+            "Expected to find something like lea (%rdi,%rsi,1), %rax but didn't!"_s);
     }
 }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -439,7 +439,7 @@ CString BytecodeDumper::formatConstant(Type type, uint64_t constant) const
         // isRefType(type) is false (likewise for externref)
         if (isRefType(type) || type.isFuncref() || type.isExternref()) {
             if (JSValue::decode(constant) == jsNull())
-                return "null";
+                return "null"_s;
             return toCString(RawHex(constant));
         }
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -158,7 +158,7 @@ CString CodeBlock::hashAsStringIfPossible() const
 {
     if (hasHash() || isSafeToComputeHash())
         return toCString(hash());
-    return "<no-hash>";
+    return "<no-hash>"_s;
 }
 
 void CodeBlock::dumpAssumingJITType(PrintStream& out, JITType jitType) const

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -168,7 +168,7 @@ RegisterID* RegExpNode::emitBytecode(BytecodeGenerator& generator, RegisterID* d
     if (regExp->isValid())
         return generator.emitNewRegExp(generator.finalDestination(dst), regExp);
 
-    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), unsafeSpan8(regExp->errorMessage()));
+    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), regExp->errorMessage().span8());
     generator.emitThrowStaticError(ErrorTypeWithExtension::SyntaxError, message);
     return generator.emitLoad(generator.finalDestination(dst), jsUndefined());
 }

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1686,7 +1686,7 @@ static void logDFGAssertionFailure(
 void Graph::logAssertionFailure(
     std::nullptr_t, const char* file, int line, const char* function, const char* assertion)
 {
-    logDFGAssertionFailure(*this, "", file, line, function, assertion);
+    logDFGAssertionFailure(*this, ""_s, file, line, function, assertion);
 }
 
 void Graph::logAssertionFailure(

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -203,7 +203,7 @@ public:
                 "jsBody_", ++compileCounter, "_", codeBlock()->inferredName(),
                 "_", codeBlock()->hash());
         } else
-            name = "jsBody";
+            name = "jsBody"_s;
 
         {
             m_proc.setNumEntrypoints(m_graph.m_numberOfEntrypoints);

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -173,7 +173,7 @@ size_t proportionalHeapSize(size_t heapSize, size_t ramSize)
 
 void recordType(TypeCountSet& set, JSCell* cell)
 {
-    const char* typeName = "[unknown]";
+    auto typeName = "[unknown]"_s;
     const ClassInfo* info = cell->classInfo();
     if (info && info->className)
         typeName = info->className;
@@ -306,8 +306,8 @@ Heap::Heap(VM& vm, HeapType heapType)
     , m_maxHeapSize(m_minBytesPerCycle)
     , m_objectSpace(this)
     , m_machineThreads(makeUnique<MachineThreads>())
-    , m_collectorSlotVisitor(makeUnique<SlotVisitor>(*this, "C"))
-    , m_mutatorSlotVisitor(makeUnique<SlotVisitor>(*this, "M"))
+    , m_collectorSlotVisitor(makeUnique<SlotVisitor>(*this, "C"_s))
+    , m_mutatorSlotVisitor(makeUnique<SlotVisitor>(*this, "M"_s))
     , m_mutatorMarkStack(makeUnique<MarkStackArray>())
     , m_raceMarkStack(makeUnique<MarkStackArray>())
     , m_constraintSet(makeUnique<MarkingConstraintSet>(*this))
@@ -390,12 +390,12 @@ Heap::Heap(VM& vm, HeapType heapType)
     , primitiveGigacageAllocator(makeUnique<GigacageAlignedMemoryAllocator>(Gigacage::Primitive))
 
     // Subspaces
-    , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary", *this, auxiliaryHeapCellType, primitiveGigacageAllocator.get()) // Hash:0x3e7cd762
-    , auxiliarySpace("Auxiliary", *this, auxiliaryHeapCellType, fastMallocAllocator.get()) // Hash:0x96255ba1
-    , immutableButterflyAuxiliarySpace("ImmutableButterfly JSCellWithIndexingHeader", *this, immutableButterflyHeapCellType, fastMallocAllocator.get()) // Hash:0xaadcb3c1
-    , cellSpace("JSCell", *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xadfb5a79
-    , variableSizedCellSpace("Variable Sized JSCell", *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xbcd769cc
-    , destructibleObjectSpace("JSDestructibleObject", *this, destructibleObjectHeapCellType, fastMallocAllocator.get()) // Hash:0x4f5ed7a9
+    , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary"_s, *this, auxiliaryHeapCellType, primitiveGigacageAllocator.get()) // Hash:0x3e7cd762
+    , auxiliarySpace("Auxiliary"_s, *this, auxiliaryHeapCellType, fastMallocAllocator.get()) // Hash:0x96255ba1
+    , immutableButterflyAuxiliarySpace("ImmutableButterfly JSCellWithIndexingHeader"_s, *this, immutableButterflyHeapCellType, fastMallocAllocator.get()) // Hash:0xaadcb3c1
+    , cellSpace("JSCell"_s, *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xadfb5a79
+    , variableSizedCellSpace("Variable Sized JSCell"_s, *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xbcd769cc
+    , destructibleObjectSpace("JSDestructibleObject"_s, *this, destructibleObjectHeapCellType, fastMallocAllocator.get()) // Hash:0x4f5ed7a9
     FOR_EACH_JSC_COMMON_ISO_SUBSPACE(INIT_SERVER_ISO_SUBSPACE)
     FOR_EACH_JSC_STRUCTURE_ISO_SUBSPACE(INIT_SERVER_STRUCTURE_ISO_SUBSPACE)
     , codeBlockSpaceAndSet ISO_SUBSPACE_INIT(*this, destructibleCellHeapCellType, CodeBlock) // Hash:0x2b743c6a

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -290,7 +290,7 @@ class Heap;
 
 
 typedef HashCountedSet<JSCell*> ProtectCountSet;
-typedef HashCountedSet<const char*> TypeCountSet;
+typedef HashCountedSet<ASCIILiteral> TypeCountSet;
 
 enum class HeapType : uint8_t { Small, Large };
 

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -100,7 +100,7 @@ ALWAYS_INLINE Allocator IsoSubspace::allocatorFor(size_t size, AllocatorForMode)
 
 } // namespace GCClient
 
-#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type, (heap), (heapCellType), sizeof(type), type::usePreciseAllocationsOnly, type::numberOfLowerTierPreciseCells)
+#define ISO_SUBSPACE_INIT(heap, heapCellType, type) (ASCIILiteral::fromLiteralUnsafe("IsoSpace " #type), (heap), (heapCellType), sizeof(type), type::usePreciseAllocationsOnly, type::numberOfLowerTierPreciseCells)
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
@@ -35,7 +35,7 @@ namespace JSC {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MarkStackMergingConstraint);
 
 MarkStackMergingConstraint::MarkStackMergingConstraint(JSC::Heap& heap)
-    : MarkingConstraint("Msm", "Mark Stack Merging", ConstraintVolatility::GreyedByExecution)
+    : MarkingConstraint("Msm"_s, "Mark Stack Merging"_s, ConstraintVolatility::GreyedByExecution)
     , m_heap(heap)
 {
 }

--- a/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
@@ -105,7 +105,7 @@ void VerifierSlotVisitor::OpaqueRootData::addMarkerData(MarkerData&& marker)
 }
 
 VerifierSlotVisitor::VerifierSlotVisitor(JSC::Heap& heap)
-    : Base(heap, "Verifier", m_opaqueRootStorage)
+    : Base(heap, "Verifier"_s, m_opaqueRootStorage)
 {
     m_needsExtraOpaqueRootHandling = true;
 }

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -256,7 +256,7 @@ void RemoteInspector::receivedDataMessage(TargetID targetIdentifier, const char*
         if (!connectionToTarget)
             return;
     }
-    connectionToTarget->sendMessageToTarget(String::fromUTF8(message));
+    connectionToTarget->sendMessageToTarget(String::fromUTF8(unsafeNullTerminated(message)));
 }
 
 void RemoteInspector::receivedCloseMessage(TargetID targetIdentifier)
@@ -302,7 +302,7 @@ void RemoteInspector::setup(TargetID targetIdentifier)
 void RemoteInspector::sendMessageToTarget(TargetID targetIdentifier, const char* message)
 {
     if (RefPtr connectionToTarget = m_targetConnectionMap.get(targetIdentifier))
-        connectionToTarget->sendMessageToTarget(String::fromUTF8(message));
+        connectionToTarget->sendMessageToTarget(String::fromUTF8(unsafeNullTerminated(message)));
 }
 
 void RemoteInspector::requestAutomationSession(const char* sessionID, const Client::SessionCapabilities& capabilities)
@@ -316,7 +316,7 @@ void RemoteInspector::requestAutomationSession(const char* sessionID, const Clie
     if (!sessionID || !sessionID[0])
         return;
 
-    m_client->requestAutomationSession(String::fromUTF8(sessionID), capabilities);
+    m_client->requestAutomationSession(String::fromUTF8(unsafeNullTerminated(sessionID)), capabilities);
     updateClientCapabilities();
 }
 

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -57,7 +57,7 @@ static RemoteInspector::Client::SessionCapabilities processSessionCapabilities(G
         const char* host;
         const char* certificateFile;
         while (g_variant_iter_loop(&iter, "(&s&s)", &host, &certificateFile))
-            capabilities.certificates.append({ String::fromUTF8(host), String::fromUTF8(certificateFile) });
+            capabilities.certificates.append({ String::fromUTF8(host), String::fromUTF8(unsafeNullTerminated(certificateFile)) });
     }
 
     if (GRefPtr<GVariant> proxy = g_variant_lookup_value(sessionCapabilities, "proxy", G_VARIANT_TYPE("a{sv}"))) {
@@ -65,32 +65,32 @@ static RemoteInspector::Client::SessionCapabilities processSessionCapabilities(G
 
         const char* proxyType;
         g_variant_lookup(proxy.get(), "type", "&s", &proxyType);
-        capabilities.proxy->type = String::fromUTF8(proxyType);
+        capabilities.proxy->type = String::fromUTF8(unsafeNullTerminated(proxyType));
 
         const char* autoconfigURL;
         if (g_variant_lookup(proxy.get(), "autoconfigURL", "&s", &autoconfigURL))
-            capabilities.proxy->autoconfigURL = String::fromUTF8(autoconfigURL);
+            capabilities.proxy->autoconfigURL = String::fromUTF8(unsafeNullTerminated(autoconfigURL));
 
         const char* ftpURL;
         if (g_variant_lookup(proxy.get(), "ftpURL", "&s", &ftpURL))
-            capabilities.proxy->ftpURL = String::fromUTF8(ftpURL);
+            capabilities.proxy->ftpURL = String::fromUTF8(unsafeNullTerminated(ftpURL));
 
         const char* httpURL;
         if (g_variant_lookup(proxy.get(), "httpURL", "&s", &httpURL))
-            capabilities.proxy->httpURL = String::fromUTF8(httpURL);
+            capabilities.proxy->httpURL = String::fromUTF8(unsafeNullTerminated(httpURL));
 
         const char* httpsURL;
         if (g_variant_lookup(proxy.get(), "httpsURL", "&s", &httpsURL))
-            capabilities.proxy->httpsURL = String::fromUTF8(httpsURL);
+            capabilities.proxy->httpsURL = String::fromUTF8(unsafeNullTerminated(httpsURL));
 
         const char* socksURL;
         if (g_variant_lookup(proxy.get(), "socksURL", "&s", &socksURL))
-            capabilities.proxy->socksURL = String::fromUTF8(socksURL);
+            capabilities.proxy->socksURL = String::fromUTF8(unsafeNullTerminated(socksURL));
 
         if (GRefPtr<GVariant> ignoreAddressList = g_variant_lookup_value(proxy.get(), "ignoreAddressList", G_VARIANT_TYPE("as"))) {
             auto addresses = gVariantGetStrv(ignoreAddressList);
             for (const char* address : addresses.span())
-                capabilities.proxy->ignoreAddressList.append(String::fromUTF8(address));
+                capabilities.proxy->ignoreAddressList.append(String::fromUTF8(unsafeNullTerminated(address)));
         }
     }
 

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp
@@ -90,7 +90,7 @@ std::optional<RemoteInspectorConnectionClient::Event> RemoteInspectorConnectionC
     if (data.isEmpty())
         return std::nullopt;
 
-    String jsonData = String::fromUTF8(data);
+    String jsonData = String::fromUTF8(unsafeNullTerminated(data));
 
     auto messageValue = JSON::Value::parseJSON(jsonData);
     if (!messageValue)

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -252,7 +252,7 @@ void RemoteInspector::setup(TargetID targetIdentifier)
 void RemoteInspector::sendMessageToTarget(TargetID targetIdentifier, const char* message)
 {
     if (auto connectionToTarget = m_targetConnectionMap.get(targetIdentifier))
-        connectionToTarget->sendMessageToTarget(String::fromUTF8(message));
+        connectionToTarget->sendMessageToTarget(String::fromUTF8(unsafeNullTerminated(message)));
 }
 
 String RemoteInspector::backendCommands() const

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -1063,14 +1063,14 @@ UncheckedKeyHashMap<CString, Seconds> JIT::compileTimeStats()
 {
     UncheckedKeyHashMap<CString, Seconds> result;
     if (Options::reportTotalCompileTimes()) {
-        result.add("Total Compile Time", totalCompileTime());
-        result.add("Baseline Compile Time", totalBaselineCompileTime);
+        result.add("Total Compile Time"_s, totalCompileTime());
+        result.add("Baseline Compile Time"_s, totalBaselineCompileTime);
 #if ENABLE(DFG_JIT)
-        result.add("DFG Compile Time", totalDFGCompileTime);
+        result.add("DFG Compile Time"_s, totalDFGCompileTime);
 #if ENABLE(FTL_JIT)
-        result.add("FTL Compile Time", totalFTLCompileTime);
-        result.add("FTL (DFG) Compile Time", totalFTLDFGCompileTime);
-        result.add("FTL (B3) Compile Time", totalFTLB3CompileTime);
+        result.add("FTL Compile Time"_s, totalFTLCompileTime);
+        result.add("FTL (DFG) Compile Time"_s, totalFTLDFGCompileTime);
+        result.add("FTL (B3) Compile Time"_s, totalFTLB3CompileTime);
 #endif // ENABLE(FTL_JIT)
 #endif // ENABLE(DFG_JIT)
     }

--- a/Source/JavaScriptCore/jit/JITDisassembler.cpp
+++ b/Source/JavaScriptCore/jit/JITDisassembler.cpp
@@ -84,9 +84,9 @@ void JITDisassembler::reportToProfiler(Profiler::Compilation* compilation, LinkB
     compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toCString()));
     
     reportInstructions(compilation, linkBuffer, "    ", m_labelForBytecodeIndexInMainPath, firstSlowLabel());
-    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Main Path)\n"));
+    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Main Path)\n"_s));
     reportInstructions(compilation, linkBuffer, "    (S) ", m_labelForBytecodeIndexInSlowPath, m_endOfSlowPath);
-    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Slow Path)\n"));
+    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Slow Path)\n"_s));
     out.reset();
     dumpDisassembly(out, linkBuffer, m_endOfSlowPath, m_endOfCode);
     compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toCString()));

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
@@ -129,7 +129,7 @@ bool Database::save(const char* filename) const
 
 void Database::registerToSaveAtExit(const char* filename)
 {
-    m_atExitSaveFilename = filename;
+    m_atExitSaveFilename = unsafeNullTerminated(filename);
     
     if (m_shouldSaveAtExit)
         return;

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
@@ -53,7 +53,7 @@ Ref<JSON::Value> Event::toJSON(Dumper& dumper) const
     result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
     if (m_compilation)
         result->setString(dumper.keys().m_compilationUID, makeString(m_compilation->uid()));
-    result->setString(dumper.keys().m_summary, String::fromUTF8(m_summary));
+    result->setString(dumper.keys().m_summary, String::fromUTF8(unsafeNullTerminated(m_summary)));
     if (m_detail.length())
         result->setString(dumper.keys().m_detail, String::fromUTF8(m_detail.span()));
 

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -119,7 +119,6 @@ public:
     static Identifier fromString(VM&, Ref<AtomStringImpl>&&);
     static Identifier fromString(VM&, const AtomString&);
     static Identifier fromString(VM& vm, SymbolImpl*);
-    static Identifier fromLatin1(VM&, const char*);
 
     static Identifier fromUid(VM&, UniquedStringImpl* uid);
     static Identifier fromUid(const PrivateName&);

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -120,11 +120,6 @@ inline Identifier Identifier::fromString(VM& vm, SymbolImpl* symbolImpl)
     return Identifier(vm, symbolImpl);
 }
 
-inline Identifier Identifier::fromLatin1(VM& vm, const char* s)
-{
-    return Identifier(vm, AtomString::fromLatin1(s));
-}
-
 inline JSValue identifierToJSValue(VM& vm, const Identifier& identifier)
 {
     if (identifier.isSymbol())

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -332,7 +332,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
             break;
         }
 
-        buffer = vm.intlCache().getFieldDisplayName(m_localeCString.data(), field.value(), style, status);
+        buffer = vm.intlCache().getFieldDisplayName(m_localeCString, field.value(), style, status);
         if (U_FAILURE(status))
             return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, WTFMove(code));
         return jsString(vm, String(WTFMove(buffer)));

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -89,16 +89,16 @@ public:
             case NumberType::Integer: {
                 double value = std::get<double>(m_value);
                 if (isNegativeZero(value))
-                    m_value = CString("-0");
+                    m_value = CString("-0"_s);
                 else
                     m_value = String::number(value).ascii();
                 break;
             }
             case NumberType::NaN:
-                m_value = CString("nan");
+                m_value = CString("nan"_s);
                 break;
             case NumberType::Infinity:
-                m_value = CString(m_sign ? "-infinity" : "infinity");
+                m_value = CString(m_sign ? "-infinity"_s : "infinity"_s);
                 break;
             }
         }

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2894,7 +2894,7 @@ void JSObject::reifyAllStaticProperties(JSGlobalObject* globalObject)
 
         for (auto& value : *hashTable) {
             unsigned attributes;
-            auto key = Identifier::fromLatin1(vm, value.m_key);
+            auto key = Identifier::fromString(vm, value.m_key);
             PropertyOffset offset = getDirectOffset(vm, key, attributes);
             if (!isValidOffset(offset))
                 reifyStaticProperty(vm, hashTable->classForThis, key, value, *this);

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -821,7 +821,7 @@ ALWAYS_INLINE void JSObject::getNonReifiedStaticPropertyNames(VM& vm, PropertyNa
 
         for (auto iter = table->begin(); iter != table->end(); ++iter) {
             if (mode == DontEnumPropertiesMode::Include || !(iter->attributes() & PropertyAttribute::DontEnum)) {
-                auto identifier = Identifier::fromLatin1(vm, iter.key());
+                auto identifier = Identifier::fromString(vm, iter.key());
                 // If the structure is shadowing the static property use it's attributes to determine if
                 // the property name is enumerable but add it here to preserve the right property order.
                 unsigned structureAttributes;

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -68,7 +68,7 @@ public:
     const String& pattern() const { return m_patternString; }
 
     bool isValid() const { return !Yarr::hasError(m_constructionErrorCode); }
-    const char* errorMessage() const { return Yarr::errorMessage(m_constructionErrorCode); }
+    ASCIILiteral errorMessage() const { return Yarr::errorMessage(m_constructionErrorCode); }
     JSObject* errorToThrow(JSGlobalObject* globalObject) { return Yarr::errorToThrow(globalObject, m_constructionErrorCode); }
     void reset()
     {

--- a/Source/JavaScriptCore/testRegExp.cpp
+++ b/Source/JavaScriptCore/testRegExp.cpp
@@ -302,7 +302,7 @@ static RegExp* parseRegExpLine(VM& vm, char* line, int lineLength, const char** 
 
     ++i;
 
-    auto flags = Yarr::parseFlags(StringView::fromLatin1(line + i));
+    auto flags = Yarr::parseFlags(StringView(unsafeNullTerminated(line + i)));
     if (!flags) {
         *regexpError = Yarr::errorMessage(Yarr::ErrorCode::InvalidRegularExpressionFlags);
         return nullptr;

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -405,7 +405,7 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
     auto valueAsString = [&] (JSValue v) -> CString {
         if (!v.isCell() || VMInspector::isValidCell(&vm.heap, reinterpret_cast<JSCell*>(JSValue::encode(v))))
             return toCString(v);
-        return "";
+        return ""_s;
     };
 
     CallFrame* topCallFrame = vm.topCallFrame;

--- a/Source/JavaScriptCore/yarr/YarrUnicodeProperties.cpp
+++ b/Source/JavaScriptCore/yarr/YarrUnicodeProperties.cpp
@@ -60,7 +60,7 @@ struct HashTable {
             return -1;
 
         while (true) {
-            if (WTF::equal(key, StringView::fromLatin1(values[valueIndex].key)))
+            if (WTF::equal(key, StringView(unsafeNullTerminated(values[valueIndex].key))))
                 return values[valueIndex].index;
 
             indexEntry = index[indexEntry].next;

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -601,7 +601,7 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
     }
 #endif
 
-    for (auto logLevelComponent : StringView::fromLatin1(logLevel).split(',')) {
+    for (auto logLevelComponent : StringView(unsafeNullTerminated(logLevel)).split(',')) {
         auto componentInfo = logLevelComponent.split('=');
         auto it = componentInfo.begin();
         if (it == componentInfo.end())

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -911,7 +911,7 @@ double parseDate(std::span<const LChar> dateString, bool& isLocalTime)
             for (auto& knownZone : knownZones) {
                 // Since the passed-in length is used for both strings, the following checks that
                 // dateString has the time zone name as a prefix, not that it is equal.
-                auto tzName = unsafeSpan8(knownZone.tzName);
+                auto tzName = knownZone.tzName.span8();
                 if (skipLettersExactlyIgnoringASCIICase(dateString, tzName)) {
                     offset = knownZone.tzOffset;
                     isLocalTime = false;

--- a/Source/WTF/wtf/LogChannels.cpp
+++ b/Source/WTF/wtf/LogChannels.cpp
@@ -69,7 +69,7 @@ void LogChannels::initializeLogChannelsIfNecessary(std::optional<String> logChan
     m_logChannelsNeedInitialization = false;
 
     String enabledChannelsString = logChannelString ? logChannelString.value() : logLevelString();
-    WTFInitializeLogChannelStatesFromString(m_logChannels.data(), m_logChannels.size(), enabledChannelsString.utf8().data());
+    WTFInitializeLogChannelStatesFromString(m_logChannels.data(), m_logChannels.size(), enabledChannelsString.utf8().nullTerminated());
 }
 
 WTFLogChannel* LogChannels::getLogChannel(const String& name)

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -55,7 +55,7 @@ struct LogArgument {
     template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, AtomString>, String> toString(const AtomString& argument) { return argument.string(); }
     template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, String>, String> toString(String argument) { return argument; }
     template<typename U = T> static std::enable_if_t<std::is_same_v<typename std::remove_reference_t<U>, StringBuilder*>, String> toString(StringBuilder* argument) { return argument->toString(); }
-    template<typename U = T> static std::enable_if_t<std::is_same_v<U, const char*>, String> toString(const char* argument) { return String::fromLatin1(argument); }
+    template<typename U = T> static std::enable_if_t<std::is_same_v<U, const char*>, String> toString(const char* argument) { return String(unsafeNullTerminated(argument)); }
     template<typename U = T> static std::enable_if_t<std::is_same_v<U, ASCIILiteral>, String> toString(ASCIILiteral argument) { return argument; }
 #ifdef __OBJC__
     template<typename U = T> static std::enable_if_t<std::is_base_of_v<NSError, std::remove_pointer_t<U>>, String> toString(NSError *argument) { return String(argument.localizedDescription); }

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1497,6 +1497,36 @@ ALWAYS_INLINE void lazyInitialize(const std::unique_ptr<T>& ptr, std::unique_ptr
     const_cast<std::unique_ptr<T>&>(ptr) = std::move(obj);
 }
 
+class NullTerminated {
+public:
+    // Caller must ensure that 'string' is null terminated, or nullptr
+    static constexpr NullTerminated fromUnsafe(const char* string) { return string; }
+
+    constexpr NullTerminated()
+        : m_string(nullptr)
+    {
+    }
+
+    // Can be nullptr
+    constexpr operator const char*() const { return m_string; }
+
+    // Can be nullptr
+    constexpr const char* nullTerminated() const { return m_string; }
+
+private:
+    constexpr NullTerminated(const char* string)
+        : m_string(string)
+    {
+    }
+
+    const char* m_string;
+};
+
+inline NullTerminated unsafeNullTerminated(const char* string) { return NullTerminated::fromUnsafe(string); }
+
+// NullTerminated is null terminated
+inline const char* safePrintfType(NullTerminated nullTerminated) { return nullTerminated; }
+
 } // namespace WTF
 
 #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
@@ -1563,11 +1593,13 @@ using WTF::spanReinterpretCast;
 using WTF::toTwosComplement;
 using WTF::tryBinarySearch;
 using WTF::unsafeMakeSpan;
+using WTF::unsafeNullTerminated;
 using WTF::valueOrCompute;
 using WTF::valueOrDefault;
 using WTF::zeroBytes;
 using WTF::zeroSpan;
 using WTF::Invocable;
+using WTF::NullTerminated;
 using WTF::VariantWrapper;
 using WTF::VariantOrSingle;
 

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -196,7 +196,7 @@ const char* Thread::normalizeThreadName(const char* threadName)
     // This name can be com.apple.WebKit.ProcessLauncher or com.apple.CoreIPC.ReceiveQueue.
     // We are using those names for the thread name, but both are longer than the limit of
     // the platform thread name length, 32 for Windows and 16 for Linux.
-    auto result = StringView::fromLatin1(threadName);
+    auto result = StringView(unsafeNullTerminated(threadName));
     size_t size = result.reverseFind('.');
     if (size != notFound)
         result = result.substring(size + 1);

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -930,7 +930,7 @@ String userVisibleURL(const CString& url)
     }
     
     // Check string to see if it can be converted to display using UTF-8  
-    String result = String::fromUTF8(after.data());
+    String result = String::fromUTF8(unsafeNullTerminated(after.data()));
     if (!result) {
         // Could not convert to UTF-8.
         // Convert characters greater than 0x7f to escape sequences.
@@ -953,7 +953,7 @@ String userVisibleURL(const CString& url)
         }
         after[afterIndex] = '\0';
         // Note: after.data() points to a null-terminated, pure ASCII string.
-        result = String::fromUTF8(after.data());
+        result = String::fromUTF8(unsafeNullTerminated(after.data()));
         ASSERT(!!result);
     }
 

--- a/Source/WTF/wtf/cf/FileSystemCF.cpp
+++ b/Source/WTF/wtf/cf/FileSystemCF.cpp
@@ -52,7 +52,7 @@ CString FileSystem::fileSystemRepresentation(const String& path)
         return CString();
     }
 
-    return buffer.data();
+    return unsafeNullTerminated(buffer.data());
 }
 
 String FileSystem::stringFromFileSystemRepresentation(const char* fileSystemRepresentation)

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -77,7 +77,7 @@ String createTemporaryZipArchive(const String& path)
 
     RetainPtr coordinator = adoptNS([[NSFileCoordinator alloc] initWithFilePresenter:nil]);
     [coordinator coordinateReadingItemAtURL:[NSURL fileURLWithPath:path] options:NSFileCoordinatorReadingWithoutChanges error:nullptr byAccessor:[&](NSURL *newURL) mutable {
-        CString archivePath([NSTemporaryDirectory() stringByAppendingPathComponent:@"WebKitGeneratedFileXXXXXX"].fileSystemRepresentation);
+        CString archivePath(unsafeNullTerminated([NSTemporaryDirectory() stringByAppendingPathComponent:@"WebKitGeneratedFileXXXXXX"].fileSystemRepresentation));
         int fd = mkostemp(archivePath.mutableSpanIncludingNullTerminator().data(), O_CLOEXEC);
         if (fd == -1)
             return;
@@ -155,7 +155,7 @@ std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, Strin
     if (platformFileHandle == invalidPlatformFileHandle)
         return { nullString(), invalidPlatformFileHandle };
 
-    return { String::fromUTF8(temporaryFilePath.data()), platformFileHandle };
+    return { String::fromUTF8(unsafeNullTerminated(temporaryFilePath.data())), platformFileHandle };
 }
 
 NSString *createTemporaryDirectory(NSString *directoryPrefix)

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -63,7 +63,7 @@ static String uuidToString(const uuid_t& uuid)
 {
     uuid_string_t uuid_string = { };
     uuid_unparse(uuid, uuid_string);
-    return String::fromUTF8(uuid_string);
+    return String::fromUTF8(unsafeNullTerminated(uuid_string));
 }
 
 class LibraryPathDiagnosticsLogger final {

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.mm
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.mm
@@ -38,7 +38,7 @@ namespace WTF {
 OSLogPrintStream::OSLogPrintStream(os_log_t log, os_log_type_t logType)
     : m_log(log)
     , m_logType(logType)
-    , m_string("initial string... lol")
+    , m_string("initial string... lol"_s)
 {
 }
 

--- a/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
+++ b/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
@@ -69,7 +69,7 @@ static size_t computeMemoryFootprint()
                 return;
             }
             if (scannedCount == 7) {
-                auto pathString = StringView::fromLatin1(path);
+                auto pathString = StringView(unsafeNullTerminated(path));
                 isAnonymous = pathString == "[heap]"_s || pathString.startsWith("[stack"_s);
                 return;
             }

--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -273,5 +273,5 @@ inline String xpc_dictionary_get_wtfstring(xpc_object_t xdict, ASCIILiteral key)
     auto* cstring = xpc_dictionary_get_string(xdict, key.characters()); // NOLINT
     if (!cstring)
         return { };
-    return String::fromUTF8(cstring);
+    return String::fromUTF8(unsafeNullTerminated(cstring));
 }

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -76,6 +76,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     constexpr bool isNull() const { return m_charactersWithNullTerminator.empty(); }
 
     constexpr const char* characters() const { return m_charactersWithNullTerminator.data(); }
+    constexpr const NullTerminated nullTerminated() const { return unsafeNullTerminated(m_charactersWithNullTerminator.data()); }
     constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
     constexpr std::span<const char> span() const { return m_charactersWithNullTerminator.first(length()); }
     std::span<const LChar> span8() const { return byteCast<LChar>(m_charactersWithNullTerminator.first(length())); }

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -32,8 +32,7 @@ public:
     AtomString();
     AtomString(std::span<const LChar>);
     AtomString(std::span<const UChar>);
-
-    ALWAYS_INLINE static AtomString fromLatin1(const char* characters) { return AtomString(characters); }
+    AtomString(NullTerminated);
 
     AtomString(AtomStringImpl*);
     AtomString(RefPtr<AtomStringImpl>&&);
@@ -135,8 +134,6 @@ public:
 #endif
 
 private:
-    explicit AtomString(const char*);
-
     enum class CaseConvertType { Upper, Lower };
     template<CaseConvertType> AtomString convertASCIICase() const;
 
@@ -169,7 +166,7 @@ inline AtomString::AtomString()
 {
 }
 
-inline AtomString::AtomString(const char* string)
+inline AtomString::AtomString(NullTerminated string)
     : m_string(AtomStringImpl::addCString(string))
 {
 }

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -49,7 +49,7 @@ public:
     ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral);
 
     // Not using the add() naming to encourage developers to call add(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char*);
+    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(NullTerminated);
 
     // Returns null if the input data contains an invalid UTF-8 sequence.
     static RefPtr<AtomStringImpl> add(std::span<const char8_t>);
@@ -114,9 +114,9 @@ ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(ASCIILiteral literal)
     return addLiteral(literal.span8());
 }
 
-ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addCString(const char* s)
+ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addCString(NullTerminated s)
 {
-    return s ? add(unsafeSpan8(s)) : nullptr;
+    return s ? add(WTF::span8(s)) : nullptr;
 }
 
 template<typename StringTableProvider>

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -57,6 +57,22 @@ CString::CString(const char* string)
     init(unsafeSpan(string));
 }
 
+CString::CString(ASCIILiteral string)
+{
+    if (!string)
+        return;
+
+    init(string.span());
+}
+
+CString::CString(NullTerminated string)
+{
+    if (!string)
+        return;
+
+    init(WTF::span(string));
+}
+
 CString::CString(std::span<const char> string)
 {
     if (!string.data()) {

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -67,6 +67,8 @@ class CString final {
 public:
     CString() { }
     WTF_EXPORT_PRIVATE CString(const char*);
+    WTF_EXPORT_PRIVATE CString(ASCIILiteral);
+    WTF_EXPORT_PRIVATE CString(NullTerminated);
     WTF_EXPORT_PRIVATE CString(std::span<const char>);
     CString(std::span<const LChar>);
     CString(std::span<const char8_t> characters) : CString(byteCast<LChar>(characters)) { }
@@ -75,6 +77,7 @@ public:
     CString(HashTableDeletedValueType) : m_buffer(HashTableDeletedValue) { }
 
     const char* data() const LIFETIME_BOUND;
+    NullTerminated nullTerminated() const LIFETIME_BOUND;
 
     std::string toStdString() const { return m_buffer ? std::string(m_buffer->spanIncludingNullTerminator().data()) : std::string(); }
 
@@ -126,6 +129,11 @@ inline CString::CString(std::span<const LChar> bytes)
 inline const char* CString::data() const
 {
     return m_buffer ? m_buffer->spanIncludingNullTerminator().data() : nullptr;
+}
+
+inline NullTerminated CString::nullTerminated() const
+{
+    return unsafeNullTerminated(data());
 }
 
 inline std::span<const LChar> CString::span() const

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -50,11 +50,23 @@ inline std::span<const UChar> span(const UChar& character)
     return unsafeMakeSpan(&character, 1);
 }
 
-inline std::span<const LChar> unsafeSpan8(const char* string)
+inline std::span<const char> span(NullTerminated string)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return unsafeMakeSpan(byteCast<LChar>(string), string ? strlen(string) : 0);
+    return unsafeMakeSpan(string.nullTerminated(), string ? strlen(string) : 0);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
+inline std::span<const LChar> span8(NullTerminated string)
+{
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    return unsafeMakeSpan(byteCast<LChar>(string.nullTerminated()), string ? strlen(string) : 0);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+}
+
+inline std::span<const LChar> unsafeSpan8(const char* string)
+{
+    return span8(unsafeNullTerminated(string));
 }
 
 inline std::span<const LChar> unsafeSpan8IncludingNullTerminator(const char* string)
@@ -563,9 +575,9 @@ bool equalIgnoringASCIICaseCommon(const StringClassA& a, const StringClassB& b)
     return equalIgnoringASCIICaseWithLength(a.span16(), b.span16(), b.length());
 }
 
-template<typename StringClassA> bool equalIgnoringASCIICaseCommon(const StringClassA& a, const char* b)
+template<typename StringClassA> bool equalIgnoringASCIICaseCommon(const StringClassA& a, NullTerminated b)
 {
-    auto bSpan = unsafeSpan8(b);
+    auto bSpan = span8(b);
     if (a.length() != bSpan.size())
         return false;
     if (a.is8Bit())

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -257,7 +257,7 @@ public:
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create8BitIfPossible(std::span<const UChar>);
 
     // Not using create() naming to encourage developers to call create(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(unsafeSpan8(characters)); }
+    ALWAYS_INLINE static Ref<StringImpl> createFromCString(NullTerminated characters) { return create(WTF::span8(characters)); }
 
     static Ref<StringImpl> createSubstringSharingImpl(StringImpl&, unsigned offset, unsigned length);
 
@@ -1270,7 +1270,7 @@ inline bool equalIgnoringASCIICase(const StringImpl& a, const StringImpl& b)
 
 inline bool equalIgnoringASCIICase(const StringImpl& a, ASCIILiteral b)
 {
-    return equalIgnoringASCIICaseCommon(a, b.characters());
+    return equalIgnoringASCIICaseCommon(a, b.nullTerminated());
 }
 
 inline bool equalIgnoringASCIICase(const StringImpl* a, ASCIILiteral b)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -71,8 +71,7 @@ public:
     StringView(std::span<const char> span LIFETIME_BOUND); // FIXME: Consider dropping this overload. Callers should pass LChars/UChars instead.
     StringView(const void* string LIFETIME_BOUND, unsigned length, bool is8bit);
     StringView(ASCIILiteral);
-
-    ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
+    StringView(NullTerminated);
 
     unsigned length() const;
     bool isEmpty() const;
@@ -202,9 +201,6 @@ public:
 #endif
 
 private:
-    // Clients should use StringView(ASCIILiteral) or StringView::fromLatin1() instead.
-    explicit StringView(const char*);
-
     friend bool equal(StringView, StringView);
     friend bool equal(StringView, StringView, unsigned length);
     friend WTF_EXPORT_PRIVATE bool equalRespectingNullity(StringView, StringView);
@@ -402,9 +398,9 @@ inline StringView::StringView(std::span<const UChar> characters)
     initialize(characters);
 }
 
-inline StringView::StringView(const char* characters)
+inline StringView::StringView(NullTerminated characters)
 {
-    initialize(unsafeSpan8(characters));
+    initialize(WTF::span8(characters));
 }
 
 inline StringView::StringView(std::span<const char> characters)
@@ -786,7 +782,7 @@ inline bool equalIgnoringASCIICase(StringView a, StringView b)
 
 inline bool equalIgnoringASCIICase(StringView a, ASCIILiteral b)
 {
-    return equalIgnoringASCIICaseCommon(a, b.characters());
+    return equalIgnoringASCIICaseCommon(a, b.nullTerminated());
 }
 
 class StringView::SplitResult {

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -57,8 +57,8 @@ String::String(std::span<const char> characters)
 }
 
 // Construct a string with Latin-1 data, from a null-terminated source.
-String::String(const char* nullTerminatedString)
-    : m_impl(nullTerminatedString ? RefPtr { StringImpl::createFromCString(nullTerminatedString) } : nullptr)
+String::String(NullTerminated string)
+    : m_impl(string ? RefPtr { StringImpl::createFromCString(string) } : nullptr)
 {
 }
 
@@ -603,7 +603,7 @@ void String::show() const
 String* string(const char* s)
 {
     // Intentionally leaks memory!
-    return new String(String::fromLatin1(s));
+    return new String(String(unsafeNullTerminated(s)));
 }
 
 Vector<char> asciiDebug(StringImpl* impl)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -65,7 +65,9 @@ public:
     // Construct a string with Latin-1 data.
     WTF_EXPORT_PRIVATE String(std::span<const LChar> characters);
     WTF_EXPORT_PRIVATE String(std::span<const char> characters);
-    ALWAYS_INLINE static String fromLatin1(const char* characters) { return String { characters }; }
+    WTF_EXPORT_PRIVATE String(NullTerminated characters);
+
+    ALWAYS_INLINE static String fromLatin1(const char* characters) { return String { unsafeNullTerminated(characters) }; }
 
     // Construct a string referencing an existing StringImpl.
     String(StringImpl&);
@@ -268,6 +270,7 @@ public:
     WTF_EXPORT_PRIVATE static String fromUTF8(std::span<const char8_t>);
     static String fromUTF8(std::span<const LChar> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
     static String fromUTF8(std::span<const char> characters) { return fromUTF8(byteCast<char8_t>(characters)); }
+    static String fromUTF8(NullTerminated string) { return fromUTF8(WTF::span8(string)); }
     static String fromUTF8(const char* string) { return fromUTF8(unsafeSpan8(string)); }
     static String fromUTF8ReplacingInvalidSequences(std::span<const char8_t>);
     static String fromUTF8ReplacingInvalidSequences(std::span<const LChar> characters) { return fromUTF8ReplacingInvalidSequences(byteCast<char8_t>(characters)); }
@@ -307,9 +310,6 @@ private:
     template<bool allowEmptyEntries> void splitInternal(UChar separator, const SplitFunctor&) const;
     template<bool allowEmptyEntries> Vector<String> splitInternal(UChar separator) const;
     template<bool allowEmptyEntries> Vector<String> splitInternal(StringView separator) const;
-
-    // This is intentionally private. Use fromLatin1() / fromUTF8() / String(ASCIILiteral) instead.
-    WTF_EXPORT_PRIVATE explicit String(const char* characters);
 
     RefPtr<StringImpl> m_impl;
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -123,7 +123,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
 
 RefPtr<ComputePassEncoder> CommandEncoderImpl::beginComputePass(const std::optional<ComputePassDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString("");
+    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
 
     WGPUComputePassTimestampWrites timestampWrites {
         .querySet = (descriptor && descriptor->timestampWrites && descriptor->timestampWrites->querySet) ? protectedConvertToBackingContext()->convertToBacking(*descriptor->timestampWrites->protectedQuerySet().get()) : nullptr,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -72,7 +72,7 @@ namespace WebCore::WebGPU {
 
 static auto invalidEntryPointName()
 {
-    return CString("");
+    return CString(""_s);
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceImpl);
@@ -632,7 +632,7 @@ void DeviceImpl::createRenderPipelineAsync(const RenderPipelineDescriptor& descr
 
 RefPtr<CommandEncoder> DeviceImpl::createCommandEncoder(const std::optional<CommandEncoderDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString("");
+    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
 
     WGPUCommandEncoderDescriptor backingDescriptor {
         nullptr,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -51,7 +51,7 @@ TextureImpl::~TextureImpl() = default;
 
 RefPtr<TextureView> TextureImpl::createView(const std::optional<TextureViewDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString("");
+    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
 
     Ref convertToBackingContext = m_convertToBackingContext;
 

--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
@@ -120,7 +120,7 @@ static ExceptionOr<void> validateCountryCode(const String& countryCode)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (auto* countryCodePtr = uloc_getISOCountries(); *countryCodePtr; ++countryCodePtr) {
-        if (countryCode == StringView::fromLatin1(*countryCodePtr))
+        if (countryCode == StringView(unsafeNullTerminated(*countryCodePtr)))
             return { };
     }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -138,7 +138,7 @@ static ExceptionOr<void> validateCurrencyCode(const String& currencyCode)
 
     int32_t length;
     while (auto *currencyCodePtr = uenum_next(currencyCodes.get(), &length, &errorCode)) {
-        if (currencyCode == StringView::fromLatin1(currencyCodePtr))
+        if (currencyCode == StringView(unsafeNullTerminated(currencyCodePtr)))
             return { };
     }
 

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -197,7 +197,7 @@ bool isPlayReadySanitizedInitializationData(const SharedBuffer& buffer)
     // The protection data starts with a 10-byte PlayReady version
     // header that needs to be skipped over to avoid XML parsing
     // errors.
-    auto view = StringView::fromLatin1(byteCast<char>(buffer.span().data()));
+    auto view = StringView(spanReinterpretCast<char>(buffer.span()));
     auto startTag = view.find('<');
     if (startTag == notFound)
         return false;

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -193,7 +193,7 @@ PeerConnectionBackend::~PeerConnectionBackend()
 #if !RELEASE_LOG_DISABLED && (PLATFORM(WPE) || PLATFORM(GTK))
 void PeerConnectionBackend::handleLogMessage(const WTFLogChannel& channel, WTFLogLevel, Vector<JSONLogValue>&& values)
 {
-    auto name = StringView::fromLatin1(channel.name);
+    auto name = StringView(unsafeNullTerminated(channel.name));
     if (name != "WebRTC"_s)
         return;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -97,7 +97,7 @@ GStreamerMediaEndpoint::~GStreamerMediaEndpoint()
 GStreamerMediaEndpoint::NetSimOptions GStreamerMediaEndpoint::netSimOptionsFromEnvironment(ASCIILiteral optionsEnvVarName)
 {
     NetSimOptions options;
-    auto tokens = StringView::fromLatin1(g_getenv(optionsEnvVarName));
+    auto tokens = StringView(unsafeNullTerminated(g_getenv(optionsEnvVarName)));
     for (auto it : tokens.split(',')) {
         auto option = it.toString();
         auto keyValue = option.split('=');
@@ -173,7 +173,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
         if (auto factory = adoptGRef(gst_element_factory_find("netsim"))) {
             g_signal_connect_swapped(m_webrtcBin.get(), "deep-element-added", G_CALLBACK(+[](GStreamerMediaEndpoint* self, GstBin* bin, GstElement* element) {
                 GUniquePtr<char> elementName(gst_element_get_name(element));
-                auto view = StringView::fromLatin1(elementName.get());
+                auto view = StringView(unsafeNullTerminated(elementName.get()));
                 if (view.startsWith("nice"_s))
                     self->maybeInsertNetSimForElement(bin, element);
             }), this);
@@ -604,7 +604,7 @@ void GStreamerMediaEndpoint::linkOutgoingSources(GstSDPMessage* sdpMessage)
 #endif
     for (unsigned i = 0; i < totalMedias; i++) {
         const auto media = gst_sdp_message_get_media(sdpMessage, i);
-        auto mediaType = StringView::fromLatin1(gst_sdp_media_get_media(media));
+        auto mediaType = StringView(unsafeNullTerminated(gst_sdp_media_get_media(media)));
         RealtimeMediaSource::Type sourceType;
         if (mediaType == "audio"_s)
             sourceType = RealtimeMediaSource::Type::Audio;
@@ -1016,7 +1016,7 @@ void GStreamerMediaEndpoint::processSDPMessage(const GstSDPMessage* message, Fun
             continue;
         }
 
-        mediaCallback(mediaIndex, StringView::fromLatin1(mid), media);
+        mediaCallback(mediaIndex, StringView(unsafeNullTerminated(mid)), media);
     }
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -61,7 +61,7 @@ public:
     }
     bool shouldEmitLogMessage(const WTFLogChannel& channel) const final
     {
-        return StringView::fromLatin1(channel.name).startsWith("WebRTC"_s);
+        return StringView(unsafeNullTerminated(channel.name)).startsWith("WebRTC"_s);
     }
 };
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -666,7 +666,7 @@ GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia* media)
             GST_DEBUG("Skipping media format without rtpmap");
             continue;
         }
-        auto rtpMap = StringView::fromLatin1(rtpMapValue);
+        auto rtpMap = StringView(unsafeNullTerminated(rtpMapValue));
         auto components = rtpMap.split(' ');
         auto payloadType = parseInteger<int>(*components.begin());
         if (!payloadType) {

--- a/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
@@ -91,7 +91,7 @@ bool detectTextEncoding(std::span<const uint8_t> data, ASCIILiteral hintEncoding
                 status = U_ZERO_ERROR;
                 continue;
             }
-            if (TextEncoding(StringView::fromLatin1(matchEncoding)) == hintEncoding) {
+            if (TextEncoding(StringView(unsafeNullTerminated(matchEncoding))) == hintEncoding) {
                 encoding = hintEncodingName;
                 break;
             }
@@ -104,7 +104,7 @@ bool detectTextEncoding(std::span<const uint8_t> data, ASCIILiteral hintEncoding
     if (!encoding && !matches.empty())
         encoding = ucsdet_getName(matches[0], &status);
     if (U_SUCCESS(status)) {
-        *detectedEncoding = TextEncoding(StringView::fromLatin1(encoding));
+        *detectedEncoding = TextEncoding(StringView(unsafeNullTerminated(encoding)));
         ucsdet_close(detector);
         return true;
     }    

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2531,7 +2531,7 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
             StringBuilder passwordValue;
             passwordValue.reserveCapacity(inputValue.length());
             for (size_t i = 0; i < inputValue.length(); i++)
-                passwordValue.append(String::fromUTF8("•"));
+                passwordValue.append(String::fromUTF8("•"_s));
             return passwordValue.toString();
         }
         return inputValue;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
@@ -85,8 +85,8 @@ AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule(GVariant* rul
     const char* attributeName;
     const char* attributeValue;
     while (g_variant_iter_next(attributesIter.get(), "{&s&s}", &attributeName, &attributeValue)) {
-        auto addResult = attributes.value.add(String::fromUTF8(attributeName), Vector<String> { });
-        String value = String::fromUTF8(attributeValue);
+        auto addResult = attributes.value.add(String::fromUTF8(unsafeNullTerminated(attributeName)), Vector<String> { });
+        String value = String::fromUTF8(unsafeNullTerminated(attributeValue));
         unsigned currentPos = 0;
         unsigned startPos = 0;
         size_t endPos;
@@ -122,7 +122,7 @@ AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule(GVariant* rul
 
     const char* interface;
     while (g_variant_iter_next(interfacesIter.get(), "&s", &interface))
-        interfaces.value.append(String::fromUTF8(interface));
+        interfaces.value.append(String::fromUTF8(unsafeNullTerminated(interface)));
     interfaces.type = static_cast<Atspi::CollectionMatchType>(interfacesMatchType);
 }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectDocumentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectDocumentAtspi.cpp
@@ -40,7 +40,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_documentFunctions = {
         if (!g_strcmp0(methodName, "GetAttributeValue")) {
             const char* name;
             g_variant_get(parameters, "(&s)", &name);
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(s)", atspiObject->documentAttribute(String::fromUTF8(name)).utf8().data()));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(s)", atspiObject->documentAttribute(String::fromUTF8(unsafeNullTerminated(name))).utf8().data()));
         } else if (!g_strcmp0(methodName, "GetAttributes")) {
             GVariantBuilder builder = G_VARIANT_BUILDER_INIT(G_VARIANT_TYPE("(a{ss})"));
             g_variant_builder_open(&builder, G_VARIANT_TYPE("a{ss}"));

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -123,7 +123,7 @@ GDBusInterfaceVTable AccessibilityObjectAtspi::s_textFunctions = {
             const char* name;
             g_variant_get(parameters, "(i&s)", &offset, &name);
             auto attributes = atspiObject->textAttributesWithUTF8Offset(offset);
-            g_dbus_method_invocation_return_value(invocation, g_variant_new("(s)", attributes.attributes.get(String::fromUTF8(name)).utf8().data()));
+            g_dbus_method_invocation_return_value(invocation, g_variant_new("(s)", attributes.attributes.get(String::fromUTF8(unsafeNullTerminated(name))).utf8().data()));
         } else if (!g_strcmp0(methodName, "GetAttributes")) {
             int offset;
             g_variant_get(parameters, "(i)", &offset);
@@ -278,7 +278,7 @@ String AccessibilityObjectAtspi::text() const
     if (m_coreObject->roleValue() == AccessibilityRole::ColorWell) {
         auto color = convertColor<SRGBA<float>>(m_coreObject->colorValue()).resolved();
         GUniquePtr<char> colorString(g_strdup_printf("rgb %7.5f %7.5f %7.5f 1", color.red, color.green, color.blue));
-        return String::fromUTF8(colorString.get());
+        return String::fromUTF8(unsafeNullTerminated(colorString.get()));
     }
 
     if (m_coreObject->isTextControl())

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp
@@ -177,8 +177,8 @@ void AccessibilityRootAtspi::setPath(String&& path)
 
 void AccessibilityRootAtspi::embedded(const char* parentUniqueName, const char* parentPath)
 {
-    m_parentUniqueName = String::fromUTF8(parentUniqueName);
-    m_parentPath = String::fromUTF8(parentPath);
+    m_parentUniqueName = String::fromUTF8(unsafeNullTerminated(parentUniqueName));
+    m_parentPath = String::fromUTF8(unsafeNullTerminated(parentPath));
     AccessibilityAtspi::singleton().parentChanged(*this);
 }
 

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -43,7 +43,7 @@ using namespace JSC;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMGCOutputConstraint);
 
 DOMGCOutputConstraint::DOMGCOutputConstraint(VM& vm, JSHeapData& heapData)
-    : MarkingConstraint("Domo", "DOM Output", ConstraintVolatility::SeldomGreyed, ConstraintConcurrency::Concurrent, ConstraintParallelism::Parallel)
+    : MarkingConstraint("Domo"_s, "DOM Output"_s, ConstraintVolatility::SeldomGreyed, ConstraintConcurrency::Concurrent, ConstraintParallelism::Parallel)
     , m_vm(vm)
     , m_heapData(heapData)
     , m_lastExecutionVersion(vm.heap.mutatorExecutionVersion())

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -446,7 +446,7 @@ void RedirectAction::RegexSubstitutionAction::applyToURL(URL& url) const
         size_t bufferSize = JSStringGetMaximumUTF8CStringSize(string.get());
         Vector<char> buffer(bufferSize);
         JSStringGetUTF8CString(string.get(), buffer.data(), buffer.size());
-        return String::fromUTF8(buffer.data());
+        return String::fromUTF8(unsafeNullTerminated(buffer.data()));
     };
 
     // Effectively execute this JavaScript:

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -140,7 +140,7 @@ void PingLoader::sendPing(LocalFrame& frame, const URL& pingURL, const URL& dest
 
     request.setHTTPMethod("POST"_s);
     request.setHTTPContentType("text/ping"_s);
-    request.setHTTPBody(FormData::create("PING"));
+    request.setHTTPBody(FormData::create("PING"_s));
     request.setHTTPHeaderField(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
 
     HTTPHeaderMap originalRequestHeader = request.httpHeaderFields();

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -258,7 +258,7 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
     RELEASE_LOG(MemoryPressure, "Live JavaScript objects at time of %" PUBLIC_LOG_STRING ":", description.characters());
     auto typeCounts = vm.heap.objectTypeCounts();
     for (auto& it : *typeCounts)
-        RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %d", it.key, it.value);
+        RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %d", it.key.characters(), it.value);
 }
 #endif
 

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -81,7 +81,7 @@ Vector<std::pair<ASCIILiteral, size_t>> PerformanceLogging::memoryUsageStatistic
     return stats;
 }
 
-HashCountedSet<const char*> PerformanceLogging::javaScriptObjectCounts()
+HashCountedSet<ASCIILiteral> PerformanceLogging::javaScriptObjectCounts()
 {
     return WTFMove(*commonVM().heap.objectTypeCounts());
 }

--- a/Source/WebCore/page/PerformanceLogging.h
+++ b/Source/WebCore/page/PerformanceLogging.h
@@ -48,7 +48,7 @@ public:
 
     void didReachPointOfInterest(PointOfInterest);
 
-    WEBCORE_EXPORT static HashCountedSet<const char*> javaScriptObjectCounts();
+    WEBCORE_EXPORT static HashCountedSet<ASCIILiteral> javaScriptObjectCounts();
     WEBCORE_EXPORT static Vector<std::pair<ASCIILiteral, size_t>> memoryUsageStatistics(ShouldIncludeExpensiveComputations);
     WEBCORE_EXPORT static std::optional<uint64_t> physicalFootprint();
 

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -216,7 +216,7 @@ static void collectCPUUsage(float period)
 
     struct dirent* dp;
     while ((dp = readdir(dir))) {
-        auto id = parseInteger<pid_t>(StringView::fromLatin1(dp->d_name));
+        auto id = parseInteger<pid_t>(StringView(unsafeNullTerminated(dp->d_name)));
         if (!id)
             continue;
 

--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
@@ -50,7 +50,7 @@ static std::optional<PlatformMediaSession::RemoteControlCommandType> getCommand(
     };
 
     static const SortedArrayMap map { commandList };
-    auto value = map.get(StringView::fromLatin1(name), PlatformMediaSession::RemoteControlCommandType::NoCommand);
+    auto value = map.get(StringView(unsafeNullTerminated(name)), PlatformMediaSession::RemoteControlCommandType::NoCommand);
     if (value == PlatformMediaSession::RemoteControlCommandType::NoCommand)
         return { };
     return value;
@@ -117,7 +117,7 @@ static std::optional<MprisProperty> getMprisProperty(const char* propertyName)
         { "SupportedUriSchemes"_s, MprisProperty::SupportedUriSchemes }
     };
     static constexpr SortedArrayMap map { propertiesList };
-    auto value = map.get(StringView::fromLatin1(propertyName), MprisProperty::NoProperty);
+    auto value = map.get(StringView(unsafeNullTerminated(propertyName)), MprisProperty::NoProperty);
     if (value == MprisProperty::NoProperty)
         return { };
     return value;

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -131,7 +131,7 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
     }
 
     // Probe platform early on for a working audio output device in autoaudiosink.
-    auto nameView = StringView::fromLatin1(GST_OBJECT_NAME(audioSink.get()));
+    auto nameView = StringView(unsafeNullTerminated(GST_OBJECT_NAME(audioSink.get())));
     if (nameView.startsWith("autoaudiosink"_s)) {
         g_signal_connect(audioSink.get(), "child-added", G_CALLBACK(+[](GstChildProxy*, GObject* object, gchar*, gpointer) {
             if (GST_IS_AUDIO_BASE_SINK(object))

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -262,7 +262,7 @@ String GStreamerInternalAudioEncoder::initialize(const String& codecName, const 
     GST_DEBUG_OBJECT(m_harness->element(), "Initializing encoder for codec %s", codecName.ascii().data());
 
     GUniquePtr<char> name(gst_element_get_name(m_encoder.get()));
-    auto nameView = StringView::fromLatin1(name.get());
+    auto nameView = StringView(unsafeNullTerminated(name.get()));
     if (codecName.startsWith("mp4a"_s)) {
         const char* streamFormat = config.isAacADTS.value_or(false) ? "adts" : "raw";
         m_outputCaps = adoptGRef(gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 4, "stream-format", G_TYPE_STRING, streamFormat, nullptr));

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -103,7 +103,7 @@ int decodebinAutoplugSelectCallback(GstElement*, GstPad*, GstCaps*, GstElementFa
         pluginsToSkip = GStreamerQuirksManager::singleton().disallowedWebAudioDecoders();
     });
 
-    auto factoryName = StringView::fromLatin1(gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory)));
+    auto factoryName = StringView(unsafeNullTerminated(gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory))));
     for (const auto& pluginToSkip : pluginsToSkip) {
         if (pluginToSkip == factoryName)
             return GST_AUTOPLUG_SELECT_SKIP;

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -694,8 +694,7 @@ long long BitmapImageSource::expectedContentLength() const
 
 CString BitmapImageSource::sourceUTF8() const
 {
-    constexpr const char* emptyString = "";
-    return m_bitmapImage ? m_bitmapImage->sourceUTF8() : emptyString;
+    return m_bitmapImage ? m_bitmapImage->sourceUTF8() : ""_s;
 }
 
 void BitmapImageSource::setMinimumDecodingDurationForTesting(Seconds duration)

--- a/Source/WebCore/platform/graphics/cairo/CairoPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoPaintingEngine.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<PaintingEngine> PaintingEngine::create()
     if (!numThreadsEnv)
         numThreadsEnv = getenv("WEBKIT_NICOSIA_PAINTING_THREADS");
     if (numThreadsEnv) {
-        auto newValue = parseInteger<unsigned>(StringView::fromLatin1(numThreadsEnv));
+        auto newValue = parseInteger<unsigned>(StringView(unsafeNullTerminated(numThreadsEnv)));
         if (newValue && *newValue <= 8)
             numThreads = *newValue;
         else

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
@@ -67,7 +67,7 @@ GLDisplay::GLDisplay(EGLDisplay eglDisplay)
     m_version.minor = minorVersion;
 
     const char* extensionsString = eglQueryString(m_display, EGL_EXTENSIONS);
-    auto displayExtensions = StringView::fromLatin1(extensionsString).split(' ');
+    auto displayExtensions = StringView(unsafeNullTerminated(extensionsString)).split(' ');
     auto findExtension = [&](auto extensionName) {
         return std::any_of(displayExtensions.begin(), displayExtensions.end(), [&](auto extensionEntry) {
             return extensionEntry == extensionName;

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -205,7 +205,7 @@ String FontPlatformData::familyName() const
 {
     FcChar8* family = nullptr;
     FcPatternGetString(m_pattern.get(), FC_FAMILY, 0, &family);
-    return String::fromUTF8(unsafeSpan8(reinterpret_cast<const char*>(family)));
+    return String::fromUTF8(span8(unsafeNullTerminated(reinterpret_cast<const char*>(family))));
 }
 
 Vector<FontPlatformData::FontVariationAxis> FontPlatformData::variationAxes(ShouldLocalizeAxisNames shouldLocalizeAxisNames) const

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -246,7 +246,7 @@ std::optional<TrackID> getStreamIdFromPad(const GRefPtr<GstPad>& pad)
         return std::nullopt;
     }
 
-    std::optional<TrackID> streamId(parseStreamId(StringView::fromLatin1(streamIdAsCharacters.get())));
+    std::optional<TrackID> streamId(parseStreamId(StringView(unsafeNullTerminated(streamIdAsCharacters.get()))));
     if (!streamId)
         GST_WARNING_OBJECT(pad.get(), "Got invalid stream-id from pad: %s", streamIdAsCharacters.get());
 
@@ -261,7 +261,7 @@ std::optional<TrackID> getStreamIdFromStream(const GRefPtr<GstStream>& stream)
         return std::nullopt;
     }
 
-    std::optional<TrackID> streamId(parseStreamId(StringView::fromLatin1(streamIdAsCharacters)));
+    std::optional<TrackID> streamId(parseStreamId(StringView(unsafeNullTerminated(streamIdAsCharacters))));
     if (!streamId)
         GST_WARNING_OBJECT(stream.get(), "Got invalid stream-id from stream: %s", streamIdAsCharacters);
 
@@ -1166,7 +1166,7 @@ StringView gstStructureGetString(const GstStructure* structure, StringView key)
     }
 
     auto utf8String = key.utf8();
-    return StringView::fromLatin1(gst_structure_get_string(structure, utf8String.data()));
+    return StringView(unsafeNullTerminated(gst_structure_get_string(structure, utf8String.data())));
 }
 
 StringView gstStructureGetName(const GstStructure* structure)
@@ -1176,7 +1176,7 @@ StringView gstStructureGetName(const GstStructure* structure)
         return { };
     }
 
-    return StringView::fromLatin1(gst_structure_get_name(structure));
+    return StringView(unsafeNullTerminated(gst_structure_get_name(structure)));
 }
 
 template<typename T>
@@ -1725,9 +1725,9 @@ bool gstStructureMapInPlace(GstStructure* structure, Function<bool(GstId, GValue
 StringView gstIdToString(GstId id)
 {
 #if GST_CHECK_VERSION(1, 25, 0)
-    return StringView::fromLatin1(gst_id_str_as_str(id));
+    return StringView(unsafeNullTerminated(gst_id_str_as_str(id)));
 #else
-    return StringView::fromLatin1(g_quark_to_string(id));
+    return StringView(unsafeNullTerminated(g_quark_to_string(id)));
 #endif
 }
 
@@ -1792,7 +1792,7 @@ GRefPtr<GstCaps> buildDMABufCaps()
 
     static const char* formats = g_getenv("WEBKIT_GST_DMABUF_FORMATS");
     if (formats && *formats) {
-        auto formatsString = StringView::fromLatin1(formats);
+        auto formatsString = StringView(unsafeNullTerminated(formats));
         GValue drmSupportedFormats = G_VALUE_INIT;
         g_value_init(&drmSupportedFormats, GST_TYPE_LIST);
         for (auto token : formatsString.split(',')) {

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -90,7 +90,7 @@ TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivat
 TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivateBase* owner, unsigned index, GstStream* stream)
     : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
     , m_index(index)
-    , m_gstStreamId(AtomString::fromLatin1(gst_stream_get_stream_id(stream)))
+    , m_gstStreamId(AtomString(unsafeNullTerminated(gst_stream_get_stream_id(stream))))
     , m_id(parseStreamId(m_gstStreamId).value_or(index))
     , m_stream(stream)
     , m_type(type)
@@ -115,7 +115,7 @@ void TrackPrivateBaseGStreamer::setPad(GRefPtr<GstPad>&& pad)
 
     m_pad = WTFMove(pad);
     m_bestUpstreamPad = findBestUpstreamPad(m_pad);
-    m_gstStreamId = AtomString::fromLatin1(gst_pad_get_stream_id(m_pad.get()));
+    m_gstStreamId = AtomString(unsafeNullTerminated(gst_pad_get_stream_id(m_pad.get())));
 
     if (m_shouldUsePadStreamId)
         m_id = parseStreamId(m_gstStreamId).value_or(m_index);
@@ -227,7 +227,7 @@ bool TrackPrivateBaseGStreamer::getLanguageCode(GstTagList* tags, AtomString& va
 {
     String language;
     if (getTag(tags, GST_TAG_LANGUAGE_CODE, language)) {
-        AtomString convertedLanguage = AtomString::fromLatin1(gst_tag_get_language_code_iso_639_1(language.utf8().data()));
+        AtomString convertedLanguage = AtomString(unsafeNullTerminated(gst_tag_get_language_code_iso_639_1(language.utf8().data())));
         GST_DEBUG("Converted track %d's language code to %s.", m_index, convertedLanguage.string().utf8().data());
         if (convertedLanguage != value) {
             value = WTFMove(convertedLanguage);
@@ -287,7 +287,7 @@ void TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged()
     if (!m_pad)
         return;
 
-    auto gstStreamId = AtomString::fromLatin1(gst_pad_get_stream_id(m_pad.get()));
+    auto gstStreamId = AtomString(unsafeNullTerminated(gst_pad_get_stream_id(m_pad.get())));
     auto streamId = parseStreamId(gstStreamId);
     if (!streamId)
         return;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
@@ -39,7 +39,7 @@ struct GMarkupParseContextUserData {
 static void markupStartElement(GMarkupParseContext*, const gchar* elementName, const gchar**, const gchar**, gpointer userDataPtr, GError**)
 {
     GMarkupParseContextUserData* userData = static_cast<GMarkupParseContextUserData*>(userDataPtr);
-    auto nameView = StringView::fromLatin1(elementName);
+    auto nameView = StringView(unsafeNullTerminated(elementName));
     if (nameView.endsWith("pssh"_s))
         userData->isParsingPssh = true;
 }
@@ -47,7 +47,7 @@ static void markupStartElement(GMarkupParseContext*, const gchar* elementName, c
 static void markupEndElement(GMarkupParseContext*, const gchar* elementName, gpointer userDataPtr, GError**)
 {
     GMarkupParseContextUserData* userData = static_cast<GMarkupParseContextUserData*>(userDataPtr);
-    auto nameView = StringView::fromLatin1(elementName);
+    auto nameView = StringView(unsafeNullTerminated(elementName));
     if (nameView.endsWith("pssh"_s)) {
         ASSERT(userData->isParsingPssh);
         userData->isParsingPssh = false;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -816,7 +816,7 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
 {
     ASSERT(isMainThread());
     ASSERT(m_hasReceivedFirstInitializationSegment);
-    auto trackId = AtomString::fromLatin1(GST_PAD_NAME(demuxerSrcPad));
+    auto trackId = AtomString(unsafeNullTerminated(GST_PAD_NAME(demuxerSrcPad)));
     auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(demuxerSrcPad)).get());
 
     GST_DEBUG_OBJECT(demuxerSrcPad, "Caps: %" GST_PTR_FORMAT, parsedCaps.get());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -409,7 +409,7 @@ size_t SourceBufferPrivateGStreamer::platformEvictionThreshold() const
     static size_t evictionThreshold = 0;
     static std::once_flag once;
     std::call_once(once, []() {
-        auto stringView = StringView::fromLatin1(std::getenv("MSE_BUFFER_SAMPLES_EVICTION_THRESHOLD"));
+        auto stringView = StringView(unsafeNullTerminated(std::getenv("MSE_BUFFER_SAMPLES_EVICTION_THRESHOLD")));
         if (!stringView.isEmpty())
             evictionThreshold = parseInteger<size_t>(stringView, 10).value_or(0);
     });

--- a/Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp
+++ b/Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp
@@ -53,7 +53,7 @@ auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand) -> Syste
     if (!pango_font_description_get_size_is_absolute(pangoDescription))
         size = size * (fontDPI() / 72.0);
 
-    SystemFontShorthandInfo result { AtomString::fromLatin1(pango_font_description_get_family(pangoDescription)), static_cast<float>(size), normalWeightValue() };
+    SystemFontShorthandInfo result { AtomString(unsafeNullTerminated(pango_font_description_get_family(pangoDescription))), static_cast<float>(size), normalWeightValue() };
     pango_font_description_free(pangoDescription);
     return result;
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -240,7 +240,7 @@ unsigned SkiaPaintingEngine::numberOfCPUPaintingThreads()
         numberOfThreads = std::max(1, std::min(8, WTF::numberOfProcessorCores() / 2)); // By default, use half the CPU cores, capped at 8.
 
         if (const char* envString = getenv("WEBKIT_SKIA_CPU_PAINTING_THREADS")) {
-            auto newValue = parseInteger<unsigned>(StringView::fromLatin1(envString));
+            auto newValue = parseInteger<unsigned>(StringView(unsafeNullTerminated(envString)));
             if (newValue && *newValue <= 8)
                 numberOfThreads = *newValue;
             else
@@ -264,7 +264,7 @@ unsigned SkiaPaintingEngine::numberOfGPUPaintingThreads()
         numberOfThreads = 1; // By default, use 1 GPU worker thread, if GPU painting is active.
 
         if (const char* envString = getenv("WEBKIT_SKIA_GPU_PAINTING_THREADS")) {
-            auto newValue = parseInteger<unsigned>(StringView::fromLatin1(envString));
+            auto newValue = parseInteger<unsigned>(StringView(unsafeNullTerminated(envString)));
             if (newValue && *newValue <= 4)
                 numberOfThreads = *newValue;
             else

--- a/Source/WebCore/platform/graphics/win/ImageAdapterWin.cpp
+++ b/Source/WebCore/platform/graphics/win/ImageAdapterWin.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 
 Ref<Image> ImageAdapter::loadPlatformResource(const char *name)
 {
-    auto path = webKitBundlePath(StringView::fromLatin1(name), "png"_s, "icons"_s);
+    auto path = webKitBundlePath(StringView(unsafeNullTerminated(name)), "png"_s, "icons"_s);
     auto data = FileSystem::readEntireFile(path);
     auto img = BitmapImage::create();
     if (data)

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -85,7 +85,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(con
         gst_caps_set_simple(outputCaps.get(), "level", G_TYPE_STRING, level, nullptr);
 
     StringBuilder formatBuilder;
-    auto profile = StringView::fromLatin1(gstProfile);
+    auto profile = StringView(unsafeNullTerminated(gstProfile));
     auto isY444TenBits = profile.startsWithIgnoringASCIICase("high-4:4:4"_s);
     auto isY422TenBits = profile.findIgnoringASCIICase("high-4:2:2"_s) != notFound;
     auto isI420TenBits = profile.findIgnoringASCIICase("high-10"_s) != notFound;
@@ -153,7 +153,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h265CapsFromCodecString(con
         gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, gstProfile, nullptr);
 
     StringBuilder formatBuilder;
-    auto profile = StringView::fromLatin1(gstProfile);
+    auto profile = StringView(unsafeNullTerminated(gstProfile));
     auto isY444 = profile.findIgnoringASCIICase("-444"_s) != notFound;
     auto isY422 = profile.findIgnoringASCIICase("-422"_s) != notFound;
     if (isY444)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
@@ -48,7 +48,7 @@ GStreamerQuirkBcmNexus::GStreamerQuirkBcmNexus()
 
 std::optional<bool> GStreamerQuirkBcmNexus::isHardwareAccelerated(GstElementFactory* factory)
 {
-    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    auto view = StringView(unsafeNullTerminated(GST_OBJECT_NAME(factory)));
     if (view.startsWith("brcm"_s))
         return true;
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
@@ -39,7 +39,7 @@ GStreamerQuirkBroadcom::GStreamerQuirkBroadcom()
 
 void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
-    auto view = StringView::fromLatin1(GST_ELEMENT_NAME(element));
+    auto view = StringView(unsafeNullTerminated(GST_ELEMENT_NAME(element)));
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(element), "Gstbrcmaudiosink"))
         g_object_set(G_OBJECT(element), "async", TRUE, nullptr);
     else if (view.startsWith("brcmaudiodecoder"_s)) {
@@ -59,7 +59,7 @@ void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionS
 
 std::optional<bool> GStreamerQuirkBroadcom::isHardwareAccelerated(GstElementFactory* factory)
 {
-    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    auto view = StringView(unsafeNullTerminated(GST_OBJECT_NAME(factory)));
     if (view.startsWith("brcm"_s))
         return true;
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -73,7 +73,7 @@ void GStreamerQuirkRealtek::configureElement(GstElement* element, const OptionSe
 
 std::optional<bool> GStreamerQuirkRealtek::isHardwareAccelerated(GstElementFactory* factory)
 {
-    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    auto view = StringView(unsafeNullTerminated(GST_OBJECT_NAME(factory)));
     if (view.startsWith("omx"_s))
         return true;
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -98,7 +98,7 @@ GstElement* GStreamerQuirkRialto::createWebAudioSink()
 
 std::optional<bool> GStreamerQuirkRialto::isHardwareAccelerated(GstElementFactory* factory)
 {
-    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    auto view = StringView(unsafeNullTerminated(GST_OBJECT_NAME(factory)));
     if (view.startsWith("rialto"_s))
         return true;
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -53,7 +53,7 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
 
 void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
-    auto view = StringView::fromLatin1(GST_ELEMENT_NAME(element));
+    auto view = StringView(unsafeNullTerminated(GST_ELEMENT_NAME(element)));
     if (view.startsWith("uridecodebin3"_s)) {
         GRefPtr<GstCaps> defaultCaps;
         g_object_get(element, "caps", &defaultCaps.outPtr(), nullptr);
@@ -74,7 +74,7 @@ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
 
 std::optional<bool> GStreamerQuirkWesteros::isHardwareAccelerated(GstElementFactory* factory)
 {
-    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    auto view = StringView(unsafeNullTerminated(GST_OBJECT_NAME(factory)));
     if (view.startsWith("westeros"_s))
         return true;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -133,10 +133,10 @@ void GStreamerRTPPacketizer::ensureMidExtension(const String& mid)
     g_object_get_property(G_OBJECT(m_payloader.get()), "extensions", &extensions);
     RELEASE_ASSERT(GST_VALUE_HOLDS_ARRAY(&extensions));
     auto totalExtensions = gst_value_array_get_size(&extensions);
-    auto midURI = StringView::fromLatin1(GST_RTP_HDREXT_BASE "sdes:mid");
+    auto midURI = StringView(unsafeNullTerminated(GST_RTP_HDREXT_BASE "sdes:mid"));
     for (unsigned i = 0; i < totalExtensions; i++) {
         const auto extension = GST_RTP_HEADER_EXTENSION_CAST(g_value_get_object(gst_value_array_get_value(&extensions, i)));
-        auto uri = StringView::fromLatin1(gst_rtp_header_extension_get_uri(extension));
+        auto uri = StringView(unsafeNullTerminated(gst_rtp_header_extension_get_uri(extension)));
         if (uri != midURI)
             continue;
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -570,10 +570,10 @@ RealtimeOutgoingMediaSourceGStreamer::ExtensionLookupResults RealtimeOutgoingMed
 
         StringView uri;
         if (G_VALUE_HOLDS_STRING(value))
-            uri = StringView::fromLatin1(g_value_get_string(value));
+            uri = StringView(unsafeNullTerminated(g_value_get_string(value)));
         else if (GST_VALUE_HOLDS_ARRAY(value)) {
             const auto uriValue = gst_value_array_get_value(value, 1);
-            uri = StringView::fromLatin1(g_value_get_string(uriValue));
+            uri = StringView(unsafeNullTerminated(g_value_get_string(uriValue)));
         } else
             return true;
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -129,7 +129,7 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
             return;
 
         m_openingThread = nullptr;
-        m_openErrorMessage = sqlite3_errmsg(m_db);
+        m_openErrorMessage = unsafeNullTerminated(sqlite3_errmsg(m_db));
         m_openError = sqlite3_errcode(m_db);
         close();
     });

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -188,7 +188,7 @@ int SQLiteStatement::columnCount()
 bool SQLiteStatement::isColumnDeclaredAsBlob(int col)
 {
     ASSERT(col >= 0);
-    return equalLettersIgnoringASCIICase(StringView::fromLatin1(sqlite3_column_decltype(m_statement, col)), "blob"_s);
+    return equalLettersIgnoringASCIICase(StringView(unsafeNullTerminated(sqlite3_column_decltype(m_statement, col))), "blob"_s);
 }
 
 String SQLiteStatement::columnName(int col)

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -332,7 +332,7 @@ void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGrouping
     String sessionID = createVersion4UUIDString();
     factory->addKeysToSessionWithID(sessionID, WTFMove(keyIDs.value()));
 
-    CString license { "license" };
+    CString license { "license"_s };
     callback(SharedBuffer::create(license.span()), sessionID, false, SuccessValue::Succeeded);
 }
 
@@ -377,7 +377,7 @@ void MockCDMInstanceSession::loadSession(LicenseType, const String&, const Strin
 
     // FIXME: Key status and expiration handling should be implemented once the relevant algorithms are supported.
 
-    CString messageData { "session loaded" };
+    CString messageData { "session loaded"_s };
     Message message { MessageType::LicenseRenewal, SharedBuffer::create(messageData.span()) };
 
     callback(std::nullopt, std::nullopt, WTFMove(message), SuccessValue::Succeeded, SessionLoadFailure::None);
@@ -408,7 +408,7 @@ void MockCDMInstanceSession::removeSessionData(const String& id, LicenseType, Re
         return std::pair { WTFMove(key), KeyStatus::Released };
     });
 
-    CString message { "remove-message" };
+    CString message { "remove-message"_s };
     callback(WTFMove(keyStatusVector), SharedBuffer::create(message.span()), SuccessValue::Succeeded);
 }
 

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -180,7 +180,7 @@ void Download::setPlaceholderURL(NSURL *placeholderURL, NSData *bookmarkData)
     BOOL usingSecurityScopedURL = [placeholderURL startAccessingSecurityScopedResource];
 
     SandboxExtension::Handle sandboxExtensionHandle;
-    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(StringView::fromLatin1(placeholderURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
+    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(StringView(placeholderURL.fileSystemRepresentation.span8()), SandboxExtension::Type::ReadOnly))
         sandboxExtensionHandle = WTFMove(*handle);
 
     if (usingSecurityScopedURL)
@@ -205,7 +205,7 @@ void Download::setFinalURL(NSURL *finalURL, NSData *bookmarkData)
     BOOL usingSecurityScopedURL = [finalURL startAccessingSecurityScopedResource];
 
     SandboxExtension::Handle sandboxExtensionHandle;
-    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(StringView::fromLatin1(finalURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
+    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(StringView(finalURL.fileSystemRepresentation.span8()), SandboxExtension::Type::ReadOnly))
         sandboxExtensionHandle = WTFMove(*handle);
 
     if (usingSecurityScopedURL)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
@@ -79,7 +79,7 @@ void BlobStorage::synchronize()
 String BlobStorage::blobPathForHash(const SHA1::Digest& hash) const
 {
     auto hashAsString = SHA1::hexDigest(hash);
-    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), StringView::fromLatin1(hashAsString.data()));
+    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), StringView(hashAsString.span()));
 }
 
 BlobStorage::Blob BlobStorage::add(const String& path, const Data& data)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -121,7 +121,7 @@ public:
 
 #if PLATFORM(COCOA)
     const std::optional<audit_token_t>& sourceApplicationAuditToken() const { return m_sourceApplicationAuditToken; }
-    const char* applicationBundleIdentifier() const { return m_applicationBundleIdentifier.data(); }
+    NullTerminated applicationBundleIdentifier() const { return m_applicationBundleIdentifier.nullTerminated(); }
 #endif
 
 private:

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -473,8 +473,8 @@ public:
     TrackerAddressLookupInfo(WPNetworkAddressRange *range)
         : m_network { ipAddress(range.address).value() }
         , m_netMaskLength { static_cast<unsigned>(range.netMaskLength) }
-        , m_owner { range.owner.UTF8String }
-        , m_host { range.host.UTF8String }
+        , m_owner { unsafeNullTerminated(range.owner.UTF8String) }
+        , m_host { unsafeNullTerminated(range.host.UTF8String) }
         , m_canBlock { CanBlock::Yes } // FIXME: Grab this from WPNetworkAddressRange as well, once it's available.
     {
     }

--- a/Source/WebKit/Platform/unix/EnvironmentUtilities.cpp
+++ b/Source/WebKit/Platform/unix/EnvironmentUtilities.cpp
@@ -54,15 +54,15 @@ String stripEntriesEndingWith(StringView input, StringView suffix)
     return output.toString();
 }
 
-void removeValuesEndingWith(const char* environmentVariable, const char* searchValue)
+void removeValuesEndingWith(ASCIILiteral environmentVariable, ASCIILiteral searchValue)
 {
-    const char* before = getenv(environmentVariable);
+    auto before = getenv(environmentVariable);
     if (!before)
         return;
 
-    auto after = stripEntriesEndingWith(StringView::fromLatin1(before), StringView::fromLatin1(searchValue));
+    auto after = stripEntriesEndingWith(StringView(unsafeNullTerminated(before)), StringView(searchValue));
     if (after.isEmpty()) {
-        unsetenv(environmentVariable);
+        unsetenv(environmentVariable.characters());
         return;
     }
 

--- a/Source/WebKit/Platform/unix/EnvironmentUtilities.h
+++ b/Source/WebKit/Platform/unix/EnvironmentUtilities.h
@@ -36,7 +36,7 @@ namespace WebKit {
 namespace EnvironmentUtilities {
 
 WK_EXPORT String stripEntriesEndingWith(StringView input, StringView suffix);
-WK_EXPORT void removeValuesEndingWith(const char* environmentVariable, const char* search);
+WK_EXPORT void removeValuesEndingWith(ASCIILiteral environmentVariable, ASCIILiteral search);
 
 } // namespace EnvironmentUtilities
 

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -57,7 +57,7 @@ enum class SandboxExtensionType : uint8_t {
 class SandboxExtensionImpl {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SandboxExtensionImpl);
 public:
-    static std::unique_ptr<SandboxExtensionImpl> create(const char* path, SandboxExtensionType, std::optional<audit_token_t> = std::nullopt, OptionSet<SandboxExtensionFlags> = SandboxExtensionFlags::Default);
+    static std::unique_ptr<SandboxExtensionImpl> create(NullTerminated path, SandboxExtensionType, std::optional<audit_token_t> = std::nullopt, OptionSet<SandboxExtensionFlags> = SandboxExtensionFlags::Default);
     SandboxExtensionImpl(std::span<const uint8_t>);
     ~SandboxExtensionImpl();
 
@@ -69,9 +69,9 @@ public:
         : m_token(std::exchange(other.m_token, CString()))
         , m_handle(std::exchange(other.m_handle, 0)) { }
 private:
-    char* sandboxExtensionForType(const char* path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
+    NullTerminated sandboxExtensionForType(NullTerminated path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
 
-    SandboxExtensionImpl(const char* path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
+    SandboxExtensionImpl(NullTerminated path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
 
     CString m_token;
     int64_t m_handle { 0 };

--- a/Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp
+++ b/Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp
@@ -47,20 +47,20 @@ static String findWebKitProcess(const char* processName)
 #if ENABLE(DEVELOPER_MODE)
     static const char* execDirectory = g_getenv("WEBKIT_EXEC_PATH");
     if (execDirectory) {
-        String processPath = FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(execDirectory), StringView::fromLatin1(processName));
+        String processPath = FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(execDirectory), StringView(unsafeNullTerminated(processName)));
         if (FileSystem::fileExists(processPath))
             return processPath;
     }
 
     static String executablePath = getExecutablePath();
     if (!executablePath.isNull()) {
-        String processPath = FileSystem::pathByAppendingComponent(executablePath, StringView::fromLatin1(processName));
+        String processPath = FileSystem::pathByAppendingComponent(executablePath, StringView(unsafeNullTerminated(processName)));
         if (FileSystem::fileExists(processPath))
             return processPath;
     }
 #endif
 
-    return FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(PKGLIBEXECDIR), StringView::fromLatin1(processName));
+    return FileSystem::pathByAppendingComponent(FileSystem::stringFromFileSystemRepresentation(PKGLIBEXECDIR), StringView(unsafeNullTerminated(processName)));
 }
 
 String executablePathOfWebProcess()

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -476,7 +476,7 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
         return false;
     if (!equalSpans(std::span { cachedSandboxHeader.sandboxBuildID }, unsafeSpanIncludingNullTerminator(SANDBOX_BUILD_ID)))
         return false;
-    if (StringView::fromLatin1(cachedSandboxHeader.osVersion.data()) != osVersion)
+    if (StringView(unsafeNullTerminated(cachedSandboxHeader.osVersion)) != osVersion)
         return false;
 
     const bool haveBuiltin = cachedSandboxHeader.builtinSize != std::numeric_limits<uint32_t>::max();

--- a/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
+++ b/Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp
@@ -38,9 +38,9 @@ bool AuxiliaryProcessMainCommon::parseCommandLine(int argc, char** argv)
 {
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "-clientIdentifier") && i + 1 < argc)
-            m_parameters.connectionIdentifier = IPC::Connection::Identifier { reinterpret_cast<HANDLE>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView::fromLatin1(argv[++i])).value_or(0)) };
+            m_parameters.connectionIdentifier = IPC::Connection::Identifier { reinterpret_cast<HANDLE>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView(unsafeNullTerminated(argv[++i]))).value_or(0)) };
         else if (!strcmp(argv[i], "-processIdentifier") && i + 1 < argc)
-            m_parameters.processIdentifier = ObjectIdentifier<WebCore::ProcessIdentifierType>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView::fromLatin1(argv[++i])).value_or(0));
+            m_parameters.processIdentifier = ObjectIdentifier<WebCore::ProcessIdentifierType>(parseIntegerAllowingTrailingJunk<uint64_t>(StringView(unsafeNullTerminated(argv[++i]))).value_or(0));
         else if (!strcmp(argv[i], "-configure-jsc-for-testing"))
             JSC::Config::configureForTesting();
         else if (!strcmp(argv[i], "-disable-jit"))

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
@@ -88,7 +88,7 @@ WebKitSecurityOrigin* webkit_security_origin_new(const gchar* protocol, const gc
     g_return_val_if_fail(host, nullptr);
 
     std::optional<uint16_t> optionalPort;
-    if (port && !WTF::isDefaultPortForProtocol(port, StringView::fromLatin1(protocol)))
+    if (port && !WTF::isDefaultPortForProtocol(port, StringView(unsafeNullTerminated(protocol))))
         optionalPort = port;
 
     return webkitSecurityOriginCreate(WebCore::SecurityOriginData(String::fromUTF8(protocol), String::fromUTF8(host), optionalPort));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -413,7 +413,7 @@ static void webkitWebContextSetProperty(GObject* object, guint propID, const GVa
     }
     case PROP_TIME_ZONE_OVERRIDE: {
         const auto* timeZone = g_value_get_string(value);
-        if (isTimeZoneValid(StringView::fromLatin1(timeZone)))
+        if (isTimeZoneValid(StringView(unsafeNullTerminated(timeZone))))
             context->priv->timeZoneOverride = timeZone;
         break;
     }
@@ -1373,7 +1373,7 @@ void webkit_web_context_register_uri_scheme(WebKitWebContext* context, const cha
     g_return_if_fail(scheme);
     g_return_if_fail(callback);
 
-    auto canonicalizedScheme = WTF::URLParser::maybeCanonicalizeScheme(StringView::fromLatin1(scheme));
+    auto canonicalizedScheme = WTF::URLParser::maybeCanonicalizeScheme(StringView(unsafeNullTerminated(scheme)));
     if (!canonicalizedScheme) {
         g_critical("Cannot register invalid URI scheme %s", scheme);
         return;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -76,7 +76,7 @@ void SubFrameSOAuthorizationSession::fallBackToWebPathInternal()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPathInternal: navigationAction=%p", navigationAction());
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(unsafeSpan8(soAuthorizationPostDidCancelMessageToParent)));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidCancelMessageToParent.span8()));
     appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
 }
 
@@ -102,7 +102,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
     // Cancelled the current load before loading the data to post SOAuthorizationDidStart to the parent frame.
     invokeCallback(true);
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(unsafeSpan8(soAuthorizationPostDidStartMessageToParent)));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidStartMessageToParent.span8()));
 }
 
 void SubFrameSOAuthorizationSession::didFinishLoad(IsMainFrame, const URL&)

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
@@ -207,14 +207,14 @@ void RemoteInspectorClient::setupConnection(Ref<SocketConnection>&& connection)
     m_socketConnection->sendMessage("SetupInspectorClient", g_variant_new("(@ay)", g_variant_new_bytestring(Inspector::backendCommandsHash().data())));
 }
 
-void RemoteInspectorClient::setBackendCommands(const char* backendCommands)
+void RemoteInspectorClient::setBackendCommands(NullTerminated backendCommands)
 {
     if (!backendCommands || !backendCommands[0]) {
         m_backendCommandsURL = { };
         return;
     }
 
-    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(unsafeSpan8(backendCommands)));
+    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(span8(backendCommands)));
 }
 
 void RemoteInspectorClient::connectionDidClose()

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h
@@ -78,7 +78,7 @@ private:
         CString url;
     };
 
-    void setBackendCommands(const char*);
+    void setBackendCommands(NullTerminated);
     void setTargetList(uint64_t connectionID, Vector<Target>&&);
     void sendMessageToFrontend(uint64_t connectionID, uint64_t targetID, const char*);
 

--- a/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
@@ -65,7 +65,7 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 {
 #if ENABLE(REMOTE_INSPECTOR)
     if (const char* address = getenv("WEBKIT_INSPECTOR_SERVER"))
-        initializeRemoteInspectorServer(StringView::fromLatin1(address));
+        initializeRemoteInspectorServer(StringView(unsafeNullTerminated(address)));
 
     // Currently the socket port Remote Inspector can have only one client at most.
     // Therefore, if multiple process pools are created, the first one is targeted and the second and subsequent ones are ignored.

--- a/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm
+++ b/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm
@@ -50,7 +50,7 @@ void WEBCONTENT_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t in
 
     // Remove the WebProcessShim from the DYLD_INSERT_LIBRARIES environment variable so any processes spawned by
     // the this process don't try to insert the shim and crash.
-    WebKit::EnvironmentUtilities::removeValuesEndingWith("DYLD_INSERT_LIBRARIES", "/WebProcessShim.dylib");
+    WebKit::EnvironmentUtilities::removeValuesEndingWith("DYLD_INSERT_LIBRARIES"_s, "/WebProcessShim.dylib"_s);
 
 #if PLATFORM(IOS_FAMILY)
     GSInitialize();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
@@ -58,7 +58,7 @@ void GObjectEventListener::gobjectDestroyed()
     // and later use-after-free with the m_handler = 0; assignment.
     RefPtr<GObjectEventListener> protectedThis(this);
 
-    m_coreTarget->removeEventListener(AtomString::fromLatin1(m_domEventName.data()), *this, m_capture);
+    m_coreTarget->removeEventListener(AtomString(m_domEventName.nullTerminated()), *this, m_capture);
     m_coreTarget = nullptr;
     m_handler = nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
@@ -36,13 +36,13 @@ public:
     static bool addEventListener(GObject* target, WebCore::EventTarget* coreTarget, const char* domEventName, GClosure* handler, bool useCapture)
     {
         Ref<GObjectEventListener> listener(adoptRef(*new GObjectEventListener(target, coreTarget, domEventName, handler, useCapture)));
-        return coreTarget->addEventListener(AtomString::fromLatin1(domEventName), WTFMove(listener), useCapture);
+        return coreTarget->addEventListener(AtomString(unsafeNullTerminated(domEventName)), WTFMove(listener), useCapture);
     }
 
     static bool removeEventListener(GObject* target, WebCore::EventTarget* coreTarget, const char* domEventName, GClosure* handler, bool useCapture)
     {
         GObjectEventListener key(target, coreTarget, domEventName, handler, useCapture);
-        return coreTarget->removeEventListener(AtomString::fromLatin1(domEventName), key, useCapture);
+        return coreTarget->removeEventListener(AtomString(unsafeNullTerminated(domEventName)), key, useCapture);
     }
 
     static void gobjectDestroyedCallback(GObjectEventListener* listener, GObject*)

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2998,7 +2998,7 @@ JSValueRef JSIPC::messages(JSContextRef context, JSObjectRef thisObject, JSStrin
         dictionary->putDirect(vm, isSyncIdent, JSC::jsBoolean(messageIsSync(name)));
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-        messagesObject->putDirect(vm, JSC::Identifier::fromLatin1(vm, description(name)), dictionary);
+        messagesObject->putDirect(vm, JSC::Identifier::fromString(vm, description(name)), dictionary);
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
     }
 

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -79,7 +79,7 @@ using namespace WebCore;
     return commonVM().heap.protectedGlobalObjectCount();
 }
 
-static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<const char*>& set)
+static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILiteral>& set)
 {
     auto result = adoptNS([[NSCountedSet alloc] initWithCapacity:set.size()]);
     for (auto& entry : set) {

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -45,7 +45,7 @@ TEST(WTF, StringImplCreationFromLiteral)
     const char* programmaticStringData = "Explicit Size Literal";
     auto programmaticString = StringImpl::createWithoutCopying(unsafeSpan(programmaticStringData));
     ASSERT_EQ(strlen(programmaticStringData), programmaticString->length());
-    ASSERT_TRUE(equal(programmaticString.get(), StringView::fromLatin1(programmaticStringData)));
+    ASSERT_TRUE(equal(programmaticString.get(), StringView(unsafeNullTerminated(programmaticStringData))));
     ASSERT_EQ(programmaticStringData, reinterpret_cast<const char*>(programmaticString->span8().data()));
     ASSERT_TRUE(programmaticString->is8Bit());
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -32,7 +32,7 @@ namespace TestWebKitAPI {
 
 StringView stringViewFromLiteral(const char* characters)
 {
-    return StringView::fromLatin1(characters);
+    return StringView(unsafeNullTerminated(characters));
 }
 
 StringView stringViewFromUTF8(String& ref, const char* characters)

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -154,9 +154,9 @@ TEST_F(WTF_URL, URLSetQuery)
     URL urlWithFragmentIdentifier2 = createURL("http://www.webkit.org/?#newFragment"_s);
     URL urlWithFragmentIdentifier3 = createURL("http://www.webkit.org/?test1#newFragment"_s);
 
-    urlWithFragmentIdentifier1.setQuery(StringView::fromLatin1("test\xc3\xa5"));
-    urlWithFragmentIdentifier2.setQuery(StringView::fromLatin1("test\xc3\xa5"));
-    urlWithFragmentIdentifier3.setQuery(StringView::fromLatin1("test\xc3\xa5"));
+    urlWithFragmentIdentifier1.setQuery(StringView("test\xc3\xa5"_s));
+    urlWithFragmentIdentifier2.setQuery(StringView("test\xc3\xa5"_s));
+    urlWithFragmentIdentifier3.setQuery(StringView("test\xc3\xa5"_s));
 
     EXPECT_EQ(urlWithFragmentIdentifier.string(), urlWithFragmentIdentifier1.string());
     EXPECT_EQ(urlWithFragmentIdentifier.string(), urlWithFragmentIdentifier2.string());
@@ -170,9 +170,9 @@ TEST_F(WTF_URL, URLSetFragmentIdentifier)
     URL url2 = createURL("http://www.webkit.org/#test2"_s);
     URL url3 = createURL("http://www.webkit.org/#"_s);
 
-    url1.setFragmentIdentifier(StringView::fromLatin1("newFragment\xc3\xa5"));
-    url2.setFragmentIdentifier(StringView::fromLatin1("newFragment\xc3\xa5"));
-    url3.setFragmentIdentifier(StringView::fromLatin1("newFragment\xc3\xa5"));
+    url1.setFragmentIdentifier(StringView("newFragment\xc3\xa5"_s));
+    url2.setFragmentIdentifier(StringView("newFragment\xc3\xa5"_s));
+    url3.setFragmentIdentifier(StringView("newFragment\xc3\xa5"_s));
 
     EXPECT_EQ(url.string(), url1.string());
     EXPECT_EQ(url.string(), url2.string());

--- a/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
@@ -511,8 +511,8 @@ TEST_F(WTF_URLParser, Credentials)
     testUserPassword("%F%25"_s, "%F%"_s, "%F%25"_s);
     testUserPassword("%X%25"_s, "%X%"_s, "%X%25"_s);
     testUserPassword("%%25"_s, "%%"_s, "%%25"_s);
-    testUserPassword(StringView::fromLatin1("💩"), "%C3%B0%C2%9F%C2%92%C2%A9"_s);
-    testUserPassword(StringView::fromLatin1("%💩"), "%%C3%B0%C2%9F%C2%92%C2%A9"_s);
+    testUserPassword(StringView("💩"_s), "%C3%B0%C2%9F%C2%92%C2%A9"_s);
+    testUserPassword(StringView("%💩"_s), "%%C3%B0%C2%9F%C2%92%C2%A9"_s);
     testUserPassword(validSurrogate, "%F0%90%85%95"_s);
     testUserPassword(replacementA, "%EF%BF%BDA"_s);
     testUserPassword(invalidSurrogate, replacementA, "%EF%BF%BDA"_s);
@@ -737,10 +737,10 @@ TEST_F(WTF_URLParser, ParserDifferences)
         { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://abcdefg%"_s });
     checkURLDifferences("http://abcd%7Xefg"_s,
         { ""_s, ""_s, ""_s, ""_s, 0, ""_s, ""_s, ""_s, "http://abcd%7Xefg"_s });
-    checkURL(StringView::fromLatin1("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), { "ws"_s, ""_s, ""_s, "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a/"_s }, TestTabs::No);
-    checkURL(StringView::fromLatin1("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), { "ws"_s, ""_s, ""_s, "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a/"_s }, TestTabs::No);
-    checkURL(StringView::fromLatin1("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), { "ws"_s, ""_s, ""_s, "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a/"_s }, TestTabs::No);
-    checkURL(StringView::fromLatin1("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), { "ws"_s, ""_s, ""_s, "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a/"_s }, TestTabs::No);
+    checkURL(StringView("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s), { "ws"_s, ""_s, ""_s, "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-rsb254a/"_s }, TestTabs::No);
+    checkURL(StringView("ws://äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s), { "ws"_s, ""_s, ""_s, "xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-stb515a/"_s }, TestTabs::No);
+    checkURL(StringView("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s), { "ws"_s, ""_s, ""_s, "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ssb254a/"_s }, TestTabs::No);
+    checkURL(StringView("ws://&äAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"_s), { "ws"_s, ""_s, ""_s, "xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a"_s, 0, "/"_s, ""_s, ""_s, "ws://xn--&aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-ttb515a/"_s }, TestTabs::No);
 
     // URLParser matches Chrome and the spec, but not URL::parse or Firefox.
     checkURLDifferences(utf16String(u"http://０Ｘｃ０．０２５０．０１"),
@@ -925,11 +925,11 @@ TEST_F(WTF_URLParser, ParserDifferences)
     checkURL("a://A"_s, { "a"_s, ""_s, ""_s, "A"_s, 0, ""_s, ""_s, ""_s, "a://A"_s });
     checkURL("a://A:2"_s, { "a"_s, ""_s, ""_s, "A"_s, 2, ""_s, ""_s, ""_s, "a://A:2"_s });
     checkURL("a://A:2/"_s, { "a"_s, ""_s, ""_s, "A"_s, 2, "/"_s, ""_s, ""_s, "a://A:2/"_s });
-    checkURLDifferences(StringView::fromLatin1(reinterpret_cast<const char*>(u8"asd://ß")),
+    checkURLDifferences(StringView(unsafeNullTerminated(reinterpret_cast<const char*>(u8"asd://ß"))),
         { "asd"_s, ""_s, ""_s, "%C3%83%C2%9F"_s, 0, ""_s, ""_s, ""_s, "asd://%C3%83%C2%9F"_s }, TestTabs::No);
-    checkURLDifferences(StringView::fromLatin1(reinterpret_cast<const char*>(u8"asd://ß:4")),
+    checkURLDifferences(StringView(unsafeNullTerminated(reinterpret_cast<const char*>(u8"asd://ß:4"))),
         { "asd"_s, ""_s, ""_s, "%C3%83%C2%9F"_s, 4, ""_s, ""_s, ""_s, "asd://%C3%83%C2%9F:4"_s }, TestTabs::No);
-    checkURLDifferences(StringView::fromLatin1(reinterpret_cast<const char*>(u8"asd://ß:4/")),
+    checkURLDifferences(StringView(unsafeNullTerminated(reinterpret_cast<const char*>(u8"asd://ß:4/"))),
         { "asd"_s, ""_s, ""_s, "%C3%83%C2%9F"_s, 4, "/"_s, ""_s, ""_s, "asd://%C3%83%C2%9F:4/"_s }, TestTabs::No);
     checkURLDifferences("a://[A::b]:4"_s,
         { "a"_s, ""_s, ""_s, "[a::b]"_s, 4, ""_s, ""_s, ""_s, "a://[a::b]:4"_s });
@@ -1091,7 +1091,7 @@ TEST_F(WTF_URLParser, ParserFailures)
     shouldFail("http://[1234::ab@]"_s);
     shouldFail("http://[1234::ab~]"_s);
     shouldFail("http://[2001::1"_s);
-    shouldFail(StringView::fromLatin1("http://4:b\xE1"));
+    shouldFail(StringView("http://4:b\xE1"_s));
     shouldFail("http://[1:2:3:4:5:6:7:8~]/"_s);
     shouldFail("http://[a:b:c:d:e:f:g:127.0.0.1]"_s);
     shouldFail("http://[a:b:c:d:e:f:g:h:127.0.0.1]"_s);

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp
@@ -52,9 +52,9 @@ TEST(HTTPParsers, ParseCrossOriginResourcePolicyHeader)
     EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("zameorigin"_s) == CrossOriginResourcePolicy::Invalid);
     EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("samesite"_s) == CrossOriginResourcePolicy::Invalid);
     EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("same site"_s) == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(StringView::fromLatin1("same–site")) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(StringView("same–site"_s)) == CrossOriginResourcePolicy::Invalid);
     EXPECT_TRUE(parseCrossOriginResourcePolicyHeader("SAMESITE"_s) == CrossOriginResourcePolicy::Invalid);
-    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(StringView::fromLatin1("")) == CrossOriginResourcePolicy::Invalid);
+    EXPECT_TRUE(parseCrossOriginResourcePolicyHeader(StringView(""_s)) == CrossOriginResourcePolicy::Invalid);
 }
 
 #if USE(GLIB)

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -385,7 +385,7 @@ static bool checkChunks(const std::vector<String>& chunks, const char* const exp
     }
 
     for (size_t i = 0; i < chunks.size(); ++i) {
-        if (chunks[i] != StringView::fromLatin1(expectedChunks[i]))
+        if (chunks[i] != StringView(unsafeNullTerminated(expectedChunks[i])))
             return false;
     }
     return true;


### PR DESCRIPTION
#### 7975ad6b6b62fab0dc0c45b6d93a6efa3cc5a974
<pre>
Introduce NullTerminated / reduce use of const char*
<a href="https://bugs.webkit.org/show_bug.cgi?id=286965">https://bugs.webkit.org/show_bug.cgi?id=286965</a>
<a href="https://rdar.apple.com/144119027">rdar://144119027</a>

Reviewed by NOBODY (OOPS!).

Sometimes we know that a const char* is null terminated but we don’t carry our
knowledge through the type system. Then we end up doing bounds-unsafe
operations or memory copies unnecessarily.

The compiler alerted us to this problem in the narrow case of printf(“%s”, ...),
but really it’s everywhere.

NullTerminated is a new view type that represents a null terminated const char*.
Our fundamental string types — Identifier, CString, String, StringView, and
AtomString — all know how to construct themselves from NullTerminated.

I migrated lots of const char* callers in this patch, but many callers remain,
so I left these unsafe constructors in place for now:

    String::formLatin1(const char*)
    String::fromUTF8(const char*)
    CString(const char*)

* Source/JavaScriptCore/API/JSBase.cpp:
(JSGetMemoryUsageStatistics):
* Source/JavaScriptCore/API/JSClassRef.cpp:
* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap):
* Source/JavaScriptCore/API/glib/JSCClass.cpp:
(jscClassCreateConstructor):
(jscClassAddMethod):
* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsc_value_object_define_property_data):
(jscValueObjectDefinePropertyAccessor):
(jscValueFunctionCreate):
(jsc_value_new_from_json):
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::generateCompilerConstructionSite):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testX86LeaAddAdd):
(testX86LeaAddShlLeftScale1):
* Source/JavaScriptCore/bytecode/BytecodeDumper.cpp:
(JSC::Wasm::BytecodeDumper::formatConstant const):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::hashAsStringIfPossible const):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::RegExpNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::logAssertionFailure):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::lower):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp:
(JSC::MarkStackMergingConstraint::MarkStackMergingConstraint):
* Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp:
(JSC::VerifierSlotVisitor::VerifierSlotVisitor):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::receivedDataMessage):
(Inspector::RemoteInspector::sendMessageToTarget):
(Inspector::RemoteInspector::requestAutomationSession):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp:
(Inspector::processSessionCapabilities):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp:
(Inspector::RemoteInspectorConnectionClient::extractEvent):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::sendMessageToTarget):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::compileTimeStats):
* Source/JavaScriptCore/jit/JITDisassembler.cpp:
(JSC::JITDisassembler::reportToProfiler):
* Source/JavaScriptCore/jsc.cpp:
(currentWorkingDirectory):
(runInteractive):
(jscmain):
* Source/JavaScriptCore/profiler/ProfilerDatabase.cpp:
(JSC::Profiler::Database::registerToSaveAtExit):
* Source/JavaScriptCore/profiler/ProfilerEvent.cpp:
(JSC::Profiler::Event::toJSON const):
* Source/JavaScriptCore/runtime/Identifier.h:
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::Identifier::fromLatin1): Deleted.
* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::of const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
(JSC::IntlMathematicalValue::ensureNonDouble):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::reifyAllStaticProperties):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getNonReifiedStaticPropertyNames):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/testRegExp.cpp:
(parseRegExpLine):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::dumpRegisters):
* Source/JavaScriptCore/yarr/YarrUnicodeProperties.cpp:
(JSC::Yarr::HashTable::entry const):
* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/DateMath.cpp:
(WTF::parseDate):
* Source/WTF/wtf/LogChannels.cpp:
(WTF::LogChannels::initializeLogChannelsIfNecessary):
* Source/WTF/wtf/Logger.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::NullTerminated::fromUnsafe):
(WTF::NullTerminated::NullTerminated):
(WTF::NullTerminated::operator const char* const):
(WTF::NullTerminated::nullTerminated const):
(WTF::unsafeNullTerminated):
(WTF::safePrintfType):
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::normalizeThreadName):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::userVisibleURL):
* Source/WTF/wtf/cf/FileSystemCF.cpp:
(WTF::FileSystem::fileSystemRepresentation):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::createTemporaryZipArchive):
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::uuidToString):
* Source/WTF/wtf/darwin/OSLogPrintStream.mm:
(WTF::OSLogPrintStream::OSLogPrintStream):
* Source/WTF/wtf/linux/MemoryFootprintLinux.cpp:
(WTF::computeMemoryFootprint):
* Source/WTF/wtf/spi/darwin/XPCSPI.h:
(xpc_dictionary_get_wtfstring):
* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WTF/wtf/text/AtomString.h:
(WTF::AtomString::AtomString):
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::addCString):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::CString):
* Source/WTF/wtf/text/CString.h:
(WTF::CString::nullTerminated const):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::span):
(WTF::span8):
(WTF::unsafeSpan8):
(WTF::equalIgnoringASCIICaseCommon):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::createFromCString):
(WTF::equalIgnoringASCIICase):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
(WTF::equalIgnoringASCIICase):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::String):
(string):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginComputePass):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::invalidEntryPointName):
(WebCore::WebGPU::DeviceImpl::createCommandEncoder):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::createView):
* Source/WebCore/Modules/applepay/PaymentRequestValidator.mm:
(WebCore::validateCountryCode):
(WebCore::validateCurrencyCode):
* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::isPlayReadySanitizedInitializationData):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::handleLogMessage):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::netSimOptionsFromEnvironment):
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::linkOutgoingSources):
(WebCore::GStreamerMediaEndpoint::processSDPMessage):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::capsFromSDPMedia):
* Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp:
(PAL::detectTextEncoding):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode):
* Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::CollectionMatchRule::CollectionMatchRule):
* Source/WebCore/accessibility/atspi/AccessibilityObjectDocumentAtspi.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::text const):
* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.cpp:
(WebCore::AccessibilityRootAtspi::embedded):
* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp:
(WebCore::DOMGCOutputConstraint::DOMGCOutputConstraint):
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::RedirectAction::RegexSubstitutionAction::applyToURL const):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendPing):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::logMemoryStatistics):
* Source/WebCore/page/PerformanceLogging.cpp:
(WebCore::PerformanceLogging::javaScriptObjectCounts):
(): Deleted.
* Source/WebCore/page/PerformanceLogging.h:
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::collectCPUUsage):
* Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp:
(WebCore::getCommand):
(WebCore::getMprisProperty):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::initialize):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::decodebinAutoplugSelectCallback):
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::sourceUTF8 const):
* Source/WebCore/platform/graphics/cairo/CairoPaintingEngine.cpp:
(WebCore::Cairo::PaintingEngine::create):
* Source/WebCore/platform/graphics/egl/GLDisplay.cpp:
(WebCore::GLDisplay::GLDisplay):
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
(WebCore::FontPlatformData::familyName const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getStreamIdFromPad):
(WebCore::getStreamIdFromStream):
(WebCore::gstStructureGetString):
(WebCore::gstStructureGetName):
(WebCore::gstIdToString):
(WebCore::buildDMABufCaps):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleStreamCollectionMessage):
(WebCore::MediaPlayerPrivateGStreamer::configureElement):
(WebCore::MediaPlayerPrivateGStreamer::configureDownloadBuffer):
(WebCore::isMediaDiskCacheDisabled):
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer):
(WebCore::TrackPrivateBaseGStreamer::setPad):
(WebCore::TrackPrivateBaseGStreamer::getLanguageCode):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged):
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp:
(WebCore::markupStartElement):
(WebCore::markupEndElement):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::recycleTrackForPad):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::platformEvictionThreshold const):
* Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp:
(WebCore::SystemFontDatabase::platformSystemFontShorthandInfo):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::numberOfCPUPaintingThreads):
(WebCore::SkiaPaintingEngine::numberOfGPUPaintingThreads):
* Source/WebCore/platform/graphics/win/ImageAdapterWin.cpp:
(WebCore::ImageAdapter::loadPlatformResource):
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::h264CapsFromCodecString):
(WebCore::h265CapsFromCodecString):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp:
(WebCore::GStreamerQuirkBcmNexus::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp:
(WebCore::GStreamerQuirkBroadcom::configureElement):
(WebCore::GStreamerQuirkBroadcom::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp:
(WebCore::GStreamerQuirkRealtek::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp:
(WebCore::GStreamerQuirkRialto::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp:
(WebCore::GStreamerQuirkWesteros::configureElement):
(WebCore::GStreamerQuirkWesteros::isHardwareAccelerated):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp:
(WebCore::GStreamerRTPPacketizer::ensureMidExtension):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::lookupRtpExtensions):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::append):
(WebCore::FormDataBuilder::appendQuoted):
(WebCore::FormDataBuilder::appendFormURLEncoded):
(WebCore::FormDataBuilder::generateUniqueBoundaryString):
(WebCore::FormDataBuilder::beginMultiPartHeader):
(WebCore::FormDataBuilder::addBoundaryToMultiPartHeader):
(WebCore::FormDataBuilder::addFilenameToMultiPartHeader):
(WebCore::FormDataBuilder::addContentTypeToMultiPartHeader):
(WebCore::FormDataBuilder::finishMultiPartHeader):
(WebCore::FormDataBuilder::addKeyValuePairAsFormData):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::open):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::isColumnDeclaredAsBlob):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMInstanceSession::requestLicense):
(WebCore::MockCDMInstanceSession::loadSession):
(WebCore::MockCDMInstanceSession::removeSessionData):
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::setPlaceholderURL):
(WebKit::Download::setFinalURL):
* Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp:
(WebKit::NetworkCache::BlobStorage::blobPathForHash const):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
(WebKit::NetworkRTCProvider::applicationBundleIdentifier const):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
* Source/WebKit/Platform/unix/EnvironmentUtilities.cpp:
(WebKit::EnvironmentUtilities::removeValuesEndingWith):
* Source/WebKit/Platform/unix/EnvironmentUtilities.h:
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::create):
(WebKit::SandboxExtensionImpl::sandboxExtensionForType):
(WebKit::SandboxExtensionImpl::SandboxExtensionImpl):
(WebKit::SandboxExtension::createHandleWithoutResolvingPath):
(WebKit::SandboxExtension::createHandleForTemporaryFile):
(WebKit::SandboxExtension::createHandleForGenericExtension):
(WebKit::SandboxExtension::createHandleForMachLookup):
(WebKit::SandboxExtension::createHandleForReadByAuditToken):
(WebKit::SandboxExtension::createHandleForIOKitClassExtension):
* Source/WebKit/Shared/SandboxExtension.h:
* Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp:
(WebKit::findWebKitProcess):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::tryApplyCachedSandbox):
* Source/WebKit/Shared/win/AuxiliaryProcessMainWin.cpp:
(WebKit::AuxiliaryProcessMainCommon::parseCommandLine):
* Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp:
(webkit_security_origin_new):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkitWebContextSetProperty):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::fallBackToWebPathInternal):
(WebKit::SubFrameSOAuthorizationSession::beforeStart):
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp:
(WebKit::RemoteInspectorClient::setBackendCommands):
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::pathToPDFOnDisk):
* Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp:
(WebKit::WebProcessPool::platformInitialize):
* Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm:
(WEBCONTENT_SERVICE_INITIALIZER):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp:
(WebKit::GObjectEventListener::gobjectDestroyed):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h:
(WebKit::GObjectEventListener::addEventListener):
(WebKit::GObjectEventListener::removeEventListener):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::messages):
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(createNSCountedSet):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, StringImplCreationFromLiteral)):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::stringViewFromLiteral):
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
(TestWebKitAPI::TEST_F(WTF_URL, URLSetQuery)):
(TestWebKitAPI::TEST_F(WTF_URL, URLSetFragmentIdentifier)):
* Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp:
(TestWebKitAPI::TEST_F(WTF_URLParser, Credentials)):
(TestWebKitAPI::TEST_F(WTF_URLParser, ParserDifferences)):
(TestWebKitAPI::TEST_F(WTF_URLParser, ParserFailures)):
* Tools/TestWebKitAPI/Tests/WebCore/HTTPParsers.cpp:
(TestWebKitAPI::TEST(HTTPParsers, ParseCrossOriginResourcePolicyHeader)):
* Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp:
(TestWebKitAPI::checkChunks):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7975ad6b6b62fab0dc0c45b6d93a6efa3cc5a974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7447 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42321 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92828 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38681 "Hash 7975ad6b for PR 39938 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7828 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15623 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/92828 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/38681 "Hash 7975ad6b for PR 39938 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90933 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6000 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/42321 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/92828 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5777 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/42321 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37788 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80729 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76176 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/42321 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94696 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86706 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15099 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/15623 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/94696 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15354 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/42321 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/94696 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20362 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/42321 "Hash 7975ad6b for PR 39938 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8103 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15117 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109200 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14859 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/109200 "Hash 7975ad6b for PR 39938 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->