### PR TITLE
[libpas] Add a signal for if PGM is enabled on a process

### DIFF
--- a/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
+++ b/Source/JavaScriptCore/API/PASReportCrashPrivate.cpp
@@ -32,6 +32,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #if !USE(SYSTEM_MALLOC)
 #include <bmalloc/BPlatform.h>
 #if BENABLE(LIBPAS)
+#include <bmalloc/pas_probabilistic_guard_malloc_allocator.h>
 #include <bmalloc/pas_report_crash.h>
 #endif
 #endif
@@ -41,6 +42,16 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 using namespace JSC;
 
 #ifdef __APPLE__
+kern_return_t PASPGMEnabledOnProcess()
+{
+#if !USE(SYSTEM_MALLOC)
+#if BENABLE(LIBPAS)
+    return pas_probabilistic_guard_malloc_enabled_on_process() ? KERN_SUCCESS : KERN_FAILURE;
+#endif /* BENABLE(LIBPAS) */
+#endif /* !USE(SYSTEM_MALLOC) */
+    return KERN_FAILURE;
+}
+
 kern_return_t PASReportCrashExtractResults(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader)
 {
 #if !USE(SYSTEM_MALLOC)

--- a/Source/JavaScriptCore/API/PASReportCrashPrivate.h
+++ b/Source/JavaScriptCore/API/PASReportCrashPrivate.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+JS_EXPORT kern_return_t PASPGMEnabledOnProcess(void);
 JS_EXPORT kern_return_t PASReportCrashExtractResults(vm_address_t fault_address, mach_vm_address_t pas_dead_root, unsigned version, task_t task, pas_report_crash_pgm_report *report, crash_reporter_memory_reader_t crm_reader);
 
 #ifdef __cplusplus

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -54,6 +54,7 @@
 
 #include "pas_utils.h"
 #include "pas_large_heap.h"
+#include "pas_large_map_entry.h"
 #include "pas_ptr_hash_map.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -124,6 +125,7 @@ size_t pas_probabilistic_guard_malloc_get_free_wasted_memory(void);
 pas_ptr_hash_map_entry* pas_probabilistic_guard_malloc_get_metadata_array(void);
 
 bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem);
+bool pas_probabilistic_guard_malloc_enabled_on_process(void);
 
 /*
  * Determine whether PGM can be called at runtime.


### PR DESCRIPTION
#### f880a138724d2d31485d83b359f1fee597068e40
<pre>
[libpas] Add a signal for if PGM is enabled on a process
<a href="https://bugs.webkit.org/show_bug.cgi?id=287056">https://bugs.webkit.org/show_bug.cgi?id=287056</a>
<a href="https://rdar.apple.com/144202533">rdar://144202533</a>

Reviewed by Yusuke Suzuki.

This patch adds a new function to be exposed that checks if the
`pas_probabilistic_guard_malloc_can_use` value is true or false, which
is what modulates if PGM is enabled on this process during initalization
of the heap.

It also exposes this function through a JSC SPI that allows us to use
this in other places to know if PGM was enabled at all in this process,
regardless of if we made any guarded allocations or not.

This approach is better than putting additional information in the
metadata, because metadata is only generated on PGM allocations and
deallocations, which we are not guaranteed to have due to how unlikely
they are. By exposing whether or not PGM was enabled for this process
deterministically, it can help us catch bugs or crashes in the actual
implementation.

* Source/JavaScriptCore/API/PASReportCrashPrivate.cpp:
(PASPGMEnabledOnProcess):
* Source/JavaScriptCore/API/PASReportCrashPrivate.h:
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_enabled_on_process):
(pas_probabilistic_guard_malloc_initialize_pgm_as_enabled):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:

Canonical link: <a href="https://commits.webkit.org/293336@main">https://commits.webkit.org/293336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90358639ebb42208584e29bd3537acaf4691d840

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26694 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/75066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32217 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7023 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48580 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/91297 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83796 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/7101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/97239 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18725 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/106118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85259 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/106118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21096 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5849 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19390 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25658 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/30840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/120857 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25476 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->