### PR TITLE
Delay WebContent process launch on iOS

### DIFF
--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -177,6 +177,9 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
 
 void releaseMemory(Critical critical, Synchronous synchronous, MaintainBackForwardCache maintainBackForwardCache, MaintainMemoryCache maintainMemoryCache)
 {
+    if (critical == Critical::Yes)
+        return;
+
     TraceScope scope(MemoryPressureHandlerStart, MemoryPressureHandlerEnd, static_cast<uint64_t>(critical), static_cast<uint64_t>(synchronous));
 
 #if PLATFORM(IOS_FAMILY)
@@ -212,6 +215,8 @@ void releaseMemory(Critical critical, Synchronous synchronous, MaintainBackForwa
 
 void releaseGraphicsMemory(Critical critical, Synchronous synchronous)
 {
+    if (critical == Critical::Yes)
+        return;
     TraceScope scope(MemoryPressureHandlerStart, MemoryPressureHandlerEnd, static_cast<uint64_t>(critical), static_cast<uint64_t>(synchronous));
 
     platformReleaseGraphicsMemory(critical);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -79,7 +79,8 @@ WebInspectorUIProxy::WebInspectorUIProxy(WebPageProxy& inspectedPage)
     , m_closeFrontendAfterInactivityTimer(RunLoop::main(), this, &WebInspectorUIProxy::closeFrontendAfterInactivityTimerFired)
 #endif
 {
-    protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), *this);
+    if (!protectedInspectedPage()->protectedLegacyMainFrameProcess()->isDummyProcessProxy())
+        protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), *this);
 }
 
 WebInspectorUIProxy::~WebInspectorUIProxy()
@@ -238,7 +239,8 @@ void WebInspectorUIProxy::resetState()
 void WebInspectorUIProxy::reset()
 {
     if (RefPtr inspectedPage = m_inspectedPage.get()) {
-        inspectedPage->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), inspectedPage->webPageIDInMainFrameProcess());
+        if (!inspectedPage->protectedLegacyMainFrameProcess()->isDummyProcessProxy())
+            inspectedPage->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), inspectedPage->webPageIDInMainFrameProcess());
         m_inspectedPage = nullptr;
     }
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -187,6 +187,7 @@
 #include "WebPreferencesKeys.h"
 #include "WebProcess.h"
 #include "WebProcessActivityState.h"
+#include "WebProcessCache.h"
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
@@ -893,7 +894,8 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     if (hasRunningProcess())
         didAttachToRunningProcess();
 
-    addAllMessageReceivers();
+    if (!protectedLegacyMainFrameProcess()->isDummyProcessProxy())
+        addAllMessageReceivers();
 
 #if PLATFORM(IOS_FAMILY)
     DeprecatedGlobalSettings::setDisableScreenSizeOverride(m_preferences->disableScreenSizeOverride());
@@ -1354,8 +1356,10 @@ void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
     // null after the page has closed.
     RefPtr { m_inspector }->reset();
 
-    protectedLegacyMainFrameProcess()->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);
-    removeAllMessageReceivers();
+    if (!protectedLegacyMainFrameProcess()->isDummyProcessProxy()) {
+        protectedLegacyMainFrameProcess()->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);
+        removeAllMessageReceivers();
+    }
 
     Ref processPool = m_configuration->processPool();
     RefPtr relatedPage = m_configuration->relatedPage();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -766,7 +766,8 @@ Ref<WebPageProxy> WebProcessProxy::createWebPage(PageClient& pageClient, Ref<API
 {
     Ref webPage = WebPageProxy::create(pageClient, *this, WTFMove(pageConfiguration));
 
-    addExistingWebPage(webPage.get(), BeginsUsingDataStore::Yes);
+    if (!isDummyProcessProxy())
+        addExistingWebPage(webPage.get(), BeginsUsingDataStore::Yes);
 
     return webPage;
 }


### PR DESCRIPTION
#### e65d941ce56dbaa12e5091718a3614c248dc96b0
<pre>
Delay WebContent process launch on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=287021">https://bugs.webkit.org/show_bug.cgi?id=287021</a>
<a href="https://rdar.apple.com/144166879">rdar://144166879</a>

Reviewed by NOBODY (OOPS!).

Draft.

* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::reset):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::launchProcess):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::addProcess):
(WebKit::WebProcessCache::takeProcess):
(WebKit::WebProcessCache::updateCapacity):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::globalDelaysWebProcessLaunchDefaultValue):
(WebKit::WebProcessPool::processForSite):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::createWebPage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e65d941ce56dbaa12e5091718a3614c248dc96b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/111636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/31303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/21777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/117671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/62014 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/113598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/31991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/39888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84816 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35609 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/114583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/25533 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/100469 "Found 17 new API test failures: TestWebKitAPI.WebKit.GetPDFResourceData, TestWebKitAPI.WebKit.AddSupportedAndBogusImageTypesTwice, TestWebKitAPI.WebKit.AddUnsupportedAndBogusImageTypesTwice, TestWebKitAPI.ProcessSwap.UseWebProcessCacheForLoadInNewView, TestWebKitAPI.WebKit.AutoLayoutBatchesUpdatesWhenInvalidatingIntrinsicContentSize, TestWebKitAPI.WebKit.AddUnsupportedAndBogusImageTypes, TestWebKitAPI.WebKit.AddSupportedImageType, TestWebKitAPI.URLSchemeHandler.Frames, TestWebKitAPI.WebKit.AddSupportedAndBogusImageTypes, TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65258 "Found 1 new API test failure: /TestWebKit:WebKit.PageLoadState (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/24869 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/18603 "Found 3 new test failures: media/media-source/media-managedmse-eviction.html media/media-source/media-managedmse-memorypressure-inactive.html media/media-source/media-managedmse-memorypressure.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/61503 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/94917 "Found 5 new API test failures: TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.ProcessSwap.DelayedProcessLaunchThenLoad, TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain, TestWebKitAPI.ProcessSwap.DelayedProcessLaunchThenLaunchInitialProcessIfNecessary, TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18672 "Found 3 new test failures: media/media-source/media-managedmse-eviction.html media/media-source/media-managedmse-memorypressure-inactive.html media/media-source/media-managedmse-memorypressure.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/120919 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/38689 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/28742 "Found 3 new test failures: media/media-source/media-managedmse-eviction.html media/media-source/media-managedmse-memorypressure-inactive.html media/media-source/media-managedmse-memorypressure.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93716 "Found 6 new test failures: swipe/basic-cached-back-swipe.html swipe/navigate-event-back-swipe-verify-ua-transition.html swipe/pushState-back-swipe-verify-ua-transition.html swipe/pushState-cached-back-swipe.html swipe/pushstate-with-manual-scrollrestoration.html swipe/swipe-disables-view-transition.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/39067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/96726 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93542 "Found 1 new API test failure: /TestWebKit:WebKit.PageLoadState (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/38678 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/16468 "Found 3 new test failures: media/media-source/media-managedmse-eviction.html media/media-source/media-managedmse-memorypressure-inactive.html media/media-source/media-managedmse-memorypressure.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/34725 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/38578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/44063 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/38241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/41577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/39943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->