### PR TITLE
AX: [Text Marker] TextUnit::Line on webkit.org not including link in the same line

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/line-requests-starting-after-first-line-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/line-requests-starting-after-first-line-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that requesting the current line range for a line that is not the first line works as expected.
+
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'Hello world.'
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'Here is a link'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world. Here is a link

--- a/LayoutTests/accessibility/ax-thread-text-apis/line-requests-starting-after-first-line.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/line-requests-starting-after-first-line.html
@@ -1,0 +1,43 @@
+
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="paragraph" style="width: 100px;">Hello world.
+Here is a <a href="#">link</a></p>
+
+<script>
+if (window.accessibilityController) {
+    var output = "This test verifies that requesting the current line range for a line that is not the first line works as expected.\n\n";
+
+    var paragraph = accessibilityController.accessibleElementById("paragraph");
+    var textMarkerRange = paragraph.textMarkerRangeForElement(paragraph)
+    var currentMarker = paragraph.startTextMarkerForTextMarkerRange(textMarkerRange);
+
+    currentMarker = advanceTextMarker(currentMarker, 1, paragraph);
+    var lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'Hello world.'");
+
+    currentMarker = advanceTextMarker(currentMarker, 13, paragraph);
+    lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'Here is a link'");
+
+    debug(output);
+}
+    
+function advanceTextMarker(currentMarker, offset, obj) {
+    var previousMarker = currentMarker;
+    for (var i = 0; i < offset; i++) {
+        previousMarker = currentMarker;
+        currentMarker = obj.nextTextMarker(previousMarker);
+    }
+    return currentMarker;
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -805,14 +805,16 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
     // We found the start run and associated line, now iterate until we find a line boundary.
     while (currentObject) {
         RELEASE_ASSERT(currentRuns->size());
-        unsigned cumulativeOffset = 0;
-        for (size_t i = 0; i < currentRuns->size(); i++) {
+        unsigned cumulativeOffset = runIndex ? currentRuns->runLengthSumTo(runIndex - 1) : 0;
+        for (size_t i = runIndex; i < currentRuns->size(); i++) {
             cumulativeOffset += currentRuns->runLength(i);
             if (currentRuns->lineID(i) != startLineID)
                 return linePosition;
             linePosition = AXTextMarker(*currentObject, computeOffset(cumulativeOffset, currentRuns->runLength(i)), origin);
         }
         currentObject = findObjectWithRuns(*currentObject, direction, stopAtID);
+        // Reset the runIndex to 0, since we should start iterating from the beginning of the next object's runs.
+        runIndex = 0;
         if (currentObject) {
             if (includeTrailingLineBreak == IncludeTrailingLineBreak::No && currentObject->roleValue() == AccessibilityRole::LineBreak)
                 break;


### PR DESCRIPTION
#### 4cbd5593231d3035447417c47e04f55c682179cf
<pre>
AX: [Text Marker] TextUnit::Line on webkit.org not including link in the same line
<a href="https://bugs.webkit.org/show_bug.cgi?id=286975">https://bugs.webkit.org/show_bug.cgi?id=286975</a>
<a href="https://rdar.apple.com/143915609">rdar://143915609</a>

Reviewed by Tyler Wilcock.

In the findLine method, we would always start iterating through the runs at index 0, regardless
of where the current text marker is in the runs. This means that if we have a text marker pointing
to the middle of the 2nd line, for example, we&apos;d return all of the text leading up to it but
`currentRuns-&gt;lineID(i) != startLineID` would fail before that line was included, since the
startLineID would be *after* the first linePosition.

To fix this, we can start iterating through the runs from the current runIndex, and reset the
runIndex for subsequent new objects. This means that the line boundary will be found once we are
no longer on that current line, as expected.

* LayoutTests/accessibility/ax-thread-text-apis/line-requests-starting-after-first-line-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/line-requests-starting-after-first-line.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::findLine const):

Canonical link: <a href="https://commits.webkit.org/289892@main">https://commits.webkit.org/289892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8190010bbcbd5b1050fbcd8976b54481fe0bbc2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68113 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79858 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48479 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6040 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34272 "Found 1 new test failure: editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95091 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76978 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75711 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76223 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19032 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8503 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15482 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20785 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->