### PR TITLE
Use requiredDowncast<> in Style::BuilderCustom

### DIFF
--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -197,18 +197,20 @@ inline void BuilderCustom::applyInheritZoom(BuilderState& builderState)
 
 inline void BuilderCustom::applyValueZoom(BuilderState& builderState, CSSValue& value)
 {
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
 
-    if (primitiveValue.valueID() == CSSValueNormal) {
+    if (primitiveValue->valueID() == CSSValueNormal) {
         resetUsedZoom(builderState);
         builderState.setZoom(RenderStyle::initialZoom());
-    } else if (primitiveValue.isPercentage()) {
+    } else if (primitiveValue->isPercentage()) {
         resetUsedZoom(builderState);
-        if (float percent = primitiveValue.resolveAsPercentage<float>(builderState.cssToLengthConversionData()))
+        if (float percent = primitiveValue->resolveAsPercentage<float>(builderState.cssToLengthConversionData()))
             builderState.setZoom(percent / 100.0f);
-    } else if (primitiveValue.isNumber()) {
+    } else if (primitiveValue->isNumber()) {
         resetUsedZoom(builderState);
-        if (float number = primitiveValue.resolveAsNumber<float>(builderState.cssToLengthConversionData()))
+        if (float number = primitiveValue->resolveAsNumber<float>(builderState.cssToLengthConversionData()))
             builderState.setZoom(number);
     }
 }
@@ -221,11 +223,14 @@ inline void BuilderCustom::applyInheritVerticalAlign(BuilderState& builderState)
 
 inline void BuilderCustom::applyValueVerticalAlign(BuilderState& builderState, CSSValue& value)
 {
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.valueID() != CSSValueInvalid)
-        builderState.style().setVerticalAlign(fromCSSValueID<VerticalAlign>(primitiveValue.valueID()));
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
+
+    if (primitiveValue->valueID() != CSSValueInvalid)
+        builderState.style().setVerticalAlign(fromCSSValueID<VerticalAlign>(primitiveValue->valueID()));
     else
-        builderState.style().setVerticalAlignLength(primitiveValue.convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion>(builderState.cssToLengthConversionData()));
+        builderState.style().setVerticalAlignLength(primitiveValue->convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion>(builderState.cssToLengthConversionData()));
 }
 
 inline void BuilderCustom::applyInheritTextIndent(BuilderState& builderState)
@@ -248,9 +253,15 @@ inline void BuilderCustom::applyValueTextIndent(BuilderState& builderState, CSSV
     TextIndentLine textIndentLineValue = RenderStyle::initialTextIndentLine();
     TextIndentType textIndentTypeValue = RenderStyle::initialTextIndentType();
 
-    if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
-        for (auto& item : *valueList) {
-            auto& primitiveValue = downcast<CSSPrimitiveValue>(item);
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        // Values coming from CSSTypedOM didn't go through the parser and may not have been converted to a CSSValueList.
+        lengthPercentageValue = primitiveValue->convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion>(builderState.cssToLengthConversionData());
+    } else {
+        auto list = BuilderConverter::requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
+        if (!list)
+            return;
+
+        for (auto& primitiveValue : *list) {
             if (!primitiveValue.valueID())
                 lengthPercentageValue = primitiveValue.convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion>(builderState.cssToLengthConversionData());
             else if (primitiveValue.valueID() == CSSValueEachLine)
@@ -258,11 +269,7 @@ inline void BuilderCustom::applyValueTextIndent(BuilderState& builderState, CSSV
             else if (primitiveValue.valueID() == CSSValueHanging)
                 textIndentTypeValue = TextIndentType::Hanging;
         }
-    } else if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        // Values coming from CSSTypedOM didn't go through the parser and may not have been converted to a CSSValueList.
-        lengthPercentageValue = primitiveValue->convertToLength<FixedIntegerConversion | PercentConversion | CalculatedConversion>(builderState.cssToLengthConversionData());
-    } else
-        return;
+    }
 
     if (lengthPercentageValue.isUndefined())
         return;
@@ -501,8 +508,10 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
     if (lineHeight.isNormal())
         computedLineHeight = lineHeight;
     else {
-        auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-        auto multiplier = computeLineHeightMultiplierDueToFontSize(builderState.document(), builderState.style(), primitiveValue);
+        auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+        if (!primitiveValue)
+            return;
+        auto multiplier = computeLineHeightMultiplierDueToFontSize(builderState.document(), builderState.style(), *primitiveValue);
         if (multiplier == 1)
             computedLineHeight = lineHeight;
         else
@@ -608,13 +617,15 @@ inline void BuilderCustom::applyValueClip(BuilderState& builderState, CSSValue& 
 
 inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CSSValue& value)
 {
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
 
     FontCascadeDescription fontDescription = builderState.fontDescription();
-    if (primitiveValue.valueID() == CSSValueAuto)
+    if (primitiveValue->valueID() == CSSValueAuto)
         fontDescription.setSpecifiedLocale(nullAtom());
     else
-        fontDescription.setSpecifiedLocale(AtomString { primitiveValue.stringValue() });
+        fontDescription.setSpecifiedLocale(AtomString { primitiveValue->stringValue() });
     builderState.setFontDescription(WTFMove(fontDescription));
 }
 
@@ -632,13 +643,16 @@ inline void BuilderCustom::applyValueTextOrientation(BuilderState& builderState,
 #if ENABLE(TEXT_AUTOSIZING)
 inline void BuilderCustom::applyValueWebkitTextSizeAdjust(BuilderState& builderState, CSSValue& value)
 {
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.valueID() == CSSValueAuto)
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
+
+    if (primitiveValue->valueID() == CSSValueAuto)
         builderState.style().setTextSizeAdjust(TextSizeAdjustment::autoAdjust());
-    else if (primitiveValue.valueID() == CSSValueNone)
+    else if (primitiveValue->valueID() == CSSValueNone)
         builderState.style().setTextSizeAdjust(TextSizeAdjustment::none());
     else
-        builderState.style().setTextSizeAdjust(TextSizeAdjustment(primitiveValue.resolveAsPercentage<float>(builderState.cssToLengthConversionData())));
+        builderState.style().setTextSizeAdjust(TextSizeAdjustment(primitiveValue->resolveAsPercentage<float>(builderState.cssToLengthConversionData())));
 
     builderState.setFontDirty();
 }
@@ -646,10 +660,13 @@ inline void BuilderCustom::applyValueWebkitTextSizeAdjust(BuilderState& builderS
 
 inline void BuilderCustom::applyValueWebkitTextZoom(BuilderState& builderState, CSSValue& value)
 {
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.valueID() == CSSValueNormal)
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
+
+    if (primitiveValue->valueID() == CSSValueNormal)
         builderState.style().setTextZoom(TextZoom::Normal);
-    else if (primitiveValue.valueID() == CSSValueReset)
+    else if (primitiveValue->valueID() == CSSValueReset)
         builderState.style().setTextZoom(TextZoom::Reset);
     builderState.setFontDirty();
 }
@@ -680,7 +697,9 @@ inline void BuilderCustom::applyValueTextShadow(BuilderState& builderState, CSSV
         return;
     }
 
-    Ref shadow = downcast<CSSTextShadowPropertyValue>(value);
+    RefPtr shadow = BuilderConverter::requiredDowncast<CSSTextShadowPropertyValue>(builderState, value);
+    if (!shadow)
+        return;
 
     WTF::switchOn(shadow->shadow(),
         [&](CSS::Keyword::None) {
@@ -714,7 +733,9 @@ inline void BuilderCustom::applyValueBoxShadow(BuilderState& builderState, CSSVa
         return;
     }
 
-    Ref shadow = downcast<CSSBoxShadowPropertyValue>(value);
+    RefPtr shadow = BuilderConverter::requiredDowncast<CSSBoxShadowPropertyValue>(builderState, value);
+    if (!shadow)
+        return;
 
     WTF::switchOn(shadow->shadow(),
         [&](CSS::Keyword::None) {
@@ -775,10 +796,12 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
         fontDescription.setIsSpecifiedFont(false);
         families = Vector<AtomString>::from(WTFMove(family));
     } else {
-        auto& valueList = downcast<CSSValueList>(value);
+        auto valueList = BuilderConverter::requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
+        if (!valueList)
+            return;
+
         bool isFirstFont = true;
-        families = WTF::compactMap(valueList, [&](auto& item) -> std::optional<AtomString> {
-            auto& contentValue = downcast<CSSPrimitiveValue>(item);
+        families = WTF::compactMap(*valueList, [&](auto& contentValue) -> std::optional<AtomString> {
             AtomString family;
             bool isGenericFamily = false;
             if (contentValue.isFontFamily())
@@ -895,9 +918,12 @@ inline void BuilderCustom::applyInheritBaselineShift(BuilderState& builderState)
 inline void BuilderCustom::applyValueBaselineShift(BuilderState& builderState, CSSValue& value)
 {
     SVGRenderStyle& svgStyle = builderState.style().accessSVGStyle();
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.isValueID()) {
-        switch (primitiveValue.valueID()) {
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
+
+    if (primitiveValue->isValueID()) {
+        switch (primitiveValue->valueID()) {
         case CSSValueBaseline:
             svgStyle.setBaselineShift(BaselineShift::Baseline);
             break;
@@ -912,7 +938,7 @@ inline void BuilderCustom::applyValueBaselineShift(BuilderState& builderState, C
         }
     } else {
         svgStyle.setBaselineShift(BaselineShift::Length);
-        svgStyle.setBaselineShiftValue(SVGLengthValue::fromCSSPrimitiveValue(primitiveValue, builderState.cssToLengthConversionData()));
+        svgStyle.setBaselineShiftValue(SVGLengthValue::fromCSSPrimitiveValue(*primitiveValue, builderState.cssToLengthConversionData()));
     }
 }
 
@@ -945,25 +971,34 @@ inline void BuilderCustom::applyValueAspectRatio(BuilderState& builderState, CSS
     if (value.valueID() == CSSValueAuto)
         return builderState.style().setAspectRatioType(AspectRatioType::Auto);
 
-    auto* list = dynamicDowncast<CSSValueList>(value);
+    auto list = BuilderConverter::requiredListDowncast<CSSValueList, CSSValue, 2>(builderState, value);
     if (!list)
         return;
 
     auto& conversionData = builderState.cssToLengthConversionData();
 
-    if (auto* ratioList = dynamicDowncast<CSSValueList>(*list->item(1))) {
+    auto resolveRatioList = [&](auto& listValue) -> std::optional<std::pair<double, double>> {
+        auto ratioList = BuilderConverter::requiredListDowncast<CSSValueList, CSSPrimitiveValue, 2>(builderState, listValue);
+        if (!ratioList)
+            return { };
+
+        return std::pair { ratioList->item(0).resolveAsNumber(conversionData), ratioList->item(1).resolveAsNumber(conversionData) };
+    };
+
+    if (is<CSSValueList>(list->item(1))) {
+        auto ratio = resolveRatioList(list->item(1));
+        if (!ratio)
+            return;
+        auto [width, height] = *ratio;
         builderState.style().setAspectRatioType(AspectRatioType::AutoAndRatio);
-        ASSERT(ratioList->length() == 2);
-        builderState.style().setAspectRatio(
-            downcast<CSSPrimitiveValue>(ratioList->item(0))->resolveAsNumber(conversionData),
-            downcast<CSSPrimitiveValue>(ratioList->item(1))->resolveAsNumber(conversionData)
-        );
+        builderState.style().setAspectRatio(width, height);
         return;
     }
 
-    ASSERT(list->length() == 2);
-    auto width = downcast<CSSPrimitiveValue>(list->item(0))->resolveAsNumber(conversionData);
-    auto height = downcast<CSSPrimitiveValue>(list->item(1))->resolveAsNumber(conversionData);
+    auto ratio = resolveRatioList(value);
+    if (!ratio)
+        return;
+    auto [width, height] = *ratio;
     if (!width || !height)
         builderState.style().setAspectRatioType(AspectRatioType::AutoZero);
     else
@@ -987,17 +1022,20 @@ inline void BuilderCustom::applyValueTextEmphasisStyle(BuilderState& builderStat
         return;
     }
 
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
-    if (primitiveValue.isString()) {
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
+
+    if (primitiveValue->isString()) {
         builderState.style().setTextEmphasisFill(TextEmphasisFill::Filled);
         builderState.style().setTextEmphasisMark(TextEmphasisMark::Custom);
-        builderState.style().setTextEmphasisCustomMark(AtomString { primitiveValue.stringValue() });
+        builderState.style().setTextEmphasisCustomMark(AtomString { primitiveValue->stringValue() });
         return;
     }
 
     builderState.style().setTextEmphasisCustomMark(nullAtom());
 
-    if (primitiveValue.valueID() == CSSValueFilled || primitiveValue.valueID() == CSSValueOpen) {
+    if (primitiveValue->valueID() == CSSValueFilled || primitiveValue->valueID() == CSSValueOpen) {
         builderState.style().setTextEmphasisFill(fromCSSValue<TextEmphasisFill>(value));
         builderState.style().setTextEmphasisMark(TextEmphasisMark::Auto);
     } else {
@@ -1044,9 +1082,16 @@ inline void BuilderCustom::applyValueCounter(BuilderState& builderState, CSSValu
 
     auto& conversionData = builderState.cssToLengthConversionData();
 
-    for (auto& item : downcast<CSSValueList>(value)) {
-        AtomString identifier { downcast<CSSPrimitiveValue>(item.first()).stringValue() };
-        int value = downcast<CSSPrimitiveValue>(item.second()).resolveAsNumber<int>(conversionData);
+    auto list = BuilderConverter::requiredListDowncast<CSSValueList, CSSValuePair>(builderState, value);
+    if (!list)
+        return;
+
+    for (auto& pairValue : *list) {
+        auto pair = BuilderConverter::requiredPairDowncast<CSSPrimitiveValue>(builderState, pairValue);
+        if (!pair)
+            return;
+        AtomString identifier { pair->first.stringValue() };
+        int value =  pair->second.resolveAsNumber<int>(conversionData);
         auto& directives = map.add(identifier, CounterDirectives { }).iterator->value;
         if (counterBehavior == Reset)
             directives.resetValue = value;
@@ -1122,8 +1167,12 @@ inline void BuilderCustom::applyValueCursor(BuilderState& builderState, CSSValue
     }
 
     builderState.style().setCursor(CursorType::Auto);
-    auto& list = downcast<CSSValueList>(value);
-    for (auto& item : list) {
+
+    auto list = BuilderConverter::requiredListDowncast<CSSValueList, CSSValue>(builderState, value);
+    if (!list)
+        return;
+
+    for (auto& item : *list) {
         if (auto* image = dynamicDowncast<CSSCursorImageValue>(item)) {
             auto styleImage = image->createStyleImage(builderState);
             auto hotSpot = styleImage->hotSpot();
@@ -1132,7 +1181,7 @@ inline void BuilderCustom::applyValueCursor(BuilderState& builderState, CSSValue
         }
 
         builderState.style().setCursor(fromCSSValue<CursorType>(item));
-        ASSERT_WITH_MESSAGE(&item == list.item(list.length() - 1), "Cursor ID fallback should always be last in the list");
+        ASSERT_WITH_MESSAGE(&item == &list->item(list->size() - 1), "Cursor ID fallback should always be last in the list");
         return;
     }
 }
@@ -1177,7 +1226,10 @@ inline void BuilderCustom::applyValueFill(BuilderState& builderState, CSSValue& 
     RefPtr<const CSSValue> localValue = &value;
     String url;
     if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
-        url = downcast<CSSPrimitiveValue>(list->item(0))->stringValue();
+        auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, *list->item(0));
+        if (!primitiveValue)
+            return;
+        url = primitiveValue->stringValue();
         localValue = list->protectedItem(1);
     }
 
@@ -1207,7 +1259,10 @@ inline void BuilderCustom::applyValueStroke(BuilderState& builderState, CSSValue
     RefPtr<const CSSValue> localValue = &value;
     String url;
     if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
-        url = downcast<CSSPrimitiveValue>(list->item(0))->stringValue();
+        auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, *list->item(0));
+        if (!primitiveValue)
+            return;
+        url = primitiveValue->stringValue();
         localValue = list->protectedItem(1);
     }
 
@@ -1237,8 +1292,10 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
         return;
     }
 
-    bool hasAltTextContent = is<CSSValuePair>(value);
-    auto& visibleContentList = hasAltTextContent ? downcast<CSSValuePair>(value).first() : value;
+    auto* altTextPair = dynamicDowncast<CSSValuePair>(value);
+    auto visibleContentList = BuilderConverter::requiredDowncast<CSSValueList>(builderState, altTextPair ? altTextPair->first() : value);
+    if (!visibleContentList)
+        return;
 
     auto processAttrContent = [&](const CSSPrimitiveValue& primitiveValue) -> AtomString {
         // FIXME: Can a namespace be specified for an attr(foo)?
@@ -1261,8 +1318,9 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
         return attributeValue.impl();
     };
 
+
     bool didSet = false;
-    for (auto& item : downcast<CSSValueList>(visibleContentList)) {
+    for (auto& item : *visibleContentList) {
         if (item.isImage()) {
             builderState.style().setContent(builderState.createStyleImage(item), didSet);
             didSet = true;
@@ -1312,19 +1370,21 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
         return;
     }
 
-    if (!hasAltTextContent) {
+    if (!altTextPair) {
         builderState.style().setContentAltText({ });
         return;
     }
 
-    auto& altTextContentList = downcast<CSSValuePair>(value).second();
+    auto altTextContentList = BuilderConverter::requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, altTextPair->second());
+    if (!altTextContentList)
+        return;
+
     StringBuilder altText;
-    for (auto& item : downcast<CSSValueList>(altTextContentList)) {
-        auto* primitive = dynamicDowncast<CSSPrimitiveValue>(item);
-        if (primitive && primitive->isString())
-            altText.append(primitive->stringValue());
-        else if (primitive && primitive->isAttr())
-            altText.append(processAttrContent(*primitive));
+    for (auto& item : *altTextContentList) {
+        if (item.isString())
+            altText.append(item.stringValue());
+        else if (item.isAttr())
+            altText.append(processAttrContent(item));
     }
     builderState.style().setContentAltText(altText.toString());
 }
@@ -1588,9 +1648,12 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
     float parentSize = builderState.parentStyle().fontDescription().specifiedSize();
     bool parentIsAbsoluteSize = builderState.parentStyle().fontDescription().isAbsoluteSize();
 
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
+    auto primitiveValue = BuilderConverter::requiredDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!primitiveValue)
+        return;
+
     float size = 0;
-    if (CSSValueID ident = primitiveValue.valueID()) {
+    if (CSSValueID ident = primitiveValue->valueID()) {
         fontDescription.setIsAbsoluteSize((parentIsAbsoluteSize && (ident == CSSValueLarger || ident == CSSValueSmaller || ident == CSSValueWebkitRubyText)) || CSSPropertyParserHelpers::isSystemFontShorthand(ident));
 
         if (CSSPropertyParserHelpers::isSystemFontShorthand(ident))
@@ -1621,14 +1684,14 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
             break;
         }
     } else {
-        fontDescription.setIsAbsoluteSize(parentIsAbsoluteSize || !primitiveValue.isParentFontRelativeLength());
+        fontDescription.setIsAbsoluteSize(parentIsAbsoluteSize || !primitiveValue->isParentFontRelativeLength());
         auto conversionData = builderState.cssToLengthConversionData().copyForFontSize();
-        if (primitiveValue.isLength())
-            size = primitiveValue.resolveAsLength<float>(conversionData);
-        else if (primitiveValue.isPercentage())
-            size = (primitiveValue.resolveAsPercentage<float>(conversionData) * parentSize) / 100.0f;
-        else if (primitiveValue.isCalculatedPercentageWithLength())
-            size = primitiveValue.cssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(parentSize);
+        if (primitiveValue->isLength())
+            size = primitiveValue->resolveAsLength<float>(conversionData);
+        else if (primitiveValue->isPercentage())
+            size = (primitiveValue->resolveAsPercentage<float>(conversionData) * parentSize) / 100.0f;
+        else if (primitiveValue->isCalculatedPercentageWithLength())
+            size = primitiveValue->cssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(parentSize);
         else
             return;
     }
@@ -1674,15 +1737,18 @@ inline void BuilderCustom::applyValueGridTemplateAreas(BuilderState& builderStat
         return;
     }
 
-    auto& gridTemplateAreasValue = downcast<CSSGridTemplateAreasValue>(value);
-    const NamedGridAreaMap& newNamedGridAreas = gridTemplateAreasValue.gridAreaMap();
+    auto gridTemplateAreasValue = BuilderConverter::requiredDowncast<CSSGridTemplateAreasValue>(builderState, value);
+    if (!gridTemplateAreasValue)
+        return;
+
+    const NamedGridAreaMap& newNamedGridAreas = gridTemplateAreasValue->gridAreaMap();
 
     builderState.style().setImplicitNamedGridColumnLines(BuilderConverter::createImplicitNamedGridLinesFromGridArea(builderState, newNamedGridAreas, GridTrackSizingDirection::ForColumns));
     builderState.style().setImplicitNamedGridRowLines(BuilderConverter::createImplicitNamedGridLinesFromGridArea(builderState, newNamedGridAreas, GridTrackSizingDirection::ForRows));
 
-    builderState.style().setNamedGridArea(gridTemplateAreasValue.gridAreaMap());
-    builderState.style().setNamedGridAreaRowCount(gridTemplateAreasValue.rowCount());
-    builderState.style().setNamedGridAreaColumnCount(gridTemplateAreasValue.columnCount());
+    builderState.style().setNamedGridArea(gridTemplateAreasValue->gridAreaMap());
+    builderState.style().setNamedGridAreaRowCount(gridTemplateAreasValue->rowCount());
+    builderState.style().setNamedGridAreaColumnCount(gridTemplateAreasValue->columnCount());
 }
 
 inline void BuilderCustom::applyValueStrokeWidth(BuilderState& builderState, CSSValue& value)
@@ -1767,17 +1833,17 @@ inline void BuilderCustom::applyValueContainIntrinsicWidth(BuilderState& builder
         return;
     }
 
-    auto* pair = dynamicDowncast<CSSValuePair>(value);
+    auto pair = BuilderConverter::requiredPairDowncast<CSSPrimitiveValue>(builderState, value);
     if (!pair)
         return;
 
-    ASSERT(downcast<CSSPrimitiveValue>(pair->first()).valueID() == CSSValueAuto);
-    if (downcast<CSSPrimitiveValue>(pair->second()).valueID() == CSSValueNone)
+    ASSERT(pair->first.valueID() == CSSValueAuto);
+    if (pair->second.valueID() == CSSValueNone)
         style.setContainIntrinsicWidthType(ContainIntrinsicSizeType::AutoAndNone);
     else {
-        ASSERT(downcast<CSSPrimitiveValue>(pair->second()).isLength());
+        ASSERT(pair->second.isLength());
         style.setContainIntrinsicWidthType(ContainIntrinsicSizeType::AutoAndLength);
-        auto lengthValue = downcast<CSSPrimitiveValue>(pair->second()).resolveAsLength<WebCore::Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
+        auto lengthValue = pair->second.resolveAsLength<WebCore::Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
         style.setContainIntrinsicWidth(lengthValue);
     }
 }
@@ -1811,17 +1877,18 @@ inline void BuilderCustom::applyValueContainIntrinsicHeight(BuilderState& builde
         return;
     }
 
-    auto* pair = dynamicDowncast<CSSValuePair>(value);
+
+    auto pair = BuilderConverter::requiredPairDowncast<CSSPrimitiveValue>(builderState, value);
     if (!pair)
         return;
 
-    ASSERT(downcast<CSSPrimitiveValue>(pair->first()).valueID() == CSSValueAuto);
-    if (downcast<CSSPrimitiveValue>(pair->second()).valueID() == CSSValueNone)
+    ASSERT(pair->first.valueID() == CSSValueAuto);
+    if (pair->second.valueID() == CSSValueNone)
         style.setContainIntrinsicHeightType(ContainIntrinsicSizeType::AutoAndNone);
     else {
-        ASSERT(downcast<CSSPrimitiveValue>(pair->second()).isLength());
+        ASSERT(pair->second.isLength());
         style.setContainIntrinsicHeightType(ContainIntrinsicSizeType::AutoAndLength);
-        auto lengthValue = downcast<CSSPrimitiveValue>(pair->second()).resolveAsLength<WebCore::Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
+        auto lengthValue = pair->second.resolveAsLength<WebCore::Length>(builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f));
         style.setContainIntrinsicHeight(lengthValue);
     }
 }


### PR DESCRIPTION
#### c0aaa28ca62657566d896d2667c1dd97c31eb284
<pre>
Use requiredDowncast&lt;&gt; in Style::BuilderCustom
<a href="https://bugs.webkit.org/show_bug.cgi?id=287054">https://bugs.webkit.org/show_bug.cgi?id=287054</a>
<a href="https://rdar.apple.com/144200455">rdar://144200455</a>

Reviewed by Sam Weinig.

Check for expected types.

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueZoom):
(WebCore::Style::BuilderCustom::applyValueVerticalAlign):
(WebCore::Style::BuilderCustom::applyValueTextIndent):
(WebCore::Style::BuilderCustom::applyValueLineHeight):
(WebCore::Style::BuilderCustom::applyValueWebkitLocale):
(WebCore::Style::BuilderCustom::applyValueWebkitTextSizeAdjust):
(WebCore::Style::BuilderCustom::applyValueWebkitTextZoom):
(WebCore::Style::BuilderCustom::applyValueTextShadow):
(WebCore::Style::BuilderCustom::applyValueBoxShadow):
(WebCore::Style::BuilderCustom::applyValueFontFamily):
(WebCore::Style::BuilderCustom::applyValueBaselineShift):
(WebCore::Style::BuilderCustom::applyValueAspectRatio):
(WebCore::Style::BuilderCustom::applyValueTextEmphasisStyle):
(WebCore::Style::BuilderCustom::applyValueCounter):
(WebCore::Style::BuilderCustom::applyValueCursor):
(WebCore::Style::BuilderCustom::applyValueFill):
(WebCore::Style::BuilderCustom::applyValueStroke):
(WebCore::Style::BuilderCustom::applyValueContent):
(WebCore::Style::BuilderCustom::applyValueFontSize):
(WebCore::Style::BuilderCustom::applyValueGridTemplateAreas):
(WebCore::Style::BuilderCustom::applyValueContainIntrinsicWidth):
(WebCore::Style::BuilderCustom::applyValueContainIntrinsicHeight):

Canonical link: <a href="https://commits.webkit.org/289877@main">https://commits.webkit.org/289877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a4a7bb54aebf597b93065f08c690a6c5d76151a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68039 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79758 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48407 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38039 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94980 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15351 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11260 "Found 1 new test failure: imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75614 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76144 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18752 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8378 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20668 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->