### PR TITLE
Unreviewed, reverting 289639@main (fc53eacf6a68)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt
@@ -1,6 +1,5 @@
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for img-tag to cross-http origin and no-redirect redirection from https context.
-FAIL Mixed-Content: Expects blocked for img-tag to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Mixed-Content: Expects blocked for img-tag to same-http origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt
@@ -1,13 +1,10 @@
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=keep-scheme&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=swap-scheme&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-PASS Mixed-Content: Expects allowed for img-tag to same-http origin and keep-scheme redirection from https context.
-PASS Mixed-Content: Expects allowed for img-tag to same-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects allowed for img-tag to same-http origin and swap-scheme redirection from https context.
+FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt
@@ -1,11 +1,9 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt
@@ -1,11 +1,9 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt
@@ -1,11 +1,9 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
-Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
-FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
 

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -175,7 +175,7 @@ static bool destinationIsImageAndInitiatorIsImageset(FetchOptions::Destination d
     return destination == FetchOptions::Destination::Image && initiator == Initiator::Imageset;
 }
 
-bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Destination destination, Initiator initiator)
+bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Mode mode, FetchOptions::Destination destination, Initiator initiator)
 {
     RefPtr document = frame.document();
     if (!document || !isUpgradeMixedContentEnabled(*document) || isUpgradable != IsUpgradable::Yes)
@@ -194,6 +194,9 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
 
     // 4.1 The request's URL is not upgraded in the following cases.
     if (!canModifyRequest(url, destination, initiator, shouldUpgradeIPAddressAndLocalhostForTesting))
+        return false;
+    // or CORS is excluded
+    if (mode == FetchOptions::Mode::Cors && !(document->quirks().needsRelaxedCorsMixedContentCheckQuirk() && destinationIsImageAudioOrVideo(destination)))
         return false;
 
     logConsoleWarningForUpgrade(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -51,7 +51,7 @@ enum class ShouldLogWarning { No, Yes };
 enum class IsUpgradable : bool { No, Yes, };
 
 bool frameAndAncestorsCanRunInsecureContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
-bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Destination, Initiator);
+bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Mode, FetchOptions::Destination, Initiator);
 bool shouldBlockRequestForDisplayableContent(LocalFrame&, const URL&, ContentType, IsUpgradable = IsUpgradable::No);
 bool shouldBlockRequestForRunnableContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
 void checkFormForMixedContent(LocalFrame&, const URL&);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -263,7 +263,7 @@ ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::request
         if (frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None) {
             bool isRequestUpgradable { false };
             if (RefPtr document = frame->document()) {
-                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().destination, request.options().initiator);
+                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().mode, request.options().destination, request.options().initiator);
                 request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
             }
             URL requestURL = request.resourceRequest().url();
@@ -817,7 +817,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         return true;
 
     if (RefPtr document = m_documentLoader->cachedResourceLoader().document()) {
-        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(*document->frame(), isUpgradableTypeFromResourceType(type), request.url(), options.destination, options.initiator) : false;
+        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(*document->frame(), isUpgradableTypeFromResourceType(type), request.url(), options.mode, options.destination, options.initiator) : false;
         upgradeInsecureResourceRequestIfNeeded(request, *document, alwaysUpgradeMixedContent ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
     }
 
@@ -1122,7 +1122,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
 
     bool isRequestUpgradable { false };
     if (RefPtr document = this->document()) {
-        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator);
+        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().mode, request.options().destination, request.options().initiator);
         request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
         url = request.resourceRequest().url();
     }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1516,6 +1516,13 @@ bool Quirks::needsGetElementsByNameQuirk() const
 #endif
 }
 
+// tripadvisor.com: rdar://112851939
+// FIXME: Remove this quirk when <rdar://127247321> is complete
+bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
+{
+    return needsQuirks() && m_quirksData.needsRelaxedCorsMixedContentCheckQuirk;
+}
+
 // rdar://127398734
 bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 {
@@ -2493,6 +2500,17 @@ static void handleSpotifyQuirks(QuirksData& quirksData, const URL& quirksURL, co
 #endif
 }
 
+static void handleTripAdvisorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    if (quirksDomainString != "tripadvisor.com"_s)
+        return;
+
+    UNUSED_PARAM(quirksURL);
+    UNUSED_PARAM(documentURL);
+    // tripadvisor.com: rdar://112851939
+    quirksData.needsRelaxedCorsMixedContentCheckQuirk = true;
+}
+
 static void handleVictoriasSecretQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
 {
     if (quirksDomainString != "victoriassecret.com"_s)
@@ -2780,6 +2798,7 @@ void Quirks::determineRelevantQuirks()
 #if PLATFORM(IOS_FAMILY)
         { "thesaurus"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
 #endif
+        { "tripadvisor"_s, &handleTripAdvisorQuirks },
 #if PLATFORM(MAC)
         { "trix-editor"_s, &handleTrixEditorQuirks },
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -215,6 +215,7 @@ public:
     WEBCORE_EXPORT bool shouldUseEphemeralPartitionedStorageForDOMCookies(const URL&) const;
 
     bool needsGetElementsByNameQuirk() const;
+    bool needsRelaxedCorsMixedContentCheckQuirk() const;
     bool needsLaxSameSiteCookieQuirk(const URL&) const;
 
     String scriptToEvaluateBeforeRunningScriptFromURL(const URL&);

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -53,6 +53,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsCanPlayAfterSeekedQuirk { false };
     bool needsChromeMediaControlsPseudoElementQuirk { false };
     bool needsMozillaFileTypeForDataTransferQuirk { false };
+    bool needsRelaxedCorsMixedContentCheckQuirk { false };
     bool needsResettingTransitionCancelsRunningTransitionQuirk { false };
     bool needsScrollbarWidthThinDisabledQuirk { false };
     bool needsSeekingSupportDisabledQuirk { false };


### PR DESCRIPTION
#### 5ecd4eb777462428c51acf1c7c2fd18b93272d98
<pre>
Unreviewed, reverting 289639@main (fc53eacf6a68)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286955">https://bugs.webkit.org/show_bug.cgi?id=286955</a>
<a href="https://rdar.apple.com/144111906">rdar://144111906</a>

REGRESSION(289639@main): [ macOS iOS ] imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub.html is a flaky failure (failure EWS)

Reverted change:

    Remove CORS restriction on mixed content upgrades
    <a href="https://bugs.webkit.org/show_bug.cgi?id=286624">https://bugs.webkit.org/show_bug.cgi?id=286624</a>
    <a href="https://rdar.apple.com/124531208">rdar://124531208</a>
    289639@main (fc53eacf6a68)

Canonical link: <a href="https://commits.webkit.org/289760@main">https://commits.webkit.org/289760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/601fb28dd5dc3edb7f0bd8dfd3ca69ac7af136c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87952 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/7468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42344 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90003 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/7849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15644 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/92852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90954 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/7849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/79571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/92852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/7849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/37809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/7849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/34859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/94717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/15120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/94717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/15375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/75427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/94717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13712 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/15138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/14880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/18325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->