### PR TITLE
Reduce use of const char*

### DIFF
--- a/Source/JavaScriptCore/API/JSBase.cpp
+++ b/Source/JavaScriptCore/API/JSBase.cpp
@@ -207,7 +207,7 @@ JSObjectRef JSGetMemoryUsageStatistics(JSContextRef ctx)
     auto typeCounts = vm.heap.objectTypeCounts();
     JSObject* objectTypeCounts = constructEmptyObject(globalObject);
     for (auto& it : *typeCounts)
-        objectTypeCounts->putDirect(vm, Identifier::fromLatin1(vm, it.key), jsNumber(it.value));
+        objectTypeCounts->putDirect(vm, Identifier::fromString(vm, it.key), jsNumber(it.value));
 
     JSObject* object = constructEmptyObject(globalObject);
     object->putDirect(vm, Identifier::fromString(vm, "heapSize"_s), jsNumber(vm.heap.size()));

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -175,7 +175,7 @@ void testX86LeaAddAdd()
                 return strstr(disassembly, "lea 0x64(%rdi,%rsi,1), %rax")
                     || strstr(disassembly, "lea 0x64(%rsi,%rdi,1), %rax");
             },
-            "Expected to find something like lea 0x64(%rdi,%rsi,1), %rax but didn't!");
+            "Expected to find something like lea 0x64(%rdi,%rsi,1), %rax but didn't!"_s);
     }
 }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -439,7 +439,7 @@ CString BytecodeDumper::formatConstant(Type type, uint64_t constant) const
         // isRefType(type) is false (likewise for externref)
         if (isRefType(type) || type.isFuncref() || type.isExternref()) {
             if (JSValue::decode(constant) == jsNull())
-                return "null";
+                return "null"_s;
             return toCString(RawHex(constant));
         }
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -158,7 +158,7 @@ CString CodeBlock::hashAsStringIfPossible() const
 {
     if (hasHash() || isSafeToComputeHash())
         return toCString(hash());
-    return "<no-hash>";
+    return "<no-hash>"_s;
 }
 
 void CodeBlock::dumpAssumingJITType(PrintStream& out, JITType jitType) const

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -168,7 +168,7 @@ RegisterID* RegExpNode::emitBytecode(BytecodeGenerator& generator, RegisterID* d
     if (regExp->isValid())
         return generator.emitNewRegExp(generator.finalDestination(dst), regExp);
 
-    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), unsafeSpan8(regExp->errorMessage()));
+    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), regExp->errorMessage().span8());
     generator.emitThrowStaticError(ErrorTypeWithExtension::SyntaxError, message);
     return generator.emitLoad(generator.finalDestination(dst), jsUndefined());
 }

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1686,7 +1686,7 @@ static void logDFGAssertionFailure(
 void Graph::logAssertionFailure(
     std::nullptr_t, const char* file, int line, const char* function, const char* assertion)
 {
-    logDFGAssertionFailure(*this, "", file, line, function, assertion);
+    logDFGAssertionFailure(*this, ""_s, file, line, function, assertion);
 }
 
 void Graph::logAssertionFailure(

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -203,7 +203,7 @@ public:
                 "jsBody_", ++compileCounter, "_", codeBlock()->inferredName(),
                 "_", codeBlock()->hash());
         } else
-            name = "jsBody";
+            name = "jsBody"_s;
 
         {
             m_proc.setNumEntrypoints(m_graph.m_numberOfEntrypoints);

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -173,7 +173,7 @@ size_t proportionalHeapSize(size_t heapSize, size_t ramSize)
 
 void recordType(TypeCountSet& set, JSCell* cell)
 {
-    const char* typeName = "[unknown]";
+    auto typeName = "[unknown]"_s;
     const ClassInfo* info = cell->classInfo();
     if (info && info->className)
         typeName = info->className;
@@ -306,8 +306,8 @@ Heap::Heap(VM& vm, HeapType heapType)
     , m_maxHeapSize(m_minBytesPerCycle)
     , m_objectSpace(this)
     , m_machineThreads(makeUnique<MachineThreads>())
-    , m_collectorSlotVisitor(makeUnique<SlotVisitor>(*this, "C"))
-    , m_mutatorSlotVisitor(makeUnique<SlotVisitor>(*this, "M"))
+    , m_collectorSlotVisitor(makeUnique<SlotVisitor>(*this, "C"_s))
+    , m_mutatorSlotVisitor(makeUnique<SlotVisitor>(*this, "M"_s))
     , m_mutatorMarkStack(makeUnique<MarkStackArray>())
     , m_raceMarkStack(makeUnique<MarkStackArray>())
     , m_constraintSet(makeUnique<MarkingConstraintSet>(*this))
@@ -390,12 +390,12 @@ Heap::Heap(VM& vm, HeapType heapType)
     , primitiveGigacageAllocator(makeUnique<GigacageAlignedMemoryAllocator>(Gigacage::Primitive))
 
     // Subspaces
-    , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary", *this, auxiliaryHeapCellType, primitiveGigacageAllocator.get()) // Hash:0x3e7cd762
-    , auxiliarySpace("Auxiliary", *this, auxiliaryHeapCellType, fastMallocAllocator.get()) // Hash:0x96255ba1
-    , immutableButterflyAuxiliarySpace("ImmutableButterfly JSCellWithIndexingHeader", *this, immutableButterflyHeapCellType, fastMallocAllocator.get()) // Hash:0xaadcb3c1
-    , cellSpace("JSCell", *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xadfb5a79
-    , variableSizedCellSpace("Variable Sized JSCell", *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xbcd769cc
-    , destructibleObjectSpace("JSDestructibleObject", *this, destructibleObjectHeapCellType, fastMallocAllocator.get()) // Hash:0x4f5ed7a9
+    , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary"_s, *this, auxiliaryHeapCellType, primitiveGigacageAllocator.get()) // Hash:0x3e7cd762
+    , auxiliarySpace("Auxiliary"_s, *this, auxiliaryHeapCellType, fastMallocAllocator.get()) // Hash:0x96255ba1
+    , immutableButterflyAuxiliarySpace("ImmutableButterfly JSCellWithIndexingHeader"_s, *this, immutableButterflyHeapCellType, fastMallocAllocator.get()) // Hash:0xaadcb3c1
+    , cellSpace("JSCell"_s, *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xadfb5a79
+    , variableSizedCellSpace("Variable Sized JSCell"_s, *this, cellHeapCellType, fastMallocAllocator.get()) // Hash:0xbcd769cc
+    , destructibleObjectSpace("JSDestructibleObject"_s, *this, destructibleObjectHeapCellType, fastMallocAllocator.get()) // Hash:0x4f5ed7a9
     FOR_EACH_JSC_COMMON_ISO_SUBSPACE(INIT_SERVER_ISO_SUBSPACE)
     FOR_EACH_JSC_STRUCTURE_ISO_SUBSPACE(INIT_SERVER_STRUCTURE_ISO_SUBSPACE)
     , codeBlockSpaceAndSet ISO_SUBSPACE_INIT(*this, destructibleCellHeapCellType, CodeBlock) // Hash:0x2b743c6a

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -290,7 +290,7 @@ class Heap;
 
 
 typedef HashCountedSet<JSCell*> ProtectCountSet;
-typedef HashCountedSet<const char*> TypeCountSet;
+typedef HashCountedSet<ASCIILiteral> TypeCountSet;
 
 enum class HeapType : uint8_t { Small, Large };
 

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -100,7 +100,7 @@ ALWAYS_INLINE Allocator IsoSubspace::allocatorFor(size_t size, AllocatorForMode)
 
 } // namespace GCClient
 
-#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type, (heap), (heapCellType), sizeof(type), type::usePreciseAllocationsOnly, type::numberOfLowerTierPreciseCells)
+#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type ""_s, (heap), (heapCellType), sizeof(type), type::usePreciseAllocationsOnly, type::numberOfLowerTierPreciseCells)
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
@@ -35,7 +35,7 @@ namespace JSC {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MarkStackMergingConstraint);
 
 MarkStackMergingConstraint::MarkStackMergingConstraint(JSC::Heap& heap)
-    : MarkingConstraint("Msm", "Mark Stack Merging", ConstraintVolatility::GreyedByExecution)
+    : MarkingConstraint("Msm"_s, "Mark Stack Merging"_s, ConstraintVolatility::GreyedByExecution)
     , m_heap(heap)
 {
 }

--- a/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp
@@ -105,7 +105,7 @@ void VerifierSlotVisitor::OpaqueRootData::addMarkerData(MarkerData&& marker)
 }
 
 VerifierSlotVisitor::VerifierSlotVisitor(JSC::Heap& heap)
-    : Base(heap, "Verifier", m_opaqueRootStorage)
+    : Base(heap, "Verifier"_s, m_opaqueRootStorage)
 {
     m_needsExtraOpaqueRootHandling = true;
 }

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -1063,14 +1063,14 @@ UncheckedKeyHashMap<CString, Seconds> JIT::compileTimeStats()
 {
     UncheckedKeyHashMap<CString, Seconds> result;
     if (Options::reportTotalCompileTimes()) {
-        result.add("Total Compile Time", totalCompileTime());
-        result.add("Baseline Compile Time", totalBaselineCompileTime);
+        result.add("Total Compile Time"_s, totalCompileTime());
+        result.add("Baseline Compile Time"_s, totalBaselineCompileTime);
 #if ENABLE(DFG_JIT)
-        result.add("DFG Compile Time", totalDFGCompileTime);
+        result.add("DFG Compile Time"_s, totalDFGCompileTime);
 #if ENABLE(FTL_JIT)
-        result.add("FTL Compile Time", totalFTLCompileTime);
-        result.add("FTL (DFG) Compile Time", totalFTLDFGCompileTime);
-        result.add("FTL (B3) Compile Time", totalFTLB3CompileTime);
+        result.add("FTL Compile Time"_s, totalFTLCompileTime);
+        result.add("FTL (DFG) Compile Time"_s, totalFTLDFGCompileTime);
+        result.add("FTL (B3) Compile Time"_s, totalFTLB3CompileTime);
 #endif // ENABLE(FTL_JIT)
 #endif // ENABLE(DFG_JIT)
     }

--- a/Source/JavaScriptCore/jit/JITDisassembler.cpp
+++ b/Source/JavaScriptCore/jit/JITDisassembler.cpp
@@ -84,9 +84,9 @@ void JITDisassembler::reportToProfiler(Profiler::Compilation* compilation, LinkB
     compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toCString()));
     
     reportInstructions(compilation, linkBuffer, "    ", m_labelForBytecodeIndexInMainPath, firstSlowLabel());
-    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Main Path)\n"));
+    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Main Path)\n"_s));
     reportInstructions(compilation, linkBuffer, "    (S) ", m_labelForBytecodeIndexInSlowPath, m_endOfSlowPath);
-    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Slow Path)\n"));
+    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Slow Path)\n"_s));
     out.reset();
     dumpDisassembly(out, linkBuffer, m_endOfSlowPath, m_endOfCode);
     compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toCString()));

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -118,8 +118,7 @@ public:
     static Identifier fromString(VM&, AtomStringImpl*);
     static Identifier fromString(VM&, Ref<AtomStringImpl>&&);
     static Identifier fromString(VM&, const AtomString&);
-    static Identifier fromString(VM& vm, SymbolImpl*);
-    static Identifier fromLatin1(VM&, const char*);
+    static Identifier fromString(VM&, SymbolImpl*);
 
     static Identifier fromUid(VM&, UniquedStringImpl* uid);
     static Identifier fromUid(const PrivateName&);

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -120,11 +120,6 @@ inline Identifier Identifier::fromString(VM& vm, SymbolImpl* symbolImpl)
     return Identifier(vm, symbolImpl);
 }
 
-inline Identifier Identifier::fromLatin1(VM& vm, const char* s)
-{
-    return Identifier(vm, AtomString::fromLatin1(s));
-}
-
 inline JSValue identifierToJSValue(VM& vm, const Identifier& identifier)
 {
     if (identifier.isSymbol())

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -332,7 +332,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
             break;
         }
 
-        buffer = vm.intlCache().getFieldDisplayName(m_localeCString.data(), field.value(), style, status);
+        buffer = vm.intlCache().getFieldDisplayName(m_localeCString, field.value(), style, status);
         if (U_FAILURE(status))
             return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, WTFMove(code));
         return jsString(vm, String(WTFMove(buffer)));

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -89,16 +89,16 @@ public:
             case NumberType::Integer: {
                 double value = std::get<double>(m_value);
                 if (isNegativeZero(value))
-                    m_value = CString("-0");
+                    m_value = CString("-0"_s);
                 else
                     m_value = String::number(value).ascii();
                 break;
             }
             case NumberType::NaN:
-                m_value = CString("nan");
+                m_value = CString("nan"_s);
                 break;
             case NumberType::Infinity:
-                m_value = CString(m_sign ? "-infinity" : "infinity");
+                m_value = CString(m_sign ? "-infinity"_s : "infinity"_s);
                 break;
             }
         }

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2894,7 +2894,7 @@ void JSObject::reifyAllStaticProperties(JSGlobalObject* globalObject)
 
         for (auto& value : *hashTable) {
             unsigned attributes;
-            auto key = Identifier::fromLatin1(vm, value.m_key);
+            auto key = Identifier::fromString(vm, value.m_key);
             PropertyOffset offset = getDirectOffset(vm, key, attributes);
             if (!isValidOffset(offset))
                 reifyStaticProperty(vm, hashTable->classForThis, key, value, *this);

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -821,7 +821,7 @@ ALWAYS_INLINE void JSObject::getNonReifiedStaticPropertyNames(VM& vm, PropertyNa
 
         for (auto iter = table->begin(); iter != table->end(); ++iter) {
             if (mode == DontEnumPropertiesMode::Include || !(iter->attributes() & PropertyAttribute::DontEnum)) {
-                auto identifier = Identifier::fromLatin1(vm, iter.key());
+                auto identifier = Identifier::fromString(vm, iter.key());
                 // If the structure is shadowing the static property use it's attributes to determine if
                 // the property name is enumerable but add it here to preserve the right property order.
                 unsigned structureAttributes;

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -68,7 +68,7 @@ public:
     const String& pattern() const { return m_patternString; }
 
     bool isValid() const { return !Yarr::hasError(m_constructionErrorCode); }
-    const char* errorMessage() const { return Yarr::errorMessage(m_constructionErrorCode); }
+    ASCIILiteral errorMessage() const { return Yarr::errorMessage(m_constructionErrorCode); }
     JSObject* errorToThrow(JSGlobalObject* globalObject) { return Yarr::errorToThrow(globalObject, m_constructionErrorCode); }
     void reset()
     {

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -405,7 +405,7 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
     auto valueAsString = [&] (JSValue v) -> CString {
         if (!v.isCell() || VMInspector::isValidCell(&vm.heap, reinterpret_cast<JSCell*>(JSValue::encode(v))))
             return toCString(v);
-        return "";
+        return ""_s;
     };
 
     CallFrame* topCallFrame = vm.topCallFrame;

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -911,7 +911,7 @@ double parseDate(std::span<const LChar> dateString, bool& isLocalTime)
             for (auto& knownZone : knownZones) {
                 // Since the passed-in length is used for both strings, the following checks that
                 // dateString has the time zone name as a prefix, not that it is equal.
-                auto tzName = unsafeSpan8(knownZone.tzName);
+                auto tzName = knownZone.tzName.span8();
                 if (skipLettersExactlyIgnoringASCIICase(dateString, tzName)) {
                     offset = knownZone.tzOffset;
                     isLocalTime = false;

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.mm
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.mm
@@ -38,7 +38,7 @@ namespace WTF {
 OSLogPrintStream::OSLogPrintStream(os_log_t log, os_log_type_t logType)
     : m_log(log)
     , m_logType(logType)
-    , m_string("initial string... lol")
+    , m_string("initial string... lol"_s)
 {
 }
 

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -33,8 +33,6 @@ public:
     AtomString(std::span<const LChar>);
     AtomString(std::span<const UChar>);
 
-    ALWAYS_INLINE static AtomString fromLatin1(const char* characters) { return AtomString(characters); }
-
     AtomString(AtomStringImpl*);
     AtomString(RefPtr<AtomStringImpl>&&);
     AtomString(Ref<AtomStringImpl>&&);
@@ -166,11 +164,6 @@ WTF_EXPORT_PRIVATE AtomString replaceUnpairedSurrogatesWithReplacementCharacter(
 WTF_EXPORT_PRIVATE String replaceUnpairedSurrogatesWithReplacementCharacter(String&&);
 
 inline AtomString::AtomString()
-{
-}
-
-inline AtomString::AtomString(const char* string)
-    : m_string(AtomStringImpl::addCString(string))
 {
 }
 

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -48,9 +48,6 @@ public:
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const StaticStringImpl*);
     ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral);
 
-    // Not using the add() naming to encourage developers to call add(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char*);
-
     // Returns null if the input data contains an invalid UTF-8 sequence.
     static RefPtr<AtomStringImpl> add(std::span<const char8_t>);
 
@@ -112,11 +109,6 @@ ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::add(RefPtr<StringImpl>&& st
 ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(ASCIILiteral literal)
 {
     return addLiteral(literal.span8());
-}
-
-ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addCString(const char* s)
-{
-    return s ? add(unsafeSpan8(s)) : nullptr;
 }
 
 template<typename StringTableProvider>

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -49,6 +49,14 @@ Ref<CStringBuffer> CStringBuffer::createUninitialized(size_t length)
     return buffer;
 }
 
+CString::CString(ASCIILiteral string)
+{
+    if (!string)
+        return;
+
+    init(string.span());
+}
+
 CString::CString(const char* string)
 {
     if (!string)

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -66,6 +66,7 @@ class CString final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     CString() { }
+    WTF_EXPORT_PRIVATE CString(ASCIILiteral);
     WTF_EXPORT_PRIVATE CString(const char*);
     WTF_EXPORT_PRIVATE CString(std::span<const char>);
     CString(std::span<const LChar>);

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -72,6 +72,7 @@ public:
     StringView(const void* string LIFETIME_BOUND, unsigned length, bool is8bit);
     StringView(ASCIILiteral);
 
+    ALWAYS_INLINE static StringView fromLatin1(std::span<const LChar> span LIFETIME_BOUND) { return StringView { span }; } // FIXME: This can become span<const char> once CString::span() changes to match
     ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
 
     unsigned length() const;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -123,7 +123,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
 
 RefPtr<ComputePassEncoder> CommandEncoderImpl::beginComputePass(const std::optional<ComputePassDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString("");
+    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
 
     WGPUComputePassTimestampWrites timestampWrites {
         .querySet = (descriptor && descriptor->timestampWrites && descriptor->timestampWrites->querySet) ? protectedConvertToBackingContext()->convertToBacking(*descriptor->timestampWrites->protectedQuerySet().get()) : nullptr,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -72,7 +72,7 @@ namespace WebCore::WebGPU {
 
 static auto invalidEntryPointName()
 {
-    return CString("");
+    return CString(""_s);
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DeviceImpl);
@@ -632,7 +632,7 @@ void DeviceImpl::createRenderPipelineAsync(const RenderPipelineDescriptor& descr
 
 RefPtr<CommandEncoder> DeviceImpl::createCommandEncoder(const std::optional<CommandEncoderDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString("");
+    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
 
     WGPUCommandEncoderDescriptor backingDescriptor {
         nullptr,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -51,7 +51,7 @@ TextureImpl::~TextureImpl() = default;
 
 RefPtr<TextureView> TextureImpl::createView(const std::optional<TextureViewDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString("");
+    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
 
     Ref convertToBackingContext = m_convertToBackingContext;
 

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -43,7 +43,7 @@ using namespace JSC;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DOMGCOutputConstraint);
 
 DOMGCOutputConstraint::DOMGCOutputConstraint(VM& vm, JSHeapData& heapData)
-    : MarkingConstraint("Domo", "DOM Output", ConstraintVolatility::SeldomGreyed, ConstraintConcurrency::Concurrent, ConstraintParallelism::Parallel)
+    : MarkingConstraint("Domo"_s, "DOM Output"_s, ConstraintVolatility::SeldomGreyed, ConstraintConcurrency::Concurrent, ConstraintParallelism::Parallel)
     , m_vm(vm)
     , m_heapData(heapData)
     , m_lastExecutionVersion(vm.heap.mutatorExecutionVersion())

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -140,7 +140,7 @@ void PingLoader::sendPing(LocalFrame& frame, const URL& pingURL, const URL& dest
 
     request.setHTTPMethod("POST"_s);
     request.setHTTPContentType("text/ping"_s);
-    request.setHTTPBody(FormData::create("PING"));
+    request.setHTTPBody(FormData::create("PING"_s));
     request.setHTTPHeaderField(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
 
     HTTPHeaderMap originalRequestHeader = request.httpHeaderFields();

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -258,7 +258,7 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
     RELEASE_LOG(MemoryPressure, "Live JavaScript objects at time of %" PUBLIC_LOG_STRING ":", description.characters());
     auto typeCounts = vm.heap.objectTypeCounts();
     for (auto& it : *typeCounts)
-        RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %d", it.key, it.value);
+        RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %d", it.key.characters(), it.value);
 }
 #endif
 

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -81,7 +81,7 @@ Vector<std::pair<ASCIILiteral, size_t>> PerformanceLogging::memoryUsageStatistic
     return stats;
 }
 
-HashCountedSet<const char*> PerformanceLogging::javaScriptObjectCounts()
+HashCountedSet<ASCIILiteral> PerformanceLogging::javaScriptObjectCounts()
 {
     return WTFMove(*commonVM().heap.objectTypeCounts());
 }

--- a/Source/WebCore/page/PerformanceLogging.h
+++ b/Source/WebCore/page/PerformanceLogging.h
@@ -48,7 +48,7 @@ public:
 
     void didReachPointOfInterest(PointOfInterest);
 
-    WEBCORE_EXPORT static HashCountedSet<const char*> javaScriptObjectCounts();
+    WEBCORE_EXPORT static HashCountedSet<ASCIILiteral> javaScriptObjectCounts();
     WEBCORE_EXPORT static Vector<std::pair<ASCIILiteral, size_t>> memoryUsageStatistics(ShouldIncludeExpensiveComputations);
     WEBCORE_EXPORT static std::optional<uint64_t> physicalFootprint();
 

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -694,8 +694,7 @@ long long BitmapImageSource::expectedContentLength() const
 
 CString BitmapImageSource::sourceUTF8() const
 {
-    constexpr const char* emptyString = "";
-    return m_bitmapImage ? m_bitmapImage->sourceUTF8() : emptyString;
+    return m_bitmapImage ? m_bitmapImage->sourceUTF8() : ""_s;
 }
 
 void BitmapImageSource::setMinimumDecodingDurationForTesting(Seconds duration)

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -90,7 +90,7 @@ TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivat
 TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivateBase* owner, unsigned index, GstStream* stream)
     : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
     , m_index(index)
-    , m_gstStreamId(AtomString::fromLatin1(gst_stream_get_stream_id(stream)))
+    , m_gstStreamId(AtomString(unsafeSpan8(gst_stream_get_stream_id(stream))))
     , m_id(parseStreamId(m_gstStreamId).value_or(index))
     , m_stream(stream)
     , m_type(type)
@@ -115,7 +115,7 @@ void TrackPrivateBaseGStreamer::setPad(GRefPtr<GstPad>&& pad)
 
     m_pad = WTFMove(pad);
     m_bestUpstreamPad = findBestUpstreamPad(m_pad);
-    m_gstStreamId = AtomString::fromLatin1(gst_pad_get_stream_id(m_pad.get()));
+    m_gstStreamId = AtomString(unsafeSpan8(gst_pad_get_stream_id(m_pad.get())));
 
     if (m_shouldUsePadStreamId)
         m_id = parseStreamId(m_gstStreamId).value_or(m_index);
@@ -227,7 +227,7 @@ bool TrackPrivateBaseGStreamer::getLanguageCode(GstTagList* tags, AtomString& va
 {
     String language;
     if (getTag(tags, GST_TAG_LANGUAGE_CODE, language)) {
-        AtomString convertedLanguage = AtomString::fromLatin1(gst_tag_get_language_code_iso_639_1(language.utf8().data()));
+        AtomString convertedLanguage = AtomString(unsafeSpan8(gst_tag_get_language_code_iso_639_1(language.utf8().data())));
         GST_DEBUG("Converted track %d's language code to %s.", m_index, convertedLanguage.string().utf8().data());
         if (convertedLanguage != value) {
             value = WTFMove(convertedLanguage);
@@ -287,7 +287,7 @@ void TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged()
     if (!m_pad)
         return;
 
-    auto gstStreamId = AtomString::fromLatin1(gst_pad_get_stream_id(m_pad.get()));
+    auto gstStreamId = AtomString(unsafeSpan8(gst_pad_get_stream_id(m_pad.get())));
     auto streamId = parseStreamId(gstStreamId);
     if (!streamId)
         return;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -816,7 +816,7 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
 {
     ASSERT(isMainThread());
     ASSERT(m_hasReceivedFirstInitializationSegment);
-    auto trackId = AtomString::fromLatin1(GST_PAD_NAME(demuxerSrcPad));
+    auto trackId = AtomString(unsafeSpan8(GST_PAD_NAME(demuxerSrcPad)));
     auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(demuxerSrcPad)).get());
 
     GST_DEBUG_OBJECT(demuxerSrcPad, "Caps: %" GST_PTR_FORMAT, parsedCaps.get());

--- a/Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp
+++ b/Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp
@@ -53,7 +53,7 @@ auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand) -> Syste
     if (!pango_font_description_get_size_is_absolute(pangoDescription))
         size = size * (fontDPI() / 72.0);
 
-    SystemFontShorthandInfo result { AtomString::fromLatin1(pango_font_description_get_family(pangoDescription)), static_cast<float>(size), normalWeightValue() };
+    SystemFontShorthandInfo result { AtomString(unsafeSpan8(pango_font_description_get_family(pangoDescription))), static_cast<float>(size), normalWeightValue() };
     pango_font_description_free(pangoDescription);
     return result;
 }

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -332,7 +332,7 @@ void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGrouping
     String sessionID = createVersion4UUIDString();
     factory->addKeysToSessionWithID(sessionID, WTFMove(keyIDs.value()));
 
-    CString license { "license" };
+    CString license { "license"_s };
     callback(SharedBuffer::create(license.span()), sessionID, false, SuccessValue::Succeeded);
 }
 
@@ -377,7 +377,7 @@ void MockCDMInstanceSession::loadSession(LicenseType, const String&, const Strin
 
     // FIXME: Key status and expiration handling should be implemented once the relevant algorithms are supported.
 
-    CString messageData { "session loaded" };
+    CString messageData { "session loaded"_s };
     Message message { MessageType::LicenseRenewal, SharedBuffer::create(messageData.span()) };
 
     callback(std::nullopt, std::nullopt, WTFMove(message), SuccessValue::Succeeded, SessionLoadFailure::None);
@@ -408,7 +408,7 @@ void MockCDMInstanceSession::removeSessionData(const String& id, LicenseType, Re
         return std::pair { WTFMove(key), KeyStatus::Released };
     });
 
-    CString message { "remove-message" };
+    CString message { "remove-message"_s };
     callback(WTFMove(keyStatusVector), SharedBuffer::create(message.span()), SuccessValue::Succeeded);
 }
 

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -180,7 +180,7 @@ void Download::setPlaceholderURL(NSURL *placeholderURL, NSData *bookmarkData)
     BOOL usingSecurityScopedURL = [placeholderURL startAccessingSecurityScopedResource];
 
     SandboxExtension::Handle sandboxExtensionHandle;
-    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(StringView::fromLatin1(placeholderURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
+    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(String::fromUTF8(placeholderURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
         sandboxExtensionHandle = WTFMove(*handle);
 
     if (usingSecurityScopedURL)
@@ -205,7 +205,7 @@ void Download::setFinalURL(NSURL *finalURL, NSData *bookmarkData)
     BOOL usingSecurityScopedURL = [finalURL startAccessingSecurityScopedResource];
 
     SandboxExtension::Handle sandboxExtensionHandle;
-    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(StringView::fromLatin1(finalURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
+    if (auto handle = SandboxExtension::createHandleWithoutResolvingPath(String::fromUTF8(finalURL.fileSystemRepresentation), SandboxExtension::Type::ReadOnly))
         sandboxExtensionHandle = WTFMove(*handle);
 
     if (usingSecurityScopedURL)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
@@ -79,7 +79,7 @@ void BlobStorage::synchronize()
 String BlobStorage::blobPathForHash(const SHA1::Digest& hash) const
 {
     auto hashAsString = SHA1::hexDigest(hash);
-    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), StringView::fromLatin1(hashAsString.data()));
+    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), StringView::fromLatin1(hashAsString.span()));
 }
 
 BlobStorage::Blob BlobStorage::add(const String& path, const Data& data)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -76,7 +76,7 @@ void SubFrameSOAuthorizationSession::fallBackToWebPathInternal()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPathInternal: navigationAction=%p", navigationAction());
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(unsafeSpan8(soAuthorizationPostDidCancelMessageToParent)));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidCancelMessageToParent.span8()));
     appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
 }
 
@@ -102,7 +102,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
     // Cancelled the current load before loading the data to post SOAuthorizationDidStart to the parent frame.
     invokeCallback(true);
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(unsafeSpan8(soAuthorizationPostDidStartMessageToParent)));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(soAuthorizationPostDidStartMessageToParent.span8()));
 }
 
 void SubFrameSOAuthorizationSession::didFinishLoad(IsMainFrame, const URL&)

--- a/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm
+++ b/Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm
@@ -50,7 +50,7 @@ void WEBCONTENT_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t in
 
     // Remove the WebProcessShim from the DYLD_INSERT_LIBRARIES environment variable so any processes spawned by
     // the this process don't try to insert the shim and crash.
-    WebKit::EnvironmentUtilities::removeValuesEndingWith("DYLD_INSERT_LIBRARIES", "/WebProcessShim.dylib");
+    WebKit::EnvironmentUtilities::removeValuesEndingWith("DYLD_INSERT_LIBRARIES"_s, "/WebProcessShim.dylib"_s);
 
 #if PLATFORM(IOS_FAMILY)
     GSInitialize();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
@@ -58,7 +58,7 @@ void GObjectEventListener::gobjectDestroyed()
     // and later use-after-free with the m_handler = 0; assignment.
     RefPtr<GObjectEventListener> protectedThis(this);
 
-    m_coreTarget->removeEventListener(AtomString::fromLatin1(m_domEventName.data()), *this, m_capture);
+    m_coreTarget->removeEventListener(AtomString(m_domEventName.span()), *this, m_capture);
     m_coreTarget = nullptr;
     m_handler = nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
@@ -36,13 +36,13 @@ public:
     static bool addEventListener(GObject* target, WebCore::EventTarget* coreTarget, const char* domEventName, GClosure* handler, bool useCapture)
     {
         Ref<GObjectEventListener> listener(adoptRef(*new GObjectEventListener(target, coreTarget, domEventName, handler, useCapture)));
-        return coreTarget->addEventListener(AtomString::fromLatin1(domEventName), WTFMove(listener), useCapture);
+        return coreTarget->addEventListener(AtomString(unsafeSpan8(domEventName)), WTFMove(listener), useCapture);
     }
 
     static bool removeEventListener(GObject* target, WebCore::EventTarget* coreTarget, const char* domEventName, GClosure* handler, bool useCapture)
     {
         GObjectEventListener key(target, coreTarget, domEventName, handler, useCapture);
-        return coreTarget->removeEventListener(AtomString::fromLatin1(domEventName), key, useCapture);
+        return coreTarget->removeEventListener(AtomString(unsafeSpan8(domEventName)), key, useCapture);
     }
 
     static void gobjectDestroyedCallback(GObjectEventListener* listener, GObject*)

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2998,7 +2998,7 @@ JSValueRef JSIPC::messages(JSContextRef context, JSObjectRef thisObject, JSStrin
         dictionary->putDirect(vm, isSyncIdent, JSC::jsBoolean(messageIsSync(name)));
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-        messagesObject->putDirect(vm, JSC::Identifier::fromLatin1(vm, description(name)), dictionary);
+        messagesObject->putDirect(vm, JSC::Identifier::fromString(vm, description(name)), dictionary);
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
     }
 

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -79,7 +79,7 @@ using namespace WebCore;
     return commonVM().heap.protectedGlobalObjectCount();
 }
 
-static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<const char*>& set)
+static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILiteral>& set)
 {
     auto result = adoptNS([[NSCountedSet alloc] initWithCapacity:set.size()]);
     for (auto& entry : set) {


### PR DESCRIPTION
#### 1fb1a474fa4edeb7294e165044a3de7a3d977cf3
<pre>
Reduce use of const char*
<a href="https://bugs.webkit.org/show_bug.cgi?id=287028">https://bugs.webkit.org/show_bug.cgi?id=287028</a>
<a href="https://rdar.apple.com/144168610">rdar://144168610</a>

Reviewed by Chris Dumez.

Because it&apos;s not bounds-safe.

Removed Identifier::fromLatin1(const char*) and AtomString::fromLatin1(const char*).
Fixed up a bunch of call sites to use ASCIILiteral or CString.

* Source/JavaScriptCore/API/JSBase.cpp:
(JSGetMemoryUsageStatistics):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testX86LeaAddAdd):
* Source/JavaScriptCore/bytecode/BytecodeDumper.cpp:
(JSC::Wasm::BytecodeDumper::formatConstant const):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::hashAsStringIfPossible const):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::RegExpNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::logAssertionFailure):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::lower):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp:
(JSC::MarkStackMergingConstraint::MarkStackMergingConstraint):
* Source/JavaScriptCore/heap/VerifierSlotVisitor.cpp:
(JSC::VerifierSlotVisitor::VerifierSlotVisitor):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::compileTimeStats):
* Source/JavaScriptCore/jit/JITDisassembler.cpp:
(JSC::JITDisassembler::reportToProfiler):
* Source/JavaScriptCore/runtime/Identifier.h:
* Source/JavaScriptCore/runtime/IdentifierInlines.h:
(JSC::Identifier::fromLatin1): Deleted.
* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::of const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
(JSC::IntlMathematicalValue::ensureNonDouble):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::reifyAllStaticProperties):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getNonReifiedStaticPropertyNames):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::dumpRegisters):
* Source/WTF/wtf/DateMath.cpp:
(WTF::parseDate):
* Source/WTF/wtf/darwin/OSLogPrintStream.mm:
(WTF::OSLogPrintStream::OSLogPrintStream):
* Source/WTF/wtf/text/AtomString.h:
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::addCString): Deleted.
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::CString):
* Source/WTF/wtf/text/CString.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginComputePass):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::invalidEntryPointName):
(WebCore::WebGPU::DeviceImpl::createCommandEncoder):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::createView):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode):
* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp:
(WebCore::DOMGCOutputConstraint::DOMGCOutputConstraint):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendPing):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::logMemoryStatistics):
* Source/WebCore/page/PerformanceLogging.cpp:
(WebCore::PerformanceLogging::javaScriptObjectCounts):
(): Deleted.
* Source/WebCore/page/PerformanceLogging.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::sourceUTF8 const):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::append):
(WebCore::FormDataBuilder::appendQuoted):
(WebCore::FormDataBuilder::appendFormURLEncoded):
(WebCore::FormDataBuilder::generateUniqueBoundaryString):
(WebCore::FormDataBuilder::beginMultiPartHeader):
(WebCore::FormDataBuilder::addBoundaryToMultiPartHeader):
(WebCore::FormDataBuilder::addFilenameToMultiPartHeader):
(WebCore::FormDataBuilder::addContentTypeToMultiPartHeader):
(WebCore::FormDataBuilder::finishMultiPartHeader):
(WebCore::FormDataBuilder::addKeyValuePairAsFormData):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMInstanceSession::requestLicense):
(WebCore::MockCDMInstanceSession::loadSession):
(WebCore::MockCDMInstanceSession::removeSessionData):
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::setPlaceholderURL):
(WebKit::Download::setFinalURL):
* Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp:
(WebKit::NetworkCache::BlobStorage::blobPathForHash const):
* Source/WebKit/Platform/unix/EnvironmentUtilities.cpp:
(WebKit::EnvironmentUtilities::removeValuesEndingWith):
* Source/WebKit/Platform/unix/EnvironmentUtilities.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::fallBackToWebPathInternal):
(WebKit::SubFrameSOAuthorizationSession::beforeStart):
* Source/WebKit/WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm:
(WEBCONTENT_SERVICE_INITIALIZER):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::messages):
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(createNSCountedSet):
* Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp:
(TestWebKitAPI::TEST_F(WTF_URLParser, ParserDifferences)):

Canonical link: <a href="https://commits.webkit.org/289866@main">https://commits.webkit.org/289866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/536085fed31ffc248908530e546a7dbc9978c6d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38956 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68054 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79778 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48422 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34189 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38064 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81004 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95005 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/86982 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76913 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75634 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76157 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8403 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13775 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15394 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20693 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109475 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15136 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26325 "Found 17 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, stress/regexp-escape-oom.js.default, wasm.yaml/wasm/gc/array_new_data.js.default-wasm, wasm.yaml/wasm/gc/array_new_data.js.wasm-bbq, wasm.yaml/wasm/gc/array_new_data.js.wasm-collect-continuously, wasm.yaml/wasm/gc/array_new_data.js.wasm-eager, wasm.yaml/wasm/gc/array_new_data.js.wasm-eager-jettison, wasm.yaml/wasm/gc/array_new_data.js.wasm-no-cjit, wasm.yaml/wasm/gc/array_new_data.js.wasm-slow-memory, wasm.yaml/wasm/stress/array-element-creation.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->