### PR TITLE
[Materials] Add rendering support for vibrancy effects

### DIFF
--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
@@ -21,7 +21,9 @@ bar
               (position 8.00 26.00)
               (bounds 200.00 200.00)
               (drawsContent 1)
-              (appleVisualEffect blur-material-chrome)
+              (appleVisualEffectData
+              (effect blur-material-chrome)
+              (contextEffect blur-material-chrome))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
@@ -21,7 +21,9 @@ bar
               (position 8.00 26.00)
               (bounds 200.00 200.00)
               (drawsContent 1)
-              (appleVisualEffect blur-material-thick)
+              (appleVisualEffectData
+              (effect blur-material-thick)
+              (contextEffect blur-material-thick))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
@@ -21,7 +21,9 @@ bar
               (position 8.00 26.00)
               (bounds 200.00 200.00)
               (drawsContent 1)
-              (appleVisualEffect blur-material-thin)
+              (appleVisualEffectData
+              (effect blur-material-thin)
+              (contextEffect blur-material-thin))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
@@ -21,7 +21,9 @@ bar
               (position 8.00 26.00)
               (bounds 200.00 200.00)
               (drawsContent 1)
-              (appleVisualEffect blur-material-ultra-thin)
+              (appleVisualEffectData
+              (effect blur-material-ultra-thin)
+              (contextEffect blur-material-ultra-thin))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt
@@ -1,5 +1,8 @@
 foo
 bar
+two
+three
+four
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -31,6 +34,32 @@ bar
               (backdrop layer (material)
                 (position 0.00 0.00)
                 (bounds 200.00 200.00)
+              )
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 18.00)
+                  (bounds 200.00 18.00)
+                  (drawsContent 1)
+                  (appleVisualEffectData
+                  (effect vibrancy-secondary-label)
+                  (contextEffect blur-material))
+                )
+                (GraphicsLayer
+                  (position 0.00 36.00)
+                  (bounds 200.00 18.00)
+                  (drawsContent 1)
+                  (appleVisualEffectData
+                  (effect vibrancy-tertiary-label)
+                  (contextEffect blur-material))
+                )
+                (GraphicsLayer
+                  (position 0.00 54.00)
+                  (bounds 200.00 18.00)
+                  (drawsContent 1)
+                  (appleVisualEffectData
+                  (effect vibrancy-quaternary-label)
+                  (contextEffect blur-material))
+                )
               )
             )
           )

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that the default material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+.vibrant2 {
+    -apple-visual-effect: -apple-system-vibrancy-secondary-label;
+}
+
+.vibrant3 {
+    -apple-visual-effect: -apple-system-vibrancy-tertiary-label;
+}
+
+.vibrant4 {
+    -apple-visual-effect: -apple-system-vibrancy-quaternary-label;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals)
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS)
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar<div class=vibrant2>two</div><div class=vibrant3>three</div><div class=vibrant4>four</div></div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
@@ -12,7 +12,9 @@ bar
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
-          (appleVisualEffect blur-material-chrome)
+          (appleVisualEffectData
+          (effect blur-material-chrome)
+          (contextEffect blur-material-chrome))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
@@ -12,7 +12,9 @@ bar
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
-          (appleVisualEffect blur-material)
+          (appleVisualEffectData
+          (effect blur-material)
+          (contextEffect blur-material))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
@@ -12,7 +12,9 @@ bar
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
-          (appleVisualEffect blur-material-thick)
+          (appleVisualEffectData
+          (effect blur-material-thick)
+          (contextEffect blur-material-thick))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
@@ -12,7 +12,9 @@ bar
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
-          (appleVisualEffect blur-material-thin)
+          (appleVisualEffectData
+          (effect blur-material-thin)
+          (contextEffect blur-material-thin))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
@@ -12,7 +12,9 @@ bar
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
-          (appleVisualEffect blur-material-ultra-thin)
+          (appleVisualEffectData
+          (effect blur-material-ultra-thin)
+          (contextEffect blur-material-ultra-thin))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt
@@ -1,0 +1,60 @@
+foo
+bar
+two
+three
+four
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 28.00)
+          (bounds 200.00 200.00)
+          (drawsContent 1)
+          (appleVisualEffectData
+          (effect blur-material)
+          (contextEffect blur-material))
+          (structural layer
+            (position 108.00 128.00)
+            (bounds 200.00 200.00)
+          )
+          (backdrop layer (material)
+            (position 0.00 0.00)
+            (bounds 200.00 200.00)
+          )
+          (children 3
+            (GraphicsLayer
+              (position 0.00 20.00)
+              (bounds 200.00 20.00)
+              (drawsContent 1)
+              (appleVisualEffectData
+              (effect vibrancy-secondary-label)
+              (contextEffect blur-material))
+            )
+            (GraphicsLayer
+              (position 0.00 40.00)
+              (bounds 200.00 20.00)
+              (drawsContent 1)
+              (appleVisualEffectData
+              (effect vibrancy-tertiary-label)
+              (contextEffect blur-material))
+            )
+            (GraphicsLayer
+              (position 0.00 60.00)
+              (bounds 200.00 20.00)
+              (drawsContent 1)
+              (appleVisualEffectData
+              (effect vibrancy-quaternary-label)
+              (contextEffect blur-material))
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
@@ -34,11 +34,24 @@
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, CoreMaterial)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, MTMaterialLayer)
 
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipeNone, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinLight, NSString *)
+
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryStroke, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryFill, NSString *)
+
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleNone, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStylePrimary, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleSecondary, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleTertiary, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleQuaternary, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleSeparator, NSString *)
+
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMaterial, MTVisualStylingCreateDictionaryRepresentation, NSDictionary *, (MTCoreMaterialRecipe recipe, MTCoreMaterialVisualStyleCategory category, MTCoreMaterialVisualStyle style, NSDictionary *options), (recipe, category, style, options))
 
 SPECIALIZE_OBJC_TYPE_TRAITS(MTMaterialLayer, PAL::getMTMaterialLayerClass())
 

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm
@@ -34,10 +34,23 @@ SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, PAL_EXPORT
 
 SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTMaterialLayer, PAL_EXPORT)
 
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipeNone, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinLight, NSString *, PAL_EXPORT)
+
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryStroke, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryFill, NSString *, PAL_EXPORT)
+
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleNone, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStylePrimary, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleSecondary, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleTertiary, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleQuaternary, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleSeparator, NSString *, PAL_EXPORT)
+
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTVisualStylingCreateDictionaryRepresentation, NSDictionary *, (MTCoreMaterialRecipe recipe, MTCoreMaterialVisualStyleCategory category, MTCoreMaterialVisualStyle style, NSDictionary *options), (recipe, category, style, options), PAL_EXPORT)
 
 #endif // HAVE(CORE_MATERIAL)

--- a/Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h
@@ -36,13 +36,30 @@
 
 #else
 
+typedef NSString * MTCoreMaterialVisualStyleCategory NS_STRING_ENUM;
+
+extern MTCoreMaterialVisualStyleCategory const MTCoreMaterialVisualStyleCategoryStroke;
+extern MTCoreMaterialVisualStyleCategory const MTCoreMaterialVisualStyleCategoryFill;
+
+typedef NSString * MTCoreMaterialVisualStyle NS_STRING_ENUM;
+
+extern MTCoreMaterialVisualStyle const MTCoreMaterialVisualStyleNone;
+extern MTCoreMaterialVisualStyle const MTCoreMaterialVisualStylePrimary;
+extern MTCoreMaterialVisualStyle const MTCoreMaterialVisualStyleSecondary;
+extern MTCoreMaterialVisualStyle const MTCoreMaterialVisualStyleTertiary;
+extern MTCoreMaterialVisualStyle const MTCoreMaterialVisualStyleQuaternary;
+extern MTCoreMaterialVisualStyle const MTCoreMaterialVisualStyleSeparator;
+
 typedef NSString * MTCoreMaterialRecipe NS_STRING_ENUM;
 
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipeNone;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformChromeLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentUltraThinLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThinLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThickLight;
+
+extern NSDictionary <NSString *, id> *MTVisualStylingCreateDictionaryRepresentation(MTCoreMaterialRecipe, MTCoreMaterialVisualStyleCategory, MTCoreMaterialVisualStyle, NSDictionary <NSString *, id> *);
 
 @interface MTMaterialLayer : CABackdropLayer
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -314,6 +314,7 @@ extern NSString * const kCAFilterColorSaturate;
 extern NSString * const kCAFilterGaussianBlur;
 extern NSString * const kCAFilterPlusD;
 extern NSString * const kCAFilterPlusL;
+extern NSString * const kCAFilterVibrantColorMatrix;
 
 extern NSString * const kCAFilterNormalBlendMode;
 extern NSString * const kCAFilterMultiplyBlendMode;
@@ -331,6 +332,8 @@ extern NSString * const kCAFilterHueBlendMode;
 extern NSString * const kCAFilterSaturationBlendMode;
 extern NSString * const kCAFilterColorBlendMode;
 extern NSString * const kCAFilterLuminosityBlendMode;
+
+extern NSString * const kCAFilterInputColorMatrix;
 
 extern NSString * const kCAContextCIFilterBehavior;
 extern NSString * const kCAContextDisplayName;

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -57,6 +57,31 @@ bool appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
     return false;
 }
 
+bool appleVisualEffectAppliesFilter(AppleVisualEffect effect)
+{
+    switch (effect) {
+    case AppleVisualEffect::None:
+    case AppleVisualEffect::BlurUltraThinMaterial:
+    case AppleVisualEffect::BlurThinMaterial:
+    case AppleVisualEffect::BlurMaterial:
+    case AppleVisualEffect::BlurThickMaterial:
+    case AppleVisualEffect::BlurChromeMaterial:
+        return false;
+    case AppleVisualEffect::VibrancyLabel:
+    case AppleVisualEffect::VibrancySecondaryLabel:
+    case AppleVisualEffect::VibrancyTertiaryLabel:
+    case AppleVisualEffect::VibrancyQuaternaryLabel:
+    case AppleVisualEffect::VibrancyFill:
+    case AppleVisualEffect::VibrancySecondaryFill:
+    case AppleVisualEffect::VibrancyTertiaryFill:
+    case AppleVisualEffect::VibrancySeparator:
+        return true;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
 {
     switch (effect) {
@@ -103,6 +128,13 @@ TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
         ts << "vibrancy-separator";
         break;
     }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, AppleVisualEffectData effectData)
+{
+    ts.dumpProperty("effect", effectData.effect);
+    ts.dumpProperty("contextEffect", effectData.contextEffect);
     return ts;
 }
 

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.h
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.h
@@ -51,8 +51,18 @@ enum class AppleVisualEffect : uint8_t {
 };
 
 WEBCORE_EXPORT bool appleVisualEffectNeedsBackdrop(AppleVisualEffect);
+WEBCORE_EXPORT bool appleVisualEffectAppliesFilter(AppleVisualEffect);
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, AppleVisualEffect);
+
+struct AppleVisualEffectData {
+    AppleVisualEffect effect { AppleVisualEffect::None };
+    AppleVisualEffect contextEffect { AppleVisualEffect::None };
+
+    bool operator==(const AppleVisualEffectData&) const = default;
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, AppleVisualEffectData);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -420,7 +420,7 @@ void GraphicsLayer::removeFromParentInternal()
 bool GraphicsLayer::needsBackdrop() const
 {
 #if HAVE(CORE_MATERIAL)
-    if (appleVisualEffectNeedsBackdrop(m_appleVisualEffect))
+    if (appleVisualEffectNeedsBackdrop(m_appleVisualEffectData.effect))
         return true;
 #endif
     return !m_backdropFilters.isEmpty();
@@ -1016,8 +1016,8 @@ void GraphicsLayer::dumpProperties(TextStream& ts, OptionSet<LayerTreeAsTextOpti
     }
 
 #if HAVE(CORE_MATERIAL)
-    if (m_appleVisualEffect != AppleVisualEffect::None)
-        ts << indent << "(appleVisualEffect "_s << m_appleVisualEffect << ")\n"_s;
+    if (m_appleVisualEffectData.effect != AppleVisualEffect::None)
+        ts << indent << "(appleVisualEffectData "_s << m_appleVisualEffectData << ")\n"_s;
 #endif
 
     if (m_maskLayer) {

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -450,8 +450,8 @@ public:
 #endif
 
 #if HAVE(CORE_MATERIAL)
-    AppleVisualEffect appleVisualEffect() const { return m_appleVisualEffect; }
-    virtual void setAppleVisualEffect(AppleVisualEffect effect) { m_appleVisualEffect = effect; }
+    AppleVisualEffectData appleVisualEffectData() const { return m_appleVisualEffectData; }
+    virtual void setAppleVisualEffectData(AppleVisualEffectData effectData) { m_appleVisualEffectData = effectData; }
 #endif
 
     bool needsBackdrop() const;
@@ -810,7 +810,7 @@ protected:
     CustomAppearance m_customAppearance { CustomAppearance::None };
 
 #if HAVE(CORE_MATERIAL)
-    AppleVisualEffect m_appleVisualEffect { AppleVisualEffect::None };
+    AppleVisualEffectData m_appleVisualEffectData;
 #endif
 
     OptionSet<GraphicsLayerPaintingPhase> m_paintingPhase { GraphicsLayerPaintingPhase::Foreground, GraphicsLayerPaintingPhase::Background };

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -112,7 +112,7 @@ public:
 #endif
 
 #if HAVE(CORE_MATERIAL)
-    WEBCORE_EXPORT void setAppleVisualEffect(AppleVisualEffect) override;
+    WEBCORE_EXPORT void setAppleVisualEffectData(AppleVisualEffectData) override;
 #endif
 
     WEBCORE_EXPORT void setBackgroundColor(const Color&) override;
@@ -530,7 +530,7 @@ private:
     void updateContentsScalingFilters();
 
 #if HAVE(CORE_MATERIAL)
-    void updateAppleVisualEffect();
+    void updateAppleVisualEffectData();
 #endif
 
     enum StructuralLayerPurpose {

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -310,8 +310,8 @@ public:
 #endif
 
 #if HAVE(CORE_MATERIAL)
-    virtual AppleVisualEffect appleVisualEffect() const = 0;
-    virtual void setAppleVisualEffect(AppleVisualEffect) = 0;
+    virtual AppleVisualEffectData appleVisualEffectData() const = 0;
+    virtual void setAppleVisualEffectData(AppleVisualEffectData) = 0;
 #endif
 
     virtual TiledBacking* tiledBacking() = 0;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -201,8 +201,8 @@ public:
 #endif
 
 #if HAVE(CORE_MATERIAL)
-    AppleVisualEffect appleVisualEffect() const override;
-    void setAppleVisualEffect(AppleVisualEffect) override;
+    AppleVisualEffectData appleVisualEffectData() const override;
+    void setAppleVisualEffectData(AppleVisualEffectData) override;
 #endif
 
     TiledBacking* tiledBacking() override;
@@ -232,9 +232,6 @@ private:
     RetainPtr<NSObject> m_delegate;
     std::unique_ptr<PlatformCALayerList> m_customSublayers;
     GraphicsLayer::CustomAppearance m_customAppearance { GraphicsLayer::CustomAppearance::None };
-#if HAVE(CORE_MATERIAL)
-    AppleVisualEffect m_appleVisualEffect { AppleVisualEffect::None };
-#endif
     std::unique_ptr<FloatRoundedRect> m_shapeRoundedRect;
 #if ENABLE(SCROLLING_THREAD)
     Markable<ScrollingNodeID> m_scrollingNodeID;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1154,16 +1154,15 @@ void PlatformCALayerCocoa::setIsDescendentOfSeparatedPortal(bool)
 
 #if HAVE(CORE_MATERIAL)
 
-AppleVisualEffect PlatformCALayerCocoa::appleVisualEffect() const
+AppleVisualEffectData PlatformCALayerCocoa::appleVisualEffectData() const
 {
     // FIXME: Add an implementation for when UI-side compositing is disabled.
-    return m_appleVisualEffect;
+    return { };
 }
 
-void PlatformCALayerCocoa::setAppleVisualEffect(AppleVisualEffect effect)
+void PlatformCALayerCocoa::setAppleVisualEffectData(AppleVisualEffectData)
 {
     // FIXME: Add an implementation for when UI-side compositing is disabled.
-    m_appleVisualEffect = effect;
 }
 
 #endif

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -896,7 +896,10 @@ void RenderLayerBacking::updateContentsScalingFilters(const RenderStyle& style)
 #if HAVE(CORE_MATERIAL)
 void RenderLayerBacking::updateAppleVisualEffect(const RenderStyle& style)
 {
-    m_graphicsLayer->setAppleVisualEffect(style.appleVisualEffect());
+    AppleVisualEffectData visualEffectData;
+    visualEffectData.effect = style.appleVisualEffect();
+    visualEffectData.contextEffect = style.usedAppleVisualEffectForSubtree();
+    m_graphicsLayer->setAppleVisualEffectData(visualEffectData);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1223,6 +1223,13 @@ bool RenderStyle::changeRequiresLayerRepaint(const RenderStyle& other, OptionSet
             return true;
     }
 
+#if HAVE(CORE_MATERIAL)
+    if (m_rareInheritedData.ptr() != other.m_rareInheritedData.ptr()
+        && m_rareInheritedData->usedAppleVisualEffectForSubtree != other.m_rareInheritedData->usedAppleVisualEffectForSubtree) {
+        changedContextSensitiveProperties.add(StyleDifferenceContextSensitiveProperty::Filter);
+    }
+#endif
+
     return false;
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1164,6 +1164,8 @@ public:
     inline AppleVisualEffect appleVisualEffect() const;
     inline bool hasAppleVisualEffect() const;
     inline bool hasAppleVisualEffectRequiringBackdropFilter() const;
+
+    inline AppleVisualEffect usedAppleVisualEffectForSubtree() const;
 #endif
 
     inline MathStyle mathStyle() const;
@@ -1679,6 +1681,7 @@ public:
 
 #if HAVE(CORE_MATERIAL)
     inline void setAppleVisualEffect(AppleVisualEffect);
+    inline void setUsedAppleVisualEffectForSubtree(AppleVisualEffect);
 #endif
 
     void addCustomPaintWatchProperty(const AtomString&);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -212,6 +212,9 @@ inline const ContentData* RenderStyle::contentData() const { return m_nonInherit
 inline ContentVisibility RenderStyle::contentVisibility() const { return static_cast<ContentVisibility>(m_nonInheritedData->rareData->contentVisibility); }
 inline CursorList* RenderStyle::cursors() const { return m_rareInheritedData->cursorData.get(); }
 inline StyleAppearance RenderStyle::usedAppearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->usedAppearance); }
+#if HAVE(CORE_MATERIAL)
+inline AppleVisualEffect RenderStyle::usedAppleVisualEffectForSubtree() const { return static_cast<AppleVisualEffect>(m_rareInheritedData->usedAppleVisualEffectForSubtree); }
+#endif
 inline OptionSet<Containment> RenderStyle::usedContain() const { return m_nonInheritedData->rareData->usedContain(); }
 inline bool RenderStyle::effectiveInert() const { return m_rareInheritedData->effectiveInert; }
 inline PointerEvents RenderStyle::usedPointerEvents() const { return effectiveInert() ? PointerEvents::None : pointerEvents(); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -82,6 +82,7 @@ inline void RenderStyle::setAppearance(StyleAppearance appearance) { SET_NESTED_
 inline void RenderStyle::setAppleColorFilter(FilterOperations&& ops) { SET_NESTED(m_rareInheritedData, appleColorFilter, operations, WTFMove(ops)); }
 #if HAVE(CORE_MATERIAL)
 inline void RenderStyle::setAppleVisualEffect(AppleVisualEffect effect) { SET_NESTED(m_nonInheritedData, rareData, appleVisualEffect, static_cast<unsigned>(effect)); }
+inline void RenderStyle::setUsedAppleVisualEffectForSubtree(AppleVisualEffect effect) { SET(m_rareInheritedData, usedAppleVisualEffectForSubtree, static_cast<unsigned>(effect)); }
 #endif
 inline void RenderStyle::setAspectRatio(double width, double height) { SET_NESTED_PAIR(m_nonInheritedData, miscData, aspectRatioWidth, width, aspectRatioHeight, height); }
 inline void RenderStyle::setAspectRatioType(AspectRatioType aspectRatioType) { SET_NESTED(m_nonInheritedData, miscData, aspectRatioType, static_cast<unsigned>(aspectRatioType)); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -143,6 +143,9 @@ StyleRareInheritedData::StyleRareInheritedData()
     , isInSubtreeWithBlendMode(false)
     , isInVisibilityAdjustmentSubtree(false)
     , usedContentVisibility(static_cast<unsigned>(ContentVisibility::Visible))
+#if HAVE(CORE_MATERIAL)
+    , usedAppleVisualEffectForSubtree(static_cast<unsigned>(AppleVisualEffect::None))
+#endif
     , usedTouchActions(RenderStyle::initialTouchActions())
     , strokeWidth(RenderStyle::initialStrokeWidth())
     , strokeColor(RenderStyle::initialStrokeColor())
@@ -239,6 +242,9 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , isInSubtreeWithBlendMode(o.isInSubtreeWithBlendMode)
     , isInVisibilityAdjustmentSubtree(o.isInVisibilityAdjustmentSubtree)
     , usedContentVisibility(o.usedContentVisibility)
+#if HAVE(CORE_MATERIAL)
+    , usedAppleVisualEffectForSubtree(o.usedAppleVisualEffectForSubtree)
+#endif
     , usedTouchActions(o.usedTouchActions)
     , eventListenerRegionTypes(o.eventListenerRegionTypes)
     , strokeWidth(o.strokeWidth)
@@ -369,6 +375,9 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && eventListenerRegionTypes == o.eventListenerRegionTypes
         && effectiveInert == o.effectiveInert
         && usedContentVisibility == o.usedContentVisibility
+#if HAVE(CORE_MATERIAL)
+        && usedAppleVisualEffectForSubtree == o.usedAppleVisualEffectForSubtree
+#endif
         && strokeWidth == o.strokeWidth
         && strokeColor == o.strokeColor
         && visitedLinkStrokeColor == o.visitedLinkStrokeColor
@@ -489,6 +498,9 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
 
     LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, usedContentVisibility);
 
+#if HAVE(CORE_MATERIAL)
+    LOG_IF_DIFFERENT_WITH_CAST(AppleVisualEffect, usedAppleVisualEffectForSubtree);
+#endif
 
     LOG_IF_DIFFERENT(usedTouchActions);
     LOG_IF_DIFFERENT(eventListenerRegionTypes);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -179,6 +179,10 @@ public:
 
     unsigned usedContentVisibility : 2; // ContentVisibility
 
+#if HAVE(CORE_MATERIAL)
+    unsigned usedAppleVisualEffectForSubtree : 4; // AppleVisualEffect
+#endif
+
     OptionSet<TouchAction> usedTouchActions;
     OptionSet<EventListenerRegionType> eventListenerRegionTypes;
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -716,6 +716,13 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     if (m_parentBoxStyle.justifyItems().positionType() == ItemPositionType::Legacy && style.justifyItems().position() == ItemPosition::Legacy)
         style.setJustifyItems(m_parentBoxStyle.justifyItems());
 
+#if HAVE(CORE_MATERIAL)
+    if (appleVisualEffectNeedsBackdrop(style.appleVisualEffect()))
+        style.setUsedAppleVisualEffectForSubtree(style.appleVisualEffect());
+    else
+        style.setUsedAppleVisualEffectForSubtree(m_parentStyle.usedAppleVisualEffectForSubtree());
+#endif
+
     style.setUsedTouchActions(computeUsedTouchActions(style, m_parentStyle.usedTouchActions()));
 
     // Counterparts in Element::addToTopLayer/removeFromTopLayer & SharingResolver::canShareStyleWithElement need to match!

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -212,7 +212,7 @@ struct LayerProperties {
 #endif
     WebCore::ContentsFormat contentsFormat { WebCore::ContentsFormat::RGBA8 };
 #if HAVE(CORE_MATERIAL)
-    WebCore::AppleVisualEffect appleVisualEffect { WebCore::AppleVisualEffect::None };
+    WebCore::AppleVisualEffectData appleVisualEffectData;
 #endif
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -282,7 +282,7 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
 #endif
     [OptionalTupleBit=WebKit::LayerChange::ContentsFormatChanged] WebCore::ContentsFormat contentsFormat;
 #if HAVE(CORE_MATERIAL)
-    [OptionalTupleBit=WebKit::LayerChange::AppleVisualEffectChanged] WebCore::AppleVisualEffect appleVisualEffect;
+    [OptionalTupleBit=WebKit::LayerChange::AppleVisualEffectChanged] WebCore::AppleVisualEffectData appleVisualEffectData;
 #endif
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -248,7 +248,7 @@ static void dumpChangedLayers(TextStream& ts, const LayerPropertiesMap& changedL
 
 #if HAVE(CORE_MATERIAL)
         if (layerProperties.changedProperties & LayerChange::AppleVisualEffectChanged)
-            ts.dumpProperty("appleVisualEffect", layerProperties.appleVisualEffect);
+            ts.dumpProperty("appleVisualEffectData", layerProperties.appleVisualEffectData);
 #endif
     }
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7988,6 +7988,12 @@ enum class WebCore::AppleVisualEffect : uint8_t {
     VibrancySeparator,
 };
 
+header: <WebCore/AppleVisualEffect.h>
+[CustomHeader] struct WebCore::AppleVisualEffectData {
+    WebCore::AppleVisualEffect effect;
+    WebCore::AppleVisualEffect contextEffect;
+};
+
 #endif
 
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -237,8 +237,8 @@ public:
 #endif
 
 #if HAVE(CORE_MATERIAL)
-    WebCore::AppleVisualEffect appleVisualEffect() const override;
-    void setAppleVisualEffect(WebCore::AppleVisualEffect) override;
+    WebCore::AppleVisualEffectData appleVisualEffectData() const override;
+    void setAppleVisualEffectData(WebCore::AppleVisualEffectData) override;
 #endif
 
     WebCore::TiledBacking* tiledBacking() override { return nullptr; }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -1120,17 +1120,17 @@ void PlatformCALayerRemote::setIsDescendentOfSeparatedPortal(bool value)
 
 #if HAVE(CORE_MATERIAL)
 
-WebCore::AppleVisualEffect PlatformCALayerRemote::appleVisualEffect() const
+WebCore::AppleVisualEffectData PlatformCALayerRemote::appleVisualEffectData() const
 {
-    return m_properties.appleVisualEffect;
+    return m_properties.appleVisualEffectData;
 }
 
-void PlatformCALayerRemote::setAppleVisualEffect(WebCore::AppleVisualEffect effect)
+void PlatformCALayerRemote::setAppleVisualEffectData(WebCore::AppleVisualEffectData effectData)
 {
-    if (m_properties.appleVisualEffect == effect)
+    if (m_properties.appleVisualEffectData == effectData)
         return;
 
-    m_properties.appleVisualEffect = effect;
+    m_properties.appleVisualEffectData = effectData;
     m_properties.notePropertiesChanged(LayerChange::AppleVisualEffectChanged);
 }
 


### PR DESCRIPTION
#### 4729a93d096e6934a2a4375977e885ef005eadea
<pre>
[Materials] Add rendering support for vibrancy effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=286992">https://bugs.webkit.org/show_bug.cgi?id=286992</a>
<a href="https://rdar.apple.com/144138408">rdar://144138408</a>

Reviewed by Megan Gardner, Richard Robinson, and Abrar Rahman Protyasha.

Apply filters from CoreMaterial when using `-apple-visual-effect` with one of
the `-apple-system-vibrancy` keywords. Note that this is not web-exposed.

* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects.html: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt: Added.
* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm:
* Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::appleVisualEffectAppliesFilter):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/cocoa/AppleVisualEffect.h:

Introduce `AppleVisualEffectData` to encompass a primary effect and a context
effect. This is necessary as vibrancy effects are dependent on the nearest blur
material.

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::needsBackdrop const):
(WebCore::GraphicsLayer::dumpProperties const):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::appleVisualEffectData const):
(WebCore::GraphicsLayer::setAppleVisualEffectData):
(WebCore::GraphicsLayer::appleVisualEffect const): Deleted.
(WebCore::GraphicsLayer::setAppleVisualEffect): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setAppleVisualEffectData):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::updateBackdropFilters):
(WebCore::GraphicsLayerCA::updateAppleVisualEffectData):

Apply the vibrancy effect to the main layer.

(WebCore::GraphicsLayerCA::purposeNameForInnerLayer const):
(WebCore::GraphicsLayerCA::setAppleVisualEffect): Deleted.
(WebCore::GraphicsLayerCA::updateAppleVisualEffect): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::appleVisualEffectData const):

Make this method an actual stub, since it does nothing right now.

(WebCore::PlatformCALayerCocoa::setAppleVisualEffectData):

Make this method an actual stub, since it does nothing right now.

(WebCore::PlatformCALayerCocoa::appleVisualEffect const): Deleted.
(WebCore::PlatformCALayerCocoa::setAppleVisualEffect): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAppleVisualEffect):

Ensure the context effect is also provided, so that the vibrancy effect may be resolved.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresLayerRepaint const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::usedAppleVisualEffectForSubtree const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setUsedAppleVisualEffectForSubtree):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Ensure the used blur (material) effect is propagated down the tree, so that
vibrancy effects may be resolved correctly.

* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::materialRecipeForAppleVisualEffect):
(WebKit::materialVisualStyleForAppleVisualEffect):
(WebKit::materialVisualStyleCategoryForAppleVisualEffect):
(WebKit::applyVisualStylingToLayer):

Read the filter definition from CoreMaterial, and apply to the layer.

(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::dumpChangedLayers):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::appleVisualEffectData const):
(WebKit::PlatformCALayerRemote::setAppleVisualEffectData):
(WebKit::PlatformCALayerRemote::appleVisualEffect const): Deleted.
(WebKit::PlatformCALayerRemote::setAppleVisualEffect): Deleted.

Canonical link: <a href="https://commits.webkit.org/289911@main">https://commits.webkit.org/289911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef7c11658f971afbc33aa4f4d3a84fadacb2190c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68122 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25840 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48489 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38161 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95099 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76988 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15730 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76232 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20624 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8511 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13813 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15490 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20795 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->