### PR TITLE
[WebAuthn] Compute autofill username if single field with webauthn

### DIFF
--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -107,7 +107,7 @@ std::optional<AutofillElements> AutofillElements::computeAutofillElements(Ref<HT
 
     // Handle the case where a username field appears separately from a password field.
     auto autofillData = start->autofillData();
-    if (toAutofillFieldName(autofillData.fieldName) == AutofillFieldName::Username)
+    if (toAutofillFieldName(autofillData.fieldName) == AutofillFieldName::Username || toAutofillFieldName(autofillData.fieldName) == AutofillFieldName::WebAuthn)
         return {{ WTFMove(start), nullptr, nullptr }};
 
     return std::nullopt;

--- a/Tools/TestWebKitAPI/Tests/ios/WKWebViewAutofillTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKWebViewAutofillTests.mm
@@ -194,6 +194,22 @@ TEST(WKWebViewAutoFillTests, StandaloneUsernameField)
     EXPECT_FALSE([webView acceptsAutoFillLoginCredentials]);
 }
 
+TEST(WKWebViewAutoFillTests, StandaloneUsernameWebauthnField)
+{
+    auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView synchronouslyLoadHTMLString:@"<input id='username' autocomplete='username webauthn'>"];
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"username.focus()"];
+    EXPECT_TRUE([webView acceptsAutoFillLoginCredentials]);
+
+    auto credentialSuggestion = [UITextAutofillSuggestion autofillSuggestionWithUsername:@"frederik" password:@"famos"];
+    [[webView _autofillInputView] insertTextSuggestion:credentialSuggestion];
+
+    EXPECT_WK_STREQ("frederik", [webView stringByEvaluatingJavaScript:@"username.value"]);
+
+    [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.activeElement.blur()"];
+    EXPECT_FALSE([webView acceptsAutoFillLoginCredentials]);
+}
+
 TEST(WKWebViewAutoFillTests, StandaloneTextField)
 {
     auto webView = adoptNS([[AutoFillTestView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);


### PR DESCRIPTION
#### 6943cb7a4456b0d5493fc7045ad068b81fe2a5f2
<pre>
[WebAuthn] Compute autofill username if single field with webauthn
<a href="https://bugs.webkit.org/show_bug.cgi?id=286978">https://bugs.webkit.org/show_bug.cgi?id=286978</a>
<a href="https://rdar.apple.com/144123374">rdar://144123374</a>

Reviewed by Charlie Wolfe.

Autofill has a heuristic for saying that a single text field with
an autofill fieldName=username is the username field where it should
perform the autofill. However, whenever you perform the steps for processing
the webauthn token, the field value will be webauthn.

This patch updates the special case such that a single text field with the
parsed webauthn field name is recongized as a single username field as well.

Added API test.

* Source/WebCore/editing/cocoa/AutofillElements.cpp:
(WebCore::AutofillElements::computeAutofillElements):

Canonical link: <a href="https://commits.webkit.org/289798@main">https://commits.webkit.org/289798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e17f76952f7f6a0189ba9879e2eabbd0bcf9046

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67902 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25640 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5798 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33992 "Found 1 new test failure: accessibility/negative-tabindex-does-not-expose-label.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94731 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15134 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11129 "Found 1 new test failure: ipc/decode-object-array-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76754 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75992 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20384 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18799 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8138 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20453 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->