### PR TITLE
Make type casts in RemoteLayerTreePropertyApplier.mm safe

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
@@ -29,6 +29,7 @@
 
 #import <pal/spi/cocoa/CoreMaterialSPI.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, CoreMaterial)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, MTMaterialLayer)
@@ -38,5 +39,7 @@ SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChr
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinLight, NSString *)
+
+SPECIALIZE_OBJC_TYPE_TRAITS(MTMaterialLayer, PAL::getMTMaterialLayerClass())
 
 #endif // HAVE(CORE_MATERIAL)

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -16,7 +16,6 @@ Shared/APIWebArchive.mm
 Shared/Cocoa/WKNSURL.mm
 Shared/Cocoa/WKObject.h
 Shared/RTCNetwork.cpp
-Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
 Shared/UserData.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKDownload.mm

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -357,8 +357,8 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
             playerLayer = [(WKVideoView*)layerTreeNode->uiView() playerLayer];
 #endif
         ASSERT([playerLayer respondsToSelector:@selector(setVideoGravity:)]);
-        if ([playerLayer respondsToSelector:@selector(setVideoGravity:)])
-            [(WebAVPlayerLayer*)playerLayer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(properties.videoGravity)];
+        if (RetainPtr webAVPlayerLayer = dynamic_objc_cast<WebAVPlayerLayer>(playerLayer))
+            [webAVPlayerLayer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(properties.videoGravity)];
     }
 #endif
 
@@ -376,9 +376,9 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
 
 #if HAVE(CORE_MATERIAL)
     if (properties.changedProperties & LayerChange::AppleVisualEffectChanged) {
-        if ([layer isKindOfClass:PAL::getMTMaterialLayerClass()]) {
+        if (RetainPtr materialLayer = dynamic_objc_cast<MTMaterialLayer>(layer)) {
             if (RetainPtr recipe = materialRecipeForAppleVisualEffect(properties.appleVisualEffect))
-                [(MTMaterialLayer *)layer setRecipe:recipe.get()];
+                [materialLayer setRecipe:recipe.get()];
         }
     }
 #endif


### PR DESCRIPTION
#### dec32d4d22199816744642b9450f5b41a3bc57ea
<pre>
Make type casts in RemoteLayerTreePropertyApplier.mm safe
<a href="https://bugs.webkit.org/show_bug.cgi?id=286971">https://bugs.webkit.org/show_bug.cgi?id=286971</a>

Reviewed by Aditya Keerthi and Geoffrey Garen.

Use dynamic_objc_cast in more places to address static analyzer warnings.

* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h:
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):

Canonical link: <a href="https://commits.webkit.org/289812@main">https://commits.webkit.org/289812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a067a6b2e20e037f5231857559eabd1e507395c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67899 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25636 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79586 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48268 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5791 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33994 "Found 60 new test failures: accessibility/out-of-bounds-rowspan.html compositing/repaint/iframes/compositing-iframe-scroll-repaint.html editing/undo/redo-reapply-edit-command-crash.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/security/file-system-access-via-dataTransfer.html http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub.html imported/w3c/web-platform-tests/css/css-conditional/css-supports-008.xht imported/w3c/web-platform-tests/css/css-content/quotes-018.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94727 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15130 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11126 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCRtpSender-replaceTrack.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76752 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75442 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75990 "Found 100 new API test failures: /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select, /TestWebKit:WebKit.InjectedBundleBasic, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /TestWebKit:WebKit.LoadAlternateHTMLStringWithNonDirectoryURL, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /TestWebKit:WebKit.InjectedBundleFrameHitTest, /TestWebKit:WebKit.ForceRepaint, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/usermedia-permission-requests ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18801 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8134 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13744 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20449 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->