### PR TITLE
Deploy more smart pointers in RemoteLayerTreeHost

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -3,7 +3,6 @@ UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKProcessPool.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
-UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/WebPageProxy.cpp
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -238,7 +238,6 @@ UIProcess/ProcessAssertion.cpp
 UIProcess/ProcessThrottler.cpp
 UIProcess/ProvisionalFrameProxy.cpp
 UIProcess/ProvisionalPageProxy.cpp
-UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
 UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -46,7 +46,6 @@ UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
 UIProcess/Notifications/WebNotificationManagerProxy.cpp
 UIProcess/ProcessThrottler.cpp
 UIProcess/ProvisionalPageProxy.cpp
-UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
 UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -108,6 +108,8 @@ public:
     void remotePageProcessDidTerminate(WebCore::ProcessIdentifier);
 
 private:
+    Ref<RemoteLayerTreeDrawingAreaProxy> protectedDrawingArea() const;
+
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     RefPtr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -83,6 +83,11 @@ RemoteLayerTreeDrawingAreaProxy& RemoteLayerTreeHost::drawingArea() const
     return *m_drawingArea;
 }
 
+Ref<RemoteLayerTreeDrawingAreaProxy> RemoteLayerTreeHost::protectedDrawingArea() const
+{
+    return drawingArea();
+}
+
 LayerContentsType RemoteLayerTreeHost::layerContentsType() const
 {
     // If a surface will be referenced by multiple layers (as in the tile debug indicator), CAMachPort cannot be used.
@@ -90,7 +95,8 @@ LayerContentsType RemoteLayerTreeHost::layerContentsType() const
         return LayerContentsType::IOSurface;
 
     // If e.g. SceneKit will be doing an in-process snapshot of the layer tree, CAMachPort cannot be used: rdar://problem/47481972
-    if (m_drawingArea->page() && m_drawingArea->page()->windowKind() == WindowKind::InProcessSnapshotting)
+    RefPtr page = m_drawingArea->page();
+    if (page && page->windowKind() == WindowKind::InProcessSnapshotting)
         return LayerContentsType::IOSurface;
 
     if (PAL::canLoad_QuartzCore_CAIOSurfaceCreate())
@@ -105,7 +111,8 @@ LayerContentsType RemoteLayerTreeHost::layerContentsType() const
 bool RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStore() const
 {
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    return m_drawingArea->page() && m_drawingArea->page()->preferences().replayCGDisplayListsIntoBackingStore();
+    RefPtr page = m_drawingArea->page();
+    return page && page->protectedPreferences()->replayCGDisplayListsIntoBackingStore();
 #else
     return false;
 #endif
@@ -113,12 +120,14 @@ bool RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStor
 
 bool RemoteLayerTreeHost::threadedAnimationResolutionEnabled() const
 {
-    return m_drawingArea->page() && m_drawingArea->page()->preferences().threadedAnimationResolutionEnabled();
+    RefPtr page = m_drawingArea->page();
+    return page && page->protectedPreferences()->threadedAnimationResolutionEnabled();
 }
 
 bool RemoteLayerTreeHost::cssUnprefixedBackdropFilterEnabled() const
 {
-    return m_drawingArea->page() && m_drawingArea->page()->preferences().cssUnprefixedBackdropFilterEnabled();
+    RefPtr page = m_drawingArea->page();
+    return page && page->protectedPreferences()->cssUnprefixedBackdropFilterEnabled();
 }
 
 #if PLATFORM(MAC)
@@ -154,7 +163,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     if (!m_drawingArea)
         return false;
 
-    auto* sender = AuxiliaryProcessProxy::fromConnection(connection);
+    RefPtr sender = AuxiliaryProcessProxy::fromConnection(connection);
     if (!sender) {
         ASSERT_NOT_REACHED();
         return false;
@@ -165,12 +174,12 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
         createLayer(createdLayer);
 
     bool rootLayerChanged = false;
-    auto* rootNode = nodeForID(transaction.rootLayerID());
+    RefPtr rootNode = nodeForID(transaction.rootLayerID());
     
     if (!rootNode)
         REMOTE_LAYER_TREE_HOST_RELEASE_LOG("%p RemoteLayerTreeHost::updateLayerTree - failed to find root layer with ID %llu", this, transaction.rootLayerID() ? transaction.rootLayerID()->object().toUInt64() : 0);
 
-    if (m_rootNode != rootNode && transaction.isMainFrameProcessTransaction()) {
+    if (m_rootNode.get() != rootNode.get() && transaction.isMainFrameProcessTransaction()) {
         m_rootNode = rootNode;
         rootLayerChanged = true;
     }
@@ -185,7 +194,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     for (auto& [layerID, propertiesPointer] : transaction.changedLayerProperties()) {
         const auto& properties = *propertiesPointer;
 
-        auto* node = nodeForID(layerID);
+        RefPtr node = nodeForID(layerID);
         ASSERT(node);
 
         if (!node) {
@@ -203,7 +212,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
             return HashSet<WebCore::PlatformLayerIdentifier>();
         }).iterator->value.add(rootNode->layerID());
         rootNode->setRemoteContextHostedIdentifier(*contextHostedID);
-        if (auto* remoteRootNode = nodeForID(m_hostingLayers.getOptional(*contextHostedID)))
+        if (RefPtr remoteRootNode = nodeForID(m_hostingLayers.getOptional(*contextHostedID)))
             rootNode->addToHostingNode(*remoteRootNode);
     }
 
@@ -241,7 +250,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     // Drop the contents of any layers which were unparented; the Web process will re-send
     // the backing store in the commit that reparents them.
     for (auto& newlyUnreachableLayerID : transaction.layerIDsWithNewlyUnreachableBackingStore()) {
-        auto* node = nodeForID(newlyUnreachableLayerID);
+        RefPtr node = nodeForID(newlyUnreachableLayerID);
         ASSERT(node);
         if (node) {
             node->layer().contents = nullptr;
@@ -259,7 +268,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
 
 void RemoteLayerTreeHost::asyncSetLayerContents(PlatformLayerIdentifier layerID, ImageBufferBackendHandle&& handle, const WebCore::RenderingResourceIdentifier& identifier)
 {
-    auto* node = nodeForID(layerID);
+    RefPtr node = nodeForID(layerID);
     if (!node)
         return;
 
@@ -303,7 +312,8 @@ void RemoteLayerTreeHost::layerWillBeRemoved(WebCore::ProcessIdentifier processI
 #if HAVE(AVKIT)
     auto videoLayerIter = m_videoLayers.find(layerID);
     if (videoLayerIter != m_videoLayers.end()) {
-        if (auto videoManager = m_drawingArea->page() ? m_drawingArea->page()->videoPresentationManager() : nullptr)
+        RefPtr page = m_drawingArea->page();
+        if (auto videoManager = page ? page->videoPresentationManager() : nullptr)
             videoManager->willRemoveLayerForID(videoLayerIter->value);
         m_videoLayers.remove(videoLayerIter);
     }
@@ -311,7 +321,8 @@ void RemoteLayerTreeHost::layerWillBeRemoved(WebCore::ProcessIdentifier processI
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
     if (m_modelLayers.contains(layerID)) {
-        if (auto modelPresentationManager = m_drawingArea->page() ? m_drawingArea->page()->modelPresentationManagerProxy() : nullptr)
+        RefPtr page = m_drawingArea->page();
+        if (auto modelPresentationManager = page ? page->modelPresentationManagerProxy() : nullptr)
             modelPresentationManager->invalidateModel(layerID);
         m_modelLayers.remove(layerID);
     }
@@ -336,7 +347,7 @@ void RemoteLayerTreeHost::animationDidStart(std::optional<WebCore::PlatformLayer
     }
 
     if (!animationKey.isEmpty())
-        m_drawingArea->acceleratedAnimationDidStart(*layerID, animationKey, startTime);
+        protectedDrawingArea()->acceleratedAnimationDidStart(*layerID, animationKey, startTime);
 }
 
 void RemoteLayerTreeHost::animationDidEnd(std::optional<WebCore::PlatformLayerIdentifier> layerID, CAAnimation *animation)
@@ -357,7 +368,7 @@ void RemoteLayerTreeHost::animationDidEnd(std::optional<WebCore::PlatformLayerId
     }
 
     if (!animationKey.isEmpty())
-        m_drawingArea->acceleratedAnimationDidEnd(*layerID, animationKey);
+        protectedDrawingArea()->acceleratedAnimationDidEnd(*layerID, animationKey);
 }
 
 void RemoteLayerTreeHost::detachFromDrawingArea()
@@ -369,7 +380,7 @@ void RemoteLayerTreeHost::clearLayers()
 {
     for (auto& keyAndNode : m_nodes) {
         m_animationDelegates.remove(keyAndNode.key);
-        keyAndNode.value->detachFromParent();
+        Ref { keyAndNode.value }->detachFromParent();
     }
 
     m_nodes.clear();
@@ -383,7 +394,7 @@ CALayer *RemoteLayerTreeHost::layerWithIDForTesting(WebCore::PlatformLayerIdenti
 
 CALayer *RemoteLayerTreeHost::layerForID(std::optional<WebCore::PlatformLayerIdentifier> layerID) const
 {
-    auto* node = nodeForID(layerID);
+    RefPtr node = nodeForID(layerID);
     if (!node)
         return nil;
     return node->layer();
@@ -410,7 +421,7 @@ void RemoteLayerTreeHost::createLayer(const RemoteLayerTreeTransaction::LayerCre
 
     if (auto* hostIdentifier = std::get_if<WebCore::LayerHostingContextIdentifier>(&properties.additionalData)) {
         m_hostingLayers.set(*hostIdentifier, *properties.layerID);
-        if (auto* hostedNode = nodeForID(m_hostedLayers.getOptional(*hostIdentifier)))
+        if (RefPtr hostedNode = nodeForID(m_hostedLayers.getOptional(*hostIdentifier)))
             hostedNode->addToHostingNode(*node);
     }
 
@@ -466,7 +477,8 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
 
 #if HAVE(AVKIT)
         if (properties.videoElementData) {
-            if (auto videoManager = m_drawingArea->page() ? m_drawingArea->page()->videoPresentationManager() : nullptr) {
+            RefPtr page = m_drawingArea->page();
+            if (auto videoManager = page ? page->videoPresentationManager() : nullptr) {
                 m_videoLayers.add(*properties.layerID, properties.videoElementData->playerIdentifier);
                 return makeWithLayer(videoManager->createLayerWithID(properties.videoElementData->playerIdentifier, properties.hostingContextID(), properties.videoElementData->initialSize, properties.videoElementData->naturalSize, properties.hostingDeviceScaleFactor()));
             }
@@ -509,29 +521,29 @@ void RemoteLayerTreeHost::mapAllIOSurfaceBackingStore()
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 void RemoteLayerTreeHost::animationsWereAddedToNode(RemoteLayerTreeNode& node)
 {
-    m_drawingArea->animationsWereAddedToNode(node);
+    protectedDrawingArea()->animationsWereAddedToNode(node);
 }
 
 void RemoteLayerTreeHost::animationsWereRemovedFromNode(RemoteLayerTreeNode& node)
 {
-    m_drawingArea->animationsWereRemovedFromNode(node);
+    protectedDrawingArea()->animationsWereRemovedFromNode(node);
 }
 
 Seconds RemoteLayerTreeHost::acceleratedTimelineTimeOrigin(WebCore::ProcessIdentifier processIdentifier) const
 {
-    return m_drawingArea->acceleratedTimelineTimeOrigin(processIdentifier);
+    return protectedDrawingArea()->acceleratedTimelineTimeOrigin(processIdentifier);
 }
 
 MonotonicTime RemoteLayerTreeHost::animationCurrentTime(WebCore::ProcessIdentifier processIdentifier) const
 {
-    return m_drawingArea->animationCurrentTime(processIdentifier);
+    return protectedDrawingArea()->animationCurrentTime(processIdentifier);
 }
 #endif
 
 void RemoteLayerTreeHost::remotePageProcessDidTerminate(WebCore::ProcessIdentifier processIdentifier)
 {
     for (auto layerID : m_hostedLayersInProcess.take(processIdentifier)) {
-        if (auto* node = nodeForID(layerID))
+        if (RefPtr node = nodeForID(layerID))
             node->removeFromHostingNode();
         layerWillBeRemoved(processIdentifier, layerID);
     }


### PR DESCRIPTION
#### b79266f0799fd65eb17d44d53860ba3bc86086be
<pre>
Deploy more smart pointers in RemoteLayerTreeHost
<a href="https://bugs.webkit.org/show_bug.cgi?id=286979">https://bugs.webkit.org/show_bug.cgi?id=286979</a>

Reviewed by Chris Dumez.

Fixed more static analyzer warnings.

* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::protectedDrawingArea const):
(WebKit::RemoteLayerTreeHost::layerContentsType const):
(WebKit::RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStore const):
(WebKit::RemoteLayerTreeHost::threadedAnimationResolutionEnabled const):
(WebKit::RemoteLayerTreeHost::cssUnprefixedBackdropFilterEnabled const):
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::asyncSetLayerContents):
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
(WebKit::RemoteLayerTreeHost::animationDidStart):
(WebKit::RemoteLayerTreeHost::animationDidEnd):
(WebKit::RemoteLayerTreeHost::clearLayers):
(WebKit::RemoteLayerTreeHost::layerForID const):
(WebKit::RemoteLayerTreeHost::createLayer):
(WebKit::RemoteLayerTreeHost::makeNode):
(WebKit::RemoteLayerTreeHost::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeHost::animationsWereRemovedFromNode):
(WebKit::RemoteLayerTreeHost::acceleratedTimelineTimeOrigin const):
(WebKit::RemoteLayerTreeHost::animationCurrentTime const):
(WebKit::RemoteLayerTreeHost::remotePageProcessDidTerminate):

Canonical link: <a href="https://commits.webkit.org/289773@main">https://commits.webkit.org/289773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07948b943166c57770eab78a074fb123c38bdf5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92858 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38705 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25633 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5788 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37812 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94720 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15123 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76746 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75984 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20375 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18793 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8127 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13720 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15141 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20442 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->