### PR TITLE
REGRESSION(285181@main): UIP crash from CheckedPtr assertion under com.apple.WebKit: -[WKPaymentAuthorizationDelegate(Protected) _didFinish] when WP dies

### DIFF
--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
@@ -29,6 +29,7 @@
 
 #include "CocoaWindow.h"
 #include <WebCore/ApplePaySessionPaymentRequest.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -58,9 +59,8 @@ class PaymentAuthorizationPresenter : public RefCountedAndCanMakeWeakPtr<Payment
     WTF_MAKE_TZONE_ALLOCATED(PaymentAuthorizationPresenter);
     WTF_MAKE_NONCOPYABLE(PaymentAuthorizationPresenter);
 public:
-    struct Client : public CanMakeWeakPtr<Client>, public CanMakeCheckedPtr<Client> {
+    struct Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
-        WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(Client);
 
         virtual ~Client() = default;
 
@@ -78,8 +78,7 @@ public:
 
     virtual ~PaymentAuthorizationPresenter() = default;
 
-    Client* client() { return m_client.get(); }
-    CheckedPtr<Client> checkedClient() { return m_client.get(); }
+    RefPtr<Client> protectedClient() { return m_client.get(); }
 
     void completeMerchantValidation(const WebCore::PaymentMerchantSession&);
     void completePaymentMethodSelection(std::optional<WebCore::ApplePayPaymentMethodUpdate>&&);

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -49,7 +49,11 @@
     if (!(self = [super _initWithRequest:request presenter:presenter]))
         return nil;
 
-    _presentingWindow = presenter.checkedClient()->presentingWindowForPaymentAuthorization(presenter);
+    RefPtr client = presenter.protectedClient();
+    if (!client)
+        return nil;
+
+    _presentingWindow = client->presentingWindowForPaymentAuthorization(presenter);
     return self;
 }
 

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -85,7 +85,6 @@ class WebPaymentCoordinatorProxy final
     , public PaymentAuthorizationPresenter::Client
     , public RefCounted<WebPaymentCoordinatorProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WebPaymentCoordinatorProxy);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPaymentCoordinatorProxy);
 public:
     USING_CAN_MAKE_WEAKPTR(MessageReceiver);
 


### PR DESCRIPTION
#### c288f170a2f5469bc9fed5ebe83dd406c9a29382
<pre>
REGRESSION(285181@main): UIP crash from CheckedPtr assertion under com.apple.WebKit: -[WKPaymentAuthorizationDelegate(Protected) _didFinish] when WP dies
<a href="https://bugs.webkit.org/show_bug.cgi?id=287010">https://bugs.webkit.org/show_bug.cgi?id=287010</a>
<a href="https://rdar.apple.com/140611989">rdar://140611989</a>

Reviewed by Wenson Hsieh.

In 285181@main, PaymentAuthorizationPresenter::Client callers adopted
its CheckedPtr instances, notably in WKPaymentAuthorizationDelegate.
This seemed appropriate for the Client usage pattern prior to said
patch. However, upon further analysis of the ownership model, clearing
the RefPtr&lt;PaymentAuthorizationPresenter::Client&gt; held by WebPageProxy
whenever we are executing a Client method causes a CheckedPtr assertion
to fire, crashing the UI process. This exact flow occurs whenever the
web process crashes while a user is finalizing a payment in the Apple
Pay sheet, since WebPageProxy::resetState() clears the client pointer it
holds.

Based on the analysis above, it makes sense for us to start protecting
this Client object before calling into it. As such, we introduce a
RefPtr accessor (and delete the CheckedPtr variant). To facilitate an
accessor like this, we make PaymentAuthorizationPresenter::Client
inherit from AbstractRefCountedAndCanMakeWeakPtr. We still want to make
a WeakPtr from the Client since we don&apos;t change the ownership model
where PaymentAuthorizationPresenter holds onto a weak reference to the
Client.

Tested manually. Unfortunately we do not have test infrastructure in
place to exercise calling into PassKit flows.

* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h:
(WebKit::PaymentAuthorizationPresenter::protectedClient):
(WebKit::PaymentAuthorizationPresenter::client): Deleted.
(WebKit::PaymentAuthorizationPresenter::checkedClient): Deleted.
* Source/WebKit/Platform/cocoa/WKPaymentAuthorizationDelegate.mm:
(-[WKPaymentAuthorizationDelegate _didAuthorizePayment:completion:]):
(-[WKPaymentAuthorizationDelegate _didFinish]):
(-[WKPaymentAuthorizationDelegate _didRequestMerchantSession:]):
(-[WKPaymentAuthorizationDelegate _didSelectPaymentMethod:completion:]):
(-[WKPaymentAuthorizationDelegate _didSelectShippingContact:completion:]):
(-[WKPaymentAuthorizationDelegate _didSelectShippingMethod:completion:]):
(-[WKPaymentAuthorizationDelegate _didChangeCouponCode:completion:]):
* Source/WebKit/Platform/ios/PaymentAuthorizationController.mm:
(-[WKPaymentAuthorizationControllerDelegate initWithRequest:presenter:]):

Canonical link: <a href="https://commits.webkit.org/289806@main">https://commits.webkit.org/289806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9fdf87468e69ace9ef35294e2565db13d241c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38769 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25681 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48314 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5843 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37876 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94814 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15187 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11165 "Found 1 new test failure: ipc/decode-object-array-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75491 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76035 "Found 101 new API test failures: /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select, /TestWebKit:WebKit.InjectedBundleBasic, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /TestWebKit:WebKit.LoadAlternateHTMLStringWithNonDirectoryURL, /WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /TestWebKit:WebKit.InjectedBundleFrameHitTest, /TestWebKit:WebKit.ForceRepaint, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20430 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8191 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20506 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->