### PR TITLE
Fix broken caret painting in vertical writing modes

### DIFF
--- a/LayoutTests/editing/inserting/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/editing/inserting/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,3 @@
+This is a test of writingsideways in vertical text
+withseverallines of text and alongwordthat'slong andanotherword.
+Test 1 -81,44,20,1

--- a/LayoutTests/editing/inserting/caret-position-vertical-rl.html
+++ b/LayoutTests/editing/inserting/caret-position-vertical-rl.html
@@ -1,0 +1,67 @@
+<html style="writing-mode: vertical-rl">
+<style>
+#test {
+    /* If this test ends up being flaky, consider using Ahem. */
+    outline: solid gray 1px;
+    padding: 1em;
+    width: 10em;
+    height: 20ch;
+    font: 20px/1 monospace;
+    background: /* Create a 10px grid to help with debugging. */
+        repeating-linear-gradient(transparent 0em 9px, #8F88 9px 10px),
+        repeating-linear-gradient(to left, transparent 0px 9px, #8F88 9px 10px);
+}
+</style>
+
+<div id=test contenteditable>
+This is a test <span id=first>of writingsideways in vertical text</span><br>
+withseverallines of <span>text</span> and alongwordthat'slong andanotherword.
+</div>
+
+<hr>
+
+<ul id="console"></ul>
+
+<script>
+
+var test = document.getElementById('test');
+var testRightEdge = test.offsetLeft + test.offsetWidth;
+var testTopEdge = test.offsetTop;
+
+function stringifyCaret(caretRect) {
+    // Convert to box-relative coords and stringify
+    return (caretRect.x - testRightEdge) + ","
+        + (caretRect.y - testTopEdge) + ","
+        + caretRect.width + ","
+        + caretRect.height;
+}
+
+function log(str) {
+    var li = document.createElement("li");
+    li.appendChild(document.createTextNode(str));
+    var console = document.getElementById("console");
+    console.appendChild(li);
+}
+
+function testCaretPosition(testID, element)
+{
+    element.focus();
+    var caretRect = window.internals.absoluteCaretBounds();
+    log(testID + " " + stringifyCaret(caretRect));
+}
+
+function runTest()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    // Bug XXX
+    var first = document.getElementById('first');
+    window.getSelection().collapse(first.firstChild, 24);
+    testCaretPosition("Test 1", first);
+
+}
+
+runTest();
+
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7708,8 +7708,6 @@ webkit.org/b/288694 [ Debug arm64 ] fast/multicol/body-stuck-with-dirty-bit-with
 
 webkit.org/b/288888 [ arm64 ] compositing/contents-format/deep-color-backing-store.html [ Failure ]
 
-webkit.org/b/288896 editing/caret/caret-position-vertical-rl.html [ Failure ]
-
 webkit.org/b/287569 http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe.html [ Timeout ]
 
 webkit.org/b/287033 fast/mediastream/microphone-interruption-and-audio-session.html [ Failure ]

--- a/LayoutTests/platform/ios/editing/inserting/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/platform/ios/editing/inserting/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,3 @@
+This is a test of writingsideways in vertical text
+withseverallines of text and alongwordthat'slong andanotherword.
+Test 1 -80,43,20,2

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -78,7 +78,7 @@ public:
     {
         auto writingMode = formattingContextRoot().writingMode();
         if (writingMode.isLogicalLeftLineLeft())
-            return line().lineBoxLeft() + line().contentLogicalLeftIgnoringInlineDirection();
+            return line().lineBoxLogicalRect().x() + line().contentLogicalLeftIgnoringInlineDirection();
         ASSERT(writingMode.isVertical()); // Currently only sideways-lr gets this far.
         return line().bottom() - (line().contentLogicalLeftIgnoringInlineDirection() + line().contentLogicalWidth());
     }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -63,13 +63,13 @@ public:
 
     float contentLogicalTopAdjustedForPrecedingLineBox() const
     {
-        if (formattingContextRoot().writingMode().isLineInverted() || !m_lineIndex)
+        if (!m_lineIndex)
             return contentLogicalTop();
         return LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex - 1 }.contentLogicalBottom();
     }
     float contentLogicalBottomAdjustedForFollowingLineBox() const
     {
-        if (!formattingContextRoot().writingMode().isLineInverted() || m_lineIndex == lines().size() - 1)
+        if (m_lineIndex == lines().size() - 1)
             return contentLogicalBottom();
         return LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex + 1 }.contentLogicalTop();
     }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -896,9 +896,9 @@ VisiblePosition RenderText::positionForPoint(const LayoutPoint& point, HitTestSo
             if (logicalPoint.y() < bottom || (blocksAreFlipped && logicalPoint.y() == bottom)) {
                 ShouldAffinityBeDownstream shouldAffinityBeDownstream;
 #if PLATFORM(IOS_FAMILY)
-                if (logicalPoint.x() != run->logicalLeft() && point.x() < run->logicalLeft() + run->logicalWidth()) {
+                if (logicalPoint.x() != run->logicalLeft() && logicalPoint.x() < run->logicalLeft() + run->logicalWidth()) {
                     auto half = LayoutUnit { run->logicalLeft() + run->logicalWidth() / 2.f };
-                    shouldAffinityBeDownstream = point.x() < half ? AlwaysDownstream : AlwaysUpstream;
+                    shouldAffinityBeDownstream = logicalPoint.x() < half ? AlwaysDownstream : AlwaysUpstream;
                     return createVisiblePositionAfterAdjustingOffsetForBiDi(run, offsetForPositionInRun(*run, logicalPoint.x()), shouldAffinityBeDownstream);
                 }
 #endif


### PR DESCRIPTION
#### e7b36b4c7c59d1f442bf6983fd964142570ddc0f
<pre>
Fix broken caret painting in vertical writing modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=286961">https://bugs.webkit.org/show_bug.cgi?id=286961</a>
<a href="https://rdar.apple.com/144117372">rdar://144117372</a>

Reviewed by NOBODY (OOPS!).

We clip caret painting to the line&apos;s content bounds using contentLogicalLeft(),
but contentLogicalLeft() adds the visual rect left, which is the wrong axis
in vertical writing modes. This patch switches us to use the logical rect left.

* LayoutTests/editing/inserting/caret-position-vertical-rl-expected.txt: Added.
* LayoutTests/editing/inserting/caret-position-vertical-rl.html: Added.
* LayoutTests/platform/ios/editing/inserting/caret-position-vertical-rl-expected.txt: Added.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::contentLogicalLeft const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf830daff6519b0130f604570da0806d8774374

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21581 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71477 "Found 2 new test failures: fast/multicol/hit-test-end-of-column-with-line-height.html fast/text/mark-matches-overflow-clip.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28856 "Found 4 new test failures: editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/inserting/caret-position-vertical-rl.html editing/selection/caret-in-div-containing-br-in-vertical-mode.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96567 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10038 "Found 16 new test failures: accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html accessibility/mixed-contenteditable-visible-character-range-hang.html accessibility/visible-character-range-vertical-rl.html editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/caret/ios/caret-in-overflow-area.html editing/inserting/caret-position-vertical-rl.html editing/selection/caret-in-div-containing-br-in-vertical-mode.html editing/selection/ios/bidi-visually-contiguous-selection-multiline.html editing/selection/ios/hide-selection-after-hiding-contenteditable.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51812 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9720 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2237 "Found 4 new test failures: editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/inserting/caret-position-vertical-rl.html fast/multicol/hit-test-end-of-column-with-line-height.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43405 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79995 "Found 3 new API test failures: TestWebKitAPI.AccessibilityTests.RectsForSpeakingSelectionWithLineWrapping, TestWebKitAPI.AccessibilityTests.StoreSelection, TestWebKitAPI.AccessibilityTests.RectsForSpeakingSelectionBasic (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2300 "Found 7 new test failures: accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html accessibility/mixed-contenteditable-visible-character-range-hang.html accessibility/visible-character-range-vertical-rl.html editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/inserting/caret-position-vertical-rl.html fast/multicol/hit-test-end-of-column-with-line-height.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100600 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20617 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15074 "Found 7 new test failures: accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html accessibility/mixed-contenteditable-visible-character-range-hang.html accessibility/visible-character-range-vertical-rl.html editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/inserting/caret-position-vertical-rl.html fast/multicol/hit-test-end-of-column-with-line-height.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80495 "Found 8 new test failures: editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/input/reveal-caret-of-multiline-input.html editing/inserting/caret-position-vertical-rl.html editing/selection/caret-in-div-containing-br-in-vertical-mode.html fast/multicol/hit-test-end-of-column-with-line-height.html fast/repaint/selection-ruby-rl.html fast/text/mark-matches-overflow-clip.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20869 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80551 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79830 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24363 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1713 "Found 7 new test failures: accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html accessibility/mixed-contenteditable-visible-character-range-hang.html accessibility/visible-character-range-vertical-rl.html editing/caret/caret-position-sideways-lr.html editing/caret/caret-position-vertical-rl.html editing/inserting/caret-position-vertical-rl.html fast/multicol/hit-test-end-of-column-with-line-height.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13765 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25779 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->