### PR TITLE
Remove CORS restriction on mixed content upgrades

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt
@@ -1,5 +1,6 @@
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and no-redirect redirection from https context.
 PASS Mixed-Content: Expects blocked for img-tag to cross-http origin and no-redirect redirection from https context.
-PASS Mixed-Content: Expects blocked for img-tag to same-http origin and no-redirect redirection from https context.
+FAIL Mixed-Content: Expects blocked for img-tag to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt
@@ -1,10 +1,13 @@
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=keep-scheme&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=swap-scheme&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Mixed-Content: Expects allowed for img-tag to cross-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and keep-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Mixed-Content: Expects allowed for img-tag to same-http origin and swap-scheme redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Mixed-Content: Expects allowed for img-tag to same-http origin and keep-scheme redirection from https context.
+PASS Mixed-Content: Expects allowed for img-tag to same-http origin and no-redirect redirection from https context.
+PASS Mixed-Content: Expects allowed for img-tag to same-http origin and swap-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and keep-scheme redirection from https context.
 PASS Mixed-Content: Expects allowed for img-tag to same-https origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Cross-Origin audio should get upgraded even if CORS is set assert_unreached: Audio of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/test.wav?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
-FAIL Cross-Origin image should get upgraded even if CORS is set assert_unreached: image of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/pass.png?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
+PASS Cross-Origin audio should get upgraded even if CORS is set
+PASS Cross-Origin image should get upgraded even if CORS is set
 FAIL Cross-Origin video should get upgraded even if CORS is set assert_unreached: Video of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/test.ogv?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt
@@ -1,9 +1,11 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt
@@ -1,9 +1,11 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt
@@ -1,9 +1,11 @@
 Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=no-redirect&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
+Blocked access to external URL https://www1.localhost:9443/common/security-features/subresource/image.py?redirection=downgrade&action=purge&key=GENERATED_KEY&path=%2Fmixed-content
 
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and downgrade redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-http-downgrade origin and no-redirect redirection from https context.
 PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to cross-https origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context.
-PASS Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context.
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
+FAIL Upgrade-Insecure-Requests: Expects blocked for img-tag to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'blocked'. expected "blocked" but got "allowed"
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4366,6 +4366,12 @@ webkit.org/b/216763 webrtc/captureCanvas-webrtc-software-h264-high.html [ Skip ]
 
 webkit.org/b/285921 media/media-source/media-source-seek-past-end.html [ Failure ]
 
+imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https.html [ Failure Pass ]
+imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https.html [ Failure Pass ]
+imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https.html [ Failure Pass ]
+imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https.html [ Failure Pass ]
+imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https.html [ Failure Pass ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2894,6 +2894,7 @@ imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties
 # webkit.org/b/272115 REGRESSION (274826@main): [ Sonoma WK1 ] 2X imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades tests are flaky failures
 [ Ventura+ ] imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub.html [ Pass Failure ]
 [ Ventura+ ] imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub.html [ Pass Failure ]
+[ Ventura+ ] imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub.html [ Pass Failure ]
 
 # webkit.org/b/272081 [web-animations] update WPT import for web-animations
 [ Sonoma ] imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-drop-shadow.html [ ImageOnlyFailure ]

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -175,7 +175,7 @@ static bool destinationIsImageAndInitiatorIsImageset(FetchOptions::Destination d
     return destination == FetchOptions::Destination::Image && initiator == Initiator::Imageset;
 }
 
-bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Mode mode, FetchOptions::Destination destination, Initiator initiator)
+bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgradable isUpgradable, const URL& url, FetchOptions::Destination destination, Initiator initiator)
 {
     RefPtr document = frame.document();
     if (!document || !isUpgradeMixedContentEnabled(*document) || isUpgradable != IsUpgradable::Yes)
@@ -194,9 +194,6 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
 
     // 4.1 The request's URL is not upgraded in the following cases.
     if (!canModifyRequest(url, destination, initiator, shouldUpgradeIPAddressAndLocalhostForTesting))
-        return false;
-    // or CORS is excluded
-    if (mode == FetchOptions::Mode::Cors && !(document->quirks().needsRelaxedCorsMixedContentCheckQuirk() && destinationIsImageAudioOrVideo(destination)))
         return false;
 
     logConsoleWarningForUpgrade(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -51,7 +51,7 @@ enum class ShouldLogWarning { No, Yes };
 enum class IsUpgradable : bool { No, Yes, };
 
 bool frameAndAncestorsCanRunInsecureContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
-bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Mode, FetchOptions::Destination, Initiator);
+bool shouldUpgradeInsecureContent(LocalFrame&, IsUpgradable, const URL&, FetchOptions::Destination, Initiator);
 bool shouldBlockRequestForDisplayableContent(LocalFrame&, const URL&, ContentType, IsUpgradable = IsUpgradable::No);
 bool shouldBlockRequestForRunnableContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
 void checkFormForMixedContent(LocalFrame&, const URL&);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -263,7 +263,7 @@ ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::request
         if (frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None) {
             bool isRequestUpgradable { false };
             if (RefPtr document = frame->document()) {
-                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().mode, request.options().destination, request.options().initiator);
+                isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(*frame, MixedContentChecker::IsUpgradable::Yes, request.resourceRequest().url(), request.options().destination, request.options().initiator);
                 request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
             }
             URL requestURL = request.resourceRequest().url();
@@ -817,7 +817,7 @@ bool CachedResourceLoader::updateRequestAfterRedirection(CachedResource::Type ty
         return true;
 
     if (RefPtr document = m_documentLoader->cachedResourceLoader().document()) {
-        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(*document->frame(), isUpgradableTypeFromResourceType(type), request.url(), options.mode, options.destination, options.initiator) : false;
+        bool alwaysUpgradeMixedContent = document->frame() ? MixedContentChecker::shouldUpgradeInsecureContent(*document->frame(), isUpgradableTypeFromResourceType(type), request.url(), options.destination, options.initiator) : false;
         upgradeInsecureResourceRequestIfNeeded(request, *document, alwaysUpgradeMixedContent ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
     }
 
@@ -1122,7 +1122,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
 
     bool isRequestUpgradable { false };
     if (RefPtr document = this->document()) {
-        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().mode, request.options().destination, request.options().initiator);
+        isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator);
         request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
         url = request.resourceRequest().url();
     }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1504,13 +1504,6 @@ bool Quirks::needsGetElementsByNameQuirk() const
 #endif
 }
 
-// tripadvisor.com: rdar://112851939
-// FIXME: Remove this quirk when <rdar://127247321> is complete
-bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
-{
-    return needsQuirks() && m_quirksData.needsRelaxedCorsMixedContentCheckQuirk;
-}
-
 // rdar://127398734
 bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 {
@@ -2513,17 +2506,6 @@ static void handleSpotifyQuirks(QuirksData& quirksData, const URL& quirksURL, co
 #endif
 }
 
-static void handleTripAdvisorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
-{
-    if (quirksDomainString != "tripadvisor.com"_s)
-        return;
-
-    UNUSED_PARAM(quirksURL);
-    UNUSED_PARAM(documentURL);
-    // tripadvisor.com: rdar://112851939
-    quirksData.needsRelaxedCorsMixedContentCheckQuirk = true;
-}
-
 static void handleVictoriasSecretQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
 {
     if (quirksDomainString != "victoriassecret.com"_s)
@@ -2812,7 +2794,6 @@ void Quirks::determineRelevantQuirks()
 #if PLATFORM(IOS_FAMILY)
         { "thesaurus"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
 #endif
-        { "tripadvisor"_s, &handleTripAdvisorQuirks },
 #if PLATFORM(MAC)
         { "trix-editor"_s, &handleTrixEditorQuirks },
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -215,7 +215,6 @@ public:
     WEBCORE_EXPORT bool shouldUseEphemeralPartitionedStorageForDOMCookies(const URL&) const;
 
     bool needsGetElementsByNameQuirk() const;
-    bool needsRelaxedCorsMixedContentCheckQuirk() const;
     bool needsLaxSameSiteCookieQuirk(const URL&) const;
 
     String scriptToEvaluateBeforeRunningScriptFromURL(const URL&);

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -54,7 +54,6 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsChromeMediaControlsPseudoElementQuirk { false };
     bool needsHotelsAnimationQuirk { false };
     bool needsMozillaFileTypeForDataTransferQuirk { false };
-    bool needsRelaxedCorsMixedContentCheckQuirk { false };
     bool needsResettingTransitionCancelsRunningTransitionQuirk { false };
     bool needsScrollbarWidthThinDisabledQuirk { false };
     bool needsSeekingSupportDisabledQuirk { false };


### PR DESCRIPTION
#### a7c31c36ea7c80460755abe46b21f3db5cde239a
<pre>
Remove CORS restriction on mixed content upgrades
<a href="https://bugs.webkit.org/show_bug.cgi?id=286624">https://bugs.webkit.org/show_bug.cgi?id=286624</a>
<a href="https://rdar.apple.com/124531208">rdar://124531208</a>

Reviewed by Anne van Kesteren.

It turns out that we&apos;re not actually spec-compliant by requiring that requests
are non-CORS. This requirement is mentioned in the spec, but it is not actually
specified in any of the algorithms and was removed in
<a href="https://github.com/w3c/webappsec-mixed-content/pull/67.">https://github.com/w3c/webappsec-mixed-content/pull/67.</a> The spec still needs to
be cleaned up.

This change brings WebKit in-line with Chromium and Gecko on a few
upgrade-insecure-request WPT tests. We now begin failing a few
block-all-mixed-content tests because it is deprecated.

* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/unset/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
* Source/WebCore/loader/MixedContentChecker.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestImage):
(WebCore::CachedResourceLoader::updateRequestAfterRedirection):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::determineRelevantQuirks):
(WebCore::Quirks::needsRelaxedCorsMixedContentCheckQuirk const): Deleted.
(WebCore::handleTripAdvisorQuirks): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/290106@main">https://commits.webkit.org/290106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25d2a90cf2bada7f8238ffcf7d4bcc2778051aae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68457 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38685 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95627 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11696 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77324 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76607 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9063 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21323 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15753 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->