### PR TITLE
[Grid] Crash in gridAreaPositionForOutOfFlowGridItem when accessing out of flow item map during simplified layout.

### DIFF
--- a/LayoutTests/fast/css-grid-layout/simplified-layout-with-oof-children-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/simplified-layout-with-oof-children-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it does not crash.
+

--- a/LayoutTests/fast/css-grid-layout/simplified-layout-with-oof-children-crash.html
+++ b/LayoutTests/fast/css-grid-layout/simplified-layout-with-oof-children-crash.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+  .grid {
+    display: grid;
+    position: relative;
+    transform: translate(10px);
+  }
+  .abspos {
+    position: absolute;
+  }
+  .removeFromGrid {
+    grid-column: 1;
+  }
+</style>
+<body>
+  This test passes if it does not crash.
+    <div class="grid">
+      <div class="removeFromGrid abspos"></div>
+      <div class="removeFromGrid abspos"></div>
+      <div class="removeFromGrid abspos"></div>
+    </div>
+<script>
+let grid = document.querySelector(".grid");
+
+for (let i = 0; i < 100; ++i) {
+  let newElement = document.createElement("div");
+  newElement.classList += "abspos";
+  grid.appendChild(newElement);
+}
+document.body.offsetHeight;
+
+let elementsToRemove = Array.from(document.getElementsByClassName("removeFromGrid"));
+elementsToRemove.forEach(elementToRemove => {
+  grid.removeChild(elementToRemove);
+});
+document.body.offsetHeight;
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -433,10 +433,10 @@ void RenderGrid::layoutGrid(bool relayoutChildren)
         if (size() != previousSize)
             relayoutChildren = true;
 
-        m_outOfFlowItemColumn.clear();
-        m_outOfFlowItemRow.clear();
 
         layoutPositionedObjects(relayoutChildren || isDocumentElementRenderer());
+        m_outOfFlowItemColumn.clear();
+        m_outOfFlowItemRow.clear();
         m_trackSizingAlgorithm.reset();
 
         computeOverflow(layoutOverflowLogicalBottom(*this));
@@ -567,10 +567,10 @@ void RenderGrid::layoutMasonry(bool relayoutChildren)
         if (size() != previousSize)
             relayoutChildren = true;
 
-        m_outOfFlowItemColumn.clear();
-        m_outOfFlowItemRow.clear();
 
         layoutPositionedObjects(relayoutChildren || isDocumentElementRenderer());
+        m_outOfFlowItemColumn.clear();
+        m_outOfFlowItemRow.clear();
         m_trackSizingAlgorithm.reset();
 
         computeOverflow(layoutOverflowLogicalBottom(*this));


### PR DESCRIPTION
#### baa760883a1ef5c21028df5b61903dab6b7dd41c
<pre>
[Grid] Crash in gridAreaPositionForOutOfFlowGridItem when accessing out of flow item map during simplified layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287031">https://bugs.webkit.org/show_bug.cgi?id=287031</a>
<a href="https://rdar.apple.com/143376323">rdar://143376323</a>

Reviewed by Alan Baradlay.

Currently, grid layout will clear its out of flow positioned maps before
it lays out its positioned content. This can lead to a crash if we
perform simplified layout afterwards as there is no guarantee that the
items in the map are still there (like in the testcase). We should
clear this map after we have performed laid out the positioned content
as there is currently no reason to query it after we are done with
layout. We only seem to use these maps during layout to query and set
the offsets for grid items.

The reason for this is due to the fact that when we subsequently enter
simplified layout we will check to see if a grid item is in the map via
gridAreaPositionForOutOfFlowGridItem. If we end up computing an index in
the map for a renderer that was removed from the tree before we entered
simplified layout, then we will end up hitting a RELEASE_ASSERT in
WeakRef code.

Also apply the same logic for Masonry as there is no reason as far as
I know why this should not follow the same idea.

* LayoutTests/fast/css-grid-layout/simplified-layout-with-oof-children-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/simplified-layout-with-oof-children-crash.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):

Canonical link: <a href="https://commits.webkit.org/289863@main">https://commits.webkit.org/289863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/736c8a16bdeced7e01bf02292c49c0da0912ea00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68046 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25772 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79799 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48438 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5963 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34209 "Found 1 new test failure: inspector/runtime/CommandLineAPI-inspect.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38056 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94997 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11269 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76906 "Found 23 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-wildcard-no-star.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75655 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76150 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8395 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20685 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15128 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18574 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->