### PR TITLE
Common types used across [Platform]MouseEvent.h should be declared in a standalone header

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1118,6 +1118,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/MessagePortIdentifier.h
     dom/MouseEvent.h
     dom/MouseEventInit.h
+    dom/MouseEventTypes.h
     dom/MouseRelatedEvent.h
     dom/MutationEvent.h
     dom/MutationObserver.h

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -57,7 +57,6 @@
 #include "ModelPlayerProvider.h"
 #include "MouseEvent.h"
 #include "Page.h"
-#include "PlatformMouseEvent.h"
 #include "RenderBoxInlines.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -26,8 +26,8 @@
 
 #include "EventTarget.h"
 #include "MouseEventInit.h"
+#include "MouseEventTypes.h"
 #include "MouseRelatedEvent.h"
-#include "PlatformMouseEvent.h"
 
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 #include "PlatformTouchEventIOS.h"

--- a/Source/WebCore/dom/MouseEventTypes.h
+++ b/Source/WebCore/dom/MouseEventTypes.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <wtf/EnumTraits.h>
+
+namespace WebCore {
+
+static constexpr double ForceAtClick = 1;
+static constexpr double ForceAtForceClick = 2;
+
+enum class SyntheticClickType : uint8_t { NoTap, OneFingerTap, TwoFingerTap };
+
+// These button numbers match the ones used in the DOM API, 0 through 2, except for None and Other which aren't specified.
+// We reserve -2 for the former and -1 to represent pointer events that indicate that the pressed mouse button hasn't
+// changed since the last event, as specified in the DOM API for Pointer Events.
+// https://w3c.github.io/uievents/#dom-mouseevent-button
+// https://w3c.github.io/pointerevents/#the-button-property
+enum class MouseButton : int8_t { None = -2, PointerHasNotChanged, Left, Middle, Right, Other };
+
+inline MouseButton buttonFromShort(int16_t buttonValue)
+{
+    static constexpr std::array knownMouseButtonCases { MouseButton::None, MouseButton::PointerHasNotChanged, MouseButton::Left, MouseButton::Middle, MouseButton::Right };
+    bool isKnownButton = std::ranges::any_of(knownMouseButtonCases, [buttonValue](MouseButton button) {
+        return buttonValue == enumToUnderlyingType(button);
+    });
+    return isKnownButton ? static_cast<MouseButton>(buttonValue) : MouseButton::Other;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -59,6 +59,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
+#include "MouseEventTypes.h"
 #include "MutationEvent.h"
 #include "NodeName.h"
 #include "NodeRareDataInlines.h"

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -27,8 +27,8 @@
 #include "PointerEvent.h"
 
 #include "EventNames.h"
+#include "MouseEventTypes.h"
 #include "Node.h"
-#include "PlatformMouseEvent.h"
 #include "PointerEventTypeNames.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -32,7 +32,6 @@
 #include "Element.h"
 #include "EventNames.h"
 #include "MouseEvent.h"
-#include "PlatformMouseEvent.h"
 #include "PointerEvent.h"
 #include "PointerID.h"
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -26,8 +26,8 @@
 
 #include "DataTransfer.h"
 #include "EventNames.h"
+#include "MouseEventTypes.h"
 #include "Node.h"
-#include "PlatformMouseEvent.h"
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/dom/ios/MouseEventIOS.cpp
+++ b/Source/WebCore/dom/ios/MouseEventIOS.cpp
@@ -25,7 +25,6 @@
 
 #import "config.h"
 #import "MouseEvent.h"
-#import "PlatformMouseEvent.h"
 
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -29,7 +29,7 @@
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY)
 
 #import "EventNames.h"
-#import "PlatformMouseEvent.h"
+#import "MouseEventTypes.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -45,7 +45,6 @@
 #include "MouseEvent.h"
 #include "OriginAccessPatterns.h"
 #include "PingLoader.h"
-#include "PlatformMouseEvent.h"
 #include "PlatformStrategies.h"
 #include "PrivateClickMeasurement.h"
 #include "RegistrableDomain.h"

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -65,7 +65,6 @@
 #include "NodeName.h"
 #include "NodeRenderStyle.h"
 #include "Page.h"
-#include "PlatformMouseEvent.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "RadioInputType.h"
 #include "RenderStyleSetters.h"

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -53,7 +53,6 @@
 #include "NodeName.h"
 #include "NodeRareData.h"
 #include "Page.h"
-#include "PlatformMouseEvent.h"
 #include "RenderListBox.h"
 #include "RenderMenuList.h"
 #include "RenderTheme.h"

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -38,7 +38,6 @@
 #include "LocalFrame.h"
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
-#include "PlatformMouseEvent.h"
 #include "Quirks.h"
 #include "RenderSearchField.h"
 #include "RenderStyleSetters.h"

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -33,6 +33,7 @@
 #include "HitTestResult.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "MouseEventTypes.h"
 #include "Page.h"
 #include "RenderBox.h"
 #include "RenderListBox.h"

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -33,6 +33,7 @@
 #include "EventNames.h"
 #include "EventTarget.h"
 #include "HitTestResult.h"
+#include "MouseEventTypes.h"
 #include "Page.h"
 #include "PointerEvent.h"
 #include "Quirks.h"

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -26,7 +26,7 @@
 
 #include "EventTarget.h"
 #include "ExceptionOr.h"
-#include "PlatformMouseEvent.h"
+#include "MouseEventTypes.h"
 #include "PointerID.h"
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -42,6 +42,7 @@
 #import "KeyboardEvent.h"
 #import "LocalFrame.h"
 #import "LocalFrameView.h"
+#import "MouseEventTypes.h"
 #import "MouseEventWithHitTestResults.h"
 #import "Page.h"
 #import "Pasteboard.h"

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -43,6 +43,7 @@
 #import "LocalFrame.h"
 #import "LocalFrameView.h"
 #import "Logging.h"
+#import "MouseEventTypes.h"
 #import "Page.h"
 #import "PageOverlayController.h"
 #import "Settings.h"

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "IntPoint.h"
+#include "MouseEventTypes.h"
 #include "PlatformEvent.h"
 #include "PointerEventTypeNames.h"
 #include "PointerID.h"
@@ -33,17 +34,6 @@
 #include <wtf/WindowsExtras.h>
 
 namespace WebCore {
-
-const double ForceAtClick = 1;
-const double ForceAtForceClick = 2;
-
-// These button numbers match the ones used in the DOM API, 0 through 2, except for None and Other which aren't specified.
-// We reserve -2 for the former and -1 to represent pointer events that indicate that the pressed mouse button hasn't
-// changed since the last event, as specified in the DOM API for Pointer Events.
-// https://w3c.github.io/uievents/#dom-mouseevent-button
-// https://w3c.github.io/pointerevents/#the-button-property
-enum class MouseButton : int8_t { None = -2, PointerHasNotChanged, Left, Middle, Right, Other };
-enum class SyntheticClickType : uint8_t { NoTap, OneFingerTap, TwoFingerTap };
 
 class PlatformMouseEvent : public PlatformEvent {
 public:

--- a/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
@@ -32,6 +32,7 @@
 #import "KeyEventCocoa.h"
 #import "KeyEventCodesIOS.h"
 #import "Logging.h"
+#import "MouseEventTypes.h"
 #import "WAKAppKitStubs.h"
 #import "WebEvent.h"
 #import "WindowsKeyboardCodes.h"

--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -30,6 +30,7 @@
 
 #import "KeyEventCocoa.h"
 #import "Logging.h"
+#import "MouseEventTypes.h"
 #import "PlatformScreen.h"
 #import "Scrollbar.h"
 #import "WindowsKeyboardCodes.h"

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -46,7 +46,6 @@
 #include "Page.h"
 #include "PaintInfo.h"
 #include "Path.h"
-#include "PlatformMouseEvent.h"
 #include "PluginViewBase.h"
 #include "RenderBoxInlines.h"
 #include "RenderLayoutState.h"

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -55,7 +55,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/LayoutMilestone.h>
-#include <WebCore/PlatformMouseEvent.h>
+#include <WebCore/MouseEventTypes.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/UserContentTypes.h>
 #include <WebCore/UserScriptTypes.h>

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -30,6 +30,7 @@
 #include "WebMouseEvent.h"
 #include "WebTouchEvent.h"
 #include "WebWheelEvent.h"
+#include <WebCore/PlatformMouseEvent.h>
 
 #if ENABLE(MAC_GESTURE_EVENTS)
 #include "WebGestureEvent.h"

--- a/Source/WebKit/Shared/WebMouseEvent.cpp
+++ b/Source/WebKit/Shared/WebMouseEvent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebMouseEvent.h"
 
+#include <WebCore/MouseEventTypes.h>
 #include <WebCore/NavigationAction.h>
 
 namespace WebKit {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -84,6 +84,7 @@
 #include <WebCore/JSRange.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/MouseEventTypes.h>
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/Page.h>
 #include <WebCore/PluginDocument.h>

--- a/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
+++ b/Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm
@@ -40,7 +40,6 @@
 #import <WebCore/HTMLFormElement.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/MouseEvent.h>
-#import <WebCore/PlatformMouseEvent.h>
 #import <WebKitLegacy/WebDataSourcePrivate.h>
 #import <WebKitLegacy/WebFramePrivate.h>
 #import <WebKitLegacy/WebJSPDFDoc.h>

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -93,6 +93,7 @@
 #import <WebCore/LocalFrame.h>
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/MIMETypeRegistry.h>
+#import <WebCore/MouseEventTypes.h>
 #import <WebCore/MutableStyleProperties.h>
 #import <WebCore/OriginAccessPatterns.h>
 #import <WebCore/Page.h>

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -61,7 +61,6 @@
 #import <WebCore/LocalFrame.h>
 #import <WebCore/MouseEvent.h>
 #import <WebCore/PlatformEventFactoryMac.h>
-#import <WebCore/PlatformMouseEvent.h>
 #import <WebCore/Range.h>
 #import <WebCore/ReferrerPolicy.h>
 #import <WebCore/SimpleRange.h>

--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -39,7 +39,7 @@
 #import "DumpRenderTreePasteboard.h"
 #import "ModifierKeys.h"
 #import "WebCoreTestSupport.h"
-#import <WebCore/PlatformMouseEvent.h>
+#import <WebCore/MouseEventTypes.h>
 #import <WebKit/DOMPrivate.h>
 #import <WebKit/WebViewPrivate.h>
 #import <functional>

--- a/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm
@@ -27,6 +27,7 @@
 
 #import "PlatformUtilities.h"
 #import <Carbon/Carbon.h> // For GetCurrentEventTime
+#import <WebCore/MouseEventTypes.h>
 #import <WebCore/PlatformEventFactoryMac.h>
 #import <pal/spi/mac/NSMenuSPI.h>
 #import <wtf/RetainPtr.h>

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -35,7 +35,7 @@
 #import "TestRunnerWKWebView.h"
 #import "WebKitTestRunnerWindow.h"
 #import <Carbon/Carbon.h>
-#import <WebCore/PlatformMouseEvent.h>
+#import <WebCore/MouseEventTypes.h>
 #import <WebKit/WKString.h>
 #import <WebKit/WKPagePrivate.h>
 #import <WebKit/WKWebView.h>


### PR DESCRIPTION
#### 0bfd0b0c2c3be61710f849f4d63f510f29b0a9b1
<pre>
Common types used across [Platform]MouseEvent.h should be declared in a standalone header
<a href="https://bugs.webkit.org/show_bug.cgi?id=287059">https://bugs.webkit.org/show_bug.cgi?id=287059</a>
<a href="https://rdar.apple.com/144204277">rdar://144204277</a>

Reviewed by Wenson Hsieh and Aditya Keerthi.

There are some common types/constants used across [Platform]MouseEvent.h
that often need to be referenced throughout the codebase in other
projects (WebKit/WKTR/TestWebKitAPI/etc.), and having these types be
defined across the event headers makes for quite heavy include costs.
For example, pulling in WebCore/MouseEvent.h from DumpRenderTree also
necessitates the inclusion of WebCore/Node.h.

This patch splits out some of these common types/constants into a
separate header, namely MouseEventTypes.h. It also introduces a helper
function WebCore::buttonFromShort(), that will be used from some test
harness code in a forthcoming patch.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/MouseEvent.h:
* Source/WebCore/dom/MouseEventTypes.h: Added.
(WebCore::buttonFromShort):
* Source/WebCore/dom/Node.cpp:
* Source/WebCore/dom/PointerEvent.cpp:
* Source/WebCore/dom/SimulatedClick.cpp:
* Source/WebCore/dom/WheelEvent.cpp:
* Source/WebCore/dom/ios/MouseEventIOS.cpp:
* Source/WebCore/dom/ios/PointerEventIOS.cpp:
* Source/WebCore/html/HTMLAnchorElement.cpp:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/html/HTMLSelectElement.cpp:
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
* Source/WebCore/page/AutoscrollController.cpp:
* Source/WebCore/page/PointerCaptureController.cpp:
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
* Source/WebCore/page/mac/ServicesOverlayController.mm:
* Source/WebCore/platform/PlatformMouseEvent.h:
* Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm:
* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
* Source/WebKit/Shared/WebEventConversion.cpp:
* Source/WebKit/Shared/WebMouseEvent.cpp:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
* Source/WebKitLegacy/ios/WebView/WebPDFViewPlaceholder.mm:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
* Tools/DumpRenderTree/mac/EventSendingController.mm:
* Tools/TestWebKitAPI/Tests/mac/MenuTypesForMouseEvents.mm:
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:

Canonical link: <a href="https://commits.webkit.org/289859@main">https://commits.webkit.org/289859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70cfffa143520b86a7e34e7d29652ba9f7c3f2c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68064 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25785 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79796 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48433 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95030 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15401 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76929 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75652 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76174 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8428 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15419 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->