### PR TITLE
[WebGPU] drawIndexed validation allows baseVertex which result in negative final vertices

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286967-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286967-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286967.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286967.html
@@ -1,0 +1,195 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+// START
+device0 = await adapter0.requestDevice({
+  });
+{
+}
+texture17 = device0.createTexture({
+  size : [ 1278, 120, 16 ],
+  dimension : '3d',
+  format : 'bgra8unorm-srgb',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT});
+textureView16 = texture17.createView();
+{
+}
+querySet4 = commandEncoder29 = device0.createCommandEncoder();
+{
+}
+{
+}
+shaderModule3 = device0.createShaderModule({
+  code : ` ;
+              fn unconst_u32(v: u32) -> u32 {
+            return v;
+            }
+              struct VertexOutput3 {
+              @location(7) f7: vec4f,   @invariant @builtin(position) f8: vec4f,   @location(8) f9: i32}
+              override override7: f32;
+              struct FragmentOutput3 {
+              @location(0) f0: vec4f}
+              fn fn3() -> u32 {
+              var out: u32;
+              return out;
+            }
+              @must_use  fn fn4(a0: FragmentOutput4) -> VertexOutput3 {
+              var out: VertexOutput3;
+              return out;
+              _ = override7;
+            }
+              struct FragmentOutput4 {
+              f0: vec4f}
+              @vertex fn vertex3(@builtin(vertex_index) a0: u32, @location(12) a1: vec4i, @location(7) a2: vec2i, @location(15) a3: f32, @location(6) a4: vec4u, @location(14) a5: vec2i, @location(2) a6: vec2h, @location(5) a7: f16, @location(11) a8: vec4u, @location(3) a9: vec4u, @location(1) a10: u32) -> VertexOutput3 {
+              var out: VertexOutput3;
+              out.f7 = unpack4x8snorm(a9[unconst_u32(599)]);
+              return out;
+            }
+              @fragment fn fragment4() -> FragmentOutput3 {
+              var out: FragmentOutput3;
+              _ = fn4(FragmentOutput4(vec4f(unpack4xI8(unconst_u32(260)))));
+              return out;
+            }
+             `});
+renderPassEncoder34 = commandEncoder29.beginRenderPass({
+  colorAttachments : [ {
+    view : textureView16,
+    depthSlice : 7,
+    clearValue : {
+      r : 791.1,
+      g : 190.8,
+      b : 826.1,
+      a : 370.9},
+    loadOp : 'load',
+    storeOp : 'store'} ],
+  querySet4});
+{
+}
+pipeline15 = device0.createRenderPipeline({
+  layout : 'auto',
+  multisample : {mask : 0x1329388},
+  fragment : {
+    module : shaderModule3,
+    constants : {override7 : 1},
+    targets : [ {
+      format : 'bgra8unorm-srgb',
+      writeMask : GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED
+    } ]},
+  vertex : {
+    module : shaderModule3,
+    buffers : [
+      {
+        arrayStride : 176,
+        attributes : [
+          {format : 'uint32x3', offset : 12, shaderLocation : 6},
+          {format : 'uint32', offset : 40, shaderLocation : 11},
+          {format : 'sint32x4', offset : 80, shaderLocation : 7},
+          {format : 'uint32x3', offset : 0, shaderLocation : 3},
+          {format : 'float32', offset : 28, shaderLocation : 2},
+          {format : 'float16x2', offset : 0, shaderLocation : 5},
+          {format : 'sint32x3', offset : 36, shaderLocation : 12},
+          {format : 'uint32x3', offset : 12, shaderLocation : 1},
+          {format : 'sint16x4', offset : 64, shaderLocation : 14},
+          {format : 'float16x2', offset : 40, shaderLocation : 15}]}]},
+  primitive : {
+    topology : 'line-strip',
+    stripIndexFormat : 'uint16',
+    }});
+{
+}
+buffer58 = device0.createBuffer({
+  size : 5523,
+  usage : GPUBufferUsage.INDEX |
+              GPUBufferUsage});
+{
+}
+try {
+  renderPassEncoder34.setIndexBuffer(buffer58, 'uint16', )} catch {
+}
+try {
+  renderPassEncoder34.setPipeline(pipeline15)} catch {
+}
+buffer69 = device0.createBuffer({
+  size : 20824,
+  usage : GPUBufferUsage.VERTEX});
+try {
+  renderPassEncoder34.setVertexBuffer(0, buffer69)} catch {
+}
+{
+}
+try {
+  renderPassEncoder34.drawIndexed(77, 65, 14, -1)} catch {
+}
+
+  try {
+  renderPassEncoder34.end()} catch {
+}
+commandBuffer11 = commandEncoder29.finish();
+{
+}
+try {
+  device0.queue.submit([ commandBuffer11 ])} catch {
+}
+// END
+await device1.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### e3fd2ac242daa17f83f6b911a48cf9db9c0dcbeb
<pre>
[WebGPU] drawIndexed validation allows baseVertex which result in negative final vertices
<a href="https://bugs.webkit.org/show_bug.cgi?id=286967">https://bugs.webkit.org/show_bug.cgi?id=286967</a>
<a href="https://rdar.apple.com/144077021">rdar://144077021</a>

Reviewed by Tadeu Zagallo.

Strip index formats, which use 2^16 - 1 or 2^32 - 1 to denote the restart
value, allowed for bypassing validation logic. Avoid this by ensuring
the resulting sum would not be negative when the calculation is performed
at 32-bit signed integer arithmetic.

* LayoutTests/fast/webgpu/nocrash/fuzz-286967-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-286967.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Device.mm:

Canonical link: <a href="https://commits.webkit.org/289855@main">https://commits.webkit.org/289855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97f1fd42d69289ccd1cc51755c8f19cbad880abc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38889 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68017 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25745 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79727 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48383 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94936 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15307 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11237 "Found 3 new test failures: http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html imported/w3c/web-platform-tests/screen-orientation/lock-basic.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76875 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75583 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76117 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18734 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15325 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20626 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->