### PR TITLE
Use Style::BuilderConverter::requiredDowncast<> when resolving font properties

### DIFF
--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1712,32 +1712,32 @@ inline FilterOperations BuilderConverter::convertAppleColorFilterOperations(Buil
 // The input value needs to parsed and valid, this function returns std::nullopt if the input was "normal".
 inline std::optional<FontSelectionValue> BuilderConverter::convertFontStyleFromValue(BuilderState& builderState, const CSSValue& value)
 {
-    return Style::fontStyleFromCSSValue(value, builderState.cssToLengthConversionData());
+    return Style::fontStyleFromCSSValue(builderState, value);
 }
 
 inline FontSelectionValue BuilderConverter::convertFontWeight(BuilderState& builderState, const CSSValue& value)
 {
-    return Style::fontWeightFromCSSValue(value, builderState.cssToLengthConversionData());
+    return Style::fontWeightFromCSSValue(builderState, value);
 }
 
 inline FontSelectionValue BuilderConverter::convertFontWidth(BuilderState& builderState, const CSSValue& value)
 {
-    return Style::fontStretchFromCSSValue(value, builderState.cssToLengthConversionData());
+    return Style::fontStretchFromCSSValue(builderState, value);
 }
 
 inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderState& builderState, const CSSValue& value)
 {
-    return Style::fontFeatureSettingsFromCSSValue(value, builderState.cssToLengthConversionData());
+    return Style::fontFeatureSettingsFromCSSValue(builderState, value);
 }
 
 inline FontVariationSettings BuilderConverter::convertFontVariationSettings(BuilderState& builderState, const CSSValue& value)
 {
-    return Style::fontVariationSettingsFromCSSValue(value, builderState.cssToLengthConversionData());
+    return Style::fontVariationSettingsFromCSSValue(builderState, value);
 }
 
 inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& builderState, const CSSValue& value)
 {
-    return Style::fontSizeAdjustFromCSSValue(value, builderState.cssToLengthConversionData());
+    return Style::fontSizeAdjustFromCSSValue(builderState, value);
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/style/StyleResolveForFont.h
+++ b/Source/WebCore/style/StyleResolveForFont.h
@@ -53,24 +53,26 @@ struct UnresolvedFont;
 
 namespace Style {
 
+class BuilderState;
+
 FontSelectionValue fontWeightFromCSSValueDeprecated(const CSSValue&);
-FontSelectionValue fontWeightFromCSSValue(const CSSValue&, const CSSToLengthConversionData&);
+FontSelectionValue fontWeightFromCSSValue(BuilderState&, const CSSValue&);
 
 FontSelectionValue fontStretchFromCSSValueDeprecated(const CSSValue&);
-FontSelectionValue fontStretchFromCSSValue(const CSSValue&, const CSSToLengthConversionData&);
+FontSelectionValue fontStretchFromCSSValue(BuilderState&, const CSSValue&);
 
 FontSelectionValue fontStyleAngleFromCSSValueDeprecated(const CSSValue&);
-FontSelectionValue fontStyleAngleFromCSSValue(const CSSValue&, const CSSToLengthConversionData&);
+FontSelectionValue fontStyleAngleFromCSSValue(BuilderState&, const CSSValue&);
 
 std::optional<FontSelectionValue> fontStyleAngleFromCSSFontStyleWithAngleValueDeprecated(const CSSFontStyleWithAngleValue&);
-std::optional<FontSelectionValue> fontStyleAngleFromCSSFontStyleWithAngleValue(const CSSFontStyleWithAngleValue&, const CSSToLengthConversionData&);
+std::optional<FontSelectionValue> fontStyleAngleFromCSSFontStyleWithAngleValue(BuilderState&, const CSSFontStyleWithAngleValue&);
 
 std::optional<FontSelectionValue> fontStyleFromCSSValueDeprecated(const CSSValue&);
-std::optional<FontSelectionValue> fontStyleFromCSSValue(const CSSValue&, const CSSToLengthConversionData&);
+std::optional<FontSelectionValue> fontStyleFromCSSValue(BuilderState&, const CSSValue&);
 
-FontFeatureSettings fontFeatureSettingsFromCSSValue(const CSSValue&, const CSSToLengthConversionData&);
-FontVariationSettings fontVariationSettingsFromCSSValue(const CSSValue&, const CSSToLengthConversionData&);
-FontSizeAdjust fontSizeAdjustFromCSSValue(const CSSValue&, const CSSToLengthConversionData&);
+FontFeatureSettings fontFeatureSettingsFromCSSValue(BuilderState&, const CSSValue&);
+FontVariationSettings fontVariationSettingsFromCSSValue(BuilderState&, const CSSValue&);
+FontSizeAdjust fontSizeAdjustFromCSSValue(BuilderState&, const CSSValue&);
 
 std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpers::UnresolvedFont&, FontCascadeDescription&&, ScriptExecutionContext&);
 


### PR DESCRIPTION
#### 65de3d622850de8dddea105e1531f9ba46d7aa98
<pre>
Use Style::BuilderConverter::requiredDowncast&lt;&gt; when resolving font properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=286976">https://bugs.webkit.org/show_bug.cgi?id=286976</a>
<a href="https://rdar.apple.com/144127492">rdar://144127492</a>

Reviewed by Alan Baradlay.

Remove more unhandled downcast&lt;&gt;s.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFontStyleFromValue):
(WebCore::Style::BuilderConverter::convertFontWeight):
(WebCore::Style::BuilderConverter::convertFontWidth):
(WebCore::Style::BuilderConverter::convertFontFeatureSettings):
(WebCore::Style::BuilderConverter::convertFontVariationSettings):
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):

Pass in BuilderState.

* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontWeightFromCSSValue):
(WebCore::Style::fontStretchFromCSSValue):
(WebCore::Style::fontStyleAngleFromCSSValue):
(WebCore::Style::fontStyleAngleFromCSSFontStyleWithAngleValue):
(WebCore::Style::fontStyleFromCSSValue):
(WebCore::Style::fontFeatureSettingsFromCSSValue):
(WebCore::Style::fontVariationSettingsFromCSSValue):
(WebCore::Style::fontSizeAdjustFromCSSValue):

Use requiredDowncast&lt;&gt; functions.

* Source/WebCore/style/StyleResolveForFont.h:

Canonical link: <a href="https://commits.webkit.org/289764@main">https://commits.webkit.org/289764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fad1cad99a50e7f6c4dc9fac89a87159d7b541f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15643 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25632 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37808 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94716 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15119 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76743 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75981 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20368 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8123 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15137 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18324 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->