### PR TITLE
Fix unexpected smart pointer warnings in Page, StyleResolveForFont, and NavigationState

### DIFF
--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -88,7 +88,7 @@ FontSelectionValue fontWeightFromCSSValueDeprecated(const CSSValue& value)
 
 FontSelectionValue fontWeightFromCSSValue(BuilderState& builderState, const CSSValue& value)
 {
-    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    RefPtr primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
     if (!primitiveValue)
         return { };
 
@@ -164,7 +164,7 @@ FontSelectionValue fontStretchFromCSSValueDeprecated(const CSSValue& value)
 
 FontSelectionValue fontStretchFromCSSValue(BuilderState& builderState, const CSSValue& value)
 {
-    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    RefPtr primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
     if (!primitiveValue)
         return { };
 
@@ -188,7 +188,7 @@ FontSelectionValue fontStyleAngleFromCSSValueDeprecated(const CSSValue& value)
 
 FontSelectionValue fontStyleAngleFromCSSValue(BuilderState& builderState, const CSSValue& value)
 {
-    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    RefPtr primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
     if (!primitiveValue)
         return { };
 
@@ -435,8 +435,8 @@ FontFeatureSettings fontFeatureSettingsFromCSSValue(BuilderState& builderState, 
         return { };
 
     FontFeatureSettings settings;
-    for (auto& feature : *list)
-        settings.insert(FontFeature(feature.tag(), feature.value().resolveAsNumber<int>(builderState.cssToLengthConversionData())));
+    for (Ref feature : *list)
+        settings.insert(FontFeature(feature->tag(), feature->value().resolveAsNumber<int>(builderState.cssToLengthConversionData())));
     return settings;
 }
 
@@ -454,8 +454,8 @@ FontVariationSettings fontVariationSettingsFromCSSValue(BuilderState& builderSta
         return { };
 
     FontVariationSettings settings;
-    for (auto& feature : *list)
-        settings.insert({ feature.tag(), feature.value().resolveAsNumber<float>(builderState.cssToLengthConversionData()) });
+    for (Ref feature : *list)
+        settings.insert({ feature->tag(), feature->value().resolveAsNumber<float>(builderState.cssToLengthConversionData()) });
     return settings;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -554,7 +554,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
 {
     bool subframeNavigation = navigationAction->targetFrame() && !navigationAction->targetFrame()->isMainFrame();
 
-    RefPtr<API::WebsitePolicies> defaultWebsitePolicies = webPageProxy.configuration().protectedDefaultWebsitePolicies()->copy();
+    RefPtr<API::WebsitePolicies> defaultWebsitePolicies = webPageProxy.protectedConfiguration()->protectedDefaultWebsitePolicies()->copy();
 
     if (!m_navigationState || (!m_navigationState->m_navigationDelegateMethods.webViewDecidePolicyForNavigationActionDecisionHandler
         && !m_navigationState->m_navigationDelegateMethods.webViewDecidePolicyForNavigationActionWithPreferencesUserInfoDecisionHandler


### PR DESCRIPTION
#### 9362bd1ee033df8cfc3ae9363ec6c58c52eb95d1
<pre>
Fix unexpected smart pointer warnings in Page, StyleResolveForFont, and NavigationState
<a href="https://bugs.webkit.org/show_bug.cgi?id=286999">https://bugs.webkit.org/show_bug.cgi?id=286999</a>

Reviewed by Chris Dumez.

Address smart pointer static analyzer warnings in these files.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::updateRendering):
(WebCore::dispatchPrintEvent):
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontWeightFromCSSValue):
(WebCore::Style::fontStretchFromCSSValue):
(WebCore::Style::fontStyleAngleFromCSSValue):
(WebCore::Style::fontFeatureSettingsFromCSSValue):
(WebCore::Style::fontVariationSettingsFromCSSValue):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/289835@main">https://commits.webkit.org/289835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ccf80160d623baa6f474b9e3158a883f47f600f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67927 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25669 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5830 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34031 "Found 2 new test failures: accessibility/noscript-ignored.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37860 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76783 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76021 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18828 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8175 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13759 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20490 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14931 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18376 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->