### PR TITLE
[meta] Python CGI shouldn't convert LF with CRLF on stdout for Windows Python

### DIFF
--- a/LayoutTests/http/tests/app-privacy-report/resources/app-initiated-post.py
+++ b/LayoutTests/http/tests/app-privacy-report/resources/app-initiated-post.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/app-privacy-report/resources/cors-preflight.py
+++ b/LayoutTests/http/tests/app-privacy-report/resources/cors-preflight.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/app-privacy-report/resources/frame-with-authenticated-resource.py
+++ b/LayoutTests/http/tests/app-privacy-report/resources/frame-with-authenticated-resource.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: max-age=0\r\n'

--- a/LayoutTests/http/tests/app-privacy-report/resources/redirect-with-cors-preflight-check.py
+++ b/LayoutTests/http/tests/app-privacy-report/resources/redirect-with-cors-preflight-check.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if_none_match = os.environ.get('HTTP_IF_NONE_MATCH', None)
 if_modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', None)

--- a/LayoutTests/http/tests/app-privacy-report/resources/resource-with-auth.py
+++ b/LayoutTests/http/tests/app-privacy-report/resources/resource-with-auth.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/app-privacy-report/resources/user-initiated-post.py
+++ b/LayoutTests/http/tests/app-privacy-report/resources/user-initiated-post.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/blink/sendbeacon/resources/check-beacon.py
+++ b/LayoutTests/http/tests/blink/sendbeacon/resources/check-beacon.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 import time
 

--- a/LayoutTests/http/tests/blink/sendbeacon/resources/save-beacon.py
+++ b/LayoutTests/http/tests/blink/sendbeacon/resources/save-beacon.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from base64 import b64encode
 from datetime import datetime, timedelta

--- a/LayoutTests/http/tests/cache/disk-cache/resources/json.py
+++ b/LayoutTests/http/tests/cache/disk-cache/resources/json.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 def send304():

--- a/LayoutTests/http/tests/cache/disk-cache/resources/make-sha1-collision.py
+++ b/LayoutTests/http/tests/cache/disk-cache/resources/make-sha1-collision.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 path = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('path', [''])[0]

--- a/LayoutTests/http/tests/cache/disk-cache/resources/redirect-chain.py
+++ b/LayoutTests/http/tests/cache/disk-cache/resources/redirect-chain.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cache/disk-cache/resources/redirect-to-data.py
+++ b/LayoutTests/http/tests/cache/disk-cache/resources/redirect-to-data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 301\r\n'

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/cacheable-redirect-frame.py
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/cacheable-redirect-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: max-age=0\r\n'

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/css-to-revalidate.py
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/css-to-revalidate.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 match = os.environ.get('HTTP_IF_NONE_MATCH', '')
 if match == 'foo':

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/frame-with-authenticated-resource.py
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/frame-with-authenticated-resource.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: max-age=0\r\n'

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/redirect-to-css.py
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/redirect-to-css.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 302\r\n'

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/request-headers-script.py
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/request-headers-script.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 headers = {}
 for headername, headervalue in os.environ.items():

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/resource-with-auth.py
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/resource-with-auth.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/validation-request-frame.py
+++ b/LayoutTests/http/tests/cache/disk-cache/speculative-validation/resources/validation-request-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from uuid import uuid1
 
 cookie = f'speculativeRequestValidation={uuid1()}'

--- a/LayoutTests/http/tests/cache/post-redirect-get.py
+++ b/LayoutTests/http/tests/cache/post-redirect-get.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/cache/post-with-cached-subresources.py
+++ b/LayoutTests/http/tests/cache/post-with-cached-subresources.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from datetime import datetime, timedelta
 

--- a/LayoutTests/http/tests/cache/reload-main-resource.py
+++ b/LayoutTests/http/tests/cache/reload-main-resource.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/cache/resources/body.py
+++ b/LayoutTests/http/tests/cache/resources/body.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 data = ''.join(sys.stdin.readlines())
 

--- a/LayoutTests/http/tests/cache/resources/cache-control-redirect.py
+++ b/LayoutTests/http/tests/cache/resources/cache-control-redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cache/resources/cacheable-iframe.py
+++ b/LayoutTests/http/tests/cache/resources/cacheable-iframe.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 
 max_age = 12 * 31 * 24 * 60 * 60

--- a/LayoutTests/http/tests/cache/resources/cacheable-random-text.py
+++ b/LayoutTests/http/tests/cache/resources/cacheable-random-text.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cache/resources/iframe304.py
+++ b/LayoutTests/http/tests/cache/resources/iframe304.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')

--- a/LayoutTests/http/tests/cache/resources/iframe304body.py
+++ b/LayoutTests/http/tests/cache/resources/iframe304body.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')
 

--- a/LayoutTests/http/tests/cache/resources/load-and-check-referer.py
+++ b/LayoutTests/http/tests/cache/resources/load-and-check-referer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 def contentType(path):

--- a/LayoutTests/http/tests/cache/resources/no-cache-main-resource-next.py
+++ b/LayoutTests/http/tests/cache/resources/no-cache-main-resource-next.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/cache/resources/no-cache-main-resource.py
+++ b/LayoutTests/http/tests/cache/resources/no-cache-main-resource.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/cache/resources/no-cache-with-validation.py
+++ b/LayoutTests/http/tests/cache/resources/no-cache-with-validation.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')
 

--- a/LayoutTests/http/tests/cache/resources/partitioned-cache-echo-state.py
+++ b/LayoutTests/http/tests/cache/resources/partitioned-cache-echo-state.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/cache/resources/permanent-redirect.py
+++ b/LayoutTests/http/tests/cache/resources/permanent-redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 location = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('location', [''])[0]

--- a/LayoutTests/http/tests/cache/resources/post-image-to-verify.py
+++ b/LayoutTests/http/tests/cache/resources/post-image-to-verify.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/cache/resources/prefetched-main-resource-iframe.py
+++ b/LayoutTests/http/tests/cache/resources/prefetched-main-resource-iframe.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 purpose = os.environ.get('HTTP_PURPOSE', '')
 

--- a/LayoutTests/http/tests/cache/resources/prefetched-main-resource.py
+++ b/LayoutTests/http/tests/cache/resources/prefetched-main-resource.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 purpose = os.environ.get('HTTP_PURPOSE', '')
 

--- a/LayoutTests/http/tests/cache/resources/reload-main-resource-iframe.py
+++ b/LayoutTests/http/tests/cache/resources/reload-main-resource-iframe.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from datetime import datetime, timedelta
 

--- a/LayoutTests/http/tests/cache/resources/slow-iframe.py
+++ b/LayoutTests/http/tests/cache/resources/slow-iframe.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(1)

--- a/LayoutTests/http/tests/cache/resources/stylesheet-html.py
+++ b/LayoutTests/http/tests/cache/resources/stylesheet-html.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 sheet = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('sheet', ['404.css'])[0]

--- a/LayoutTests/http/tests/cache/resources/stylesheet304-bad-content-type.py
+++ b/LayoutTests/http/tests/cache/resources/stylesheet304-bad-content-type.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')

--- a/LayoutTests/http/tests/cache/resources/svg-defs-vary.py
+++ b/LayoutTests/http/tests/cache/resources/svg-defs-vary.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: image/svg+xml\r\n'

--- a/LayoutTests/http/tests/cache/resources/x-frame-options.py
+++ b/LayoutTests/http/tests/cache/resources/x-frame-options.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 
 modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', '')

--- a/LayoutTests/http/tests/cache/resources/xhr-vary-header-response.py
+++ b/LayoutTests/http/tests/cache/resources/xhr-vary-header-response.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 origin = True if os.environ.get('HTTP_ORIGIN', None) is not None else False
 

--- a/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cache.py
+++ b/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cache.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Clear-Site-Data: "cache"\r\n'

--- a/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cookies.py
+++ b/LayoutTests/http/tests/clear-site-data/resources/clear-site-data-cookies.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Clear-Site-Data: "cookies"\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/at-import-stylesheets-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/at-import-stylesheets-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.html\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/cross-origin-frames-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/cross-origin-frames-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.html\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/echo-http-referer.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/echo-http-referer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 sys.stdout.write(

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/external-stylesheets-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/external-stylesheets-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.html\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/form-submission-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/form-submission-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.html\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/http-equiv-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/http-equiv-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.html\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/plugins-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/plugins-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.html\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/referer-header-stripped-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/referer-header-stripped-frame.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 referrer = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('referrer', [''])[0]

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/scripts-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/scripts-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.html\r\n'

--- a/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/xml-stylesheet-processing-instructions-frame.py
+++ b/LayoutTests/http/tests/contentdispositionattachmentsandbox/resources/xml-stylesheet-processing-instructions-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test.xhtml\r\n'

--- a/LayoutTests/http/tests/contentextensions/block-cookies-in-csp-report.py
+++ b/LayoutTests/http/tests/contentextensions/block-cookies-in-csp-report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'self\'; report-uri /contentextensions/resources/save-ping.py?test=contentextensions-block-cookies-in-csp-report\r\n'

--- a/LayoutTests/http/tests/contentextensions/block-csp-report.py
+++ b/LayoutTests/http/tests/contentextensions/block-csp-report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'self\'; report-uri http://localhost:8000/contentextensions/resources/save-ping.py?test=contentextensions-block-csp-report\r\n'

--- a/LayoutTests/http/tests/contentextensions/block-everything-unless-domain-redirect.py
+++ b/LayoutTests/http/tests/contentextensions/block-everything-unless-domain-redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: http://localhost/contentextensions/resources/should-not-load.html\r\n'

--- a/LayoutTests/http/tests/contentextensions/hide-on-csp-report.py
+++ b/LayoutTests/http/tests/contentextensions/hide-on-csp-report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'self\'; report-uri http://localhost:8000/contentextensions/resources/save-ping.py?test=contentextensions-hide-on-csp-report\r\n'

--- a/LayoutTests/http/tests/contentextensions/main-resource-redirect-blocked.py
+++ b/LayoutTests/http/tests/contentextensions/main-resource-redirect-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: resources/main-resource-redirect-blocked-target.html\r\n'

--- a/LayoutTests/http/tests/contentextensions/resources/delete-ping.py
+++ b/LayoutTests/http/tests/contentextensions/resources/delete-ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from ping_file_path import ping_filepath
 
 if os.path.isfile(ping_filepath):

--- a/LayoutTests/http/tests/contentextensions/resources/get-ping-data.py
+++ b/LayoutTests/http/tests/contentextensions/resources/get-ping-data.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from ping_file_path import ping_filepath
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/contentextensions/resources/ping_file_path.py
+++ b/LayoutTests/http/tests/contentextensions/resources/ping_file_path.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/contentextensions/resources/redirect.py
+++ b/LayoutTests/http/tests/contentextensions/resources/redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 to = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('to', [None])[0]

--- a/LayoutTests/http/tests/contentextensions/resources/save-ping-and-redirect-to-save-ping.py
+++ b/LayoutTests/http/tests/contentextensions/resources/save-ping-and-redirect-to-save-ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from save_ping import save_ping
 
 query_string = os.environ.get('QUERY_STRING', None)

--- a/LayoutTests/http/tests/contentextensions/resources/save_ping.py
+++ b/LayoutTests/http/tests/contentextensions/resources/save_ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from ping_file_path import ping_filepath
 

--- a/LayoutTests/http/tests/contentextensions/resources/subresource-redirect.py
+++ b/LayoutTests/http/tests/contentextensions/resources/subresource-redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: http://localhost:8000/resources/square128.png\r\n'

--- a/LayoutTests/http/tests/cookies/multiple-redirect-and-set-cookie.py
+++ b/LayoutTests/http/tests/cookies/multiple-redirect-and-set-cookie.py
@@ -3,6 +3,7 @@
 import hashlib
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cookies/resources/cookie-utility.py
+++ b/LayoutTests/http/tests/cookies/resources/cookie-utility.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cookies/resources/cookie-with-multiple-level-path.py
+++ b/LayoutTests/http/tests/cookies/resources/cookie-with-multiple-level-path.py
@@ -2,5 +2,6 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html\r\n\r\n{}'.format(os.environ.get('HTTP_COOKIE', '')))

--- a/LayoutTests/http/tests/cookies/resources/cookie_utilities.py
+++ b/LayoutTests/http/tests/cookies/resources/cookie_utilities.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/cookies/resources/delete-cookie.py
+++ b/LayoutTests/http/tests/cookies/resources/delete-cookie.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cookies/resources/echo-cookies.py
+++ b/LayoutTests/http/tests/cookies/resources/echo-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n\r\n'

--- a/LayoutTests/http/tests/cookies/resources/echo-http-and-dom-cookies-and-notify-done.py
+++ b/LayoutTests/http/tests/cookies/resources/echo-http-and-dom-cookies-and-notify-done.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/cookies/resources/echo-json.py
+++ b/LayoutTests/http/tests/cookies/resources/echo-json.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/cookies/resources/post-cookies-to-opener.py
+++ b/LayoutTests/http/tests/cookies/resources/post-cookies-to-opener.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py
+++ b/LayoutTests/http/tests/cookies/resources/set-cookie-and-redirect-back.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cookies/resources/set-cookie-on-redirect.py
+++ b/LayoutTests/http/tests/cookies/resources/set-cookie-on-redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cookies/resources/set-http-only-cookie.py
+++ b/LayoutTests/http/tests/cookies/resources/set-http-only-cookie.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py
+++ b/LayoutTests/http/tests/cookies/same-site/lax-samesite-cookie-after-cross-site-history-load.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/cookies/same-site/resources/click-hyperlink.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/click-hyperlink.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-navigating-iframe-in-cross-origin-page.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-cross-origin-redirect.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-cross-origin-redirect.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-navigation-from-cross-origin-page.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-navigation-from-cross-origin-page.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-navigation-initiated-from-iframe-in-cross-origin-page.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-navigation-initiated-from-iframe-in-cross-origin-page.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-same-origin-redirect.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-after-top-level-same-origin-redirect.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))

--- a/LayoutTests/http/tests/cookies/same-site/resources/fetch-in-same-origin-service-worker.py
+++ b/LayoutTests/http/tests/cookies/same-site/resources/fetch-in-same-origin-service-worker.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file)))))

--- a/LayoutTests/http/tests/cookies/same-site/set-first-party-cross-site-cookies.py
+++ b/LayoutTests/http/tests/cookies/same-site/set-first-party-cross-site-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.abspath(os.path.dirname(file)))

--- a/LayoutTests/http/tests/cookies/same-site/set-first-party-same-site-cookies.py
+++ b/LayoutTests/http/tests/cookies/same-site/set-first-party-same-site-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.abspath(os.path.dirname(file)))

--- a/LayoutTests/http/tests/cookies/same-site/user-load-cross-site-redirect.py
+++ b/LayoutTests/http/tests/cookies/same-site/user-load-cross-site-redirect.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import quote
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/css/resources/500.py
+++ b/LayoutTests/http/tests/css/resources/500.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(0.0001)

--- a/LayoutTests/http/tests/css/resources/delayedCircle.py
+++ b/LayoutTests/http/tests/css/resources/delayedCircle.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(0.01)

--- a/LayoutTests/http/tests/css/resources/webfont-request.py
+++ b/LayoutTests/http/tests/css/resources/webfont-request.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/dom/resources/send-mime-type.py
+++ b/LayoutTests/http/tests/dom/resources/send-mime-type.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 content_type = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('m', ['text/html'])[0]

--- a/LayoutTests/http/tests/download/resources/basic-ascii.py
+++ b/LayoutTests/http/tests/download/resources/basic-ascii.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: attachment; filename=test file.txt\r\n'

--- a/LayoutTests/http/tests/download/resources/content-disposition-pass-no-extension-octet-stream.py
+++ b/LayoutTests/http/tests/download/resources/content-disposition-pass-no-extension-octet-stream.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: Attachment; filename=PASS\r\n'

--- a/LayoutTests/http/tests/download/resources/content-disposition-pass-no-extension-text-plain.py
+++ b/LayoutTests/http/tests/download/resources/content-disposition-pass-no-extension-text-plain.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: Attachment; filename=PASS\r\n'

--- a/LayoutTests/http/tests/download/resources/content-disposition-pass.py
+++ b/LayoutTests/http/tests/download/resources/content-disposition-pass.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Disposition: Attachment; filename=PASS.txt\r\n'

--- a/LayoutTests/http/tests/download/resources/literal-koi8-r.py
+++ b/LayoutTests/http/tests/download/resources/literal-koi8-r.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Disposition: attachment; filename=SU\xf3\xf3\xe5SS.txt\r\n'.encode('latin-1').decode('koi8-r', 'replace'))
 sys.stdout.write(

--- a/LayoutTests/http/tests/download/resources/literal-utf-8.py
+++ b/LayoutTests/http/tests/download/resources/literal-utf-8.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Disposition: attachment; filename=SU\xd0\xa1\xd0\xa1\xd0\x95SS.txt\r\n'.encode('latin-1').decode('utf-8', 'replace'))
 sys.stdout.write(

--- a/LayoutTests/http/tests/eventsource/resources/es-cors-basic.py
+++ b/LayoutTests/http/tests/eventsource/resources/es-cors-basic.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 request_method = os.environ.get('REQUEST_METHOD')

--- a/LayoutTests/http/tests/eventsource/resources/es-cors-credentials.py
+++ b/LayoutTests/http/tests/eventsource/resources/es-cors-credentials.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 request_method = os.environ.get('REQUEST_METHOD')

--- a/LayoutTests/http/tests/eventsource/resources/es-eof.py
+++ b/LayoutTests/http/tests/eventsource/resources/es-eof.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 id = float(os.environ.get('HTTP_LAST_EVENT_ID', 0)) + 1
 

--- a/LayoutTests/http/tests/eventsource/resources/event-stream.py
+++ b/LayoutTests/http/tests/eventsource/resources/event-stream.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/event-stream\r\n\r\n\n'

--- a/LayoutTests/http/tests/eventsource/resources/infinite-event-stream.py
+++ b/LayoutTests/http/tests/eventsource/resources/infinite-event-stream.py
@@ -4,6 +4,7 @@ import json
 import os
 import random
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from datetime import datetime
 

--- a/LayoutTests/http/tests/eventsource/resources/reconnect.py
+++ b/LayoutTests/http/tests/eventsource/resources/reconnect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/event-stream\r\n\r\n')
 

--- a/LayoutTests/http/tests/eventsource/resources/response-content-type-charset.py
+++ b/LayoutTests/http/tests/eventsource/resources/response-content-type-charset.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 contentType = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('contentType', [''])[0]

--- a/LayoutTests/http/tests/eventsource/resources/status-codes.py
+++ b/LayoutTests/http/tests/eventsource/resources/status-codes.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 status_code = int(parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('status-code', [200])[0])

--- a/LayoutTests/http/tests/eventsource/resources/wait-then-notify-done.py
+++ b/LayoutTests/http/tests/eventsource/resources/wait-then-notify-done.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/fetch/resources/dump-authorization-header.py
+++ b/LayoutTests/http/tests/fetch/resources/dump-authorization-header.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html\r\n\r\n')
 if os.environ.get('HTTP_AUTHORIZATION'):

--- a/LayoutTests/http/tests/fetch/resources/get-set-temp-file.py
+++ b/LayoutTests/http/tests/fetch/resources/get-set-temp-file.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 import time
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/fetch/resources/redirect-with-cache.py
+++ b/LayoutTests/http/tests/fetch/resources/redirect-with-cache.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/gzip-content-encoding/resources/echo-data-encoding-with-gzip.py
+++ b/LayoutTests/http/tests/gzip-content-encoding/resources/echo-data-encoding-with-gzip.py
@@ -3,6 +3,7 @@
 import gzip
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/history/back-to-post.py
+++ b/LayoutTests/http/tests/history/back-to-post.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-control: no-cache, no-store\r\n'

--- a/LayoutTests/http/tests/history/back-with-fragment-change.py
+++ b/LayoutTests/http/tests/history/back-with-fragment-change.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 # We intentionally want the page to load slowly (every time, hence no caching), 

--- a/LayoutTests/http/tests/history/resources/back-during-onload-hung-page.py
+++ b/LayoutTests/http/tests/history/resources/back-during-onload-hung-page.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(60)

--- a/LayoutTests/http/tests/history/resources/replacestate-current.py
+++ b/LayoutTests/http/tests/history/resources/replacestate-current.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 method = os.environ.get('REQUEST_METHOD', '')
 

--- a/LayoutTests/http/tests/history/resources/replacestate-forward-back.py
+++ b/LayoutTests/http/tests/history/resources/replacestate-forward-back.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 method = os.environ.get('REQUEST_METHOD', '')
 

--- a/LayoutTests/http/tests/history/resources/slow-image.py
+++ b/LayoutTests/http/tests/history/resources/slow-image.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(30)

--- a/LayoutTests/http/tests/iframe-monitor/resources/generate-byte.py
+++ b/LayoutTests/http/tests/iframe-monitor/resources/generate-byte.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import random
 import string
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/in-app-browser-privacy/resources/redirect.py
+++ b/LayoutTests/http/tests/in-app-browser-privacy/resources/redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 step = int(parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('step', [0])[0])

--- a/LayoutTests/http/tests/incremental/resources/delayed-css.py
+++ b/LayoutTests/http/tests/incremental/resources/delayed-css.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/inspector/network/resources/404.py
+++ b/LayoutTests/http/tests/inspector/network/resources/404.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 s = '12345678'
 for i in range(0, 6):

--- a/LayoutTests/http/tests/inspector/network/resources/basic-auth.py
+++ b/LayoutTests/http/tests/inspector/network/resources/basic-auth.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html' + '\r\n')
 

--- a/LayoutTests/http/tests/inspector/network/resources/beacon.py
+++ b/LayoutTests/http/tests/inspector/network/resources/beacon.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 status = int(parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('status', [200])[0])

--- a/LayoutTests/http/tests/inspector/network/resources/delay.py
+++ b/LayoutTests/http/tests/inspector/network/resources/delay.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/inspector/network/resources/echo.py
+++ b/LayoutTests/http/tests/inspector/network/resources/echo.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/inspector/network/resources/event-source.py
+++ b/LayoutTests/http/tests/inspector/network/resources/event-source.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 sys.stdout.write('Content-Type: text/html\r\n')

--- a/LayoutTests/http/tests/inspector/network/resources/fetch-cachable.py
+++ b/LayoutTests/http/tests/inspector/network/resources/fetch-cachable.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 status = os.environ.get('HTTP_X_STATUS_CODE_NEEDED')
 

--- a/LayoutTests/http/tests/inspector/network/resources/gzipped-lorem-no-content-length.py
+++ b/LayoutTests/http/tests/inspector/network/resources/gzipped-lorem-no-content-length.py
@@ -3,6 +3,7 @@
 import gzip
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 text = b'''Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus a luctus justo, a placerat est. Vestibulum a venenatis lectus. Phasellus vehicula neque id est semper, ac congue felis commodo. Suspendisse potenti. Nam eget placerat erat. Nulla ultricies consequat eros ac vestibulum. Aliquam imperdiet massa augue, nec faucibus nisi semper ac. Ut nibh nisl, iaculis id mattis sit amet, ultricies sed eros. Vivamus vel mi ante. Praesent commodo finibus justo, sed hendrerit urna convallis eget. Maecenas condimentum mi elit, eu gravida eros consequat at. Nulla rutrum lorem neque, ut finibus metus posuere non. Quisque nulla justo, scelerisque sed ornare eu, aliquet id est. Ut at ornare dui.
 

--- a/LayoutTests/http/tests/inspector/network/resources/gzipped-lorem.py
+++ b/LayoutTests/http/tests/inspector/network/resources/gzipped-lorem.py
@@ -3,6 +3,7 @@
 import gzip
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 text = b'''Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus a luctus justo, a placerat est. Vestibulum a venenatis lectus. Phasellus vehicula neque id est semper, ac congue felis commodo. Suspendisse potenti. Nam eget placerat erat. Nulla ultricies consequat eros ac vestibulum. Aliquam imperdiet massa augue, nec faucibus nisi semper ac. Ut nibh nisl, iaculis id mattis sit amet, ultricies sed eros. Vivamus vel mi ante. Praesent commodo finibus justo, sed hendrerit urna convallis eget. Maecenas condimentum mi elit, eu gravida eros consequat at. Nulla rutrum lorem neque, ut finibus metus posuere non. Quisque nulla justo, scelerisque sed ornare eu, aliquet id est. Ut at ornare dui.
 

--- a/LayoutTests/http/tests/inspector/network/resources/intercept-echo.py
+++ b/LayoutTests/http/tests/inspector/network/resources/intercept-echo.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 headers = {}

--- a/LayoutTests/http/tests/inspector/network/resources/json.py
+++ b/LayoutTests/http/tests/inspector/network/resources/json.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: application/json\r\n\r\n'

--- a/LayoutTests/http/tests/inspector/network/resources/ping.py
+++ b/LayoutTests/http/tests/inspector/network/resources/ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 sys.stdout.write('Content-Type: text/html\r\n')

--- a/LayoutTests/http/tests/inspector/network/resources/redirect.py
+++ b/LayoutTests/http/tests/inspector/network/resources/redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n\r\n'

--- a/LayoutTests/http/tests/inspector/network/resources/x-frame-options.py
+++ b/LayoutTests/http/tests/inspector/network/resources/x-frame-options.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 option = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('option', ['DENY'])[0]

--- a/LayoutTests/http/tests/inspector/page/resources/set-cookie.py
+++ b/LayoutTests/http/tests/inspector/page/resources/set-cookie.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/loading/authentication-after-redirect-stores-wrong-credentials/resources/wrong-credential-1-redirect-to-auth.py
+++ b/LayoutTests/http/tests/loading/authentication-after-redirect-stores-wrong-credentials/resources/wrong-credential-1-redirect-to-auth.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 # This page was supposed to be loaded using a localhost URL.
 # That is important, and the next page has to be loaded using 127.0.0.1.

--- a/LayoutTests/http/tests/loading/authentication-after-redirect-stores-wrong-credentials/resources/wrong-credential-2-auth-then-redirect-to-finish.py
+++ b/LayoutTests/http/tests/loading/authentication-after-redirect-stores-wrong-credentials/resources/wrong-credential-2-auth-then-redirect-to-finish.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 

--- a/LayoutTests/http/tests/loading/authentication-after-redirect-stores-wrong-credentials/resources/wrong-credential-3-output-credentials-then-finish.py
+++ b/LayoutTests/http/tests/loading/authentication-after-redirect-stores-wrong-credentials/resources/wrong-credential-3-output-credentials-then-finish.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/loading/nested_bad_objects.py
+++ b/LayoutTests/http/tests/loading/nested_bad_objects.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from urllib.parse import parse_qs
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
 
@@ -21,4 +22,4 @@ else:
         '    </object>\n'
         '    PASS - nested image objects with bad mimetype do not cause a crash.\n'
         '</html>\n'
-)
+    )

--- a/LayoutTests/http/tests/loading/preload-append-scan.py
+++ b/LayoutTests/http/tests/loading/preload-append-scan.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/loading/preload-slow-loading.py
+++ b/LayoutTests/http/tests/loading/preload-slow-loading.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/loading/resourceLoadStatistics/resources/get-cookies.py
+++ b/LayoutTests/http/tests/loading/resourceLoadStatistics/resources/get-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/loading/resources/303-to-307-target.py
+++ b/LayoutTests/http/tests/loading/resources/303-to-307-target.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 307\r\n'

--- a/LayoutTests/http/tests/loading/resources/307-post-output-target.py
+++ b/LayoutTests/http/tests/loading/resources/307-post-output-target.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 request = {}
 form = cgi.FieldStorage()

--- a/LayoutTests/http/tests/loading/resources/basic-auth-testing.py
+++ b/LayoutTests/http/tests/loading/resources/basic-auth-testing.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')

--- a/LayoutTests/http/tests/loading/resources/cached-stylesheet-from-different-domain-frame.css.py
+++ b/LayoutTests/http/tests/loading/resources/cached-stylesheet-from-different-domain-frame.css.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: public, max-age=264\r\n'

--- a/LayoutTests/http/tests/loading/resources/imported-stylesheet-varying-according-domain.css.py
+++ b/LayoutTests/http/tests/loading/resources/imported-stylesheet-varying-according-domain.css.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 host = os.environ.get('HTTP_HOST', '')

--- a/LayoutTests/http/tests/loading/resources/oauth-subresource.py
+++ b/LayoutTests/http/tests/loading/resources/oauth-subresource.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 realm = os.environ.get('REQUEST_URI', '')
 

--- a/LayoutTests/http/tests/loading/resources/othersubresources/protected-resource.py
+++ b/LayoutTests/http/tests/loading/resources/othersubresources/protected-resource.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/loading/resources/post-in-iframe-with-back-navigation-page-1.py
+++ b/LayoutTests/http/tests/loading/resources/post-in-iframe-with-back-navigation-page-1.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 now = time.time()

--- a/LayoutTests/http/tests/loading/resources/post-in-iframe-with-back-navigation-page-2.py
+++ b/LayoutTests/http/tests/loading/resources/post-in-iframe-with-back-navigation-page-2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 now = time.time()

--- a/LayoutTests/http/tests/loading/resources/post-in-iframe-with-back-navigation-page-3.py
+++ b/LayoutTests/http/tests/loading/resources/post-in-iframe-with-back-navigation-page-3.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 now = time.time()

--- a/LayoutTests/http/tests/loading/resources/post-to-303-target.py
+++ b/LayoutTests/http/tests/loading/resources/post-to-303-target.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 303\r\n'

--- a/LayoutTests/http/tests/loading/resources/protected-resource.py
+++ b/LayoutTests/http/tests/loading/resources/protected-resource.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/loading/resources/redirect-methods-result.py
+++ b/LayoutTests/http/tests/loading/resources/redirect-methods-result.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/loading/resources/redirect-with-no-location-crash.py
+++ b/LayoutTests/http/tests/loading/resources/redirect-with-no-location-crash.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 302\r\n'

--- a/LayoutTests/http/tests/loading/resources/resource-that-goes-back-while-still-loading.py
+++ b/LayoutTests/http/tests/loading/resources/resource-that-goes-back-while-still-loading.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/loading/resources/server-redirect.py
+++ b/LayoutTests/http/tests/loading/resources/server-redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: server-redirect-result.html\r\n'

--- a/LayoutTests/http/tests/loading/resources/slowimage.py
+++ b/LayoutTests/http/tests/loading/resources/slowimage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(30)

--- a/LayoutTests/http/tests/loading/resources/subresources/protected-resource.py
+++ b/LayoutTests/http/tests/loading/resources/subresources/protected-resource.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/loading/resources/test2/basic-auth-testing.py
+++ b/LayoutTests/http/tests/loading/resources/test2/basic-auth-testing.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')

--- a/LayoutTests/http/tests/loading/resources/test2/protected-resource.py
+++ b/LayoutTests/http/tests/loading/resources/test2/protected-resource.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py
+++ b/LayoutTests/http/tests/media/resources/hls/dynamic-ext-date-range.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime
 from datetime import timedelta
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/media/resources/hls/generate-vod.py
+++ b/LayoutTests/http/tests/media/resources/hls/generate-vod.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/media/resources/hls/sub-playlist-with-cookie.py
+++ b/LayoutTests/http/tests/media/resources/hls/sub-playlist-with-cookie.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/media/resources/hls/test-live.py
+++ b/LayoutTests/http/tests/media/resources/hls/test-live.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/media/resources/serve_video.py
+++ b/LayoutTests/http/tests/media/resources/serve_video.py
@@ -9,6 +9,7 @@ import json
 import math
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from datetime import datetime
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/media/resources/video-auth.py
+++ b/LayoutTests/http/tests/media/resources/video-auth.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs, urlencode
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]

--- a/LayoutTests/http/tests/media/resources/video-check-useragent.py
+++ b/LayoutTests/http/tests/media/resources/video-check-useragent.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs, urlencode
 
 user_agent = os.environ.get('HTTP_USER_AGENT', None)

--- a/LayoutTests/http/tests/media/resources/video-cookie-check-cookie.py
+++ b/LayoutTests/http/tests/media/resources/video-cookie-check-cookie.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/media/resources/video-referer-check-referer.py
+++ b/LayoutTests/http/tests/media/resources/video-referer-check-referer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs, urlencode
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/mime/quoted-charset.py
+++ b/LayoutTests/http/tests/mime/quoted-charset.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html; charset="utf-8"\r\n\r\n')
 

--- a/LayoutTests/http/tests/mime/resources/style-with-charset.py
+++ b/LayoutTests/http/tests/mime/resources/style-with-charset.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/css; charset=utf-8\r\n\r\n'

--- a/LayoutTests/http/tests/mime/resources/style-with-text-css-and-invalid-type.py
+++ b/LayoutTests/http/tests/mime/resources/style-with-text-css-and-invalid-type.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/css, 200904131203\r\n\r\n'

--- a/LayoutTests/http/tests/mime/resources/style-with-text-plain.py
+++ b/LayoutTests/http/tests/mime/resources/style-with-text-plain.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/plain\r\n\r\n'

--- a/LayoutTests/http/tests/mime/resources/uppercase-mime-type.py
+++ b/LayoutTests/http/tests/mime/resources/uppercase-mime-type.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: TEXT/HTML\r\n\r\n')
 

--- a/LayoutTests/http/tests/misc/401-alternative-content.py
+++ b/LayoutTests/http/tests/misc/401-alternative-content.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 

--- a/LayoutTests/http/tests/misc/authentication-redirect-1/resources/auth-echo.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-1/resources/auth-echo.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/misc/authentication-redirect-1/resources/auth-then-redirect.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-1/resources/auth-then-redirect.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')

--- a/LayoutTests/http/tests/misc/authentication-redirect-2/resources/auth-echo.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-2/resources/auth-echo.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/misc/authentication-redirect-2/resources/auth-then-redirect.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-2/resources/auth-then-redirect.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')

--- a/LayoutTests/http/tests/misc/authentication-redirect-3/resources/auth-echo.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-3/resources/auth-echo.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/misc/authentication-redirect-3/resources/auth-then-redirect-with-url-credentials.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-3/resources/auth-then-redirect-with-url-credentials.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')

--- a/LayoutTests/http/tests/misc/authentication-redirect-3/resources/auth-then-redirect.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-3/resources/auth-then-redirect.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')

--- a/LayoutTests/http/tests/misc/authentication-redirect-4/resources/auth-echo.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-4/resources/auth-echo.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/misc/authentication-redirect-4/resources/auth-then-redirect.py
+++ b/LayoutTests/http/tests/misc/authentication-redirect-4/resources/auth-then-redirect.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/misc/extract-http-content-language-against-equiv.py
+++ b/LayoutTests/http/tests/misc/extract-http-content-language-against-equiv.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Language: zh-CN\r\n'

--- a/LayoutTests/http/tests/misc/extract-http-content-language-malformed.py
+++ b/LayoutTests/http/tests/misc/extract-http-content-language-malformed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Language: ,es\r\n'

--- a/LayoutTests/http/tests/misc/extract-http-content-language-multiple.py
+++ b/LayoutTests/http/tests/misc/extract-http-content-language-multiple.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Language:  fr \t , fi \r\n'

--- a/LayoutTests/http/tests/misc/extract-http-content-language.py
+++ b/LayoutTests/http/tests/misc/extract-http-content-language.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Language: zh-CN\r\n'

--- a/LayoutTests/http/tests/misc/ftp-eplf-directory.py
+++ b/LayoutTests/http/tests/misc/ftp-eplf-directory.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/misc/large-js-program.py
+++ b/LayoutTests/http/tests/misc/large-js-program.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n\r\n'

--- a/LayoutTests/http/tests/misc/location-with-space.py
+++ b/LayoutTests/http/tests/misc/location-with-space.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 302\r\n'

--- a/LayoutTests/http/tests/misc/redirect-with-quotes.py
+++ b/LayoutTests/http/tests/misc/redirect-with-quotes.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Refresh: 0, URL    =   "resources/redirect-step2.py"\r\n'

--- a/LayoutTests/http/tests/misc/redirect.py
+++ b/LayoutTests/http/tests/misc/redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: resources/redirect-result.py\r\n'

--- a/LayoutTests/http/tests/misc/refresh-headers.py
+++ b/LayoutTests/http/tests/misc/refresh-headers.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 cache_control = os.environ.get('HTTP_CACHE_CONTROL', '')
 pragma = os.environ.get('HTTP_PRAGMA', '')

--- a/LayoutTests/http/tests/misc/resources/3rd-level-iframe-with-blocking-resource.py
+++ b/LayoutTests/http/tests/misc/resources/3rd-level-iframe-with-blocking-resource.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(1)

--- a/LayoutTests/http/tests/misc/resources/404image.py
+++ b/LayoutTests/http/tests/misc/resources/404image.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 404\r\n'

--- a/LayoutTests/http/tests/misc/resources/bad-charset-alias.py
+++ b/LayoutTests/http/tests/misc/resources/bad-charset-alias.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 charset = query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('charset', [''])[0]

--- a/LayoutTests/http/tests/misc/resources/basic-echo-post.py
+++ b/LayoutTests/http/tests/misc/resources/basic-echo-post.py
@@ -4,6 +4,7 @@ import base64
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/misc/resources/bocu-1-cyrillic.py
+++ b/LayoutTests/http/tests/misc/resources/bocu-1-cyrillic.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html; charset=BOCU-1\r\n\r\n'

--- a/LayoutTests/http/tests/misc/resources/char-encoding-in-hidden-charset-field.py
+++ b/LayoutTests/http/tests/misc/resources/char-encoding-in-hidden-charset-field.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 request_method = os.environ.get('REQUEST_METHOD', '')

--- a/LayoutTests/http/tests/misc/resources/charset-sniffer-end-sniffing.py
+++ b/LayoutTests/http/tests/misc/resources/charset-sniffer-end-sniffing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/misc/resources/check-query-param.py
+++ b/LayoutTests/http/tests/misc/resources/check-query-param.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/misc/resources/check-test-file.py
+++ b/LayoutTests/http/tests/misc/resources/check-test-file.py
@@ -2,6 +2,7 @@
 
 import cgi
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 form = cgi.FieldStorage()
 data = form.getvalue('data')

--- a/LayoutTests/http/tests/misc/resources/check-unnamed-file-included-in-formdata.py
+++ b/LayoutTests/http/tests/misc/resources/check-unnamed-file-included-in-formdata.py
@@ -2,6 +2,7 @@
 
 import cgi
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 form = cgi.FieldStorage()
 data = form.getvalue('data')

--- a/LayoutTests/http/tests/misc/resources/delayed-log.py
+++ b/LayoutTests/http/tests/misc/resources/delayed-log.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/misc/resources/dns-prefetch-control.py
+++ b/LayoutTests/http/tests/misc/resources/dns-prefetch-control.py
@@ -3,6 +3,7 @@
 import os
 import random
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 value = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('value', [''])[0]

--- a/LayoutTests/http/tests/misc/resources/echo-query-param.py
+++ b/LayoutTests/http/tests/misc/resources/echo-query-param.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 q = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('q', [''])[0]

--- a/LayoutTests/http/tests/misc/resources/form-post-textplain.py
+++ b/LayoutTests/http/tests/misc/resources/form-post-textplain.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 content_type = os.environ.get('CONTENT_TYPE', '')
 data = ''.join(sys.stdin.readlines())

--- a/LayoutTests/http/tests/misc/resources/hang-connection.py
+++ b/LayoutTests/http/tests/misc/resources/hang-connection.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write('Content-Type: text/html\r\n\r\n')

--- a/LayoutTests/http/tests/misc/resources/image-checks-for-accept.py
+++ b/LayoutTests/http/tests/misc/resources/image-checks-for-accept.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 http_accept = os.environ.get('HTTP_ACCEPT', '')
 

--- a/LayoutTests/http/tests/misc/resources/image-heic-accept.py
+++ b/LayoutTests/http/tests/misc/resources/image-heic-accept.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 http_accept = os.environ.get('HTTP_ACCEPT', '')
 

--- a/LayoutTests/http/tests/misc/resources/prefetch-purpose.py
+++ b/LayoutTests/http/tests/misc/resources/prefetch-purpose.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/misc/resources/protected/protected-image.py
+++ b/LayoutTests/http/tests/misc/resources/protected/protected-image.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 uri = os.environ.get('REQUEST_URI', '')
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]

--- a/LayoutTests/http/tests/misc/resources/random-no-store.py
+++ b/LayoutTests/http/tests/misc/resources/random-no-store.py
@@ -2,6 +2,7 @@
 
 import random
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: no-store\r\n'

--- a/LayoutTests/http/tests/misc/resources/redirect-result.py
+++ b/LayoutTests/http/tests/misc/resources/redirect-result.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 user_agent = os.environ.get('HTTP_USER_AGENT', '')
 

--- a/LayoutTests/http/tests/misc/resources/redirect-step2.py
+++ b/LayoutTests/http/tests/misc/resources/redirect-step2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Refresh:   0   ;   url=    \'redirect-step3.py\'   \r\n'

--- a/LayoutTests/http/tests/misc/resources/redirect-step3.py
+++ b/LayoutTests/http/tests/misc/resources/redirect-step3.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n\r\n'

--- a/LayoutTests/http/tests/misc/resources/redirect-step4.py
+++ b/LayoutTests/http/tests/misc/resources/redirect-step4.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n\r\n'

--- a/LayoutTests/http/tests/misc/resources/redirect-to-about-blank.py
+++ b/LayoutTests/http/tests/misc/resources/redirect-to-about-blank.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: about:blank\r\n'

--- a/LayoutTests/http/tests/misc/resources/redirect-to-external-url.py
+++ b/LayoutTests/http/tests/misc/resources/redirect-to-external-url.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: spaceballs://the-flamethrower/\r\n'

--- a/LayoutTests/http/tests/misc/resources/redirect-to-http-url.py
+++ b/LayoutTests/http/tests/misc/resources/redirect-to-http-url.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: http://www.example.com/\r\n'

--- a/LayoutTests/http/tests/misc/resources/referrer-result.py
+++ b/LayoutTests/http/tests/misc/resources/referrer-result.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/misc/resources/script-500.py
+++ b/LayoutTests/http/tests/misc/resources/script-500.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 500\r\n'

--- a/LayoutTests/http/tests/misc/resources/scsu-cyrillic.py
+++ b/LayoutTests/http/tests/misc/resources/scsu-cyrillic.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html; charset=SCSU\r\n\r\n'

--- a/LayoutTests/http/tests/misc/resources/slowimage.py
+++ b/LayoutTests/http/tests/misc/resources/slowimage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(30)

--- a/LayoutTests/http/tests/misc/resources/stylesheet-bad-mime-type.py
+++ b/LayoutTests/http/tests/misc/resources/stylesheet-bad-mime-type.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 http_accept = os.environ.get('HTTP_ACCEPT', '')
 

--- a/LayoutTests/http/tests/misc/resources/webtiming-cross-origin-and-back-redirect1.py
+++ b/LayoutTests/http/tests/misc/resources/webtiming-cross-origin-and-back-redirect1.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: http://localhost:8000/misc/resources/webtiming-cross-origin-and-back-redirect2.py\r\n'

--- a/LayoutTests/http/tests/misc/resources/webtiming-cross-origin-and-back-redirect2.py
+++ b/LayoutTests/http/tests/misc/resources/webtiming-cross-origin-and-back-redirect2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 # 127.0.0.1 is where the test originally started. We redirected to "localhost" before this.
 sys.stdout.write(

--- a/LayoutTests/http/tests/misc/webtiming-cross-origin-redirect.py
+++ b/LayoutTests/http/tests/misc/webtiming-cross-origin-redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: http://localhost:8080/misc/resources/webtiming-cross-origin-redirect.html\r\n'

--- a/LayoutTests/http/tests/misc/webtiming-one-redirect.py
+++ b/LayoutTests/http/tests/misc/webtiming-one-redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: resources/webtiming-one-redirect.html\r\n'

--- a/LayoutTests/http/tests/misc/webtiming-slow-load.py
+++ b/LayoutTests/http/tests/misc/webtiming-slow-load.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/misc/webtiming-ssl.py
+++ b/LayoutTests/http/tests/misc/webtiming-ssl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: https://127.0.0.1:8443/misc/resources/webtiming-ssl.html\r\n'

--- a/LayoutTests/http/tests/misc/webtiming-two-redirects.py
+++ b/LayoutTests/http/tests/misc/webtiming-two-redirects.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: ../resources/redirect.py?url=../misc/resources/webtiming-two-redirects.html\r\n'

--- a/LayoutTests/http/tests/misc/xhtml.py
+++ b/LayoutTests/http/tests/misc/xhtml.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 accept = os.environ.get('HTTP_ACCEPT', '')
 

--- a/LayoutTests/http/tests/navigation/post-redirect-get-reload.py
+++ b/LayoutTests/http/tests/navigation/post-redirect-get-reload.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 method = os.environ.get('REQUEST_METHOD', '')
 

--- a/LayoutTests/http/tests/navigation/pushstate-at-unique-origin-denied.py
+++ b/LayoutTests/http/tests/navigation/pushstate-at-unique-origin-denied.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: sandbox allow-scripts\r\n'

--- a/LayoutTests/http/tests/navigation/resources/back-send-referrer-helper.py
+++ b/LayoutTests/http/tests/navigation/resources/back-send-referrer-helper.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/navigation/resources/check-ping-app-initiated-data.py
+++ b/LayoutTests/http/tests/navigation/resources/check-ping-app-initiated-data.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from ping_file_path import ping_filepath
 

--- a/LayoutTests/http/tests/navigation/resources/check-ping-user-initiated-data.py
+++ b/LayoutTests/http/tests/navigation/resources/check-ping-user-initiated-data.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from ping_file_path import ping_filepath
 

--- a/LayoutTests/http/tests/navigation/resources/check-ping.py
+++ b/LayoutTests/http/tests/navigation/resources/check-ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from ping_file_path import ping_filepath
 

--- a/LayoutTests/http/tests/navigation/resources/delete-ping.py
+++ b/LayoutTests/http/tests/navigation/resources/delete-ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from ping_file_path import ping_filepath
 
 sys.stdout.write('Content-Type: text/html\r\n\r\n')

--- a/LayoutTests/http/tests/navigation/resources/goback-with-policydelegate.py
+++ b/LayoutTests/http/tests/navigation/resources/goback-with-policydelegate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n\r\n'

--- a/LayoutTests/http/tests/navigation/resources/https-in-page-cache-1.py
+++ b/LayoutTests/http/tests/navigation/resources/https-in-page-cache-1.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'cache-control: no-store\r\n'

--- a/LayoutTests/http/tests/navigation/resources/https-in-page-cache-2.py
+++ b/LayoutTests/http/tests/navigation/resources/https-in-page-cache-2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'cache-control: no-cacher\r\n'

--- a/LayoutTests/http/tests/navigation/resources/no-referrer-helper.py
+++ b/LayoutTests/http/tests/navigation/resources/no-referrer-helper.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: no-store, private, max-age=0\r\n'

--- a/LayoutTests/http/tests/navigation/resources/no-referrer-reset-helper.py
+++ b/LayoutTests/http/tests/navigation/resources/no-referrer-reset-helper.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: no-store, private, max-age=0\r\n'

--- a/LayoutTests/http/tests/navigation/resources/no-referrer-same-window-helper.py
+++ b/LayoutTests/http/tests/navigation/resources/no-referrer-same-window-helper.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: no-store, private, max-age=0\r\n'

--- a/LayoutTests/http/tests/navigation/resources/no-store-frame.py
+++ b/LayoutTests/http/tests/navigation/resources/no-store-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'cache-control: no-store\r\n'

--- a/LayoutTests/http/tests/navigation/resources/ping_file_path.py
+++ b/LayoutTests/http/tests/navigation/resources/ping_file_path.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs, urlparse
 

--- a/LayoutTests/http/tests/navigation/resources/post-goback-same-url.py
+++ b/LayoutTests/http/tests/navigation/resources/post-goback-same-url.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 request_method = os.environ.get('REQUEST_METHOD', '')
 

--- a/LayoutTests/http/tests/navigation/resources/post-target-policy-test.py
+++ b/LayoutTests/http/tests/navigation/resources/post-target-policy-test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n\r\n'

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/0.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/0.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/1.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/1.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/2.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/2.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/3.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/3.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/4.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/4.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/5.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/5.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/6.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/6.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/7.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/7.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/8.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/8.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/9.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/9.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', ''):
     sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/resources/randomredirects/randomredirect.py
+++ b/LayoutTests/http/tests/navigation/resources/randomredirects/randomredirect.py
@@ -2,6 +2,7 @@
 
 import random
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 302\r\n'

--- a/LayoutTests/http/tests/navigation/resources/redirect-on-back-updates-history-item.py
+++ b/LayoutTests/http/tests/navigation/resources/redirect-on-back-updates-history-item.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 cookies = {}
 if 'HTTP_COOKIE' in os.environ:

--- a/LayoutTests/http/tests/navigation/resources/redirect-on-reload-updates-history-item-statistics.py
+++ b/LayoutTests/http/tests/navigation/resources/redirect-on-reload-updates-history-item-statistics.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 cookies = {}
 if 'HTTP_COOKIE' in os.environ:

--- a/LayoutTests/http/tests/navigation/resources/redirect-on-reload-updates-history-item.py
+++ b/LayoutTests/http/tests/navigation/resources/redirect-on-reload-updates-history-item.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 cookies = {}
 if 'HTTP_COOKIE' in os.environ:

--- a/LayoutTests/http/tests/navigation/resources/redirect-preserves-fragment.py
+++ b/LayoutTests/http/tests/navigation/resources/redirect-preserves-fragment.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: success.html\r\n'

--- a/LayoutTests/http/tests/navigation/resources/redirect-to-fragment.py
+++ b/LayoutTests/http/tests/navigation/resources/redirect-to-fragment.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: success.html#bar\r\n'

--- a/LayoutTests/http/tests/navigation/resources/redirect-to-fragment2.py
+++ b/LayoutTests/http/tests/navigation/resources/redirect-to-fragment2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: redirect-preserves-fragment.py#bar\r\n'

--- a/LayoutTests/http/tests/navigation/resources/redirect-to-invalid-url-frame.py
+++ b/LayoutTests/http/tests/navigation/resources/redirect-to-invalid-url-frame.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Location: http://localhost:xyz/none-existed.html\r\n'

--- a/LayoutTests/http/tests/navigation/resources/redirected-post-request-contents.py
+++ b/LayoutTests/http/tests/navigation/resources/redirected-post-request-contents.py
@@ -3,6 +3,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 

--- a/LayoutTests/http/tests/navigation/resources/redirection-response.py
+++ b/LayoutTests/http/tests/navigation/resources/redirection-response.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/navigation/resources/referrer.py
+++ b/LayoutTests/http/tests/navigation/resources/referrer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/navigation/resources/save-ping-and-redirect-to-save-ping.py
+++ b/LayoutTests/http/tests/navigation/resources/save-ping-and-redirect-to-save-ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from save_ping import save_ping
 
 query_string = os.environ.get('QUERY_STRING', '')

--- a/LayoutTests/http/tests/navigation/resources/save_ping.py
+++ b/LayoutTests/http/tests/navigation/resources/save_ping.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from ping_file_path import ping_filepath
 

--- a/LayoutTests/http/tests/navigation/resources/target-blank-opener-post-window.py
+++ b/LayoutTests/http/tests/navigation/resources/target-blank-opener-post-window.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/navigation/resources/target-blank-opener-window.py
+++ b/LayoutTests/http/tests/navigation/resources/target-blank-opener-window.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/navigation/resources/user-agent-script.py
+++ b/LayoutTests/http/tests/navigation/resources/user-agent-script.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 user_agent = os.environ.get('HTTP_USER_AGENT', '')
 

--- a/LayoutTests/http/tests/navigation/slow-loading-page-with-slow-script.py
+++ b/LayoutTests/http/tests/navigation/slow-loading-page-with-slow-script.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/navigation/useragent-reload.py
+++ b/LayoutTests/http/tests/navigation/useragent-reload.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 user_agent = os.environ.get('HTTP_USER_AGENT', '')
 

--- a/LayoutTests/http/tests/navigation/useragent.py
+++ b/LayoutTests/http/tests/navigation/useragent.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 user_agent = os.environ.get('HTTP_USER_AGENT', '')
 

--- a/LayoutTests/http/tests/performance/paint-timing/resources/slowscript.py
+++ b/LayoutTests/http/tests/performance/paint-timing/resources/slowscript.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import unquote
 

--- a/LayoutTests/http/tests/performance/paint-timing/resources/slowstyle.py
+++ b/LayoutTests/http/tests/performance/paint-timing/resources/slowstyle.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/preconnect/resources/header-preconnect.py
+++ b/LayoutTests/http/tests/preconnect/resources/header-preconnect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <http://localhost:8000>; rel=preconnect\r\n'

--- a/LayoutTests/http/tests/preload/preload-encoding.py
+++ b/LayoutTests/http/tests/preload/preload-encoding.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <resources/success.js>; rel=preload; as=script\r\n'

--- a/LayoutTests/http/tests/preload/resources/download_resources_from_header.py
+++ b/LayoutTests/http/tests/preload/resources/download_resources_from_header.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <../resources/dummy.js>; rel=preload; as=script\r\n'

--- a/LayoutTests/http/tests/preload/resources/dummy-preloads-subresource.css.py
+++ b/LayoutTests/http/tests/preload/resources/dummy-preloads-subresource.css.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <../resources/dummy.js>; rel=preload; as=script\r\n'

--- a/LayoutTests/http/tests/preload/single_download_preload_headers.py
+++ b/LayoutTests/http/tests/preload/single_download_preload_headers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <http://127.0.0.1:8000/resources/dummy.js>; rel=preload; as=script\r\n'

--- a/LayoutTests/http/tests/preload/single_download_preload_headers_charset.py
+++ b/LayoutTests/http/tests/preload/single_download_preload_headers_charset.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <http://127.0.0.1:8000/resources/dummy.js>; rel=preload; as=script\r\n'

--- a/LayoutTests/http/tests/preload/viewport/meta-viewport-link-headers.py
+++ b/LayoutTests/http/tests/preload/viewport/meta-viewport-link-headers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <http://127.0.0.1:8000/resources/square100.png?timer>;rel=preload;as=image;\"\r\n'

--- a/LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py
+++ b/LayoutTests/http/tests/priority-hints/link-header-fetch-priority.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <../resources/dummy.css?lh0>; rel=preload; as=style; fetchpriority=low;\r\n'

--- a/LayoutTests/http/tests/privateClickMeasurement/resources/conversionReport.py
+++ b/LayoutTests/http/tests/privateClickMeasurement/resources/conversionReport.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from conversionFilePath import conversion_file_path
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/privateClickMeasurement/resources/fraudPreventionTestURL.py
+++ b/LayoutTests/http/tests/privateClickMeasurement/resources/fraudPreventionTestURL.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from tokenSigningFilePath import token_signing_filepath
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/privateClickMeasurement/resources/getConversionData.py
+++ b/LayoutTests/http/tests/privateClickMeasurement/resources/getConversionData.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from conversionFilePath import conversion_file_path
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/privateClickMeasurement/resources/getTokenSigningData.py
+++ b/LayoutTests/http/tests/privateClickMeasurement/resources/getTokenSigningData.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from tokenSigningFilePath import token_signing_filepath
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/privateClickMeasurement/resources/redirectToConversion.py
+++ b/LayoutTests/http/tests/privateClickMeasurement/resources/redirectToConversion.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/privateClickMeasurement/resources/redirectToConversionOnIPAddress.py
+++ b/LayoutTests/http/tests/privateClickMeasurement/resources/redirectToConversionOnIPAddress.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/privateClickMeasurement/resources/redirectToConversionWithAttributionSource.py
+++ b/LayoutTests/http/tests/privateClickMeasurement/resources/redirectToConversionWithAttributionSource.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/quicklook/resources/word-document-with-csp-block-frame-ancestors.py
+++ b/LayoutTests/http/tests/quicklook/resources/word-document-with-csp-block-frame-ancestors.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document\r\n'

--- a/LayoutTests/http/tests/referrer-policy/resources/check-referrer.py
+++ b/LayoutTests/http/tests/referrer-policy/resources/check-referrer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 referer = os.environ.get('HTTP_REFERER', '')

--- a/LayoutTests/http/tests/referrer-policy/resources/check-sec-fetch-site.py
+++ b/LayoutTests/http/tests/referrer-policy/resources/check-sec-fetch-site.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 secFetchSite = os.environ.get('HTTP_SEC_FETCH_SITE', 'missing')

--- a/LayoutTests/http/tests/referrer-policy/resources/image.py
+++ b/LayoutTests/http/tests/referrer-policy/resources/image.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 referer = os.environ.get('HTTP_REFERER', '')

--- a/LayoutTests/http/tests/referrer-policy/resources/script.py
+++ b/LayoutTests/http/tests/referrer-policy/resources/script.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache: no-cache, no-store\r\n'

--- a/LayoutTests/http/tests/resourceLoadStatistics/do-not-switch-session-on-navigation-to-prevalent-without-interaction.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/do-not-switch-session-on-navigation-to-prevalent-without-interaction.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: no-store\r\n'

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/cached-permanent-redirect.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/cached-permanent-redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if_none_match = os.environ.get('HTTP_IF_NONE_MATCH', None)
 if_modified_since = os.environ.get('HTTP_IF_MODIFIED_SINCE', None)

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/echo-query.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/echo-query.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 value = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('value', [None])[0]

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/echo-referrer.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/echo-referrer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/get-cookies.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/get-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 cookies = {}

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/redirect.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/script-revealing-cookies.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/script-revealing-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/set-all-kinds-of-cookies.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/set-all-kinds-of-cookies.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 
 expires = datetime.utcnow() + timedelta(seconds=300)

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie-on-redirect.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie-on-redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/resources/set-cookie.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/resourceLoadStatistics/switch-session-on-navigation-to-prevalent-with-interaction.py
+++ b/LayoutTests/http/tests/resourceLoadStatistics/switch-session-on-navigation-to-prevalent-with-interaction.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Cache-Control: no-store\r\n'

--- a/LayoutTests/http/tests/resources/download-json-with-delay.py
+++ b/LayoutTests/http/tests/resources/download-json-with-delay.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/resources/echo-iframe-src.py
+++ b/LayoutTests/http/tests/resources/echo-iframe-src.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 src = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('src', [''])[0]

--- a/LayoutTests/http/tests/resources/file-last-modified.py
+++ b/LayoutTests/http/tests/resources/file-last-modified.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 path = os.path.abspath(parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('path', [__file__])[0])

--- a/LayoutTests/http/tests/resources/load-and-stall.py
+++ b/LayoutTests/http/tests/resources/load-and-stall.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/resources/network-simulator.py
+++ b/LayoutTests/http/tests/resources/network-simulator.py
@@ -6,6 +6,7 @@
 import os
 import re
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 import time
 from datetime import datetime

--- a/LayoutTests/http/tests/resources/redirect-to-video-if-accepted.py
+++ b/LayoutTests/http/tests/resources/redirect-to-video-if-accepted.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 video = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('video', [''])[0]

--- a/LayoutTests/http/tests/resources/redirect.py
+++ b/LayoutTests/http/tests/resources/redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import unquote
 
 

--- a/LayoutTests/http/tests/resources/reset-temp-file.py
+++ b/LayoutTests/http/tests/resources/reset-temp-file.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/resources/slow-image.py
+++ b/LayoutTests/http/tests/resources/slow-image.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(0.4)

--- a/LayoutTests/http/tests/resources/slow-notify-done.py
+++ b/LayoutTests/http/tests/resources/slow-notify-done.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(0.1)

--- a/LayoutTests/http/tests/resources/touch-temp-file.py
+++ b/LayoutTests/http/tests/resources/touch-temp-file.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/resources/write-temp-file.py
+++ b/LayoutTests/http/tests/resources/write-temp-file.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/security/401-logout/401-logout.py
+++ b/LayoutTests/http/tests/security/401-logout/401-logout.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/report-uri-effective-directive.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: default-src \'self\'; report-uri ../resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/module-scriptnonce-in-enforced-policy-and-not-in-report-only.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/module-scriptnonce-in-enforced-policy-and-not-in-report-only.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src \'nonce-test\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/module-scriptnonce-in-one-enforced-policy-neither-in-another-enforced-policy-nor-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/module-scriptnonce-in-one-enforced-policy-neither-in-another-enforced-policy-nor-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: object-src \'none\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scripthash-in-enforced-policy-and-not-in-report-only.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scripthash-in-enforced-policy-and-not-in-report-only.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src \'sha256-c8f8z1SC90Yj05k41+FT0HF/rrGJP94TPLhRvGGE8eM=\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scripthash-in-one-enforced-policy-neither-in-another-enforced-policy-nor-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scripthash-in-one-enforced-policy-neither-in-another-enforced-policy-nor-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: object-src \'none\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scriptnonce-in-enforced-policy-and-not-in-report-only.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scriptnonce-in-enforced-policy-and-not-in-report-only.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src \'nonce-test\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scriptnonce-in-one-enforced-policy-neither-in-another-enforced-policy-nor-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/scriptnonce-in-one-enforced-policy-neither-in-another-enforced-policy-nor-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: object-src \'none\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/testScriptHash.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/testScriptHash.py
@@ -3,6 +3,7 @@
 from ast import literal_eval
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs, unquote_plus
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/script-blocked-sends-multiple-reports.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/script-blocked-sends-multiple-reports.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src http://example.com \'unsafe-inline\'; report-uri ../resources/save-report.py?test=script-blocked-sends-multiple-reports-report-only\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-33badf00d3badf00d3badf00d3badf00d3badf00d33=\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-33badf00d3badf00d3badf00d3badf00d3badf00d33=\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scripthash-allowed-by-enforced-policy-and-blocked-by-report-policy2.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-33badf00d3badf00d3badf00d3badf00d3badf00d33=\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-33badf00d3badf00d3badf00d3badf00d3badf00d33=\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scripthash-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy2.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-enforced-policy-and-allowed-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-enforced-policy-and-allowed-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-AJqUvsXuHfMNXALcBPVqeiKkFk8OLvn3U7ksHP/QQ90=\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-enforced-policy-and-allowed-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-enforced-policy-and-allowed-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-AJqUvsXuHfMNXALcBPVqeiKkFk8OLvn3U7ksHP/QQ90=\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-AJqUvsXuHfMNXALcBPVqeiKkFk8OLvn3U7ksHP/QQ90=\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-AJqUvsXuHfMNXALcBPVqeiKkFk8OLvn3U7ksHP/QQ90=\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-33badf00d3badf00d3badf00d3badf00d3badf00d33=\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'sha256-33badf00d3badf00d3badf00d3badf00d3badf00d33=\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scripthash-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy2.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-that-is-not-equal-to-dummy\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-that-is-not-equal-to-dummy\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-that-is-not-equal-to-dummy\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-that-is-not-equal-to-dummy\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-legacy-enforced-policy-and-blocked-by-report-policy2.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-enforced-policy-and-allowed-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-enforced-policy-and-allowed-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-dummy\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-enforced-policy-and-allowed-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-enforced-policy-and-allowed-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-dummy\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-dummy\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-allowed-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-dummy\' \'nonce-dump-as-text\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-that-is-not-equal-to-dummy\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'nonce-that-is-not-equal-to-dummy\' \'nonce-dump-as-text\'; report-uri ../resources/save-report.py?test=/security/contentSecurityPolicy/1.1/scriptnonce-blocked-by-legacy-enforced-policy-and-blocked-by-report-policy.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-css-report-only.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-css-report-only.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: block-all-mixed-content; report-uri ../../resources/save-report.py?test=/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-css-report-only.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-image-with-enforced-and-report-policies.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-image-with-enforced-and-report-policies.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: block-all-mixed-content\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-allowed-in-report-only-mode-and-sends-report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-allowed-in-report-only-mode-and-sends-report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'self\' \'unsafe-inline\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-allowed-in-report-only-mode.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-allowed-in-report-only-mode.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'self\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: multipart/x-mixed-replace; boundary=TEST\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: multipart/x-mixed-replace; boundary=TEST\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/nonce-hiding-on-svg-script.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src \'nonce-abc\' \'unsafe-eval\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-and-enforce.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-and-enforce.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'self\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-data-uri.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-data-uri.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-file-uri.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-file-uri.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-uri-and-do-not-follow-redirect-when-sending-report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-uri-and-do-not-follow-redirect-when-sending-report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: img-src \'none\'; report-uri resources/save-report-and-redirect-to-save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-uri-cross-origin.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-uri-cross-origin.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: img-src \'none\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-uri.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-blocked-uri.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: img-src \'none\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-enabled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-enabled.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri http://localhost:8080/security/contentSecurityPolicy/resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-toggled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies-when-private-browsing-toggled.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri http://localhost:8080/security/contentSecurityPolicy/resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-cross-origin-no-cookies.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri http://localhost:8080/security/contentSecurityPolicy/resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-01.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: img-src \'none\'; report-uri resources/does-not-exist\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-multiple-violations-02.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'unsafe-inline\' \'self\'; report-uri resources/does-not-exist\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-connect-src-beacon-redirect-blocked.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-connect-src-beacon-redirect-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: connect-src http://127.0.0.1:8000/security/contentSecurityPolicy/resources/redir.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-connect-src-xmlhttprequest-redirect-to-blocked.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-connect-src-xmlhttprequest-redirect-to-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: connect-src http://127.0.0.1:8000/security/contentSecurityPolicy/resources/redir.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-from-header.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-from-header.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'self\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-report-uri-missing.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-report-uri-missing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'unsafe-inline\';\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-upgrade-insecure.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-only-upgrade-insecure.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'self\'; upgrade-insecure-requests; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-only.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-only.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy-Report-Only: script-src \'self\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-no-cookies-when-private-browsing-toggled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-no-cookies-when-private-browsing-toggled.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri /security/contentSecurityPolicy/resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies-when-private-browsing-enabled.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies-when-private-browsing-enabled.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri /security/contentSecurityPolicy/resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-same-origin-with-cookies.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri /security/contentSecurityPolicy/resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri-from-inline-javascript.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri-from-inline-javascript.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri-from-javascript.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri-from-javascript.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri-scheme-relative.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri-scheme-relative.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src \'self\'; report-uri //127.0.0.1:8080/security/contentSecurityPolicy/resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/report-uri.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src \'self\'; report-uri resources/save-report.py\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-report.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from report_file_path import report_filepath
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/generate-csp-report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/generate-csp-report.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 test = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('test', [''])[0]

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/go-to-echo-report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/go-to-echo-report.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 test = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('test', [''])[0]

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/image-document-default-src-none-iframe.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/image-document-default-src-none-iframe.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 filename = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), 'resources', 'square.png')
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/redir.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/redir.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 url = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('url', [''])[0]

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/report_file_path.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/report_file_path.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 from urllib.parse import parse_qs, urlparse
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/sandbox.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/sandbox.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/sandboxed-eval.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/sandboxed-eval.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: sandbox allow-scripts allow-modals\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/save-report-and-redirect-to-save-report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/save-report-and-redirect-to-save-report.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from save_report import save_report
 
 query_string = os.environ.get('QUERY_STRING', '')

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/save_report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/save_report.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from report_file_path import report_filepath
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/utils.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/utils.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 csp = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('csp', [''])[0]

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-importScript-redirect-cross-origin-allowed.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-importScript-redirect-cross-origin-allowed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from utils import determine_content_security_policy_header
 
 determine_content_security_policy_header()

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-importScript-redirect-cross-origin-blocked.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-importScript-redirect-cross-origin-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from utils import determine_content_security_policy_header
 
 determine_content_security_policy_header()

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-xhr-allowed.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-xhr-allowed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from utils import determine_content_security_policy_header
 
 determine_content_security_policy_header()

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-xhr-redirect-cross-origin-allowed.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-xhr-redirect-cross-origin-allowed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from utils import determine_content_security_policy_header
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-xhr-redirect-cross-origin-blocked.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker-xhr-redirect-cross-origin-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from utils import determine_content_security_policy_header
 
 determine_content_security_policy_header()

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/worker.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/xhr-redirect-not-allowed.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/xhr-redirect-not-allowed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/plain\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/xsl-redirect-allowed.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/xsl-redirect-allowed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from utils import determine_content_security_policy_header
 
 determine_content_security_policy_header()

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/xsl-redirect-blocked.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/xsl-redirect-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: application/xhtml+xml\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/sandbox-allow-scripts-in-http-header2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/sandbox-allow-scripts-in-http-header2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: sandbox allow-scripts allow-modals\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/sandbox-empty-in-http-header-inherited-by-subframe.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/sandbox-empty-in-http-header-inherited-by-subframe.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: sandbox\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/sandbox-empty-in-http-header.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/sandbox-empty-in-http-header.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: sandbox\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-inline-report.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/script-src-strict-dynamic-inline-report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     "Content-Security-Policy: script-src 'nonce-dummy' 'strict-dynamic'; report-uri resources/save-report.py\r\n"

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/stylesheet-allowed-with-nonce.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/stylesheet-allowed-with-nonce.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src \'unsafe-inline\' \'self\'; style-src \'nonce-test\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/user-style-sheet-font-crasher.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/user-style-sheet-font-crasher.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: font-src http://webkit.org; report-uri http://webkit.org/report;\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-allowed.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-allowed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: script-src * \'unsafe-inline\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-blocked.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: application/xhtml+xml\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-img-blocked.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-img-blocked.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: img-src \'none\'\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-unaffected-by-style-src-1.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-unaffected-by-style-src-1.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: application/xhtml+xml\r\n'

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-unaffected-by-style-src-2.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/xsl-unaffected-by-style-src-2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: style-src \'none\'; script-src * \'unsafe-inline\'\r\n'

--- a/LayoutTests/http/tests/security/cookies/cookies-wrong-domain-rejected-result.py
+++ b/LayoutTests/http/tests/security/cookies/cookies-wrong-domain-rejected-result.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/security/cookies/cookies-wrong-domain-rejected.py
+++ b/LayoutTests/http/tests/security/cookies/cookies-wrong-domain-rejected.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Set-Cookie: one_cookie=shouldBeRejeced; domain=WrongDomain\r\n'

--- a/LayoutTests/http/tests/security/cookies/resources/set-a-cookie.py
+++ b/LayoutTests/http/tests/security/cookies/resources/set-a-cookie.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Set-Cookie: test_cookie=1; path=/\r\n'

--- a/LayoutTests/http/tests/security/http-0.9/resources/close-connection.py
+++ b/LayoutTests/http/tests/security/http-0.9/resources/close-connection.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Connection: close\r\n'

--- a/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-image.py
+++ b/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-image.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 uri = os.environ.get('REQUEST_URI', '')

--- a/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-page.py
+++ b/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-page.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 uri = os.environ.get('REQUEST_URI', '')

--- a/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-script.py
+++ b/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-script.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 uri = os.environ.get('REQUEST_URI', '')

--- a/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-stylesheet.py
+++ b/LayoutTests/http/tests/security/mixedContent/resources/subresource/protected-stylesheet.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 

--- a/LayoutTests/http/tests/security/mixedContent/resources/subresource2/protected-image.py
+++ b/LayoutTests/http/tests/security/mixedContent/resources/subresource2/protected-image.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 uri = os.environ.get('REQUEST_URI', '')

--- a/LayoutTests/http/tests/security/no-javascript-refresh-percent-escaped.py
+++ b/LayoutTests/http/tests/security/no-javascript-refresh-percent-escaped.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 200\r\n'

--- a/LayoutTests/http/tests/security/no-javascript-refresh-spaces.py
+++ b/LayoutTests/http/tests/security/no-javascript-refresh-spaces.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 200\r\n'

--- a/LayoutTests/http/tests/security/no-javascript-refresh.py
+++ b/LayoutTests/http/tests/security/no-javascript-refresh.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 200\r\n'

--- a/LayoutTests/http/tests/security/resources/abe-allow-credentials.py
+++ b/LayoutTests/http/tests/security/resources/abe-allow-credentials.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Access-Control-Allow-Origin: http://127.0.0.1:8000\r\n'

--- a/LayoutTests/http/tests/security/resources/abe-allow-star.py
+++ b/LayoutTests/http/tests/security/resources/abe-allow-star.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 allowCache = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('allowCache', [''])[0]

--- a/LayoutTests/http/tests/security/resources/allow-if-origin.py
+++ b/LayoutTests/http/tests/security/resources/allow-if-origin.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/security/resources/attempt-top-level-navigation-with-csp.py
+++ b/LayoutTests/http/tests/security/resources/attempt-top-level-navigation-with-csp.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Security-Policy: sandbox allow-scripts allow-top-navigation\r\n'

--- a/LayoutTests/http/tests/security/resources/auth-echo.py
+++ b/LayoutTests/http/tests/security/resources/auth-echo.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/security/resources/basic-auth.py
+++ b/LayoutTests/http/tests/security/resources/basic-auth.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')

--- a/LayoutTests/http/tests/security/resources/captions-with-access-control-headers.py
+++ b/LayoutTests/http/tests/security/resources/captions-with-access-control-headers.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/cookie-protected-script.py
+++ b/LayoutTests/http/tests/security/resources/cookie-protected-script.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 cookies = {}
 if 'HTTP_COOKIE' in os.environ:

--- a/LayoutTests/http/tests/security/resources/cors-basic-auth.py
+++ b/LayoutTests/http/tests/security/resources/cors-basic-auth.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/security/resources/cors-deny.py
+++ b/LayoutTests/http/tests/security/resources/cors-deny.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/cors-post-redirect-target.py
+++ b/LayoutTests/http/tests/security/resources/cors-post-redirect-target.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 origin = os.environ.get('HTTP_ORIGIN', None)
 

--- a/LayoutTests/http/tests/security/resources/cors-script.py
+++ b/LayoutTests/http/tests/security/resources/cors-script.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/credentials-in-referer-frame.py
+++ b/LayoutTests/http/tests/security/resources/credentials-in-referer-frame.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 

--- a/LayoutTests/http/tests/security/resources/credentials-in-referer.py
+++ b/LayoutTests/http/tests/security/resources/credentials-in-referer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 refer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/credentials-main-resource.py
+++ b/LayoutTests/http/tests/security/resources/credentials-main-resource.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/security/resources/echo-referrer.py
+++ b/LayoutTests/http/tests/security/resources/echo-referrer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/empty-svg.py
+++ b/LayoutTests/http/tests/security/resources/empty-svg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: image/svg+xml\r\n\r\n'

--- a/LayoutTests/http/tests/security/resources/get-css-if-origin-header.py
+++ b/LayoutTests/http/tests/security/resources/get-css-if-origin-header.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 origin = os.environ.get('HTTP_ORIGIN', '')

--- a/LayoutTests/http/tests/security/resources/green-if-no-referrer-css.py
+++ b/LayoutTests/http/tests/security/resources/green-if-no-referrer-css.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/image-access-control.py
+++ b/LayoutTests/http/tests/security/resources/image-access-control.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/image-credential-check.py
+++ b/LayoutTests/http/tests/security/resources/image-credential-check.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 credentials = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')
 username = credentials[0]

--- a/LayoutTests/http/tests/security/resources/loading-subresources.py
+++ b/LayoutTests/http/tests/security/resources/loading-subresources.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Access-Control-Allow-Origin: *\r\n'

--- a/LayoutTests/http/tests/security/resources/module-nest-import.py
+++ b/LayoutTests/http/tests/security/resources/module-nest-import.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 url = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('url', [''])[0]

--- a/LayoutTests/http/tests/security/resources/network-load-swasdf.py
+++ b/LayoutTests/http/tests/security/resources/network-load-swasdf.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Status: 302\r\n'

--- a/LayoutTests/http/tests/security/resources/no-javascript-location-percent-escaped.py
+++ b/LayoutTests/http/tests/security/resources/no-javascript-location-percent-escaped.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 200\r\n'

--- a/LayoutTests/http/tests/security/resources/no-javascript-location.py
+++ b/LayoutTests/http/tests/security/resources/no-javascript-location.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 200\r\n'

--- a/LayoutTests/http/tests/security/resources/no-referrer-frame.py
+++ b/LayoutTests/http/tests/security/resources/no-referrer-frame.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/no-referrer.py
+++ b/LayoutTests/http/tests/security/resources/no-referrer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/postReferrer.py
+++ b/LayoutTests/http/tests/security/resources/postReferrer.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/redirect-allow-star.py
+++ b/LayoutTests/http/tests/security/resources/redirect-allow-star.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/redirect.py
+++ b/LayoutTests/http/tests/security/resources/redirect.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/reference-movie-cross-origin-allow.py
+++ b/LayoutTests/http/tests/security/resources/reference-movie-cross-origin-allow.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_IF_MODIFIED_SINCE', None) is not None or os.environ.get('HTTP_IF_NONE_MATCH', None) is not None:
     sys.stdout.write(

--- a/LayoutTests/http/tests/security/resources/referrer-policy-log.py
+++ b/LayoutTests/http/tests/security/resources/referrer-policy-log.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/referrer-policy-postmessage.py
+++ b/LayoutTests/http/tests/security/resources/referrer-policy-postmessage.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/send-mime-types.py
+++ b/LayoutTests/http/tests/security/resources/send-mime-types.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 mime_type = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('mt', [''])[0]

--- a/LayoutTests/http/tests/security/resources/serve-referrer-policy-and-meta-tag.py
+++ b/LayoutTests/http/tests/security/resources/serve-referrer-policy-and-meta-tag.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/serve-referrer-policy-and-test.py
+++ b/LayoutTests/http/tests/security/resources/serve-referrer-policy-and-test.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/set-cookie.py
+++ b/LayoutTests/http/tests/security/resources/set-cookie.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/security/resources/showRefererImage.py
+++ b/LayoutTests/http/tests/security/resources/showRefererImage.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 referer = os.environ.get('HTTP_REFERER', '')
 

--- a/LayoutTests/http/tests/security/resources/subresource1/protected-image.py
+++ b/LayoutTests/http/tests/security/resources/subresource1/protected-image.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 

--- a/LayoutTests/http/tests/security/resources/subresource2/protected-image.py
+++ b/LayoutTests/http/tests/security/resources/subresource2/protected-image.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 username = base64.b64decode(os.environ.get('HTTP_AUTHORIZATION', ' Og==').split(' ')[1]).decode().split(':')[0]
 

--- a/LayoutTests/http/tests/security/resources/video-cross-origin-allow-credentials.py
+++ b/LayoutTests/http/tests/security/resources/video-cross-origin-allow-credentials.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/security/resources/video-cross-origin-allow.py
+++ b/LayoutTests/http/tests/security/resources/video-cross-origin-allow.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 file = __file__.split(':/cygwin')[-1]
 http_root = os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(file))))

--- a/LayoutTests/http/tests/security/resources/xorigincss1-allow-star.py
+++ b/LayoutTests/http/tests/security/resources/xorigincss1-allow-star.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Access-Control-Allow-Origin: *\r\n'

--- a/LayoutTests/http/tests/security/resources/xss-ALLOWED-xsl-external-entity-xslt-docloader.py
+++ b/LayoutTests/http/tests/security/resources/xss-ALLOWED-xsl-external-entity-xslt-docloader.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Access-Control-Allow-Origin: *\r\n')
 sys.stdout.write('\r\n')

--- a/LayoutTests/http/tests/security/resources/xss-DENIED-xsl-external-entity-xslt-docloader.py
+++ b/LayoutTests/http/tests/security/resources/xss-DENIED-xsl-external-entity-xslt-docloader.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Access-Control-Allow-Origin: *\r\n')
 sys.stdout.write('\r\n')

--- a/LayoutTests/http/tests/ssl/resources/redirect-ping-to-http.py
+++ b/LayoutTests/http/tests/ssl/resources/redirect-ping-to-http.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 303\r\n'

--- a/LayoutTests/http/tests/ssl/resources/referer-301-redir.py
+++ b/LayoutTests/http/tests/ssl/resources/referer-301-redir.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 301\r\n'

--- a/LayoutTests/http/tests/ssl/resources/referer-303-redir.py
+++ b/LayoutTests/http/tests/ssl/resources/referer-303-redir.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 303\r\n'

--- a/LayoutTests/http/tests/ssl/verify-ssl-enabled.py
+++ b/LayoutTests/http/tests/ssl/verify-ssl-enabled.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 https = os.environ.get('HTTPS')
 

--- a/LayoutTests/http/tests/storageAccess/resources/echo-incoming-cookies-as-json.py
+++ b/LayoutTests/http/tests/storageAccess/resources/echo-incoming-cookies-as-json.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 cookies = {}
 if 'HTTP_COOKIE' in os.environ:

--- a/LayoutTests/http/tests/storageAccess/resources/get-cookies.py
+++ b/LayoutTests/http/tests/storageAccess/resources/get-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/storageAccess/resources/set-cookie.py
+++ b/LayoutTests/http/tests/storageAccess/resources/set-cookie.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/svg/resources/delayCachedLoad.py
+++ b/LayoutTests/http/tests/svg/resources/delayCachedLoad.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 # Delay load by 0.07s. This was found to be the lowest value

--- a/LayoutTests/http/tests/text/resources/font-preloading-via-header-empty-value-crash-iframe.py
+++ b/LayoutTests/http/tests/text/resources/font-preloading-via-header-empty-value-crash-iframe.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Link: <http://127.0.0.1:8000/resources/font.ttf>; as=""; type="font/ttf"\r\n'

--- a/LayoutTests/http/tests/uri/css-href.py
+++ b/LayoutTests/http/tests/uri/css-href.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 host = os.environ.get('HTTP_HOST', '')
 

--- a/LayoutTests/http/tests/uri/resources/echo-uri.py
+++ b/LayoutTests/http/tests/uri/resources/echo-uri.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 uri = os.environ.get('REQUEST_URI', '')
 

--- a/LayoutTests/http/tests/uri/resources/print-uri.py
+++ b/LayoutTests/http/tests/uri/resources/print-uri.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 uri = os.environ.get('REQUEST_URI', '')
 

--- a/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/contentextensions/block-cookies.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs
 

--- a/LayoutTests/http/tests/websocket/tests/hybi/resources/status-404-without-body.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/resources/status-404-without-body.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'status: 404\r\n'

--- a/LayoutTests/http/tests/workers/resources/subworker-encoded.py
+++ b/LayoutTests/http/tests/workers/resources/subworker-encoded.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 koi8 = '\xF0\xD2\xC9\xD7\xC5\xD4'.encode('latin-1').decode('utf-8', 'replace')
 windows = '\xCF\xF0\xE8\xE2\xE5\xF2'.encode('latin-1').decode('utf-8', 'replace')

--- a/LayoutTests/http/tests/workers/resources/worker-encoded.py
+++ b/LayoutTests/http/tests/workers/resources/worker-encoded.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 koi8 = '\xF0\xD2\xC9\xD7\xC5\xD4'

--- a/LayoutTests/http/tests/workers/resources/worker-importScripts-banned-mimetype.py
+++ b/LayoutTests/http/tests/workers/resources/worker-importScripts-banned-mimetype.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/javascript; charset=UTF-8\r\n\r\n'

--- a/LayoutTests/http/tests/workers/resources/xhr-query-utf8.py
+++ b/LayoutTests/http/tests/workers/resources/xhr-query-utf8.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('query', [''])[0]

--- a/LayoutTests/http/tests/workers/resources/xhr-response.py
+++ b/LayoutTests/http/tests/workers/resources/xhr-response.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 charset = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('charset', [''])[0]

--- a/LayoutTests/http/tests/workers/service/resources/cacheable-script-worker.py
+++ b/LayoutTests/http/tests/workers/service/resources/cacheable-script-worker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 
 max_age = 12 * 31 * 24 * 60 * 60

--- a/LayoutTests/http/tests/workers/service/resources/download-binary.py
+++ b/LayoutTests/http/tests/workers/service/resources/download-binary.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: application/my-super-binary\r\n\r\n'

--- a/LayoutTests/http/tests/workers/service/resources/download-octet-stream.py
+++ b/LayoutTests/http/tests/workers/service/resources/download-octet-stream.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Length: 16\r\n'

--- a/LayoutTests/http/tests/workers/service/resources/interception-from-dedicated-worker-on-reload-cacheable-worker.py
+++ b/LayoutTests/http/tests/workers/service/resources/interception-from-dedicated-worker-on-reload-cacheable-worker.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 max_age = 12 * 31 * 24 * 60 * 60
 

--- a/LayoutTests/http/tests/workers/service/resources/self_registration_update-worker.py
+++ b/LayoutTests/http/tests/workers/service/resources/self_registration_update-worker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 
 sys.stdout.write('Content-Type: text/javascript\r\n\r\n')

--- a/LayoutTests/http/tests/workers/service/resources/succeed-fallback-check.py
+++ b/LayoutTests/http/tests/workers/service/resources/succeed-fallback-check.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Source: network\r\n'

--- a/LayoutTests/http/tests/workers/service/resources/updating-fetch-worker.py
+++ b/LayoutTests/http/tests/workers/service/resources/updating-fetch-worker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 
 sys.stdout.write('Content-Type: text/javascript\r\n\r\n')

--- a/LayoutTests/http/tests/workers/service/resources/updating-worker.py
+++ b/LayoutTests/http/tests/workers/service/resources/updating-worker.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from random import randint
 
 sys.stdout.write('Content-Type: text/javascript\r\n\r\n')

--- a/LayoutTests/http/tests/xmlhttprequest/null-auth.py
+++ b/LayoutTests/http/tests/xmlhttprequest/null-auth.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html\r\n\r\n')
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-basic-preflight-cache-invalidation.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-basic-preflight-cache-invalidation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-basic-preflight-cache-timeout.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-basic-preflight-cache-timeout.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-basic-preflight-cache.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-basic-preflight-cache.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-preflight-denied-xsrf.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-preflight-denied-xsrf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-preflight-redirect.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-preflight-redirect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from urllib.parse import parse_qs
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-preflight-request-header-lowercase.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-preflight-request-header-lowercase.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/xmlhttprequest/resources/access-control-response-with-expose-headers.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/access-control-response-with-expose-headers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-nouserpass/basic-auth-nouserpass.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth-nouserpass/basic-auth-nouserpass.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth/access-control-auth-basic.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth/access-control-auth-basic.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 from urllib.parse import parse_qs
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth/basic-auth.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/basic-auth/basic-auth.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 from urllib.parse import parse_qs
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/xmlhttprequest/resources/big-response.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/big-response.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html\r\n\r\n')
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/cors-preflight-safelisted-headers-responder.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/cors-preflight-safelisted-headers-responder.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 from urllib.parse import parse_qs
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/xmlhttprequest/resources/custom-headers.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/custom-headers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/plain\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/download-header-with-delay.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/download-header-with-delay.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/xmlhttprequest/resources/download-with-delay.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/download-with-delay.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 from urllib.parse import parse_qs

--- a/LayoutTests/http/tests/xmlhttprequest/resources/echo-auth.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/echo-auth.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/echo-host.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/echo-host.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/plain\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/echo-request-method.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/echo-request-method.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/echo-user-agent.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/echo-user-agent.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/empty-content-type.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/empty-content-type.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: \r\n')
 sys.stdout.write('\r\n')

--- a/LayoutTests/http/tests/xmlhttprequest/resources/endlessxml.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/endlessxml.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 time.sleep(10)

--- a/LayoutTests/http/tests/xmlhttprequest/resources/get-content.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/get-content.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 from urllib.parse import unquote, unquote_to_bytes
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/get_method.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/get_method.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 method = os.environ.get('REQUEST_METHOD', 'GET')
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/gzip-lorem.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/gzip-lorem.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import gzip
 
 text = b'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/headers.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/headers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/plain\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/infinite-loop.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/infinite-loop.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/large-html-with-script-tags.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/large-html-with-script-tags.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html\r\n\r\n')
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/multipart-post-echo-filenames.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/multipart-post-echo-filenames.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import cgi
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/multipart-post-echo.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/multipart-post-echo.py
@@ -2,6 +2,7 @@
 import cgi
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/no-authenticate-header-401.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/no-authenticate-header-401.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/no-custom-header.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/no-custom-header.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/xmlhttprequest/resources/not-ascii-status.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/not-ascii-status.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/print-referer.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/print-referer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-type: text/plain\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cors-origin-null-pass.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cors-origin-null-pass.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/html\r\n')
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cors-origin-null.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cors-origin-null.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write('Content-Type: text/html\r\n')

--- a/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cors.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cors.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 from urllib.parse import parse_qs, unquote

--- a/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cross-origin-tripmine.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/redirect-cross-origin-tripmine.py
@@ -2,6 +2,7 @@
 import os
 import re
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/xmlhttprequest/resources/redirect_methods.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/redirect_methods.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 from urllib.parse import parse_qs
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)

--- a/LayoutTests/http/tests/xmlhttprequest/resources/remember-bad-password/count-failures.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/remember-bad-password/count-failures.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import tempfile
 
 file = __file__.split(':/cygwin')[-1]

--- a/LayoutTests/http/tests/xmlhttprequest/resources/status-404-without-body.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/status-404-without-body.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write(
     'Content-Type: text/html\r\n'

--- a/LayoutTests/http/tests/xmlhttprequest/resources/url-with-credentials/authenticate.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/url-with-credentials/authenticate.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 sys.stdout.write('Content-Type: text/plain\r\n\r\n')
 

--- a/LayoutTests/http/tests/xmlhttprequest/resources/url-with-credentials/authorize.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/url-with-credentials/authorize.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 if os.environ.get('HTTP_AUTHORIZATION'):
     import authenticate

--- a/LayoutTests/http/tests/xmlhttprequest/resources/xmlhttprequest-mimetype-mixed-case.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/xmlhttprequest-mimetype-mixed-case.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 sys.stdout.write(

--- a/LayoutTests/http/tests/xmlhttprequest/workers/resources/endless-response.py
+++ b/LayoutTests/http/tests/xmlhttprequest/workers/resources/endless-response.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import time
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/ci/check_for_updated_refs.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/ci/check_for_updated_refs.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from typing import IO, Container, Dict, Iterable, List, Optional
 
 GIT_PUSH = re.compile(

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/html5lib/parse.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/html5lib/parse.py
@@ -5,6 +5,7 @@ Parse a document to a tree, with optional profiling
 
 import argparse
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import traceback
 
 from html5lib import html5parser

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/capture.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/capture.py
@@ -8,6 +8,7 @@ import io
 from io import UnsupportedOperation
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from tempfile import TemporaryFile
 from types import TracebackType
 from typing import Any

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/config/__init__.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/config/__init__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import re
 import shlex
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from textwrap import dedent
 import types
 from types import FunctionType

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/debugging.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/debugging.py
@@ -4,6 +4,7 @@
 import argparse
 import functools
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import types
 from typing import Any
 from typing import Callable

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/doctest.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/doctest.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import platform
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import traceback
 import types
 from typing import Any

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/helpconfig.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/helpconfig.py
@@ -4,6 +4,7 @@
 from argparse import Action
 import os
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 from typing import Generator
 from typing import List
 from typing import Optional

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/pytester.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/src/_pytest/pytester.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import subprocess
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import traceback
 from typing import Any
 from typing import Callable

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/logging/test_reporting.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/logging/test_reporting.py
@@ -16,6 +16,7 @@ def test_nothing_logged(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
         def test_foo():
             sys.stdout.write('text going to stdout')
@@ -35,6 +36,7 @@ def test_messages_logged(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
         import logging
 
         logger = logging.getLogger(__name__)

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/python/fixtures.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/python/fixtures.py
@@ -2,6 +2,7 @@
 import os
 from pathlib import Path
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import textwrap
 
 from _pytest.compat import getfuncargnames
@@ -628,6 +629,7 @@ class TestFillFixtures:
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import traceback
             import pytest
 
@@ -720,6 +722,7 @@ class TestRequestBasic:
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import pytest
             from _pytest.fixtures import PseudoFixtureDef
             import gc
@@ -1974,6 +1977,7 @@ class TestAutouseManagement:
                 @pytest.fixture(autouse=True)
                 def app():
                     import sys
+                    sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
                     sys._myapp = "hello"
                 """
             ),
@@ -1987,6 +1991,7 @@ class TestAutouseManagement:
             textwrap.dedent(
                 """\
                 import sys
+                sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
                 def test_app():
                     assert sys._myapp == "hello"
                 """
@@ -2941,6 +2946,7 @@ class TestFixtureMarker:
             """
             import pytest
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
             @pytest.fixture
             def browser(request):

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_capture.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_capture.py
@@ -5,6 +5,7 @@ from io import UnsupportedOperation
 import os
 import subprocess
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import textwrap
 from typing import BinaryIO
 from typing import cast
@@ -107,6 +108,7 @@ def test_capturing_unicode(pytester: Pytester, method: str) -> None:
         # taken from issue 227 from nosetests
         def test_unicode():
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             print(sys.stdout)
             print(%s)
         """
@@ -132,6 +134,7 @@ def test_collect_capturing(pytester: Pytester) -> None:
     p = pytester.makepyfile(
         """
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
         print("collect %s failure" % 13)
         sys.stderr.write("collect %s_stderr failure" % 13)
@@ -181,6 +184,7 @@ class TestPerTestCapturing:
         p = pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             def setup_module(func):
                 print("module-setup")
             def setup_function(func):
@@ -268,6 +272,7 @@ class TestPerTestCapturing:
         p1 = pytester.makepyfile(
             """\
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             def test_capturing():
                 print(42)
                 sys.stderr.write(str(23))
@@ -551,6 +556,7 @@ class TestCaptureFixture:
             r"""
             def test_hello(capsysbinary):
                 import sys
+                sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
                 sys.stdout.buffer.write(b'hello')
 
@@ -680,6 +686,7 @@ class TestCaptureFixture:
         pytester.makepyfile(
             f"""\
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import pytest
 
             @pytest.fixture
@@ -715,6 +722,7 @@ class TestCaptureFixture:
         pytester.makepyfile(
             f"""\
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import pytest
             import os
 
@@ -807,6 +815,7 @@ def test_capture_binary_output(pytester: Pytester) -> None:
 
         def test_a():
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import subprocess
             subprocess.call([sys.executable, __file__])
 
@@ -1423,6 +1432,7 @@ def test_error_attribute_issue555(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
         def test_capattr():
             assert sys.stdout.errors == "replace"
             assert sys.stderr.errors == "replace"
@@ -1455,6 +1465,7 @@ def test_dontreadfrominput_has_encoding(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
         def test_capattr():
             # should not raise AttributeError
             assert sys.stdout.encoding
@@ -1472,6 +1483,7 @@ def test_crash_on_closing_tmpfile_py27(
         """
         import threading
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
         printing = threading.Event()
 
@@ -1523,6 +1535,7 @@ def test_global_capture_with_live_logging(pytester: Pytester) -> None:
         """
         import logging
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
         import pytest
 
         logger = logging.getLogger(__name__)
@@ -1571,6 +1584,7 @@ def test_capture_with_live_logging(
         f"""
         import logging
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
         logger = logging.getLogger(__name__)
 
@@ -1600,6 +1614,7 @@ def test_typeerror_encodedfile_write(pytester: Pytester) -> None:
         """
         def test_fails():
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             sys.stdout.write(b"foo")
     """
     )

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_junitxml.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_junitxml.py
@@ -509,6 +509,7 @@ class TestPython:
             """
             import logging
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
             def test_fail():
                 print("hello-stdout")
@@ -572,6 +573,7 @@ class TestPython:
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             def test_fail():
                 assert 0, "An error"
         """
@@ -685,6 +687,7 @@ class TestPython:
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import pytest
 
             @pytest.mark.xfail()
@@ -825,6 +828,7 @@ class TestPython:
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             def test_pass():
                 sys.stderr.write('hello-stderr')
         """
@@ -878,6 +882,7 @@ class TestPython:
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import pytest
 
             @pytest.fixture
@@ -908,6 +913,7 @@ class TestPython:
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import pytest
 
             @pytest.fixture
@@ -1006,6 +1012,7 @@ def test_nullbyte(pytester: Pytester, junit_logging: str) -> None:
     pytester.makepyfile(
         """
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
         def test_print_nullbyte():
             sys.stdout.write('Here the null -->' + chr(0) + '<--')
             sys.stdout.write('In repr form -->' + repr(chr(0)) + '<--')
@@ -1028,6 +1035,7 @@ def test_nullbyte_replace(pytester: Pytester, junit_logging: str) -> None:
     pytester.makepyfile(
         """
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
         def test_print_nullbyte():
             sys.stdout.write('Here the null -->' + chr(0) + '<--')
             sys.stdout.write('In repr form -->' + repr(chr(0)) + '<--')
@@ -1707,6 +1715,7 @@ def test_logging_passing_tests_disabled_does_not_log_test_output(
         import pytest
         import logging
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
         def test_func():
             sys.stdout.write('This is stdout')
@@ -1741,6 +1750,7 @@ def test_logging_passing_tests_disabled_logs_output_for_failing_test_issue5430(
         import pytest
         import logging
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
         def test_func():
             logging.warning('hello')

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_runner.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_runner.py
@@ -4,6 +4,7 @@ import inspect
 import os
 from pathlib import Path
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import types
 from typing import Dict
 from typing import List
@@ -316,6 +317,7 @@ class BaseFunctionalTests:
 
             def test_func():
                 import sys
+                sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
                 # on python2 exc_info is kept till a function exits
                 # so we would end up calling test functions while
                 # sys.exc_info would return the indexerror
@@ -1019,6 +1021,7 @@ def test_current_test_env_var(pytester: Pytester, monkeypatch: MonkeyPatch) -> N
         """
         import pytest
         import sys
+        sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
         import os
 
         @pytest.fixture
@@ -1101,6 +1104,7 @@ class TestReportContents:
             """
             import pytest
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
             @pytest.fixture
             def fix():

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_setuponly.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_setuponly.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 from _pytest.config import ExitCode
 from _pytest.pytester import Pytester

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_terminal.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/pytest/testing/test_terminal.py
@@ -5,6 +5,7 @@ from io import StringIO
 import os
 from pathlib import Path
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import textwrap
 from types import SimpleNamespace
 from typing import cast
@@ -1569,6 +1570,7 @@ def pytest_report_header(config, start_path):
         pytester.makepyfile(
             """
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import logging
             def test_one():
                 sys.stdout.write('!This is stdout!')
@@ -1622,6 +1624,7 @@ def pytest_report_header(config, start_path):
             """
             import logging
             import sys
+            sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
             import pytest
 
             @pytest.fixture(scope="function", autouse="True")

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/websockets/src/websockets/__main__.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party/websockets/src/websockets/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import signal
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import threading
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/third_party_modified/mozlog/tests/test_capture.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/third_party_modified/mozlog/tests/test_capture.py
@@ -1,4 +1,5 @@
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 import unittest
 
 from mozlog import capture, structuredlog

--- a/LayoutTests/imported/w3c/web-platform-tests/tools/wpt/testfiles.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/tools/wpt/testfiles.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+sys.stdout.reconfigure(newline="")  # prevent windows \n -> \n\r conversion
 
 from collections import OrderedDict
 


### PR DESCRIPTION
#### 44b6a6ab06852270dd0daaee80ce3ec566758298
<pre>
[meta] Python CGI should use binary mode for stdout for Windows Python
<a href="https://bugs.webkit.org/show_bug.cgi?id=264237">https://bugs.webkit.org/show_bug.cgi?id=264237</a>

Reviewed by NOBODY (OOPS!).

On Windows Python, sys.stdout.write converts \n into \r\n, this brokes
many CGI tests on Windows. Inserting sys.stdout.reconfigure(newline=&apos;&apos;)
prevents that conversions.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44b6a6ab06852270dd0daaee80ce3ec566758298

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42384 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92921 "Failed to checkout and rebase branch from PR 39971") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15683 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/92921 "Failed to checkout and rebase branch from PR 39971") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25659 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79607 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/92921 "Failed to checkout and rebase branch from PR 39971") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34015 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37848 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76010 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18818 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8163 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15177 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->