### PR TITLE
[JSC] B3 should recognize PurifyNaN idiom

### DIFF
--- a/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
@@ -122,6 +122,11 @@ Value* ConstDoubleValue::sqrtConstant(Procedure& proc) const
     return proc.add<ConstDoubleValue>(origin(), sqrt(m_value));
 }
 
+Value* ConstDoubleValue::purifyNaNConstant(Procedure& proc) const
+{
+    return proc.add<ConstDoubleValue>(origin(), purifyNaN(m_value));
+}
+
 Value* ConstDoubleValue::divConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasDouble())

--- a/Source/JavaScriptCore/b3/B3ConstDoubleValue.h
+++ b/Source/JavaScriptCore/b3/B3ConstDoubleValue.h
@@ -55,6 +55,7 @@ public:
     Value* ceilConstant(Procedure&) const final;
     Value* floorConstant(Procedure&) const final;
     Value* sqrtConstant(Procedure&) const final;
+    Value* purifyNaNConstant(Procedure&) const final;
     Value* fMinConstant(Procedure&, const Value* other) const final;
     Value* fMaxConstant(Procedure&, const Value* other) const final;
 

--- a/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
@@ -121,6 +121,11 @@ Value* ConstFloatValue::sqrtConstant(Procedure& proc) const
     return proc.add<ConstFloatValue>(origin(), static_cast<float>(sqrt(m_value)));
 }
 
+Value* ConstFloatValue::purifyNaNConstant(Procedure& proc) const
+{
+    return proc.add<ConstFloatValue>(origin(), static_cast<float>(purifyNaN(m_value)));
+}
+
 Value* ConstFloatValue::divConstant(Procedure& proc, const Value* other) const
 {
     if (!other->hasFloat())

--- a/Source/JavaScriptCore/b3/B3ConstFloatValue.h
+++ b/Source/JavaScriptCore/b3/B3ConstFloatValue.h
@@ -54,6 +54,7 @@ public:
     Value* ceilConstant(Procedure&) const final;
     Value* floorConstant(Procedure&) const final;
     Value* sqrtConstant(Procedure&) const final;
+    Value* purifyNaNConstant(Procedure&) const final;
     Value* fMinConstant(Procedure&, const Value* other) const final;
     Value* fMaxConstant(Procedure&, const Value* other) const final;
 

--- a/Source/JavaScriptCore/b3/B3LowerMacrosAfterOptimizations.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacrosAfterOptimizations.cpp
@@ -156,6 +156,21 @@ private:
                 break;
             }
 
+            case PurifyNaN: {
+                if (m_value->type() == Double) {
+                    auto* pureNaN = m_insertionSet.insert<ConstDoubleValue>(m_index, m_value->origin(), PNaN);
+                    auto* compare = m_insertionSet.insert<Value>(m_index, Equal, m_value->origin(), m_value->child(0), m_value->child(0));
+                    auto* result = m_insertionSet.insert<Value>(m_index, Select, m_value->origin(), compare, m_value->child(0), pureNaN);
+                    m_value->replaceWithIdentity(result);
+                } else {
+                    auto* pureNaN = m_insertionSet.insert<ConstFloatValue>(m_index, m_value->origin(), static_cast<float>(PNaN));
+                    auto* compare = m_insertionSet.insert<Value>(m_index, Equal, m_value->origin(), m_value->child(0), m_value->child(0));
+                    auto* result = m_insertionSet.insert<Value>(m_index, Select, m_value->origin(), compare, m_value->child(0), pureNaN);
+                    m_value->replaceWithIdentity(result);
+                }
+                break;
+            }
+
             case RotL: {
                 // ARM64 doesn't have a rotate left.
                 if (isARM64()) {

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -171,6 +171,9 @@ void printInternal(PrintStream& out, Opcode opcode)
     case Neg:
         out.print("Neg");
         return;
+    case PurifyNaN:
+        out.print("PurifyNaN");
+        return;
     case BitAnd:
         out.print("BitAnd");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -142,6 +142,8 @@ enum Opcode : uint8_t {
     FloatToDouble,
     DoubleToFloat,
 
+    PurifyNaN,
+
     // Polymorphic comparisons, usable with any value type. Returns int32 0 or 1. Note that "Not"
     // is just Equal(x, 0), and "ToBoolean" is just NotEqual(x, 0).
     Equal,

--- a/Source/JavaScriptCore/b3/B3ReduceDoubleToFloat.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceDoubleToFloat.cpp
@@ -327,6 +327,7 @@ private:
                     if (attemptTwoOperandsSimplify(value, index, insertionSet))
                         value->setType(Float);
                     break;
+                case PurifyNaN:
                 case Abs:
                 case Ceil:
                 case Floor:

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -651,17 +651,9 @@ private:
 
             // Turn this: Add(value, zero)
             // Into an Identity.
-            //
-            // Addition is subtle with doubles. Zero is not the neutral value, negative zero is:
-            //    0 + 0 = 0
-            //    0 + -0 = 0
-            //    -0 + 0 = 0
-            //    -0 + -0 = -0
-            if (!m_value->isSensitiveToNaN()) {
-                if (m_value->child(1)->isInt(0) || m_value->child(1)->isNegativeZero()) {
-                    replaceWithIdentity(m_value->child(0));
-                    break;
-                }
+            if (m_value->child(1)->isInt(0)) {
+                replaceWithIdentity(m_value->child(0));
+                break;
             }
 
             if (m_value->isInteger()) {
@@ -810,6 +802,33 @@ private:
             }
 
             break;
+
+        case PurifyNaN:
+            // Turn this: PurifyNaN(constant)
+            // Into this: PNaN or constant
+            if (Value* constant = m_value->child(0)->purifyNaNConstant(m_proc)) {
+                replaceWithNewValue(constant);
+                break;
+            }
+
+            switch (m_value->child(0)->opcode()) {
+            case Sub:
+            case Div:
+            case Sqrt:
+            case Floor:
+            case Ceil:
+            case Trunc:
+            case Abs:
+            case Neg:
+            case Mul:
+            case Add:
+            case PurifyNaN:
+                replaceWithIdentity(m_value->child(0));
+                break;
+            default:
+                break;
+            }
+            break;
             
         case Neg:
             // Turn this: Neg(constant)
@@ -896,17 +915,6 @@ private:
                         m_insertionSet.insert<Const32Value>(
                             m_index, m_value->origin(), shiftAmount));
                     break;
-                }
-            } else if (m_value->child(1)->hasDouble()) {
-                double factor = m_value->child(1)->asDouble();
-
-                // Turn this: Mul(value, 1)
-                // Into this: value
-                if (!m_value->isSensitiveToNaN()) {
-                    if (factor == 1) {
-                        replaceWithIdentity(m_value->child(0));
-                        break;
-                    }
                 }
             }
 

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -248,6 +248,12 @@ public:
                 VALIDATE(value->type() == value->child(0)->type(), ("At ", *value));
                 VALIDATE(value->type().isNumeric(), ("At ", *value));
                 break;
+            case PurifyNaN:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->type() == value->child(0)->type(), ("At ", *value));
+                VALIDATE(value->type().isFloat(), ("At ", *value));
+                break;
             case Shl:
             case SShr:
             case ZShr:

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -464,6 +464,11 @@ Value* Value::sqrtConstant(Procedure&) const
     return nullptr;
 }
 
+Value* Value::purifyNaNConstant(Procedure&) const
+{
+    return nullptr;
+}
+
 Value* Value::vectorAndConstant(Procedure&, const Value*) const
 {
     return nullptr;
@@ -646,6 +651,7 @@ Effects Value::effects() const
     case Sub:
     case Mul:
     case Neg:
+    case PurifyNaN:
     case BitAnd:
     case BitOr:
     case BitXor:
@@ -889,6 +895,7 @@ ValueKey Value::key() const
     case Check:
     case BitwiseCast:
     case Neg:
+    case PurifyNaN:
     case Depend:
         return ValueKey(kind(), type(), child(0));
     case Add:
@@ -1080,6 +1087,7 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
     case FMax:
     case FMin:
     case Neg:
+    case PurifyNaN:
     case BitAnd:
     case BitOr:
     case BitXor:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -241,6 +241,7 @@ public:
     virtual Value* ceilConstant(Procedure&) const;
     virtual Value* floorConstant(Procedure&) const;
     virtual Value* sqrtConstant(Procedure&) const;
+    virtual Value* purifyNaNConstant(Procedure&) const;
 
     virtual Value* vectorAndConstant(Procedure&, const Value* other) const;
     virtual Value* vectorOrConstant(Procedure&, const Value* other) const;
@@ -418,6 +419,7 @@ protected:
         case Identity:
         case Opaque:
         case Neg:
+        case PurifyNaN:
         case Clz:
         case Abs:
         case Ceil:
@@ -668,6 +670,7 @@ private:
         case Identity:
         case Opaque:
         case Neg:
+        case PurifyNaN:
         case Clz:
         case Abs:
         case Ceil:

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -67,6 +67,7 @@ namespace JSC { namespace B3 {
     case Identity: \
     case Opaque: \
     case Neg: \
+    case PurifyNaN: \
     case Clz: \
     case Abs: \
     case Ceil: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -71,6 +71,7 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case Ceil:
     case Sqrt:
     case Neg:
+    case PurifyNaN:
     case Depend:
     case SExt8:
     case SExt16:

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -825,6 +825,7 @@ void testSqrtImm(float);
 void testSqrtMem(float);
 void testSqrtArgWithUselessDoubleConversion(float);
 void testSqrtArgWithEffectfulDoubleConversion(float);
+void testPurifyNaN();
 void testCompareTwoFloatToDouble(float, float);
 void testCompareOneFloatToDouble(float, double);
 void testCompareFloatToDoubleThroughPhi(float, float);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -287,6 +287,8 @@ void run(const TestConfig* config)
     RUN_UNARY(testSqrtArgWithUselessDoubleConversion, floatingPointOperands<float>());
     RUN_UNARY(testSqrtArgWithEffectfulDoubleConversion, floatingPointOperands<float>());
 
+    RUN(testPurifyNaN());
+
     RUN_BINARY(testCompareTwoFloatToDouble, floatingPointOperands<float>(), floatingPointOperands<float>());
     RUN_BINARY(testCompareOneFloatToDouble, floatingPointOperands<float>(), floatingPointOperands<double>());
     RUN_BINARY(testCompareFloatToDoubleThroughPhi, floatingPointOperands<float>(), floatingPointOperands<float>());

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -2548,6 +2548,23 @@ void testSqrtArgWithEffectfulDoubleConversion(float a)
     CHECK(isIdentical(effect, expected));
 }
 
+void testPurifyNaN()
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<double>(proc, root);
+    root->appendNewControlValue(
+        proc, Return, Origin(),
+        root->appendNew<Value>(proc, PurifyNaN, Origin(), arguments[0]));
+
+    auto code = compileProc(proc);
+
+    for (auto& value : floatingPointOperands<double>())
+        CHECK(isIdentical(invoke<double>(*code, value.value), JSC::purifyNaN(value.value)));
+
+    CHECK(!isImpureNaN(invoke<double>(*code, std::bit_cast<double>(0xffff000000000000ULL))));
+}
+
 void testCompareTwoFloatToDouble(float a, float b)
 {
     Procedure proc;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -941,6 +941,19 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 setConstant(node, jsDoubleNumber(left.asNumber() + right.asNumber()));
                 break;
             }
+
+            // Addition is subtle with doubles. Zero is not the neutral value, negative zero is:
+            //    0 + 0 = 0
+            //    0 + -0 = 0
+            //    -0 + 0 = 0
+            //    -0 + -0 = -0
+            if (left && left.isNumber()) {
+                if (isNegativeZero(left.asNumber()))
+                    m_state.setShouldTryConstantFolding(true);
+            } else if (right && right.isNumber()) {
+                if (isNegativeZero(right.asNumber()))
+                    m_state.setShouldTryConstantFolding(true);
+            }
             setNonCellTypeForNode(node, 
                 typeOfDoubleSum(
                     forNode(node->child1()).m_type, forNode(node->child2()).m_type));
@@ -1269,6 +1282,15 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 setConstant(node, jsDoubleNumber(left.asNumber() * right.asNumber()));
                 break;
             }
+
+            if (left && left.isNumber()) {
+                if (left.asNumber() == 1)
+                    m_state.setShouldTryConstantFolding(true);
+            } else if (right && right.isNumber()) {
+                if (right.asNumber() == 1)
+                    m_state.setShouldTryConstantFolding(true);
+            }
+
             setNonCellTypeForNode(node, 
                 typeOfDoubleProduct(
                     forNode(node->child1()).m_type, forNode(node->child2()).m_type));

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1439,6 +1439,67 @@ private:
                 break;
             }
 
+            case ArithAdd: {
+                JSValue left = m_state.forNode(node->child1()).value();
+                JSValue right = m_state.forNode(node->child2()).value();
+                switch (node->binaryUseKind()) {
+                case DoubleRepUse: {
+                    // Addition is subtle with doubles. Zero is not the neutral value, negative zero is:
+                    //    0 + 0 = 0
+                    //    0 + -0 = 0
+                    //    -0 + 0 = 0
+                    //    -0 + -0 = -0
+                    if (left && left.isNumber()) {
+                        if (isNegativeZero(left.asNumber())) {
+                            node->convertToPurifyNaN(node->child2().node());
+                            changed = true;
+                            break;
+                        }
+                    }
+
+                    if (right && right.isNumber()) {
+                        if (isNegativeZero(right.asNumber())) {
+                            node->convertToPurifyNaN(node->child1().node());
+                            changed = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+                break;
+            }
+
+            case ArithMul: {
+                JSValue left = m_state.forNode(node->child1()).value();
+                JSValue right = m_state.forNode(node->child2()).value();
+                switch (node->binaryUseKind()) {
+                case DoubleRepUse: {
+                    if (left && left.isNumber()) {
+                        if (left.asNumber() == 1) {
+                            node->convertToPurifyNaN(node->child2().node());
+                            changed = true;
+                            break;
+                        }
+                    }
+
+                    if (right && right.isNumber()) {
+                        if (right.asNumber() == 1) {
+                            node->convertToPurifyNaN(node->child1().node());
+                            changed = true;
+                            break;
+                        }
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+                break;
+            }
+
             case PhantomNewObject:
             case PhantomNewFunction:
             case PhantomNewGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -898,8 +898,8 @@ public:
 
     void convertToPurifyNaN(Node* input)
     {
-        ASSERT(op() == DoubleRep);
-        setOp(PurifyNaN);
+        setOpAndDefaultFlags(PurifyNaN);
+        children.reset();
         children.setChild1(Edge(input, DoubleRepUse));
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -6760,6 +6760,19 @@ void SpeculativeJIT::compileArithPow(Node* node)
     doubleResult(resultFpr, node);
 }
 
+void SpeculativeJIT::compilePurifyNaN(Node* node)
+{
+    SpeculateDoubleOperand value(this, node->child1());
+    FPRTemporary result(this);
+
+    FPRReg valueFPR = value.fpr();
+    FPRReg resultFPR = result.fpr();
+
+    moveDouble(valueFPR, resultFPR);
+    purifyNaN(resultFPR);
+    doubleResult(resultFPR, node);
+}
+
 // Returns true if the compare is fused with a subsequent branch.
 bool SpeculativeJIT::compare(Node* node, RelationalCondition condition, DoubleCondition doubleCondition, S_JITOperation_GJJ operation)
 {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1619,6 +1619,7 @@ public:
     void compileArithUnary(Node*);
     void compileArithSqrt(Node*);
     void compileArithMinMax(Node*);
+    void compilePurifyNaN(Node*);
     void compileConstantStoragePointer(Node*);
     void compileGetIndexedPropertyStorage(Node*);
     void compileResolveRope(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2504,6 +2504,10 @@ void SpeculativeJIT::compile(Node* node)
         compileArithUnary(node);
         break;
 
+    case PurifyNaN:
+        compilePurifyNaN(node);
+        break;
+
     case ToBoolean: {
         bool invert = false;
         compileToBoolean(node, invert);
@@ -4399,7 +4403,6 @@ void SpeculativeJIT::compile(Node* node)
     case PutByValMegamorphic:
     case InByIdMegamorphic:
     case InByValMegamorphic:
-    case PurifyNaN:
         DFG_CRASH(m_graph, node, "unexpected node in DFG backend");
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3625,6 +3625,10 @@ void SpeculativeJIT::compile(Node* node)
         compileArithUnary(node);
         break;
 
+    case PurifyNaN:
+        compilePurifyNaN(node);
+        break;
+
     case ToBoolean: {
         bool invert = false;
         compileToBoolean(node, invert);
@@ -6492,7 +6496,6 @@ void SpeculativeJIT::compile(Node* node)
     case IdentityWithProfile:
     case CPUIntrinsic:
     case CallWasm:
-    case PurifyNaN:
         DFG_CRASH(m_graph, node, "Unexpected node");
         break;
     }

--- a/Source/JavaScriptCore/ftl/FTLOutput.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOutput.cpp
@@ -190,6 +190,11 @@ LValue Output::neg(LValue value)
     return m_block->appendNew<Value>(m_proc, B3::Neg, origin(), value);
 }
 
+LValue Output::purifyNaN(LValue value)
+{
+    return m_block->appendNew<Value>(m_proc, B3::PurifyNaN, origin(), value);
+}
+
 LValue Output::doubleAdd(LValue left, LValue right)
 {
     return m_block->appendNew<B3::Value>(m_proc, B3::Add, origin(), left, right);

--- a/Source/JavaScriptCore/ftl/FTLOutput.h
+++ b/Source/JavaScriptCore/ftl/FTLOutput.h
@@ -160,6 +160,7 @@ public:
     LValue mod(LValue, LValue);
     LValue chillMod(LValue, LValue);
     LValue neg(LValue);
+    LValue purifyNaN(LValue);
 
     LValue doubleAdd(LValue, LValue);
     LValue doubleSub(LValue, LValue);


### PR DESCRIPTION
#### 48baa22f1b6c35473346930c79bc9c615d253a43
<pre>
[JSC] B3 should recognize PurifyNaN idiom
<a href="https://bugs.webkit.org/show_bug.cgi?id=287002">https://bugs.webkit.org/show_bug.cgi?id=287002</a>
<a href="https://rdar.apple.com/144144261">rdar://144144261</a>

Reviewed by Yijia Huang.

Furhter optimizes PurifyNaN operation by integrating B3::PurifyNaN.
B3 recognizes this pattern and do strength reduction with this. We also
replace some hacks in B3 with PurifyNaN-based optimizations.

* Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp:
(JSC::B3::ConstDoubleValue::purifyNaNConstant const):
* Source/JavaScriptCore/b3/B3ConstDoubleValue.h:
* Source/JavaScriptCore/b3/B3ConstFloatValue.cpp:
(JSC::B3::ConstFloatValue::purifyNaNConstant const):
* Source/JavaScriptCore/b3/B3ConstFloatValue.h:
* Source/JavaScriptCore/b3/B3LowerMacrosAfterOptimizations.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceDoubleToFloat.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::purifyNaNConstant const):
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
(JSC::B3::Value::typeFor):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToPurifyNaN):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileValueRep):
(JSC::FTL::DFG::LowerDFGToB3::compilePurifyNaN):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):
(JSC::FTL::DFG::LowerDFGToB3::compilePutByOffset):
(JSC::FTL::DFG::LowerDFGToB3::compileMultiPutByOffset):
(JSC::FTL::DFG::LowerDFGToB3::compilePutGlobalVariable):
(JSC::FTL::DFG::LowerDFGToB3::compilePutClosureVar):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
(JSC::FTL::DFG::LowerDFGToB3::purifyNaN): Deleted.
* Source/JavaScriptCore/ftl/FTLOutput.cpp:
(JSC::FTL::Output::purifyNaN):
* Source/JavaScriptCore/ftl/FTLOutput.h:

Canonical link: <a href="https://commits.webkit.org/289853@main">https://commits.webkit.org/289853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2d08add380c44571855ddce8dba929407b4769

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93161 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15906 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79779 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5966 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38066 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81006 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95007 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86984 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15378 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75635 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20550 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13768 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15396 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109477 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26326 "Found 1 new JSC binary failure: testb3 (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18584 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->