### PR TITLE
[GTK][WPE] Fix build when DAMAGE_TRACKING is disabled

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -91,7 +91,9 @@ private:
     void willRenderFrame() override;
     void didRenderFrame() override;
 
+#if ENABLE(DAMAGE_TRACKING)
     const WebCore::Damage& addDamage(const WebCore::Damage&) override;
+#endif
 
     void didCreateCompositingRunLoop(WTF::RunLoop&) override;
     void willDestroyCompositingRunLoop() override;
@@ -118,11 +120,18 @@ private:
         virtual ~RenderTarget();
 
         uint64_t id() const { return m_id; }
+#if ENABLE(DAMAGE_TRACKING)
         const WebCore::Damage& damage() { return m_damage; }
         void addDamage(const WebCore::Damage&);
+#endif
 
         virtual void willRenderFrame() const;
-        virtual void didRenderFrame() { m_damage = WebCore::Damage { }; }
+        virtual void didRenderFrame()
+        {
+#if ENABLE(DAMAGE_TRACKING)
+            m_damage = WebCore::Damage { };
+#endif
+        }
 
         std::unique_ptr<WebCore::GLFence> createRenderingFence(bool) const;
         void setReleaseFenceFD(UnixFileDescriptor&&);
@@ -137,7 +146,9 @@ private:
         uint64_t m_surfaceID { 0 };
         unsigned m_depthStencilBuffer { 0 };
         UnixFileDescriptor m_releaseFenceFD;
+#if ENABLE(DAMAGE_TRACKING)
         WebCore::Damage m_damage { WebCore::Damage::invalid() };
+#endif
     };
 
     class RenderTargetColorBuffer : public RenderTarget {
@@ -243,7 +254,9 @@ private:
         void reset();
         void releaseUnusedBuffers();
 
+#if ENABLE(DAMAGE_TRACKING)
         void addDamage(const WebCore::Damage&);
+#endif
 
         unsigned size() const { return m_freeTargets.size() + m_lockedTargets.size(); }
 
@@ -275,7 +288,9 @@ private:
     RenderTarget* m_target { nullptr };
     bool m_isVisible { false };
     bool m_useExplicitSync { false };
+#if ENABLE(DAMAGE_TRACKING)
     WebCore::Damage m_frameDamage;
+#endif
     std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
 };
 


### PR DESCRIPTION
#### ba06d144e31c08c4bcd83dc694f2dd53e3feed6e
<pre>
[GTK][WPE] Fix build when DAMAGE_TRACKING is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=287020">https://bugs.webkit.org/show_bug.cgi?id=287020</a>

Reviewed by Adrian Perez de Castro.

Protect Damage-specific features when DAMAGE_TRACKING is disabled

* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/289867@main">https://commits.webkit.org/289867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b079519f302787eba3b5c3c28edd6b199737bc84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38815 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67981 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25711 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48344 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5872 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34083 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76071 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18742 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20463 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18869 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8250 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20552 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->