### PR TITLE
Unreviewed, fix the internal iOS engineering build

### DIFF
--- a/Tools/TestWebKitAPI/Tests/ios/SelectionByWord.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/SelectionByWord.mm
@@ -73,11 +73,10 @@ TEST(SelectionTests, SelectWordForReplacementWithDictationAlternative)
     EXPECT_WK_STREQ("foo bar", [webView selectedText]);
 }
 
-@interface SelectionChangeListener : NSObject<
+@interface SelectionChangeListener : NSObject
 #if USE(BROWSERENGINEKIT)
-    BETextInputDelegate,
+    <BETextInputDelegate>
 #endif
-    UITextInputDelegate>
 @property (nonatomic) dispatch_block_t selectionWillChangeHandler;
 @property (nonatomic) dispatch_block_t selectionDidChangeHandler;
 @end
@@ -168,12 +167,12 @@ TEST(SelectionTests, SelectWordForReplacementWithDictationAlternative)
 
 TEST(SelectionTests, SelectedTextAfterSelectingWordForReplacement)
 {
-    auto listener = adoptNS([[SelectionChangeListener alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] init]);
+    RetainPtr listener = adoptNS([[SelectionChangeListener alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
     [webView synchronouslyLoadHTMLString:@"<body contenteditable><p>Hello</p></body><script>document.body.focus()</script>"];
 
     auto contentView = [webView textInputContentView];
-    [contentView setInputDelegate:listener.get()];
+    [contentView setInputDelegate:static_cast<id<UITextInputDelegate>>(listener.get())];
 
 #if USE(BROWSERENGINEKIT)
     [webView asyncTextInput].asyncInputDelegate = listener.get();


### PR DESCRIPTION
#### 957ddd0c775176faf735e912d553937bd5c9f2f7
<pre>
Unreviewed, fix the internal iOS engineering build
<a href="https://rdar.apple.com/144198780">rdar://144198780</a>

Fix the internal iOS build after the changes in <a href="https://rdar.apple.com/141708947">rdar://141708947</a>, which adds a new required method
to the `UITextInputDelegate` protocol. Change this mock testing object (whose only purpose is to
observe calls to `-selection{Will|Did}Change:`) so that it no longer conforms to
`UITextInputDelegate` at compile-time, and instead cast it to `id&lt;UITextInputDelegate&gt;` at runtime.

This is fine in practice, since there&apos;s no WebKit code that invokes the new required method from
within WebKit.

* Tools/TestWebKitAPI/Tests/ios/SelectionByWord.mm:
(TEST(SelectionTests, SelectedTextAfterSelectingWordForReplacement)):

Canonical link: <a href="https://commits.webkit.org/289848@main">https://commits.webkit.org/289848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f8c41fdcf8c84f0570bf2ecaa2f9263e338f8e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42604 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/38946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15893 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/93149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/38946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91198 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/79764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/5957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38054 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15366 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75620 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18731 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20539 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/18947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15384 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/18572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/16908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->