### PR TITLE
Avoid starting resource load for closed web pages

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -550,6 +550,11 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 
     CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID ? loadParameters.webPageProxyID->toUInt64() : 0, loadParameters.webPageID ? loadParameters.webPageID->toUInt64() : 0, loadParameters.webFrameID ? loadParameters.webFrameID->object().toUInt64() : 0, loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, existingLoaderToResume ? existingLoaderToResume->toUInt64() : 0);
 
+    if (auto pageID = loadParameters.webPageProxyID) {
+        if (!protectedNetworkProcess()->resourceLoadEnabledForWebPage(*pageID))
+            return;
+    }
+
     if (auto* session = networkSession()) {
         if (Ref server = session->ensureSWServer(); !server->isImportCompleted()) {
             server->whenImportIsCompleted([this, protectedThis = Ref { *this }, loadParameters = WTFMove(loadParameters), existingLoaderToResume]() mutable {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -344,6 +344,8 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 
     updateStorageAccessPromptQuirks(WTFMove(parameters.storageAccessPromptQuirksData));
 
+    m_resourceLoadWebPages = WTFMove(parameters.resourceLoadWebPages);
+
     RELEASE_LOG(Process, "%p - NetworkProcess::initializeNetworkProcess: Presenting processPID=%d", this, legacyPresentingApplicationPID());
 }
 
@@ -3044,6 +3046,14 @@ void NetworkProcess::removeWebPageNetworkParameters(PAL::SessionID sessionID, We
         resourceLoadStatistics->clearFrameLoadRecordsForStorageAccess(pageID);
 
     m_pagesWithRelaxedThirdPartyCookieBlocking.remove(pageID);
+}
+
+void NetworkProcess::enableResourceLoadForWebPage(WebPageProxyIdentifier pageID, bool enabled)
+{
+    if (enabled)
+        m_resourceLoadWebPages.add(pageID);
+    else
+        m_resourceLoadWebPages.remove(pageID);
 }
 
 void NetworkProcess::countNonDefaultSessionSets(PAL::SessionID sessionID, CompletionHandler<void(size_t)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -461,6 +461,8 @@ public:
 
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlockingForPage(std::optional<WebPageProxyIdentifier>) const;
 
+    bool resourceLoadEnabledForWebPage(WebPageProxyIdentifier pageID) const { return m_resourceLoadWebPages.contains(pageID); }
+
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 
@@ -528,6 +530,7 @@ private:
 
     void addWebPageNetworkParameters(PAL::SessionID, WebPageProxyIdentifier, WebPageNetworkParameters&&);
     void removeWebPageNetworkParameters(PAL::SessionID, WebPageProxyIdentifier);
+    void enableResourceLoadForWebPage(WebPageProxyIdentifier, bool enabled);
     void countNonDefaultSessionSets(PAL::SessionID, CompletionHandler<void(size_t)>&&);
 
 #if HAVE(NW_PROXY_CONFIG)
@@ -614,6 +617,7 @@ private:
     Seconds m_serviceWorkerFetchTimeout { defaultServiceWorkerFetchTimeout };
 
     HashMap<WebCore::PageIdentifier, Vector<WebCore::UserContentURLPattern>> m_extensionCORSDisablingPatterns;
+    HashSet<WebPageProxyIdentifier> m_resourceLoadWebPages;
     HashSet<RefPtr<NetworkStorageManager>> m_closingStorageManagers;
     HashSet<String> m_localhostAliasesForTesting;
     HashSet<WebPageProxyIdentifier> m_pagesWithRelaxedThirdPartyCookieBlocking;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -228,6 +228,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
     AddWebPageNetworkParameters(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID, WebKit::WebPageNetworkParameters parameters)
     RemoveWebPageNetworkParameters(PAL::SessionID sessionID, WebKit::WebPageProxyIdentifier pageID)
+    EnableResourceLoadForWebPage(WebKit::WebPageProxyIdentifier pageID, bool enabled)
     CountNonDefaultSessionSets(PAL::SessionID sessionID) -> (size_t count)
 
     AllowFileAccessFromWebProcess(WebCore::ProcessIdentifier processIdentifier, String url) -> ()

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -28,6 +28,7 @@
 #include "AuxiliaryProcessCreationParameters.h"
 #include "CacheModel.h"
 #include "SandboxExtension.h"
+#include "WebPageProxyIdentifier.h"
 #include <WebCore/Cookie.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
@@ -82,6 +83,7 @@ struct NetworkProcessCreationParameters {
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashSet<String> localhostAliasesForTesting;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;
+    HashSet<WebPageProxyIdentifier> resourceLoadWebPages;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -61,6 +61,7 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashSet<String> localhostAliasesForTesting;
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;
+    HashSet<WebKit::WebPageProxyIdentifier> resourceLoadWebPages;
 }
 
 enum class WebKit::LoadedWebArchive : bool

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -224,6 +224,11 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
     parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::sharedSingleton().cachedListData();
 #endif
 
+    for (auto& page : WebProcessProxy::globalPages()) {
+        if (!page->isClosed())
+            parameters.resourceLoadWebPages.add(page->identifier());
+    }
+
     WebProcessPool::platformInitializeNetworkProcess(parameters);
     sendWithAsyncReply(Messages::NetworkProcess::InitializeNetworkProcess(WTFMove(parameters)), [weakThis = WeakPtr { *this }, initializationActivityAndGrant = initializationActivityAndGrant()] {
         if (RefPtr protectedThis = weakThis.get())

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1673,6 +1673,7 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
             networkProcess->send(Messages::NetworkProcess::CloneSessionStorageForWebPage(sessionID(), m_pageToCloneSessionStorageFrom->identifier(), identifier()), 0);
         if (m_configuration->shouldRelaxThirdPartyCookieBlocking() == ShouldRelaxThirdPartyCookieBlocking::Yes)
             networkProcess->send(Messages::NetworkProcess::SetShouldRelaxThirdPartyCookieBlockingForPage(identifier()), 0);
+        networkProcess->send(Messages::NetworkProcess::EnableResourceLoadForWebPage(identifier(), true), 0);
     }
     m_pageToCloneSessionStorageFrom = nullptr;
 
@@ -1787,6 +1788,9 @@ void WebPageProxy::close()
         process->send(Messages::WebPage::Close(), destinationID);
     });
     process->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);
+    if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists())
+        networkProcess->send(Messages::NetworkProcess::EnableResourceLoadForWebPage(identifier(), false), 0);
+
     removeAllMessageReceivers();
     processPool->protectedSupplement<WebNotificationManagerProxy>()->clearNotifications(this);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3297,7 +3297,6 @@ private:
     bool hasValidOpeningAppLinkActivity() const;
 #endif
 
-
 #if ENABLE(CONTENT_EXTENSIONS)
     void shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&&) const;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -550,6 +550,8 @@ public:
     void setResourceMonitorRuleLists(RefPtr<WebCompiledContentRuleList>, CompletionHandler<void()>&&);
 #endif
 
+    static Vector<Ref<WebPageProxy>> globalPages();
+
 private:
     Type type() const final { return Type::WebContent; }
 
@@ -583,7 +585,6 @@ private:
     static WebProcessProxyMap& allProcessMap();
     static Vector<Ref<WebProcessProxy>> allProcesses();
     static WebPageProxyMap& globalPageMap();
-    static Vector<Ref<WebPageProxy>> globalPages();
 
     void initializePreferencesForGPUAndNetworkProcesses(const WebPageProxy&);
 


### PR DESCRIPTION
#### 2ca91b7a7e90d13e3aa09da7ab45826f337e86d5
<pre>
Avoid starting resource load for closed web pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=286987">https://bugs.webkit.org/show_bug.cgi?id=286987</a>
<a href="https://rdar.apple.com/144137383">rdar://144137383</a>

Reviewed by NOBODY (OOPS!).

When a web page is closed, network process should not start more loads for it.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
(WebKit::NetworkProcess::enableResourceLoadForWebPage):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ca91b7a7e90d13e3aa09da7ab45826f337e86d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38727 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15669 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67908 "Failure limit exceed. At least found 413 new test failures: http/tests/contentextensions/service-worker-block-everything-if-localhost.html http/tests/contentextensions/service-worker.https.html http/tests/cookies/same-site/fetch-in-same-origin-service-worker.html http/tests/workers/service/ServiceWorkerGlobalScope_getRegistration.html http/tests/workers/service/ServiceWorkerGlobalScope_register.html http/tests/workers/service/basic-fetch.https.html http/tests/workers/service/cors-image-fetch.html http/tests/workers/service/image-fetch.html http/tests/workers/service/registration-updateViaCache-all-importScripts.html http/tests/workers/service/registration-updateViaCache-imports-importScripts.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25655 "Found 60 new test failures: http/tests/inspector/network/resource-response-service-worker.html http/tests/performance/paint-timing/performance-paint-timing-fcp-after-visually-non-empty-for-style.html http/tests/workers/service/ServiceWorkerGlobalScope_getRegistration.html http/tests/workers/service/ServiceWorkerGlobalScope_register.html http/tests/workers/service/basic-fetch.https.html http/tests/workers/service/cors-image-fetch.html http/tests/workers/service/image-fetch.html http/tests/workers/service/registration-updateViaCache-all-importScripts.html http/tests/workers/service/registration-updateViaCache-imports-importScripts.html http/tests/workers/service/registration-updateViaCache-none-importScripts.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90979 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6028 "Found 43 new test failures: http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html http/tests/workers/service/ServiceWorkerGlobalScope_getRegistration.html http/tests/workers/service/ServiceWorkerGlobalScope_register.html http/tests/workers/service/basic-fetch.https.html http/tests/workers/service/cors-image-fetch.html http/tests/workers/service/image-fetch.html http/tests/workers/service/registration-updateViaCache-all-importScripts.html http/tests/workers/service/registration-updateViaCache-imports-importScripts.html http/tests/workers/service/registration-updateViaCache-none-importScripts.html http/tests/workers/service/self_registration_update.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79596 "Found 26 new API test failures: TestWebKitAPI.ServiceWorker.ServiceWorkerProcessSwapWithNoDelay, TestWebKitAPI.WebArchive.CookieAccessAfterLoadRequest, TestWebKitAPI.ServiceWorkers.DifferentSessionsUseDifferentRegistrations, TestWebKitAPI.ServiceWorkers.InterceptFirstLoadAfterRestoreFromDisk, TestWebKitAPI.ServiceWorkers.WaitForPolicyDelegate, TestWebKitAPI.ServiceWorker.ExtensionServiceWorkerDisableCORS, TestWebKitAPI.ServiceWorker.FocusNotYetLoadedClient, TestWebKitAPI.ServiceWorkers.ServerTrust, TestWebKitAPI.ServiceWorkers.ThirdPartyRestoredFromDisk, TestWebKitAPI.SiteIsolation.WindowOpenRedirect ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48277 "Found 1 new API test failure: /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5804 "Found 60 new test failures: imported/w3c/web-platform-tests/IndexedDB/bindings-inject-keys-bypass.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-keys-bypass.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-values-bypass.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-values-bypass.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_advance_index.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_advance_index.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_advance_objectstore.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_advance_objectstore.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_continue_index.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_continue_index.any.sharedworker.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37834 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76203 "Found 29 new API test failures: TestWebKitAPI.WebArchive.CookieAccessAfterLoadRequest, TestWebKitAPI.ServiceWorkers.InterceptFirstLoadAfterRestoreFromDisk, TestWebKitAPI.ServiceWorkers.WaitForPolicyDelegate, TestWebKitAPI.ServiceWorker.ExtensionServiceWorkerDisableCORS, TestWebKitAPI.ServiceWorkers.ThirdPartyRestoredFromDisk, TestWebKitAPI.ServiceWorkers.ServerTrust, TestWebKitAPI.AppPrivacyReport.MultipleWebViewsWithSharedServiceWorker, TestWebKitAPI.SiteIsolation.WindowOpenRedirect, TestWebKitAPI.AppPrivacyReport.AppInitiatedRequestWithServiceWorkerSoftUpdate, TestWebKitAPI.WKNavigation.FrameNavigationWithPrivateTokenPermissionAndAllowOriginsAndWithServiceWorker ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34885 "Found 60 new test failures: css3/color-filters/color-filter-current-color.html fast/css/tagname-case-sensitivity-xml-in-xhtml.xhtml fast/text/emoji-gender-7.html fast/text/emoji-gender-fe0f-3.html fast/writing-mode/margins.html fullscreen/event-listener-prefixed-unprefixed.html http/tests/contentextensions/service-worker-block-everything-if-localhost.html http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html http/tests/cookies/same-site/fetch-in-same-origin-service-worker.html http/tests/inspector/network/fetch-response-body.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94748 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15145 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11137 "Found 60 new test failures: fast/forms/switch/click-animation-twice.html fast/text/glyph-display-lists/glyph-display-list-color.html fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html http/tests/contentextensions/service-worker-block-everything-if-localhost.html http/tests/cookies/same-site/fetch-in-same-origin-service-worker.html http/tests/inspector/network/fetch-response-body.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76763 "Failure limit exceed. At least found 348 new test failures: http/tests/contentextensions/service-worker-block-everything-if-localhost.html http/tests/contentextensions/service-worker.https.html http/tests/cookies/same-site/fetch-in-same-origin-service-worker.html http/tests/inspector/network/resource-response-service-worker.html http/tests/workers/service/ServiceWorkerGlobalScope_getRegistration.html http/tests/workers/service/ServiceWorkerGlobalScope_register.html http/tests/workers/service/basic-fetch.https.html http/tests/workers/service/cors-image-fetch.html http/tests/workers/service/image-fetch.html http/tests/workers/service/registration-updateViaCache-all-importScripts.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75452 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76000 "Found 1 new API test failure: /TestWebKit:WebKit.PrivateBrowsingPushStateNoHistoryCallback (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20401 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18810 "Found 60 new test failures: fast/css/scrollable-overflow-with-sticky-positioning.html fast/forms/input-placeholder-paint-order-2.html fast/forms/switch/click-animation-redundant-checked.html http/tests/contentextensions/service-worker-block-everything-if-localhost.html http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html http/tests/cookies/same-site/fetch-in-same-origin-service-worker.html http/tests/inspector/network/fetch-response-body.html http/tests/inspector/network/getSerializedCertificate.html http/tests/inspector/network/resource-response-service-worker.html http/tests/inspector/network/xhr-response-body.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20464 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->