### PR TITLE
[iOS] REGRESSION(288610@main): Captions disappear in fullscreen mode

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
@@ -70,6 +70,8 @@ public:
 private:
     WEBCORE_EXPORT VideoPresentationInterfaceAVKitLegacy(PlaybackSessionInterfaceIOS&);
 
+    WebAVPlayerLayer *fullscreenPlayerLayer() const;
+
     void updateRouteSharingPolicy() final;
     void setupPlayerViewController() final;
     void invalidatePlayerViewController() final;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -809,8 +809,13 @@ void VideoPresentationInterfaceAVKitLegacy::setupFullscreen(const FloatRect& ini
 {
     [playerController() setContentDimensions:videoDimensions];
     VideoPresentationInterfaceIOS::setupFullscreen(initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
-    if (playerLayer().captionsLayer != captionsLayer())
-        playerLayer().captionsLayer = captionsLayer();
+    if (fullscreenPlayerLayer().captionsLayer != captionsLayer())
+        fullscreenPlayerLayer().captionsLayer = captionsLayer();
+}
+
+WebAVPlayerLayer *VideoPresentationInterfaceAVKitLegacy::fullscreenPlayerLayer() const
+{
+    return (WebAVPlayerLayer *)[m_playerViewController playerLayerView].playerLayer;
 }
 
 void VideoPresentationInterfaceAVKitLegacy::updateRouteSharingPolicy()
@@ -954,8 +959,8 @@ void VideoPresentationInterfaceAVKitLegacy::setupCaptionsLayer(CALayer *, const 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     [captionsLayer() removeFromSuperlayer];
-    playerLayer().captionsLayer = captionsLayer();
-    [playerLayer() layoutSublayers];
+    fullscreenPlayerLayer().captionsLayer = captionsLayer();
+    [fullscreenPlayerLayer() layoutSublayers];
     [CATransaction commit];
 }
 


### PR DESCRIPTION
#### 7c5689faf8d70da36afcea0de61021824bb4ee86
<pre>
[iOS] REGRESSION(288610@main): Captions disappear in fullscreen mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=287027">https://bugs.webkit.org/show_bug.cgi?id=287027</a>
<a href="https://rdar.apple.com/144114434">rdar://144114434</a>

Reviewed by Eric Carlson.

When 288610@main moved ownership of WebAVPlayerLayer out of the model
and into the interface, it ended up confusing which WebAVPlayerLayer
was being referred to by the playerLayer() method. Add a new
fullscreenPlayerLayer() method and refer to it when setting up
fullscreen (including the fullscreen playerLayer&apos;s caption layer).

* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(WebCore::VideoPresentationInterfaceAVKitLegacy::setupFullscreen):
(WebCore::VideoPresentationInterfaceAVKitLegacy::fullscreenPlayerLayer const):

Canonical link: <a href="https://commits.webkit.org/289818@main">https://commits.webkit.org/289818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61c9d4a52937bd5def30521e9560660392f97766

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67987 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25716 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34096 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94873 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15245 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76079 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8274 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13749 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15263 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->