### PR TITLE
Adopt more smart pointers in GPUProcess (part 2)

### DIFF
--- a/Source/WTF/wtf/MainThread.cpp
+++ b/Source/WTF/wtf/MainThread.cpp
@@ -111,7 +111,7 @@ enum class MainStyle : bool {
 };
 
 template <MainStyle mainStyle>
-static void callOnMainAndWait(Function<void()>&& function)
+static void callOnMainAndWait(NOESCAPE Function<void()>&& function)
 {
 
     if (mainStyle == MainStyle::Thread ? isMainThread() : isMainRunLoop()) {
@@ -135,12 +135,12 @@ static void callOnMainAndWait(Function<void()>&& function)
     semaphore.wait();
 }
 
-void callOnMainRunLoopAndWait(Function<void()>&& function)
+void callOnMainRunLoopAndWait(NOESCAPE Function<void()>&& function)
 {
     callOnMainAndWait<MainStyle::RunLoop>(WTFMove(function));
 }
 
-void callOnMainThreadAndWait(Function<void()>&& function)
+void callOnMainThreadAndWait(NOESCAPE Function<void()>&& function)
 {
     callOnMainAndWait<MainStyle::Thread>(WTFMove(function));
 }

--- a/Source/WTF/wtf/MainThread.h
+++ b/Source/WTF/wtf/MainThread.h
@@ -44,7 +44,7 @@ class Thread;
 WTF_EXPORT_PRIVATE void initializeMainThread();
 
 WTF_EXPORT_PRIVATE void callOnMainThread(Function<void()>&&);
-WTF_EXPORT_PRIVATE void callOnMainThreadAndWait(Function<void()>&&);
+WTF_EXPORT_PRIVATE void callOnMainThreadAndWait(NOESCAPE Function<void()>&&);
 WTF_EXPORT_PRIVATE void ensureOnMainThread(Function<void()>&&); // Sync if called on main thread, async otherwise.
 
 #if PLATFORM(COCOA)
@@ -58,7 +58,7 @@ WTF_EXPORT_PRIVATE bool canCurrentThreadAccessThreadLocalData(Thread&);
 
 WTF_EXPORT_PRIVATE bool isMainRunLoop();
 WTF_EXPORT_PRIVATE void callOnMainRunLoop(Function<void()>&&);
-WTF_EXPORT_PRIVATE void callOnMainRunLoopAndWait(Function<void()>&&);
+WTF_EXPORT_PRIVATE void callOnMainRunLoopAndWait(NOESCAPE Function<void()>&&);
 WTF_EXPORT_PRIVATE void ensureOnMainRunLoop(Function<void()>&&); // Sync if called on main run loop, async otherwise.
 
 #if USE(WEB_THREAD)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
@@ -73,7 +73,7 @@ void BufferImpl::mapAsync(MapModeFlags mapModeFlags, Size64 offset, std::optiona
     wgpuBufferMapAsync(m_backing.get(), backingMapModeFlags, static_cast<size_t>(offset), static_cast<size_t>(usedSize), &mapAsyncCallback, Block_copy(blockPtr.get())); // Block_copy is matched with Block_release above in mapAsyncCallback().
 }
 
-void BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size, Function<void(std::span<uint8_t>)>&& callback)
+void BufferImpl::getMappedRange(Size64 offset, std::optional<Size64> size, NOESCAPE Function<void(std::span<uint8_t>)>&& callback)
 {
     auto usedSize = getMappedSize(m_backing.get(), size, offset);
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
@@ -60,7 +60,7 @@ private:
     WGPUBuffer backing() const { return m_backing.get(); }
 
     void mapAsync(MapModeFlags, Size64 offset, std::optional<Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
-    void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(std::span<uint8_t>)>&&) final;
+    void getMappedRange(Size64 offset, std::optional<Size64>, NOESCAPE Function<void(std::span<uint8_t>)>&&) final;
     std::span<uint8_t> getBufferContents() final;
     void unmap() final;
     void copyFrom(std::span<const uint8_t>, size_t offset) final;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h
@@ -141,6 +141,8 @@ public:
     virtual Ref<ComputePassEncoder> invalidComputePassEncoder() = 0;
     virtual void pauseAllErrorReporting(bool pause) = 0;
 
+    virtual bool isRemoteDeviceProxy() const { return false; }
+
 protected:
     Device(Ref<SupportedFeatures>&& features, Ref<SupportedLimits>&& limits)
         : m_features(WTFMove(features))

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
@@ -79,6 +79,8 @@ public:
 #endif
     virtual void endFrame() = 0;
 
+    virtual bool isRemoteXRProjectionLayerProxy() const { return false; }
+
 protected:
     XRProjectionLayer() = default;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -243,9 +243,10 @@ void RemoteGPU::paintNativeImageToImageBuffer(WebCore::NativeImage& nativeImage,
 
     RefPtr gpu = m_backing.get();
     Ref renderingBackend = m_renderingBackend;
+    Ref protectedNativeImage = nativeImage;
     renderingBackend->dispatch([&]() mutable {
         if (auto imageBuffer = renderingBackend->imageBuffer(imageBufferIdentifier)) {
-            gpu->paintToCanvas(nativeImage, imageBuffer->backendSize(), imageBuffer->context());
+            gpu->paintToCanvas(protectedNativeImage, imageBuffer->backendSize(), imageBuffer->context());
             imageBuffer->flushDrawingContext();
         }
         semaphore.signal();

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -116,7 +116,7 @@ private:
         std::unique_ptr<WebCore::FrameRateMonitor> frameRateMonitor;
         Deque<CompletionHandler<void(bool)>> decodingCallbacks;
     };
-    void doDecoderTask(VideoDecoderIdentifier, Function<void(Decoder&)>&&);
+    void doDecoderTask(VideoDecoderIdentifier, NOESCAPE Function<void(Decoder&)>&&);
 
     struct Encoder {
         webrtc::LocalEncoder webrtcEncoder { nullptr };

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -102,7 +102,7 @@ void RemoteSampleBufferDisplayLayerManager::createLayer(SampleBufferDisplayLayer
             return;
         }
         layer->initialize(hideRootLayer, size, shouldMaintainAspectRatio, canShowWhileLocked, [this, protectedThis = Ref { *this }, callback = WTFMove(callback), identifier, layer = Ref { *layer }](auto layerId) mutable {
-            protectedQueue()->dispatch([protectedThis = WTFMove(protectedThis), callback = WTFMove(callback), identifier, layer = WTFMove(layer), layerId = WTFMove(layerId)]() mutable {
+            protectedQueue()->dispatch([protectedThis = Ref { *this }, callback = WTFMove(callback), identifier, layer = WTFMove(layer), layerId = WTFMove(layerId)]() mutable {
                 Locker lock(protectedThis->m_layersLock);
                 ASSERT(!protectedThis->m_layers.contains(identifier));
                 protectedThis->m_layers.add(identifier, WTFMove(layer));
@@ -115,7 +115,7 @@ void RemoteSampleBufferDisplayLayerManager::createLayer(SampleBufferDisplayLayer
 void RemoteSampleBufferDisplayLayerManager::releaseLayer(SampleBufferDisplayLayerIdentifier identifier)
 {
     callOnMainRunLoop([this, protectedThis = Ref { *this }, identifier]() mutable {
-        protectedQueue()->dispatch([protectedThis = WTFMove(protectedThis), identifier] {
+        protectedQueue()->dispatch([protectedThis = Ref { *this }, identifier] {
             Locker lock(protectedThis->m_layersLock);
             ASSERT(protectedThis->m_layers.contains(identifier));
             callOnMainRunLoop([layer = protectedThis->m_layers.take(identifier)] { });

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -121,8 +121,6 @@
 #define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, this->connection(), completion)
 #define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, this->connection(), returnValue)
 
-#define MESSAGE_CHECK_WITH_THIS(assertion, thisPtr) MESSAGE_CHECK_BASE(assertion, thisPtr->connection())
-
 namespace WebKit {
 using namespace WebCore;
 
@@ -597,7 +595,7 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 
 void NetworkConnectionToWebProcess::performSynchronousLoad(NetworkResourceLoadParameters&& loadParameters, CompletionHandler<void(const ResourceError&, const ResourceResponse, Vector<uint8_t>&&)>&& reply)
 {
-    MESSAGE_CHECK_WITH_THIS(protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow, Ref { *this });
+    MESSAGE_CHECK(protectedNetworkProcess()->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow);
     CONNECTION_RELEASE_LOG(Loading, "performSynchronousLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     auto identifier = loadParameters.identifier;

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
@@ -88,7 +88,7 @@ void StreamConnectionWorkQueue::removeStreamConnection(StreamServerConnection& c
     wakeUp();
 }
 
-void StreamConnectionWorkQueue::stopAndWaitForCompletion(WTF::Function<void()>&& cleanupFunction)
+void StreamConnectionWorkQueue::stopAndWaitForCompletion(NOESCAPE WTF::Function<void()>&& cleanupFunction)
 {
     RefPtr<Thread> processingThread;
     {

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h
@@ -47,7 +47,7 @@ public:
     ~StreamConnectionWorkQueue();
     void addStreamConnection(StreamServerConnection&);
     void removeStreamConnection(StreamServerConnection&);
-    void stopAndWaitForCompletion(WTF::Function<void()>&& cleanupFunction = nullptr);
+    void stopAndWaitForCompletion(NOESCAPE WTF::Function<void()>&& cleanupFunction = nullptr);
     void wakeUp();
     Semaphore& wakeUpSemaphore() { return m_wakeUpSemaphore; }
 

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -28,8 +28,6 @@ UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/WebAuthentication/Virtual/VirtualService.mm
 UIProcess/mac/WebViewImpl.mm
-WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
-WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
 WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,6 +1,3 @@
-GPUProcess/graphics/RemoteGraphicsContextGL.cpp
-GPUProcess/graphics/WebGPU/RemoteGPU.cpp
-GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
 NetworkProcess/NetworkDataTaskBlob.cpp
 NetworkProcess/cache/NetworkCacheStorage.cpp
 Platform/IPC/HandleMessage.h
@@ -30,19 +27,13 @@ UIProcess/WebPageProxy.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
-WebProcess/Cache/WebCacheStorageConnection.cpp
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
-WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
-WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
-WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
-WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
 WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
 WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
 WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
-WebProcess/GPU/media/RemoteMediaRecorderPrivateWriter.cpp
 WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
 WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
 WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -69,7 +60,6 @@ WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebProcess.cpp
 WebProcess/WebStorage/StorageAreaMap.cpp
-WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
 WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
 webpushd/ApplePushServiceConnection.mm

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -219,11 +219,11 @@ bool RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame(WebCore::VideoFrame
     if (isContextLost())
         return false;
 
-    auto sharedVideoFrame = m_sharedVideoFrameWriter.write(videoFrame, [this](auto& semaphore) {
+    auto sharedVideoFrame = m_sharedVideoFrameWriter.write(videoFrame, [this, protectedThis = Ref { *this }](auto& semaphore) {
         auto sendResult = send(Messages::RemoteGraphicsContextGL::SetSharedVideoFrameSemaphore { semaphore });
         if (sendResult != IPC::Error::NoError)
             markContextLost();
-    }, [this](SharedMemory::Handle&& handle) {
+    }, [this, protectedThis = Ref { *this }](SharedMemory::Handle&& handle) {
         auto sendResult = send(Messages::RemoteGraphicsContextGL::SetSharedVideoFrameMemory { WTFMove(handle) });
         if (sendResult != IPC::Error::NoError)
             markContextLost();

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -66,7 +66,7 @@ static bool offsetOrSizeExceedsBounds(size_t dataSize, WebCore::WebGPU::Size64 o
     return offset >= dataSize || (requestedSize.has_value() && requestedSize.value() + offset > dataSize);
 }
 
-void RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, Function<void(std::span<uint8_t>)>&& callback)
+void RemoteBufferProxy::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, NOESCAPE Function<void(std::span<uint8_t>)>&& callback)
 {
     // FIXME: Implement error handling.
     auto sendResult = sendSync(Messages::RemoteBuffer::GetMappedRange(offset, size));

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -78,7 +78,7 @@ private:
     }
 
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;
-    void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>, Function<void(std::span<uint8_t>)>&&) final;
+    void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>, NOESCAPE Function<void(std::span<uint8_t>)>&&) final;
     std::span<uint8_t> getBufferContents() final;
     void unmap() final;
     void copyFrom(std::span<const uint8_t>, size_t offset) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RemoteCompositorIntegrationMessages.h"
+#include "RemoteDeviceProxy.h"
 #include "RemoteGPUProxy.h"
 #include "WebGPUConvertToBackingContext.h"
 #include <WebCore/ImageBuffer.h>
@@ -55,7 +56,7 @@ RemoteCompositorIntegrationProxy::~RemoteCompositorIntegrationProxy()
 #if PLATFORM(COCOA)
 Vector<MachSendRight> RemoteCompositorIntegrationProxy::recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&& destinationColorSpace, WebCore::AlphaPremultiplication alphaMode, WebCore::WebGPU::TextureFormat textureFormat, WebCore::WebGPU::Device& device)
 {
-    RemoteDeviceProxy& proxyDevice = static_cast<RemoteDeviceProxy&>(device);
+    RemoteDeviceProxy& proxyDevice = downcast<RemoteDeviceProxy>(device);
     auto sendResult = sendSync(Messages::RemoteCompositorIntegration::RecreateRenderBuffers(width, height, WTFMove(destinationColorSpace), alphaMode, textureFormat, proxyDevice.backing()));
     if (!sendResult.succeeded())
         return { };

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -176,10 +176,10 @@ RefPtr<WebCore::WebGPU::ExternalTexture> RemoteDeviceProxy::importExternalTextur
     if (!convertedDescriptor->mediaIdentifier) {
         auto* videoFrame = std::get_if<RefPtr<WebCore::VideoFrame>>(&descriptor.videoBacking);
         if (videoFrame && videoFrame->get()) {
-            convertedDescriptor->sharedFrame = m_sharedVideoFrameWriter.write(*videoFrame->get(), [&](auto& semaphore) {
+            convertedDescriptor->sharedFrame = m_sharedVideoFrameWriter.write(*videoFrame->get(), [this, protectedThis = Ref { *this }](auto& semaphore) {
                 auto sendResult = send(Messages::RemoteDevice::SetSharedVideoFrameSemaphore { semaphore });
                 UNUSED_VARIABLE(sendResult);
-            }, [&](WebCore::SharedMemory::Handle&& handle) {
+            }, [this, protectedThis = Ref { *this }](WebCore::SharedMemory::Handle&& handle) {
                 auto sendResult = send(Messages::RemoteDevice::SetSharedVideoFrameMemory { WTFMove(handle) });
                 UNUSED_VARIABLE(sendResult);
             });

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -123,6 +123,8 @@ private:
     Ref<WebCore::WebGPU::ComputePassEncoder> invalidComputePassEncoder() final;
     void pauseAllErrorReporting(bool pause) final;
 
+    bool isRemoteDeviceProxy() const final { return true; }
+
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteAdapterProxy> m_parent;
@@ -137,5 +139,9 @@ private:
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteDeviceProxy)
+    static bool isType(const WebCore::WebGPU::Device& device) { return device.isRemoteDeviceProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp
@@ -75,7 +75,7 @@ RefPtr<WebCore::WebGPU::XRSubImage> RemoteXRBindingProxy::getSubImage(WebCore::W
 RefPtr<WebCore::WebGPU::XRSubImage> RemoteXRBindingProxy::getViewSubImage(WebCore::WebGPU::XRProjectionLayer& projectionLayer)
 {
     auto identifier = WebGPUIdentifier::generate();
-    auto sendResult = send(Messages::RemoteXRBinding::GetViewSubImage(static_cast<RemoteXRProjectionLayerProxy&>(projectionLayer).backing(), identifier));
+    auto sendResult = send(Messages::RemoteXRBinding::GetViewSubImage(downcast<RemoteXRProjectionLayerProxy>(projectionLayer).backing(), identifier));
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
@@ -98,11 +98,17 @@ private:
         return root().protectedStreamClientConnection()->sendSync(WTFMove(message), backing());
     }
 
+    bool isRemoteXRProjectionLayerProxy() const final { return true; }
+
     WebGPUIdentifier m_backing;
     Ref<ConvertToBackingContext> m_convertToBackingContext;
     Ref<RemoteGPUProxy> m_parent;
 };
 
 } // namespace WebKit::WebGPU
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGPU::RemoteXRProjectionLayerProxy)
+    static bool isType(const WebCore::WebGPU::XRProjectionLayer& projectionLayer) { return projectionLayer.isRemoteXRProjectionLayerProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,3 +1,2 @@
 Storage/StorageAreaImpl.cpp
-WebCoreSupport/SocketStreamHandleImplCFNet.cpp
 mac/WebCoreSupport/WebFrameLoaderClient.mm


### PR DESCRIPTION
#### d398f9017f605266f15325c6c7ce48d82f83fe7d
<pre>
Adopt more smart pointers in GPUProcess (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286974">https://bugs.webkit.org/show_bug.cgi?id=286974</a>
<a href="https://rdar.apple.com/144126555">rdar://144126555</a>

Reviewed by Ryosuke Niwa and Mike Wyrzykowski.

Smart pointer adoption as per the static analyzer.

* Source/WTF/wtf/MainThread.cpp:
(WTF::callOnMainAndWait):
(WTF::callOnMainRunLoopAndWait):
(WTF::callOnMainThreadAndWait):
* Source/WTF/wtf/MainThread.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp:
(WebCore::WebGPU::BufferImpl::getMappedRange):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDevice.h:
(WebCore::WebGPU::Device::isRemoteDeviceProxy const):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h:
(WebCore::WebGPU::XRProjectionLayer::isRemoteXRProjectionLayerProxy const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::paintNativeImageToImageBuffer):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::performTaskAtTime):
(WebKit::RemoteMediaPlayerProxy::updateCachedVideoMetrics):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::stopListeningForIPC):
(WebKit::LibWebRTCCodecsProxy::doDecoderTask):
(WebKit::LibWebRTCCodecsProxy::notifyEncoderResult):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp:
(WebKit::RemoteSampleBufferDisplayLayerManager::createLayer):
(WebKit::RemoteSampleBufferDisplayLayerManager::releaseLayer):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::performSynchronousLoad):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp:
(IPC::StreamConnectionWorkQueue::stopAndWaitForCompletion):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h:
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::getMappedRange):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::recreateRenderBuffers):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::importExternalTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
(isType):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp:
(WebKit::WebGPU::RemoteXRBindingProxy::getViewSubImage):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h:
(isType):
* Source/WebKitLegacy/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/289870@main">https://commits.webkit.org/289870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/350db37f3d90bbe73247f244a903b2decb1c69eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25783 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91214 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79781 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48423 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change (failure); Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34191 "Found 1 new test failure: editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38070 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81010 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95011 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86988 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76918 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75637 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76162 "run-api-tests-without-change (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20553 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8409 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13777 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20699 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109481 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15142 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26327 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->