### PR TITLE
Tracking domains can set partitioned cookies

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -29,6 +29,7 @@
 #import "Logging.h"
 #import "NetworkProcess.h"
 #import "NetworkSession.h"
+#import "WebPrivacyHelpers.h"
 #import <WebCore/DNS.h>
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/Quirks.h>
@@ -316,6 +317,11 @@ WebCore::ThirdPartyCookieBlockingDecision NetworkTaskCocoa::requestThirdPartyCoo
         if (!shouldBlockCookies(thirdPartyCookieBlockingDecision))
             thirdPartyCookieBlockingDecision = networkStorageSession->thirdPartyCookieBlockingDecisionForRequest(request, frameID(), pageID(), shouldRelaxThirdPartyCookieBlocking());
     }
+
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS) && HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    if (thirdPartyCookieBlockingDecision == WebCore::ThirdPartyCookieBlockingDecision::AllExceptPartitioned && request.isThirdParty() && isKnownTrackerAddressOrDomain(request.url().host()))
+        return WebCore::ThirdPartyCookieBlockingDecision::All;
+#endif
     return thirdPartyCookieBlockingDecision;
 }
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -55,6 +55,7 @@ namespace WebKit {
 enum class RestrictedOpenerType : uint8_t;
 
 void configureForAdvancedPrivacyProtections(NSURLSession *);
+bool isKnownTrackerAddressOrDomain(StringView host);
 void requestLinkDecorationFilteringData(CompletionHandler<void(Vector<WebCore::LinkDecorationFilteringData>&&)>&&);
 
 class ListDataObserver : public RefCountedAndCanMakeWeakPtr<ListDataObserver> {

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -702,9 +702,24 @@ void configureForAdvancedPrivacyProtections(NSURLSession *session)
     });
 }
 
+bool isKnownTrackerAddressOrDomain(StringView host)
+{
+    TrackerAddressLookupInfo::populateIfNeeded();
+    TrackerDomainLookupInfo::populateIfNeeded();
+
+    if (auto address = URL::hostIsIPAddress(host) ? IPAddress::fromString(host.toStringWithoutCopying()) : std::nullopt) {
+        if (TrackerAddressLookupInfo::find(*address))
+            return true;
+    }
+
+    auto domain = WebCore::RegistrableDomain { URL { makeString("http://"_s, host) } };
+    return TrackerDomainLookupInfo::find(domain.string()).owner().length();
+}
+
 #else
 
 void configureForAdvancedPrivacyProtections(NSURLSession *) { }
+bool isKnownTrackerAddressOrDomain(StringView) { return false; }
 
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -693,6 +693,180 @@ TEST(AdvancedPrivacyProtections, DoNotHideQueryParametersAfterEffectiveSameSiteN
     EXPECT_WK_STREQ("thirdparty: custom://firstparty.co.uk/index.html?hello=123", results[0]);
 }
 
+static RetainPtr<TestWKWebView> setUpWebViewForTestingTrackerDomainBlocking(String nonTrackerFramePageSource, String subFramePageSource, NSString *requestURLString)
+{
+    HTTPServer httpsServer({
+        { "/"_s, { { }, nonTrackerFramePageSource } },
+        { "/subframe"_s, { { }, subFramePageSource } },
+        { "/initialize"_s, { { }, "initialize"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setProxyConfiguration:@{
+        (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
+        (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
+    }];
+    auto store = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);;
+    store.get()._resourceLoadStatisticsEnabled = YES;
+
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setWebsiteDataStore:store.get()];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/initialize"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:requestURLString]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView callAsyncJavaScriptAndWait:@"return new Promise(resolve => setTimeout(resolve, 0))"];
+
+    return webView;
+}
+
+TEST(AdvancedPrivacyProtections, DoNotBlockFirstPartyPartitionedCookiesFromTrackerDomain)
+{
+    auto webView = setUpWebViewForTestingTrackerDomainBlocking("<!DOCTYPE html>"
+        "<html>"
+        "    <head>"
+        "    <script>"
+        "        window.result = '';"
+        "        window.receivedMessage = 'no';"
+        "        window.addEventListener('message', (e) => {"
+        "            window.result = e.data;"
+        "            window.receivedMessage = 'yes';"
+        "        });"
+        "    </script>"
+        "    </head>"
+        "    <body>"
+        "    <iframe sandbox=\"allow-scripts allow-same-origin\" src=\"https://tracker.example/subframe\">"
+        "    </body>"
+        "</html>"_s,
+
+        "<!DOCTYPE html>"
+        "<html>"
+        "    <head>"
+        "        <script>"
+        "        document.cookie = `test=value;Secure;SameSite=None;Partitioned`;"
+        "        window.top.postMessage(document.cookie, '*');"
+        "        </script>"
+        "    </head>"
+        "    <body>Hello world</body>"
+        "</html>"_s,
+
+        @"https://tracker.example/");
+
+    NSString *receivedMessage = [webView objectByEvaluatingJavaScript:@"window.receivedMessage"];
+    while ([receivedMessage isEqualToString:@"no"]) {
+        TestWebKitAPI::Util::spinRunLoop(5000);
+        receivedMessage = [webView objectByEvaluatingJavaScript:@"window.receivedMessage"];
+    }
+
+    NSString *result = [webView objectByEvaluatingJavaScript:@"window.result"];
+
+    EXPECT_WK_STREQ(@"yes", receivedMessage);
+
+    EXPECT_NE(0U, result.length);
+    EXPECT_WK_STREQ(@"test=value", result);
+}
+
+TEST(AdvancedPrivacyProtections, DoNotBlockThirdPartyPartitionedCookiesFromSameSiteDomain)
+{
+    auto webView = setUpWebViewForTestingTrackerDomainBlocking("<!DOCTYPE html>"
+        "<html>"
+        "    <head>"
+        "    <script>"
+        "        window.result = '';"
+        "        window.receivedMessage = 'no';"
+        "        window.addEventListener('message', (e) => {"
+        "            window.result = e.data;"
+        "            window.receivedMessage = 'yes';"
+        "        });"
+        "    </script>"
+        "    </head>"
+        "    <body>"
+        "    <iframe sandbox=\"allow-scripts allow-same-origin\" src=\"https://subdomain.website.example/subframe\">"
+        "    </body>"
+        "</html>"_s,
+
+        "<!DOCTYPE html>"
+        "<html>"
+        "    <head>"
+        "        <script>"
+        "        document.cookie = `test=value;Secure;SameSite=None;Partitioned`;"
+        "        window.top.postMessage(document.cookie, '*');"
+        "        </script>"
+        "    </head>"
+        "    <body>Hello world</body>"
+        "</html>"_s,
+
+        @"https://website.example/");
+
+    NSString *receivedMessage = [webView objectByEvaluatingJavaScript:@"window.receivedMessage"];
+    while ([receivedMessage isEqualToString:@"no"]) {
+        TestWebKitAPI::Util::spinRunLoop(5000);
+        receivedMessage = [webView objectByEvaluatingJavaScript:@"window.receivedMessage"];
+    }
+
+    NSString *result = [webView objectByEvaluatingJavaScript:@"window.result"];
+
+    EXPECT_WK_STREQ(@"yes", receivedMessage);
+    EXPECT_NE(0U, result.length);
+    EXPECT_WK_STREQ(@"test=value", result);
+}
+
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+TEST(AdvancedPrivacyProtections, DoNotBlockThirdPartyPartitionedCookies)
+{
+    auto webView = setUpWebViewForTestingTrackerDomainBlocking("<!DOCTYPE html>"
+        "<html>"
+        "    <head>"
+        "    <script>"
+        "        window.result = '';"
+        "        window.receivedMessage = 'no';"
+        "        window.addEventListener('message', (e) => {"
+        "            window.result = e.data;"
+        "            window.receivedMessage = 'yes';"
+        "        });"
+        "    </script>"
+        "    </head>"
+        "    <body>"
+        "    <iframe sandbox=\"allow-scripts allow-same-origin\" src=\"https://websiteB.example/subframe\">"
+        "    </body>"
+        "</html>"_s,
+
+        "<!DOCTYPE html>"
+        "<html>"
+        "    <head>"
+        "        <script>"
+        "        document.cookie = `test=value;Secure;SameSite=None;Partitioned`;"
+        "        window.parent.postMessage(document.cookie, '*');"
+        "        </script>"
+        "    </head>"
+        "    <body>Hello world</body>"
+        "</html>"_s,
+
+        @"https://website.example/");
+
+    NSString *receivedMessage = [webView objectByEvaluatingJavaScript:@"window.receivedMessage"];
+    while ([receivedMessage isEqualToString:@"no"]) {
+        TestWebKitAPI::Util::spinRunLoop(5000);
+        receivedMessage = [webView objectByEvaluatingJavaScript:@"window.receivedMessage"];
+    }
+
+    NSString *result = [webView objectByEvaluatingJavaScript:@"window.result"];
+
+    EXPECT_WK_STREQ(@"yes", receivedMessage);
+    EXPECT_NE(0U, result.length);
+    EXPECT_WK_STREQ(@"test=value", result);
+}
+#endif
+
 TEST(AdvancedPrivacyProtections, LinkPreconnectUsesEnhancedPrivacy)
 {
     auto createMarkupString = [](unsigned serverPort) {


### PR DESCRIPTION
#### 4d2a1aa31e5701437cdcb6c9023b17d57c608972
<pre>
Tracking domains can set partitioned cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=286778">https://bugs.webkit.org/show_bug.cgi?id=286778</a>
<a href="https://rdar.apple.com/144184516">rdar://144184516</a>

Reviewed by Wenson Hsieh.

The vast majority of the partitioned cookies we currently see are being set by
tracking domains. This doesn&apos;t benefit users and only causes more memory usage.
This patch blocks third-party cookies if the request is for a tracking domain.

Tested manually, and adding a few API tests, but these tests don&apos;t cover
blocking cookies for a domain on the block list. That will require a more
invasive change, so I&apos;ll do that in a follow up.

* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::requestThirdPartyCookieBlockingDecision const):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::isKnownTrackerAddressOrDomain):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::setUpWebViewForTestingTrackerDomainBlocking):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotBlockFirstPartyPartitionedCookiesFromTrackerDomain)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotBlockThirdPartyPartitionedCookiesFromSameSiteDomain)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotBlockThirdPartyPartitionedCookies)):

Canonical link: <a href="https://commits.webkit.org/289849@main">https://commits.webkit.org/289849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2264b8a93151b383abe14e7380b4b28d35eda522

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88132 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38882 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68010 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91134 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79722 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48375 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34136 "Found 1 new test failure: accessibility/multiple-label-input.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37990 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94933 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15300 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11231 "Found 5 new test failures: fast/events/event-handler-detached-document.html http/tests/pdf/linearized-pdf-in-display-none-iframe.html imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html media/video-replaces-poster.html pdf/pdf-in-styled-embed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76871 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75578 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76112 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8329 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13764 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20619 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->