### PR TITLE
Fix errors reported by static analysis in MediaPlayerPrivateAVFoundationObjC

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -150,7 +150,6 @@ platform/graphics/GraphicsLayer.cpp
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
 platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -76,7 +76,6 @@ platform/graphics/GraphicsLayer.h
 platform/graphics/ImageBuffer.h
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
-platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/TileController.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1139,7 +1139,6 @@ platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
 platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -165,7 +165,6 @@ platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -640,7 +640,6 @@ platform/graphics/WidthIterator.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -36,6 +36,7 @@
 #include <wtf/MediaTime.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
@@ -44,7 +45,7 @@ namespace WebCore {
 using TrackID = uint64_t;
 
 class WEBCORE_EXPORT TrackPrivateBase
-    : public ThreadSafeRefCounted<TrackPrivateBase>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<TrackPrivateBase>
 #if !RELEASE_LOG_DISABLED
     , public LoggerHelper
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
@@ -59,6 +59,9 @@ public:
     int trackIndex() const override { return m_index; }
     void setTextTrackIndex(int index) { m_index = index; }
 
+    virtual bool isOutOfBandTextTrackPrivateAVF() const { return false; }
+    virtual bool isInbandTextTrackPrivateAVFObjC() const { return false; }
+
     virtual void disconnect();
 
     bool hasBeenReported() const { return m_hasBeenReported; }

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -153,6 +153,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
+    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateAVFoundation"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h
@@ -66,10 +66,16 @@ public:
 protected:
     InbandTextTrackPrivateAVFObjC(AVFInbandTrackParent*, AVMediaSelectionGroup *, AVMediaSelectionOption *, TrackID, InbandTextTrackPrivate::CueFormat);
     
+    bool isInbandTextTrackPrivateAVFObjC() const final { return true; }
+
     RetainPtr<AVMediaSelectionGroup> m_mediaSelectionGroup;
     RetainPtr<AVMediaSelectionOption> m_mediaSelectionOption;
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::InbandTextTrackPrivateAVFObjC)
+static bool isType(const WebCore::InbandTextTrackPrivateAVF& track) { return track.isInbandTextTrackPrivateAVFObjC(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -262,7 +262,7 @@ private:
     RetainPtr<CGImageRef> createImageForTimeInRect(float, const FloatRect&);
 
     using UpdateCompletion = CompletionHandler<void()>;
-    void updateLastImage(UpdateCompletion&&);
+    void updateLastImage(NOESCAPE UpdateCompletion&&);
 
     void createVideoOutput();
     void destroyVideoOutput();
@@ -299,7 +299,7 @@ private:
 #endif
 
     void setCurrentTextTrack(InbandTextTrackPrivateAVF*) final;
-    InbandTextTrackPrivateAVF* currentTextTrack() const final { return m_currentTextTrack; }
+    InbandTextTrackPrivateAVF* currentTextTrack() const final { return m_currentTextTrack.get().get(); }
 
     void updateAudioTracks();
     void updateVideoTracks();
@@ -388,6 +388,12 @@ private:
     bool supportsLinearMediaPlayer() const final { return true; }
 #endif
 
+    RefPtr<SharedBuffer> protectedKeyID() const { return m_keyID; }
+
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+    RefPtr<CDMInstanceFairPlayStreamingAVFObjC> protectedCDMInstance() const;
+#endif
+
     RetainPtr<AVURLAsset> m_avAsset;
     RetainPtr<AVPlayer> m_avPlayer;
     RetainPtr<AVPlayerItem> m_avPlayerItem;
@@ -430,7 +436,7 @@ private:
     RefPtr<MediaSelectionGroupAVFObjC> m_audibleGroup;
     RefPtr<MediaSelectionGroupAVFObjC> m_visualGroup;
 
-    InbandTextTrackPrivateAVF* m_currentTextTrack { nullptr };
+    ThreadSafeWeakPtr<InbandTextTrackPrivateAVF> m_currentTextTrack;
 
 #if ENABLE(DATACUE_VALUE)
     RefPtr<InbandMetadataTextTrackPrivateAVF> m_metadataTrack;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/OutOfBandTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/OutOfBandTextTrackPrivateAVF.h
@@ -56,11 +56,17 @@ protected:
         , m_mediaSelectionOption(selection)
     {
     }
+
+    bool isOutOfBandTextTrackPrivateAVF() const final { return true; }
     
     RetainPtr<AVMediaSelectionOption> m_mediaSelectionOption;
 };
     
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::OutOfBandTextTrackPrivateAVF)
+static bool isType(const WebCore::InbandTextTrackPrivateAVF& track) { return track.isOutOfBandTextTrackPrivateAVF(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif
 


### PR DESCRIPTION
#### beff728cbc3473ebd7e64e71b0ed318680662a71
<pre>
Fix errors reported by static analysis in MediaPlayerPrivateAVFoundationObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=286989">https://bugs.webkit.org/show_bug.cgi?id=286989</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h:
(WebCore::InbandTextTrackPrivateAVF::isOutOfBandTextTrackPrivateAVF const):
(WebCore::InbandTextTrackPrivateAVF::isInbandTextTrackPrivateAVFObjC const):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
(WebCore::MediaPlayerPrivateAVFoundation::protectedLogger const):
* Source/WebCore/platform/graphics/avfoundation/objc/InbandTextTrackPrivateAVFObjC.h:
(isType):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::MediaPlayerPrivateAVFoundationObjC):
(WebCore::MediaPlayerPrivateAVFoundationObjC::~MediaPlayerPrivateAVFoundationObjC):
(WebCore::MediaPlayerPrivateAVFoundationObjC::cancelLoad):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createVideoLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::hasAvailableVideoFrame const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::synchronizeTextTrackState):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::protectedCDMInstance const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::checkPlayability):
(WebCore::MediaPlayerPrivateAVFoundationObjC::beginLoadingMetadata):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateVideoFullscreenInlineImage):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::startVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateAVFoundationObjC::seekToTargetInternal):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
(WebCore::MediaPlayerPrivateAVFoundationObjC::tracksChanged):
(WebCore::determineChangedTracksFromNewTracksAndOldItems):
(WebCore::MediaPlayerPrivateAVFoundationObjC::audioSourceProvider):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createVideoOutput):
(WebCore::MediaPlayerPrivateAVFoundationObjC::destroyVideoOutput):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::videoOutputHasAvailableFrame):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastImage):
(WebCore::MediaPlayerPrivateAVFoundationObjC::paintWithVideoOutput):
(WebCore::MediaPlayerPrivateAVFoundationObjC::waitForVideoOutputMediaDataWillChange):
(WebCore::MediaPlayerPrivateAVFoundationObjC::outputObscuredDueToInsufficientExternalProtectionChanged):
(WebCore::MediaPlayerPrivateAVFoundationObjC::cdmInstanceAttached):
(WebCore::MediaPlayerPrivateAVFoundationObjC::attemptToDecryptWithInstance):
(WebCore::MediaPlayerPrivateAVFoundationObjC::processMediaSelectionOptions):
(WebCore::MediaPlayerPrivateAVFoundationObjC::processMetadataTrack):
(WebCore::MediaPlayerPrivateAVFoundationObjC::processCue):
(WebCore::MediaPlayerPrivateAVFoundationObjC::flushCues):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setCurrentTextTrack):
(WebCore::MediaPlayerPrivateAVFoundationObjC::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::wirelessPlaybackTargetName const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setBufferingPolicy):
(WebCore::MediaPlayerPrivateAVFoundationObjC::metadataDidArrive):
(-[WebCoreAVFMovieObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebCore/platform/graphics/avfoundation/objc/OutOfBandTextTrackPrivateAVF.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/289788@main">https://commits.webkit.org/289788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02d8ec898c4ef39a900b73f0292a1e7ab98054b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92879 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67912 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25648 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5805 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34002 "Found 1 new test failure: accessibility/noscript-ignored.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94747 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15144 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11136 "Found 1 new test failure: ipc/decode-object-array-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76764 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75450 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76007 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8148 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13730 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20463 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14904 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->