### PR TITLE
Clean up TaggedPtr

### DIFF
--- a/Source/WTF/wtf/TaggedPtr.h
+++ b/Source/WTF/wtf/TaggedPtr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,78 +25,72 @@
 
 #pragma once
 
+#include <bit>
+#include <concepts>
+
 namespace WTF {
 
-// TaggingTraits should have the following API:
-// TaggingTraits {
-//     using StorageType = ...;
-//     using TagType = ...;
-//     static constexpr TagType defaultTag;
-//     static StorageType encode(const T*, TagType);
-//     static T* extractPtr(StorageType);
-//     static TagType extractTag(StorageType);
-// }
-// FIXME: This could have a concept, which would make diagnosing TaggingTraits API errors easier.
-template<typename T, typename TaggingTraits>
+template<typename Trait, typename T>
+concept TaggingTraits = requires (const T* ptr, typename Trait::StorageType storage, typename Trait::TagType tag) {
+    { Trait::defaultTag } -> std::convertible_to<typename Trait::TagType>;
+    { Trait::wrap(ptr, tag) } -> std::convertible_to<typename Trait::StorageType>;
+    { Trait::unwrapPtr(storage) } -> std::convertible_to<T*>;
+    { Trait::unwrapTag(storage) } -> std::convertible_to<typename Trait::TagType>;
+};
+
+template<typename T, TaggingTraits<T> Traits>
 class TaggedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using StorageType = typename TaggingTraits::StorageType;
-    using TagType = typename TaggingTraits::TagType;
+    using StorageType = typename Traits::StorageType;
+    using TagType = typename Traits::TagType;
 
     TaggedPtr() = default;
-    TaggedPtr(const T* ptr, TagType tag = TaggingTraits::defaultTag)
-        : m_ptr(TaggingTraits::encode(ptr, tag))
+    TaggedPtr(const T* ptr, TagType tag = Traits::defaultTag)
+        : m_ptr(Traits::wrap(ptr, tag))
     { }
 
-    TagType tag() const { return TaggingTraits::extractTag(m_ptr); }
-    const T* ptr() const { return TaggingTraits::extractPtr(m_ptr); }
-    T* ptr() { return TaggingTraits::extractPtr(m_ptr); }
+    TagType tag() const { return Traits::unwrapTag(m_ptr); }
+    const T* ptr() const { return Traits::unwrapPtr(m_ptr); }
+    T* ptr() { return Traits::unwrapPtr(m_ptr); }
 
-    void set(const T* t, TagType tag) { m_ptr = TaggingTraits::encode(t, tag); }
-    void setTag(TagType tag) { m_ptr = TaggingTraits::encode(ptr(), tag); }
+    void set(const T* t, TagType tag) { m_ptr = Traits::wrap(t, tag); }
+    void setTag(TagType tag) { m_ptr = Traits::wrap(ptr(), tag); }
 
     TaggedPtr& operator=(const T* t)
     {
-        m_ptr = TaggingTraits::encode(t, tag());
+        m_ptr = Traits::wrap(t, tag());
         return *this;
     }
 
+    const T* operator->() const { return ptr(); }
+    T* operator->() { return ptr(); }
+
 private:
-    StorageType m_ptr { TaggingTraits::encode(nullptr, TaggingTraits::defaultTag) };
+    StorageType m_ptr { Traits::wrap(nullptr, Traits::defaultTag) };
 };
 
-// NB. This class relies on top byte ignore on ARM64 CPUs as it assumes pointer reads are more common than pointer writes.
-// So the pointer it returns from extractPtr could have high bits set on those CPUs. This is notable for places that want to
-// play with the bits of the pointer e.g. JSC's NativeCallee.
+
 template<typename T, typename Enum, Enum defaultEnumTag = static_cast<Enum>(0)>
 struct EnumTaggingTraits {
     using StorageType = uintptr_t;
     using TagType = Enum;
     static constexpr TagType defaultTag = defaultEnumTag;
 
-    static StorageType encode(const T* ptr, TagType tag)
+    static StorageType wrap(const T* ptr, TagType tag)
     {
         ASSERT_WITH_MESSAGE((static_cast<StorageType>(tag) | tagMask32Bit) == tagMask32Bit, "Tag is too big for 32-bit storage");
         ASSERT(fromStorage(toStorage(tag)) == tag);
-#if CPU(ARM64) && CPU(ADDRESS64)
-        // We could be re-encoding an old pointer so we need to strip any potential old tag.
-        return (std::bit_cast<StorageType>(ptr) & ptrMask) | toStorage(tag);
-#else
         return std::bit_cast<StorageType>(ptr) | toStorage(tag);
-#endif
     }
 
-#if CPU(ARM64) && CPU(ADDRESS64)
-    // This class relies on top byte ignore on ARM64 CPUs.
-    static T* extractPtr(StorageType storage) { return std::bit_cast<T*>(storage); }
-#elif CPU(ADDRESS64)
-    static T* extractPtr(StorageType storage) { return std::bit_cast<T*>(storage & ptrMask); }
+#if CPU(ADDRESS64)
+    static T* unwrapPtr(StorageType storage) { return std::bit_cast<T*>(storage & ptrMask); }
 #else
-    static T* extractPtr(StorageType storage) { return std::bit_cast<T*>(storage & ~tagMask32Bit); }
+    static T* unwrapPtr(StorageType storage) { return std::bit_cast<T*>(storage & ~tagMask32Bit); }
 #endif
 
-    static TagType extractTag(StorageType storage) { return fromStorage(storage); }
+    static TagType unwrapTag(StorageType storage) { return fromStorage(storage); }
 
     static constexpr StorageType tagMask32Bit = (1 << (alignof(std::remove_pointer_t<T>) - 1)) - 1;
 #if CPU(ADDRESS64)
@@ -116,9 +110,9 @@ struct NoTaggingTraits {
     using StorageType = uintptr_t;
     using TagType = unsigned;
     static constexpr TagType defaultTag = 0;
-    static StorageType encode(const T* ptr, TagType) { return std::bit_cast<StorageType>(ptr); }
-    static T* extractPtr(StorageType storage) { return std::bit_cast<T*>(storage); }
-    static TagType extractTag(StorageType) { return defaultTag; }
+    static StorageType wrap(const T* ptr, TagType) { return std::bit_cast<StorageType>(ptr); }
+    static T* unwrapPtr(StorageType storage) { return std::bit_cast<T*>(storage); }
+    static TagType unwrapTag(StorageType) { return defaultTag; }
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### 6fb73d00567745370a0757483e620a9e11976cab
<pre>
Clean up TaggedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=287018">https://bugs.webkit.org/show_bug.cgi?id=287018</a>
<a href="https://rdar.apple.com/144160928">rdar://144160928</a>

Reviewed by Yusuke Suzuki.

Relying on ARM64&apos;s top byte ignore and leaking those bits is problematic since people might try to do
pointer equality comparisions on the pointer returned by TaggedPtr or more perniciously by doing
`taggedPtr-&gt;foo()` and `foo` doing pointer comparisons. I think LLVM should be able to notice when
it can use TBI to skip stripping the tag (<a href="https://rdar.apple.com/144164498">rdar://144164498</a>).

I also added a concept to document the API for TaggedPtr&apos;s TaggingTraits and renamed things to
better match RefPtr&apos;s PtrTraits.

* Source/WTF/wtf/TaggedPtr.h:
(WTF::requires):
(WTF::TaggedPtr::TaggedPtr):
(WTF::TaggedPtr::tag const):
(WTF::TaggedPtr::ptr const):
(WTF::TaggedPtr::ptr):
(WTF::TaggedPtr::set):
(WTF::TaggedPtr::setTag):
(WTF::TaggedPtr::operator=):
(WTF::TaggedPtr::operator-&gt; const):
(WTF::TaggedPtr::operator-&gt;):
(WTF::static_cast&lt;Enum&gt;):
(WTF::NoTaggingTraits::wrap):
(WTF::NoTaggingTraits::unwrapPtr):
(WTF::NoTaggingTraits::unwrapTag):
(WTF::NoTaggingTraits::encode): Deleted.
(WTF::NoTaggingTraits::extractPtr): Deleted.
(WTF::NoTaggingTraits::extractTag): Deleted.

Canonical link: <a href="https://commits.webkit.org/289802@main">https://commits.webkit.org/289802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/573d92e1b478917c899d0937b10e04c895190b80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88070 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38820 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15764 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25715 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37927 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/80868 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94866 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86846 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15238 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18701 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20468 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8264 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15256 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109339 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14998 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26292 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->