### PR TITLE
Generate logical property group predicates for CSSProperties.h/cpp

### DIFF
--- a/Source/WebCore/css/CSSProperty.cpp
+++ b/Source/WebCore/css/CSSProperty.cpp
@@ -44,74 +44,11 @@ CSSPropertyID StylePropertyMetadata::shorthandID() const
     return shorthands[m_indexInShorthandsVector].id();
 }
 
-bool CSSProperty::isInsetProperty(CSSPropertyID propertyID)
+bool CSSProperty::isSizingProperty(CSSPropertyID propertyId)
 {
-    switch (propertyID) {
-    case CSSPropertyInset:
-    case CSSPropertyLeft:
-    case CSSPropertyRight:
-    case CSSPropertyTop:
-    case CSSPropertyBottom:
-
-    case CSSPropertyInsetInline:
-    case CSSPropertyInsetInlineStart:
-    case CSSPropertyInsetInlineEnd:
-
-    case CSSPropertyInsetBlock:
-    case CSSPropertyInsetBlockStart:
-    case CSSPropertyInsetBlockEnd:
-        return true;
-    default:
-        return false;
-    }
-};
-
-bool CSSProperty::isSizingProperty(CSSPropertyID propertyID)
-{
-    switch (propertyID) {
-    case CSSPropertyWidth:
-    case CSSPropertyMinWidth:
-    case CSSPropertyMaxWidth:
-
-    case CSSPropertyHeight:
-    case CSSPropertyMinHeight:
-    case CSSPropertyMaxHeight:
-
-    case CSSPropertyBlockSize:
-    case CSSPropertyMinBlockSize:
-    case CSSPropertyMaxBlockSize:
-
-    case CSSPropertyInlineSize:
-    case CSSPropertyMinInlineSize:
-    case CSSPropertyMaxInlineSize:
-        return true;
-    default:
-        return false;
-    }
+    return isSizeProperty(propertyId)
+        || isMaxSizeProperty(propertyId)
+        || isMinSizeProperty(propertyId);
 }
-
-bool CSSProperty::isMarginProperty(CSSPropertyID propertyID)
-{
-    switch (propertyID) {
-    case CSSPropertyMargin:
-    case CSSPropertyMarginLeft:
-    case CSSPropertyMarginRight:
-    case CSSPropertyMarginTop:
-    case CSSPropertyMarginBottom:
-
-    case CSSPropertyMarginBlock:
-    case CSSPropertyMarginBlockStart:
-    case CSSPropertyMarginBlockEnd:
-
-    case CSSPropertyMarginInline:
-    case CSSPropertyMarginInlineStart:
-    case CSSPropertyMarginInlineEnd:
-        return true;
-
-    default:
-        return false;
-    }
-}
-
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -86,15 +86,24 @@ public:
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
     static bool allowsNumberOrIntegerInput(CSSPropertyID);
 
-    // FIXME: Generate from logical property groups.
+    // Logical Property Group Predicates.
+    // NOTE: These return true if the CSSPropertyID is member of the named logical
+    // property group or is the shorthand of a member of the logical property group.
 
-    // Check if a property is an inset property, as defined in:
-    // https://drafts.csswg.org/css-logical-1/#inset-properties
+    static bool isBorderColorProperty(CSSPropertyID);
+    static bool isBorderRadiusProperty(CSSPropertyID);
+    static bool isBorderStyleProperty(CSSPropertyID);
+    static bool isBorderWidthProperty(CSSPropertyID);
+    static bool isContainIntrinsicSizeProperty(CSSPropertyID);
     static bool isInsetProperty(CSSPropertyID);
-
-    // Check if a property is a margin property, as defined in:
-    // https://drafts.csswg.org/css-box-4/#margin-properties
     static bool isMarginProperty(CSSPropertyID);
+    static bool isMaxSizeProperty(CSSPropertyID);
+    static bool isMinSizeProperty(CSSPropertyID);
+    static bool isOverscrollBehaviorProperty(CSSPropertyID);
+    static bool isPaddingProperty(CSSPropertyID);
+    static bool isScrollMarginProperty(CSSPropertyID);
+    static bool isScrollPaddingProperty(CSSPropertyID);
+    static bool isSizeProperty(CSSPropertyID);
 
     // Check if a property is a sizing property, as defined in:
     // https://drafts.csswg.org/css-sizing-3/#sizing-property


### PR DESCRIPTION
#### 5015f9ffc28bc5615e5087d41401c6af25e9aa3d
<pre>
Generate logical property group predicates for CSSProperties.h/cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287029">https://bugs.webkit.org/show_bug.cgi?id=287029</a>

Reviewed by Tim Nguyen.

Adds generation of predicate functions that check if a property is part
of a specific logical property group, allowing us to remove two hand
written functions and make the rest of the groups available for future
use as well.

CSSProperty::isSizingProperty remains hand written as it represents
multiple logical property groups.

* Source/WebCore/css/CSSProperty.cpp:
(WebCore::CSSProperty::isInsetProperty): Deleted.
(WebCore::CSSProperty::isMarginProperty): Deleted.
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/process-css-properties.py:
(StyleProperties.__init__):
(StyleProperties):
(GenerateCSSPropertyNames):

Canonical link: <a href="https://commits.webkit.org/289825@main">https://commits.webkit.org/289825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c07d96052cf9345ae26bc4562f0e7ddedab1690

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93032 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67991 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5885 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94880 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15252 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76088 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20476 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8281 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15270 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->