### PR TITLE
Make JSTests/stress/recursive-try-catch.js less flaky.

### DIFF
--- a/JSTests/stress/recursive-try-catch.js
+++ b/JSTests/stress/recursive-try-catch.js
@@ -1,4 +1,4 @@
-//@ defaultNoSamplingProfilerRun
+//@ defaultNoSamplingProfilerRun("--useConcurrentGC=0")
 // This test should run to completion without excessive memory usage
 
 let maxHeapAllowed = 10 * 1024 * 1024; // This test should run using much less than 10MB.
@@ -76,6 +76,7 @@ function test()
         if (error != "RangeError: Maximum call stack size exceeded.")
             throw "Expected: \"RangeError: Maximum call stack size exceeded.\", but got: " + error;
 
+        // The --useConcurrentGC=0 option is required in order to be able to get a predictable heap size here.
         let heapUsed = gcHeapSize();
         if (heapUsed > maxHeapAllowed)
             throw "Used too much heap.  Limit was " + maxHeapAllowed + " bytes, but we used " + heapUsed + " bytes.";

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1655,8 +1655,8 @@ def defaultNoEagerRun(*optionalTestSpecificOptions)
     defaultRunCfg({}, { :skipEager => true }, *optionalTestSpecificOptions)
 end
 
-def defaultNoSamplingProfilerRun
-    defaultRunCfg({}, { :ignoreQuickMode => true })
+def defaultNoSamplingProfilerRun(*optionalTestSpecificOptions)
+    defaultRunCfg({}, { :ignoreQuickMode => true }, *optionalTestSpecificOptions)
 end
 
 def runProfiler
@@ -2349,12 +2349,12 @@ def runNoisyTestWithEnv(kind, *additionalEnv)
     runDefaultCfg(cfg)
 end
 
-def defaultRunNoisyTest
+def defaultRunNoisyTest(*optionalTestSpecificOptions)
     cfg = {
         :outputHandler => noisyOutputHandler,
         :errorHandler => noisyErrorHandler,
     }
-    defaultRunCfg(cfg, {})
+    defaultRunCfg(cfg, {}, *optionalTestSpecificOptions)
 end
 
 def skip


### PR DESCRIPTION
#### 3d0bb4e7b1587150be98a125432e030a51c57a62
<pre>
Make JSTests/stress/recursive-try-catch.js less flaky.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286985">https://bugs.webkit.org/show_bug.cgi?id=286985</a>
<a href="https://rdar.apple.com/144136789">rdar://144136789</a>

Reviewed by Yusuke Suzuki.

The JSTests/stress/recursive-try-catch.js test checks that heap usage does not exceed
an expected max heap.  However, GC concurrency means that this requirement cannot be
guaranteed.  This test was also introduced many years ago before concurrent GC became
available.  As a result, depending on GC thread scheduling, there&apos;s a chance that the
test may fail this check.  The only way to ensure that this test passes reliably is
to require that the test is run with --useConcurrentGC=0.

Also changed defaultNoSamplingProfilerRun and defaultRunNoisyTest to be able to take
optional test specific options.  We&apos;ll be passing the --useConcurrentGC=0 option to
defaultNoSamplingProfilerRun in the recursive-try-catch.js test.

* JSTests/stress/recursive-try-catch.js:
(test):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/289767@main">https://commits.webkit.org/289767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dd47717911307850bd368afc3c1fc5dd7b44de4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90973 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48275 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/33999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37828 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/80769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94737 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86746 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15139 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75997 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20389 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8143 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13717 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15157 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109240 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14899 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26269 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18344 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->