### PR TITLE
[Model Element] Move the portal to the UI process

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -413,14 +413,6 @@ std::optional<PlatformLayerIdentifier> HTMLModelElement::modelContentsLayerID() 
     return graphicsLayer->contentsLayerIDForModel();
 }
 
-// MARK: - Background Color support.
-
-void HTMLModelElement::applyBackgroundColor(Color color)
-{
-    if (m_modelPlayer)
-        m_modelPlayer->setBackgroundColor(color);
-}
-
 #if ENABLE(MODEL_PROCESS)
 RefPtr<ModelContext> HTMLModelElement::modelContext() const
 {
@@ -432,7 +424,7 @@ RefPtr<ModelContext> HTMLModelElement::modelContext() const
     if (!modelContentsLayerHostingContextIdentifier)
         return nullptr;
 
-    return ModelContext::create(*modelLayerIdentifier, *modelContentsLayerHostingContextIdentifier).ptr();
+    return ModelContext::create(*modelLayerIdentifier, *modelContentsLayerHostingContextIdentifier, contentSize(), hasPortal() ? ModelContextDisablePortal::No : ModelContextDisablePortal::Yes, std::nullopt).ptr();
 }
 
 const DOMMatrixReadOnly& HTMLModelElement::entityTransform() const
@@ -759,6 +751,9 @@ bool HTMLModelElement::hasPortal() const
 
 void HTMLModelElement::updateHasPortal()
 {
+    if (CheckedPtr renderer = this->renderer())
+        renderer->updateFromElement();
+
     if (RefPtr modelPlayer = m_modelPlayer)
         modelPlayer->setHasPortal(hasPortal());
 }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -94,8 +94,6 @@ public:
 
     std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() const;
 
-    void applyBackgroundColor(Color);
-
 #if ENABLE(MODEL_PROCESS)
     RefPtr<ModelContext> modelContext() const;
 

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -40,10 +40,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPlayer);
 
 ModelPlayer::~ModelPlayer() = default;
 
-void ModelPlayer::setBackgroundColor(Color)
-{
-}
-
 void ModelPlayer::setEntityTransform(TransformationMatrix)
 {
 }

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -61,7 +61,6 @@ public:
     virtual void sizeDidChange(LayoutSize) = 0;
     virtual PlatformLayer* layer() = 0;
     virtual std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() = 0;
-    virtual void setBackgroundColor(Color);
     virtual void setEntityTransform(TransformationMatrix);
     virtual void enterFullscreen() = 0;
     virtual bool supportsMouseInteraction();

--- a/Source/WebCore/platform/graphics/ModelContext.cpp
+++ b/Source/WebCore/platform/graphics/ModelContext.cpp
@@ -28,14 +28,17 @@
 
 namespace WebCore {
 
-Ref<ModelContext> ModelContext::create(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier)
+Ref<ModelContext> ModelContext::create(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier, const LayoutSize& size, ModelContextDisablePortal disablePortal, std::optional<Color> backgroundColor)
 {
-    return adoptRef(*new ModelContext(modelLayerIdentifier, modelContentsLayerHostingContextIdentifier));
+    return adoptRef(*new ModelContext(modelLayerIdentifier, modelContentsLayerHostingContextIdentifier, size, disablePortal, backgroundColor));
 }
 
-ModelContext::ModelContext(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier)
+ModelContext::ModelContext(const PlatformLayerIdentifier& modelLayerIdentifier, const LayerHostingContextIdentifier& modelContentsLayerHostingContextIdentifier, const LayoutSize& size, ModelContextDisablePortal disablePortal, std::optional<Color> backgroundColor)
     : m_modelLayerIdentifier(modelLayerIdentifier)
     , m_modelContentsLayerHostingContextIdentifier(modelContentsLayerHostingContextIdentifier)
+    , m_modelLayoutSize(size)
+    , m_disablePortal(disablePortal)
+    , m_backgroundColor(backgroundColor)
 {
 }
 

--- a/Source/WebCore/platform/graphics/ModelContext.h
+++ b/Source/WebCore/platform/graphics/ModelContext.h
@@ -25,25 +25,36 @@
 
 #pragma once
 
+#include "Color.h"
 #include "LayerHostingContextIdentifier.h"
+#include "LayoutSize.h"
 #include "PlatformLayerIdentifier.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
 
+enum class ModelContextDisablePortal : bool { No, Yes };
+
 class ModelContext final : public RefCounted<ModelContext> {
 public:
-    WEBCORE_EXPORT static Ref<ModelContext> create(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&);
+    WEBCORE_EXPORT static Ref<ModelContext> create(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&, const LayoutSize&, ModelContextDisablePortal, std::optional<Color>);
     WEBCORE_EXPORT ~ModelContext();
 
     PlatformLayerIdentifier modelLayerIdentifier() const { return m_modelLayerIdentifier; }
     LayerHostingContextIdentifier modelContentsLayerHostingContextIdentifier() const { return m_modelContentsLayerHostingContextIdentifier; }
+    LayoutSize modelLayoutSize() const { return m_modelLayoutSize; }
+    ModelContextDisablePortal disablePortal() const { return m_disablePortal; }
+    std::optional<Color> backgroundColor() const { return m_backgroundColor; }
+    void setBackgroundColor(std::optional<Color> backgroundColor) { m_backgroundColor = backgroundColor; }
 
 private:
-    explicit ModelContext(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&);
+    explicit ModelContext(const PlatformLayerIdentifier&, const LayerHostingContextIdentifier&, const LayoutSize&, ModelContextDisablePortal, std::optional<Color>);
 
     PlatformLayerIdentifier m_modelLayerIdentifier;
     LayerHostingContextIdentifier m_modelContentsLayerHostingContextIdentifier;
+    LayoutSize m_modelLayoutSize;
+    ModelContextDisablePortal m_disablePortal;
+    std::optional<Color> m_backgroundColor;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1240,8 +1240,8 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
             m_graphicsLayer->setContentsToPlatformLayer(element->platformLayer(), GraphicsLayer::ContentsLayerPurpose::Model);
 #if ENABLE(MODEL_PROCESS)
         else if (auto modelContext = element->modelContext(); modelContext && element->document().settings().modelProcessEnabled()) {
+            modelContext->setBackgroundColor(rendererBackgroundColor());
             m_graphicsLayer->setContentsToModelContext(*modelContext, GraphicsLayer::ContentsLayerPurpose::HostedModel);
-            element->applyBackgroundColor(rendererBackgroundColor());
         }
 #endif
         else if (auto model = element->model())

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -80,10 +80,8 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     template<typename T> void send(T&& message);
 
-    void updateBackgroundColor();
     void updateTransform();
     void updateOpacity();
-    void updatePortalAndClipping();
     void startAnimating();
     void animationPlaybackStateDidUpdate();
 
@@ -101,7 +99,6 @@ public:
     void sizeDidChange(WebCore::LayoutSize) final;
     PlatformLayer* layer() final;
     std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier() final;
-    void setBackgroundColor(WebCore::Color) final;
     void setEntityTransform(WebCore::TransformationMatrix) final;
     void enterFullscreen() final;
     bool supportsMouseInteraction() final;
@@ -157,7 +154,6 @@ private:
     REPtr<REEntityRef> m_containerEntity;
     RetainPtr<WKModelProcessModelPlayerProxyObjCAdapter> m_objCAdapter;
 
-    WebCore::Color m_backgroundColor;
     simd_float3 m_originalBoundingBoxCenter { simd_make_float3(0, 0, 0) };
     simd_float3 m_originalBoundingBoxExtents { simd_make_float3(0, 0, 0) };
     float m_pitch { 0 };

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -30,7 +30,6 @@ messages -> ModelProcessModelPlayerProxy {
     # WebCore::ModelPlayer
     LoadModel(Ref<WebCore::Model> url, WebCore::LayoutSize layoutSize)
     SizeDidChange(WebCore::LayoutSize layoutSize)
-    SetBackgroundColor(WebCore::Color color)
     SetEntityTransform(WebCore::TransformationMatrix transform)
     SetAutoplay(bool autoplay)
     SetLoop(bool loop)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7053,9 +7053,14 @@ struct WebCore::CookieChangeSubscription {
 }
 
 #if ENABLE(MODEL_PROCESS)
+enum class WebCore::ModelContextDisablePortal : bool
+
 [RefCounted] class WebCore::ModelContext {
     WebCore::PlatformLayerIdentifier modelLayerIdentifier()
     WebCore::LayerHostingContextIdentifier modelContentsLayerHostingContextIdentifier()
+    WebCore::LayoutSize modelLayoutSize()
+    WebCore::ModelContextDisablePortal disablePortal()
+    std::optional<WebCore::Color> backgroundColor()
 };
 #endif
 

--- a/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm
@@ -52,7 +52,15 @@ RetainPtr<WKPageHostedModelView> ModelPresentationManagerProxy::setUpModelView(R
         return nil;
 
     auto& modelPresentation = ensureModelPresentation(modelContext, *webPageProxy);
-    return modelPresentation.pageHostedModelView;
+    auto view = modelPresentation.pageHostedModelView;
+    CGRect frame = [view frame];
+    frame.size.width = modelContext->modelLayoutSize().width().toFloat();
+    frame.size.height = modelContext->modelLayoutSize().height().toFloat();
+    [view setFrame:frame];
+    [view setShouldDisablePortal:modelContext->disablePortal() == WebCore::ModelContextDisablePortal::Yes];
+    [view applyBackgroundColor:modelContext->backgroundColor()];
+
+    return view;
 }
 
 void ModelPresentationManagerProxy::invalidateModel(const WebCore::PlatformLayerIdentifier& layerIdentifier)

--- a/Source/WebKit/UIProcess/ios/WKPageHostedModelView.h
+++ b/Source/WebKit/UIProcess/ios/WKPageHostedModelView.h
@@ -26,12 +26,15 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
 
 #import "RemoteLayerTreeViews.h"
+#import <WebCore/Color.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WKPageHostedModelView : WKCompositingView
 
 @property (nonatomic, retain) UIView *remoteModelView;
+@property (nonatomic) BOOL shouldDisablePortal;
+- (void)applyBackgroundColor:(std::optional<WebCore::Color>)backgroundColor;
 
 @end
 

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -158,11 +158,6 @@ void ModelProcessModelPlayer::enterFullscreen()
 {
 }
 
-void ModelProcessModelPlayer::setBackgroundColor(WebCore::Color color)
-{
-    send(Messages::ModelProcessModelPlayerProxy::SetBackgroundColor(color));
-}
-
 /// This comes from JS side, so we need to tell Model Process about it. Not to be confused with didUpdateEntityTransform().
 void ModelProcessModelPlayer::setEntityTransform(WebCore::TransformationMatrix transform)
 {

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -78,7 +78,6 @@ private:
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseMove(const WebCore::LayoutPoint&, MonotonicTime) final;
     void handleMouseUp(const WebCore::LayoutPoint&, MonotonicTime) final;
-    void setBackgroundColor(WebCore::Color) final;
     void setEntityTransform(WebCore::TransformationMatrix) final;
     bool supportsTransform(WebCore::TransformationMatrix) final;
     void enterFullscreen() final;


### PR DESCRIPTION
#### 58a1b48dcfe4906635ffeb5acd043d5cbe43bca2
<pre>
[Model Element] Move the portal to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=287000">https://bugs.webkit.org/show_bug.cgi?id=287000</a>
<a href="https://rdar.apple.com/144069542">rdar://144069542</a>

Reviewed by Mike Wyrzykowski.

By moving the portal entity and the model container entity to the UI
process, the Model process will need to host just the model entity.
This hierarchy change is needed for fixing the model drag preview
in a future patch, where we can pass the _UIRemoteView hosting just
the model (without the portal) to create a UITargetedDragPreview.

This fix changes WKPageHostedModelView such that its layer is now
the separated layer with an entity that represents the portal.
The container entity in the model process that had clipping
enabled has also been moved to WKPageHostedModelView in the UI
process. The container UIView is a subview of WKPageHostedModelView.

This also means we need to handle updates to the background color
and noportal attribute in WKPageHostedModelView. The ModelContext
has been extended to include the background color, whether portal
should be disabled, and the bounds of the element.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::modelContext const):
Fill in the new data members.
(WebCore::HTMLModelElement::updateHasPortal):
Update the renderer so the WKPageHostedModelView can be updated
with the new noportal attribute value.
(WebCore::HTMLModelElement::applyBackgroundColor): Deleted.
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::setBackgroundColor): Deleted.
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/platform/graphics/ModelContext.cpp:
(WebCore::ModelContext::create):
(WebCore::ModelContext::ModelContext):
* Source/WebCore/platform/graphics/ModelContext.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
Set the current background color on the ModelContext before passing it to
m_graphicsLayer.
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::createLayer):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
Now that the root layer no longer represents the portal, the entity should
have tracked rather than separated state. Remove the clipping component
as that is handled on the UI process side.
(WebKit::ModelProcessModelPlayerProxy::setHasPortal):
(WebKit::ModelProcessModelPlayerProxy::updateBackgroundColor): Deleted.
(WebKit::ModelProcessModelPlayerProxy::updatePortalAndClipping): Deleted.
(WebKit::ModelProcessModelPlayerProxy::setBackgroundColor): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm:
(WebKit::ModelPresentationManagerProxy::setUpModelView): Update the
WKPageHostedModelView&apos;s frame, the latest DisablePortal value, and
the latest background color.
* Source/WebKit/UIProcess/ios/WKPageHostedModelView.h:
* Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm:
(-[WKPageHostedModelView init]):
Set up the root (portal) -&gt; container view/entity hierarchy. Moved
the clipping logic from ModelProcessModelPlayerProxy to here.
(-[WKPageHostedModelView dealloc]): Added cleanup code similar to
75ec68cfc5a707e4ec0d559131519403bd5c744c.
(-[WKPageHostedModelView setRemoteModelView:]): Add the remote model
view as its subview. Update its size.
(-[WKPageHostedModelView setShouldDisablePortal:]):
Update a couple of separatedOptions flags related to clipping when
the _shouldDisablePortal changes.
(-[WKPageHostedModelView applyBackgroundColor:]):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::setBackgroundColor): Deleted.
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/289893@main">https://commits.webkit.org/289893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53a2a3bb59723c654f84f24ef7a7b36f1d081668

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67978 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25710 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34099 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18768 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20460 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18865 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8240 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15245 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->