### PR TITLE
Fix the smart pointer static analyzer warning in ProcessAssertion.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -234,7 +234,6 @@ UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
 UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
 UIProcess/Notifications/WebNotificationManagerProxy.cpp
 UIProcess/PDF/WKPDFHUDView.mm
-UIProcess/ProcessAssertion.cpp
 UIProcess/ProcessThrottler.cpp
 UIProcess/ProvisionalFrameProxy.cpp
 UIProcess/ProvisionalPageProxy.cpp

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -156,7 +156,7 @@ bool ProcessAssertion::isValid() const
 void ProcessAssertion::acquireAsync(CompletionHandler<void()>&& completionHandler)
 {
     if (completionHandler)
-        RunLoop::main().dispatch(WTFMove(completionHandler));
+        RunLoop::protectedMain()->dispatch(WTFMove(completionHandler));
 }
 
 void ProcessAssertion::acquireSync()


### PR DESCRIPTION
#### 3f4d80a2d0a13ae51555d02a92c8f42ad27aef21
<pre>
Fix the smart pointer static analyzer warning in ProcessAssertion.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286991">https://bugs.webkit.org/show_bug.cgi?id=286991</a>

Reviewed by Geoffrey Garen and Chris Dumez.

Fix the only remaining static analyzer warning in ProcessAssertion.cpp.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/ProcessAssertion.cpp:
(WebKit::ProcessAssertion::acquireAsync):

Canonical link: <a href="https://commits.webkit.org/289807@main">https://commits.webkit.org/289807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5802571a9ca1e8759302c14ab3cb3a25365bdcd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42376 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92890 "Failed to checkout and rebase branch from PR 39966") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38733 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15675 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/92890 "Failed to checkout and rebase branch from PR 39966") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25653 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90985 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6033 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79601 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/92890 "Failed to checkout and rebase branch from PR 39966") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5809 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94759 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11144 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76767 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76005 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20398 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8155 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13740 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20470 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14911 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->