### PR TITLE
Offlineasm scripts should be inputs to the LLInt Xcode build stages

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2230,7 +2230,25 @@
 			fileType = pattern.proxy;
 			inputFiles = (
 				"$(BUILT_PRODUCTS_DIR)/JSCLLIntOffsetsExtractor",
-				"$(SRCROOT)/offlineasm",
+				"$(SRCROOT)/offlineasm/arm.rb",
+				"$(SRCROOT)/offlineasm/arm64.rb",
+				"$(SRCROOT)/offlineasm/arm64e.rb",
+				"$(SRCROOT)/offlineasm/asm.rb",
+				"$(SRCROOT)/offlineasm/ast.rb",
+				"$(SRCROOT)/offlineasm/backends.rb",
+				"$(SRCROOT)/offlineasm/cloop.rb",
+				"$(SRCROOT)/offlineasm/config.rb",
+				"$(SRCROOT)/offlineasm/instructions.rb",
+				"$(SRCROOT)/offlineasm/offsets.rb",
+				"$(SRCROOT)/offlineasm/opt.rb",
+				"$(SRCROOT)/offlineasm/parser.rb",
+				"$(SRCROOT)/offlineasm/registers.rb",
+				"$(SRCROOT)/offlineasm/risc.rb",
+				"$(SRCROOT)/offlineasm/riscv64.rb",
+				"$(SRCROOT)/offlineasm/self_hash.rb",
+				"$(SRCROOT)/offlineasm/settings.rb",
+				"$(SRCROOT)/offlineasm/transform.rb",
+				"$(SRCROOT)/offlineasm/x86.rb",
 			);
 			isEditable = 1;
 			outputFiles = (
@@ -2247,7 +2265,25 @@
 			fileType = pattern.proxy;
 			inputFiles = (
 				"$(BUILT_PRODUCTS_DIR)/JSCLLIntSettingsExtractor",
-				"$(SRCROOT)/offlineasm",
+				"$(SRCROOT)/offlineasm/arm.rb",
+				"$(SRCROOT)/offlineasm/arm64.rb",
+				"$(SRCROOT)/offlineasm/arm64e.rb",
+				"$(SRCROOT)/offlineasm/ast.rb",
+				"$(SRCROOT)/offlineasm/backends.rb",
+				"$(SRCROOT)/offlineasm/cloop.rb",
+				"$(SRCROOT)/offlineasm/config.rb",
+				"$(SRCROOT)/offlineasm/generate_offset_extractor.rb",
+				"$(SRCROOT)/offlineasm/instructions.rb",
+				"$(SRCROOT)/offlineasm/offsets.rb",
+				"$(SRCROOT)/offlineasm/opt.rb",
+				"$(SRCROOT)/offlineasm/parser.rb",
+				"$(SRCROOT)/offlineasm/registers.rb",
+				"$(SRCROOT)/offlineasm/risc.rb",
+				"$(SRCROOT)/offlineasm/riscv64.rb",
+				"$(SRCROOT)/offlineasm/self_hash.rb",
+				"$(SRCROOT)/offlineasm/settings.rb",
+				"$(SRCROOT)/offlineasm/transform.rb",
+				"$(SRCROOT)/offlineasm/x86.rb",
 			);
 			isEditable = 1;
 			outputFiles = (
@@ -2263,7 +2299,25 @@
 			filePatterns = "*.asm";
 			fileType = pattern.proxy;
 			inputFiles = (
-				"$(SRCROOT)/offlineasm",
+				"$(SRCROOT)/offlineasm/arm.rb",
+				"$(SRCROOT)/offlineasm/arm64.rb",
+				"$(SRCROOT)/offlineasm/arm64e.rb",
+				"$(SRCROOT)/offlineasm/ast.rb",
+				"$(SRCROOT)/offlineasm/backends.rb",
+				"$(SRCROOT)/offlineasm/cloop.rb",
+				"$(SRCROOT)/offlineasm/config.rb",
+				"$(SRCROOT)/offlineasm/generate_settings_extractor.rb",
+				"$(SRCROOT)/offlineasm/instructions.rb",
+				"$(SRCROOT)/offlineasm/offsets.rb",
+				"$(SRCROOT)/offlineasm/opt.rb",
+				"$(SRCROOT)/offlineasm/parser.rb",
+				"$(SRCROOT)/offlineasm/registers.rb",
+				"$(SRCROOT)/offlineasm/risc.rb",
+				"$(SRCROOT)/offlineasm/riscv64.rb",
+				"$(SRCROOT)/offlineasm/self_hash.rb",
+				"$(SRCROOT)/offlineasm/settings.rb",
+				"$(SRCROOT)/offlineasm/transform.rb",
+				"$(SRCROOT)/offlineasm/x86.rb",
 			);
 			isEditable = 1;
 			outputFiles = (


### PR DESCRIPTION
#### b5226c4e1f42a66b619ae612686184f24644163d
<pre>
Offlineasm scripts should be inputs to the LLInt Xcode build stages
<a href="https://bugs.webkit.org/show_bug.cgi?id=287014">https://bugs.webkit.org/show_bug.cgi?id=287014</a>
<a href="https://rdar.apple.com/144155597">rdar://144155597</a>

Reviewed by Elliott Williams and Yusuke Suzuki.

Right now we just list the offlineasm directory but it seems like Xcode doesn&apos;t understand
how directories work. This means when you change one of the ruby files Xcode doesn&apos;t rerun
the appropriate scripts. Now I just explicitly list all the dependency `offlineasm/*.rb`
files relevant for each script.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/289815@main">https://commits.webkit.org/289815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaad3e4c8597c6c5d3110abf7df28d8a5f157cec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67967 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25697 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5857 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34071 "Found 1 new test failure: accessibility/nested-custom-element-accname.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37905 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80846 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94844 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86824 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76055 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8229 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15234 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20535 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109317 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14976 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26284 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->