### PR TITLE
http/tests/pdf/linearized-pdf-in-iframe.html is crashing at WTF::Lock::assertIsOwner() under PDFPluginBase::streamedBytesForDebugLogging()

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1972,8 +1972,7 @@ webkit.org/b/287122 imported/w3c/web-platform-tests/html/capability-delegation/d
 [ arm64 ] fast/webgpu/nocrash/fuzz-284937.html [ Skip ]
 [ arm64 ] fast/webgpu/nocrash/fuzz-287444.html [ Skip ]
 
-webkit.org/b/287865 [ Release ] pdf/two-pages-continuous-to-discrete.html [ Pass ImageOnlyFailure ]
-webkit.org/b/287865 [ Debug ] pdf/two-pages-continuous-to-discrete.html [ Pass Crash ]
+webkit.org/b/287865 pdf/two-pages-continuous-to-discrete.html [ Pass ImageOnlyFailure ]
 
 # webkit.org/b/287875 [ macOS Release wk2 x86_64 ] 2x fast/borders/border-painting-*.html are consistently failing.
 [ Sonoma x86_64 Release ] fast/borders/border-painting-inset.html [ Pass ImageOnlyFailure  ]
@@ -2017,13 +2016,6 @@ webkit.org/b/288119 imported/w3c/web-platform-tests/preload/preload-type-match.h
 webkit.org/b/288120 [ Sonoma+ Release ] fast/animation/request-animation-frame-throttling-lowPowerMode.html [ Pass Failure ]
 
 webkit.org/b/288404 [ Sonoma+ Release ] fast/text/canvas-color-fonts/stroke-gradient-COLR.html [ Pass ImageOnlyFailure ]
-
-# webkit.org/b/287012 PDF tests crashing at WTF::Lock::assertIsOwner() under PDFPluginBase::streamedBytesForDebugLogging()
-[ Debug ] http/tests/pdf/linearized-pdf-in-iframe.html [ Pass Crash ]
-[ Debug ] http/tests/pdf/linearized-pdf-in-display-none-iframe.html [ Pass Crash ]
-[ Debug ] pdf/annotations/checkbox-set-active.html [ Pass Crash ]
-[ Debug ] pdf/annotations/dropdown-select-second-option.html [ Pass Crash ]
-[ Debug ] pdf/annotations/radio-buttons-select-second.html [ Pass Crash ]
 
 webkit.org/b/288411 [ Sequoia x86_64 ] imported/w3c/web-platform-tests/webrtc/simulcast/getStats.https.html [ Failure ]
 
@@ -2119,8 +2111,6 @@ webkit.org/b/291108 [ Sequoia Debug ] imported/w3c/web-platform-tests/html/webap
 webkit.org/b/291115 [ Sequoia Debug ] imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window.html [ Pass Failure ]
 
 webkit.org/b/291119 [ Debug ] imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html [ Pass Failure ]
-
-webkit.org/b/291236 [ Debug ] http/tests/pdf/page-in-window-update-with-linearized-pdf-in-display-none-iframe.html [ Skip ]
 
 webkit.org/b/291394 [ Debug ] imported/w3c/web-platform-tests/wasm/webapi/esm-integration/script-src-blocks-wasm.tentative.sub.html [ Pass Failure ]
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -361,8 +361,8 @@ private:
     bool getByteRanges(CFMutableArrayRef, std::span<const CFRange>) const;
 
 #if !LOG_DISABLED
-    uint64_t streamedBytesForDebugLogging() const;
-    void incrementalLoaderLogWithBytes(const String&, uint64_t streamedBytes);
+    std::optional<uint64_t> streamedBytesForDebugLogging() const;
+    void incrementalLoaderLogWithBytes(const String&, std::optional<uint64_t>&& streamedBytes);
 #endif
 
 protected:


### PR DESCRIPTION
#### 361024dd33d218850fd65617d11732aa155d2d78
<pre>
http/tests/pdf/linearized-pdf-in-iframe.html is crashing at WTF::Lock::assertIsOwner() under PDFPluginBase::streamedBytesForDebugLogging()
<a href="https://bugs.webkit.org/show_bug.cgi?id=287012">https://bugs.webkit.org/show_bug.cgi?id=287012</a>
<a href="https://rdar.apple.com/144058653">rdar://144058653</a>

Reviewed by Wenson Hsieh.

In 289647@main, we added PDFPluginBase::streamedBytesForDebugLogging(),
a debug-only logging utility used to read the streamed bytes count from
the plugin. This utility either tries to adopt the data lock for the
streamed bytes value or it asserts that the lock is already held before
reading it. However, this assertion was misguided because you can
imagine an incrementalLoaderLog() caller off the main thread holding
the data lock. In that case, neither can we adopt the lock, nor should
we claim that the main thread (where incrementalLoaderLog() executes)
already holds the lock. This leads to a web process crash in some debug
configurations under streamedBytesForDebugLogging().

In this patch, we fix this crash by correcting our misguided assumption.
We do so abandoning our effort to read the streamed bytes count if the
lock is not adoptable (or held). This is fine because at worst, we do not
get the streamed bytes count in a log statement, at least we do not get
in the way of correctness.

To facilitate this &quot;do not read streamed bytes count if the lock is not
adoptable or not already held&quot; approach, we change the return type of
PDFPluginBase::streamedBytesForDebugLogging() an optional value. We then
adopt this change in callers (namely `verboseLog()`).

* LayoutTests/platform/mac-wk2/TestExpectations:

  Adjust test expectations for previously gardened tests.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::verboseLog):
(WebKit::PDFPluginBase::incrementalLoaderLog):
(WebKit::PDFPluginBase::incrementalLoaderLogWithBytes):

Canonical link: <a href="https://commits.webkit.org/294270@main">https://commits.webkit.org/294270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/805bc2a43e003f67161bcf9946927fe71fbea19a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/101218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/20880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/11183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/106366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/51845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/21189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/29374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/77087 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/34121 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/104225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/16335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/91425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/57434 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/16151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/9435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/51193 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/86037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/9510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/108722 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/28346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/20862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/86065 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/28708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/87629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/85614 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/30340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/8051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/22445 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/16485 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/28276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/33547 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/28088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/31408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/29646 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->