### PR TITLE
[JSC] `Date.prototype.set*` methods should check if `internalNumber` is NaN, before set PNaN

### DIFF
--- a/JSTests/stress/date-prototype-set-methods-toNumber-no-args.js
+++ b/JSTests/stress/date-prototype-set-methods-toNumber-no-args.js
@@ -1,0 +1,26 @@
+function assert(a) {
+    if (!a)
+        throw new Error("Assertion failed");
+}
+
+function test(setMethod) {
+    var dt = new Date();
+    assert(Number.isNaN(setMethod.call(dt)));
+    assert(isNaN(dt));
+    assert(Number.isNaN(dt.getDay()));
+}
+
+var setMethods = [
+    Date.prototype.setHours,
+    Date.prototype.setMilliseconds,
+    Date.prototype.setMinutes,
+    Date.prototype.setSeconds,
+    Date.prototype.setUTCHours,
+    Date.prototype.setUTCMilliseconds,
+    Date.prototype.setUTCMinutes,
+    Date.prototype.setUTCSeconds,
+];
+
+for (var setMethod of setMethods) {
+    test(setMethod);
+}

--- a/JSTests/stress/date-prototype-set-methods-toNumber.js
+++ b/JSTests/stress/date-prototype-set-methods-toNumber.js
@@ -1,0 +1,35 @@
+function sameValue(a, b) {
+    if (a !== b && !(Number.isNaN(a) && Number.isNaN(b)))
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function test(setMethod) {
+    var dt = new Date(NaN);
+    var valueOfCalled = 0;
+    var value = {
+      valueOf() {
+        valueOfCalled++;
+        dt.setTime(0);
+        return 1;
+      }
+    };
+    var result = setMethod.call(dt, value);
+    sameValue(valueOfCalled, 1);
+    sameValue(result, NaN);
+    sameValue(dt.getTime(), 0);
+}
+
+var setMethods = [
+    Date.prototype.setHours,
+    Date.prototype.setMilliseconds,
+    Date.prototype.setMinutes,
+    Date.prototype.setSeconds,
+    Date.prototype.setUTCHours,
+    Date.prototype.setUTCMilliseconds,
+    Date.prototype.setUTCMinutes,
+    Date.prototype.setUTCSeconds,
+];
+
+for (var setMethod of setMethods) {
+    test(setMethod);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1,30 +1,6 @@
 ---
 test/annexB/language/function-code/block-decl-func-skip-arguments.js:
   default: 'Test262Error: Expected SameValue(«"function arguments() {}"», «"[object Arguments]"») to be true'
-test/built-ins/Date/prototype/setHours/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-test/built-ins/Date/prototype/setMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-test/built-ins/Date/prototype/setMinutes/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-test/built-ins/Date/prototype/setSeconds/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-test/built-ins/Date/prototype/setUTCHours/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-test/built-ins/Date/prototype/setUTCMilliseconds/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-test/built-ins/Date/prototype/setUTCMinutes/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-test/built-ins/Date/prototype/setUTCSeconds/date-value-read-before-tonumber-when-date-is-invalid.js:
-  default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
-  strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
 test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'

--- a/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -687,12 +687,17 @@ static EncodedJSValue setNewValueFromTimeArgs(JSGlobalObject* globalObject, Call
     if (UNLIKELY(!thisDateObj))
         return throwVMTypeError(globalObject, scope);
 
-    double milli = thisDateObj->internalNumber();
+    if (!callFrame->argumentCount()) {
+        thisDateObj->setInternalNumber(PNaN);
+        return JSValue::encode(jsNaN());
+    }
 
-    if (!callFrame->argumentCount() || std::isnan(milli)) {
+    double milli = thisDateObj->internalNumber();
+    if (std::isnan(milli)) {
         applyToNumberToOtherwiseIgnoredArguments(globalObject, callFrame, numArgsToUse);
         RETURN_IF_EXCEPTION(scope, { });
-        thisDateObj->setInternalNumber(PNaN);
+        if (std::isnan(thisDateObj->internalNumber()))
+            thisDateObj->setInternalNumber(PNaN);
         return JSValue::encode(jsNaN());
     }
      


### PR DESCRIPTION
#### 998eb1b4b14e4d3b113b5bf80a2a5e58ae98f300
<pre>
[JSC] `Date.prototype.set*` methods should check if `internalNumber` is NaN, before set PNaN
<a href="https://bugs.webkit.org/show_bug.cgi?id=286973">https://bugs.webkit.org/show_bug.cgi?id=286973</a>

Reviewed by Yusuke Suzuki.

Currently, in JSC the Date#setHours, Date#setMinutes, and similar methods check if
the internalNumber is NaN and then call applyToNumberToOtherwiseIgnoredArguments
before explicitly setting internalNumber to PNaN.

However, since applyToNumberToOtherwiseIgnoredArguments can update internalNumber (e.g. when
valueOf or Symbol.toPrimitive are overridden), we must recheck that internalNumber
is still NaN immediately before assigning PNaN.

This change aligns our behavior with the expectations added in test262 (see tc39/test262#4258).

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/DatePrototype.cpp:
(JSC::setNewValueFromTimeArgs):

Canonical link: <a href="https://commits.webkit.org/290201@main">https://commits.webkit.org/290201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75dbe5c26f97550303cc5336b1d2b524430aa485

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39886 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68673 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26345 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35263 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38993 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81924 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95938 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87901 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16305 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77550 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76841 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9404 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21630 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110394 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16060 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26501 "Found 11 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-small.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/regress/llint-callee-saves-without-fast-memory.js.wasm-eager, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.wasm-slow-memory ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->