### PR TITLE
Add support for ALAC and PCM audio in MediaRecorder

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable-expected.txt
@@ -1,5 +1,6 @@
 
 
-
-PASS MediaRecorder can successfully record the video for a audio-video stream
+PASS MediaRecorder can successfully record the video for a audio-video (aac) stream
+PASS MediaRecorder can successfully record the video for a audio-video (pcm) stream
+PASS MediaRecorder can successfully record the video for a audio-video (alac) stream
 

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html
@@ -8,60 +8,31 @@
     <script src="../common/canvas-tests.js"></script>
 </head>
 <body>
-<div>
-    <video id="player">
-    </video>
-</div>
-<div>
-    <canvas id="canvas" width="200" height="200">
-    </canvas>
-    <canvas id="frame" width="200" height="200">
-    </canvas>
-</div>
+<div id="divplayer"></div>
+<div id="canvasreference"></div>
+<div id="canvascopy"></div>
 <script>
-    var context;
-    var drawStartTime;
-    // Needs to be a globabl variable to avoid being GCed (webkit.org/b/271227)
-    var oscillator;
-
-    function createVideoStream() {
-        const canvas = document.getElementById("canvas");
-        context = canvas.getContext('2d');
-        return canvas.captureStream();
-    }
-
-    function doRedImageDraw() {
-        if (context) {
-            context.fillStyle = "#ff0000";
-            context.fillRect(0, 0, 200, 200);
-            if (Date.now() - drawStartTime < 1000) {
-                window.requestAnimationFrame(doRedImageDraw);
-            } else {
-                drawStartTime = Date.now();
-                doGreenImageDraw();
-            }
-        }
-    }
-
-    function doGreenImageDraw() {
-        if (context) {
-            context.fillStyle = "#00ff00";
-            context.fillRect(0, 0, 200, 200);
-            if (Date.now() - drawStartTime < 2000) {
-                window.requestAnimationFrame(doGreenImageDraw);
-            }
-        }
-    }
-
-    function waitForEvent(object, eventName, testName)
-    {
+    function waitForEvent(object, eventName, testName) {
         return new Promise((resolve, reject) => {
             object.addEventListener(eventName, (e) => resolve(e), { once: true });
             setTimeout(() => reject("waitForEvent " + (testName ? (testName + " ") : "") + "timed out for " + eventName), 2500);
         });
     }
 
-    promise_test(async (test) => {
+    async function runTest(mimeType) {
+        let context;
+        let drawStartTime;
+        // Needs to be a globabl variable to avoid being GCed (webkit.org/b/271227)
+        let oscillator;
+
+        function createVideoStream() {
+            const canvas = document.createElement("canvas");
+            canvas.width = 200;
+            canvas.height = 200;
+            canvasreference.appendChild(canvas);
+            context = canvas.getContext('2d');
+            return canvas.captureStream();
+        }
         const ac = new AudioContext();
         oscillator = ac.createOscillator();
         const dest = ac.createMediaStreamDestination();
@@ -74,12 +45,37 @@
         assert_equals(audio.getAudioTracks().length, 1, "audio mediastream starts with one audio track");
         video.addTrack(audio.getAudioTracks()[0]);
         assert_equals(video.getAudioTracks().length, 1, "video mediastream starts with one audio track");
-        const recorder = new MediaRecorder(video);
+        assert_true(MediaRecorder.isTypeSupported(mimeType));
+        const recorder = new MediaRecorder(video, { mimeType });
+
+        function doRedImageDraw() {
+            if (context) {
+                context.fillStyle = "#ff0000";
+                context.fillRect(0, 0, 200, 200);
+                if (Date.now() - drawStartTime < 300) {
+                    window.requestAnimationFrame(doRedImageDraw);
+                } else {
+                    drawStartTime = Date.now();
+                    doGreenImageDraw();
+                }
+            }
+        }
+
+        function doGreenImageDraw() {
+            if (context) {
+                context.fillStyle = "#00ff00";
+                context.fillRect(0, 0, 200, 200);
+                if (Date.now() - drawStartTime < 300) {
+                    window.requestAnimationFrame(doGreenImageDraw);
+                } else if (recorder.state == 'recording')
+                    recorder.stop();
+            }
+        }
+
         drawStartTime = Date.now();
         doRedImageDraw();
         recorder.start();
         assert_equals(recorder.state, 'recording', 'MediaRecorder has been started successfully');
-        setTimeout(() => { recorder.stop(); }, 2000);
 
         const blobEvent = await waitForEvent(recorder, 'dataavailable');
         assert_true(blobEvent instanceof BlobEvent, 'the type of event should be BlobEvent');
@@ -89,6 +85,8 @@
         assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
 
         const MediaSource = self.ManagedMediaSource || self.MediaSource;
+        const player = document.createElement("video");
+        divplayer.appendChild(player);
         player.disableRemotePlayback = true;
         const source = new MediaSource();
         player.src = URL.createObjectURL(source);
@@ -98,14 +96,17 @@
         await waitForEvent(sourceBuffer, 'updateend');
         source.endOfStream();
 
-        const resFrame = document.getElementById("frame");
+        const resFrame = document.createElement("canvas");
+        resFrame.width = 200;
+        resFrame.height = 200;
+        canvascopy.appendChild(resFrame);
         const resContext = resFrame.getContext('2d');
 
-        assert_greater_than(player.duration, 1, 'the duration should be greater than 1s');
+        assert_greater_than(player.duration, 0.3, 'the duration should be greater than .3s');
         await player.play();
 
         player.pause();
-        player.currentTime = Math.min(1.5, player.duration - 0.05);
+        player.currentTime = player.duration - 0.05;
         await waitForEvent(player, 'seeked');
         resContext.drawImage(player, 0, 0);
         _assertPixelApprox(resFrame, 20, 20, 0, 255, 0, 255, "20, 20", "0, 255, 0, 255", 50);
@@ -115,9 +116,20 @@
         await waitForEvent(player, 'seeked');
         resContext.drawImage(player, 0, 0);
         _assertPixelApprox(resFrame, 25, 25, 255, 0, 0, 255, "25, 25", "255, 0, 0, 255", 50);
-        _assertPixelApprox(resFrame, 50, 50, 255, 0, 0, 255, "50, 50", "255, 0, 0, 255", 50);
-    }, 'MediaRecorder can successfully record the video for a audio-video stream');
+        _assertPixelApprox(resFrame, 50, 50, 255, 0, 0, 255, "50, 50", "255, 0, 0, 255", 50);        
+    }
+    
+    promise_test(async (test) => {
+        return runTest('video/mp4');
+    }, 'MediaRecorder can successfully record the video for a audio-video (aac) stream');
 
+    promise_test(async (test) => {
+        return runTest('video/mp4; codecs=avc1.42000a,pcm');
+    }, 'MediaRecorder can successfully record the video for a audio-video (pcm) stream');
+
+    promise_test(async (test) => {
+        return runTest('video/mp4; codecs=avc1.42000a,alac');
+    }, 'MediaRecorder can successfully record the video for a audio-video (alac) stream');
 </script>
 </body>
 </html>

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -66,8 +66,9 @@ bool MediaRecorderPrivateAVFImpl::isTypeSupported(Document& document, ContentTyp
                 && !((codec.startsWith("hev1."_s) || codec.startsWith("hvc1."_s)) && document.settings().webRTCH265CodecEnabled())
 #endif
 #if HAVE(AVASSETWRITER_WITH_OPUS_SUPPORTED)
-                && !codec.startsWith("opus"_s)
+                && codec != "opus"_s
 #endif
+                && codec != "pcm"_s && codec != "alac"_s
                 && !startsWithLettersIgnoringASCIICase(codec, "mp4a"_s))
                 return false;
         }

--- a/Source/WebKit/GPUProcess/media/RemoteTrackInfo.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTrackInfo.h
@@ -64,6 +64,7 @@ struct RemoteAudioInfo {
         audioInfo->codecString = codecString;
         audioInfo->trackID = trackID;
         audioInfo->rate = rate;
+        audioInfo->channels = channels;
         audioInfo->framesPerPacket = framesPerPacket;
         audioInfo->bitDepth = bitDepth;
         audioInfo->cookieData = cookieData;


### PR DESCRIPTION
#### be5f9bb0a1a7c0ec9087d5a6215870305b1d5a49
<pre>
Add support for ALAC and PCM audio in MediaRecorder
<a href="https://bugs.webkit.org/show_bug.cgi?id=287003">https://bugs.webkit.org/show_bug.cgi?id=287003</a>
<a href="https://rdar.apple.com/144145333">rdar://144145333</a>

Reviewed by Youenn Fablet.

Add test.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable-expected.txt:
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::createFormatDescriptionFromTrackInfo): Add handling of PCM description.
(WebCore::samplesBlockFromCMSampleBuffer): Don&apos;t split PCM samples block.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::isTypeSupported):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::codecStringForMediaVideoCodecId):
(WebCore::MediaRecorderPrivateEncoder::initialize):
(WebCore::MediaRecorderPrivateEncoder::audioSamplesDescriptionChanged):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
* Source/WebKit/GPUProcess/media/RemoteTrackInfo.h:
(WebKit::RemoteAudioInfo::toAudioInfo const): channels field wasn&apos;t properly initialised.

Canonical link: <a href="https://commits.webkit.org/289781@main">https://commits.webkit.org/289781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d5444ff877b663d204957b90880c0c3022ba81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15732 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25694 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48325 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37895 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94834 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15206 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76048 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18692 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/20447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8219 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15224 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->