### PR TITLE
Fix safer C++ warnings in MediaPlayerPrivate classes

### DIFF
--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -42,6 +42,7 @@ public:
 #if !RELEASE_LOG_DISABLED
 
 #define LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(logClassName(), __func__, logIdentifier())
+#define LOGIDENTIFIER_WITH_THIS(thisPtr) WTF::Logger::LogSiteIdentifier(thisPtr->logClassName(), __func__, thisPtr->logIdentifier())
 
 #if VERBOSE_RELEASE_LOG
 #define ALWAYS_LOG(...)     Ref { logger() }->logAlwaysVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
@@ -57,6 +58,7 @@ public:
 #define DEBUG_LOG(...)      Ref { logger() }->debug(logChannel(), __VA_ARGS__)
 
 #define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { thisPtr->logger() }->logAlways(thisPtr->logChannel(), __VA_ARGS__)
+#define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { thisPtr->logger() }->error(thisPtr->logChannel(), __VA_ARGS__)
 #endif
 
 #define WILL_LOG(_level_)   Ref { logger() }->willLog(logChannel(), _level_)

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1130,14 +1130,12 @@ platform/graphics/WidthIterator.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
-platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
 platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
 platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -1160,7 +1158,6 @@ platform/graphics/cg/ShareableBitmapCG.mm
 platform/graphics/cocoa/CMUtilities.mm
 platform/graphics/cocoa/FontCacheCoreText.cpp
 platform/graphics/cocoa/ImageAdapterCocoa.mm
-platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
 platform/graphics/cocoa/SourceBufferParser.cpp
 platform/graphics/cocoa/SourceBufferParserWebM.cpp
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -161,15 +161,12 @@ platform/encryptedmedia/clearkey/CDMClearKey.cpp
 platform/graphics/FontCascadeFonts.cpp
 platform/graphics/SourceBufferPrivate.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
-platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
-platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/cocoa/WebCoreDecompressionSession.mm
 platform/graphics/filters/FilterOperation.cpp

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -266,8 +266,9 @@ void MediaPlayerPrivateAVFoundation::seekToTarget(const SeekTarget& target)
 {
     if (m_seeking) {
         ALWAYS_LOG(LOGIDENTIFIER, "saving pending seek");
-        m_pendingSeek = [this, target]() {
-            seekToTarget(target);
+        m_pendingSeek = [weakThis = ThreadSafeWeakPtr { * this }, target]() {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->seekToTarget(target);
         };
         return;
     }
@@ -280,8 +281,8 @@ void MediaPlayerPrivateAVFoundation::seekToTarget(const SeekTarget& target)
     if (target.time > duration())
         adjustedTarget.time = duration();
 
-    if (currentTextTrack())
-        currentTextTrack()->beginSeeking();
+    if (RefPtr track = currentTextTrack())
+        track->beginSeeking();
 
     ALWAYS_LOG(LOGIDENTIFIER, "seeking to ", adjustedTarget.time);
 
@@ -781,7 +782,7 @@ void MediaPlayerPrivateAVFoundation::processNewAndRemovedTextTracks(const Vector
                 continue;
             }
             if (player)
-                player->removeTextTrack(*m_textTracks[i]);
+                player->removeTextTrack(Ref { *m_textTracks[i] });
             m_textTracks.remove(i);
         }
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -256,6 +256,8 @@ private:
     void updateDisplayLayer();
     RefPtr<VideoMediaSampleRenderer> layerOrVideoRenderer() const;
 
+    RefPtr<MediaSourcePrivateAVFObjC> protectedMediaSourcePrivate() const;
+
     // NOTE: Because the only way for MSE to recieve data is through an ArrayBuffer provided by
     // javascript running in the page, the video will, by necessity, always be CORS correct and
     // in the page's origin.
@@ -408,7 +410,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
     std::unique_ptr<VideoLayerManagerObjC> m_videoLayerManager;
-    Ref<EffectiveRateChangedListener> m_effectiveRateChangedListener;
+    const Ref<EffectiveRateChangedListener> m_effectiveRateChangedListener;
     uint64_t m_sampleCount { 0 };
     RetainPtr<id> m_videoFrameMetadataGatheringObserver;
     bool m_isGatheringVideoFrameMetadata { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -133,9 +133,9 @@ public:
 
     void effectiveRateChanged()
     {
-        callOnMainThread([this, protectedThis = Ref { *this }] {
-            if (m_client)
-                m_client->effectiveRateChanged();
+        callOnMainThread([protectedThis = Ref { *this }] {
+            if (RefPtr client = protectedThis->m_client.get())
+                client->effectiveRateChanged();
         });
     }
 
@@ -335,8 +335,10 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const LoadOptions& o
         client.reOpen();
     } else
         m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
-    m_mediaSourcePrivate->setResourceOwner(m_resourceOwner);
-    m_mediaSourcePrivate->setVideoRenderer(layerOrVideoRenderer().get());
+
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    mediaSourcePrivate->setResourceOwner(m_resourceOwner);
+    mediaSourcePrivate->setVideoRenderer(layerOrVideoRenderer().get());
     m_loadOptions = options;
 
     acceleratedRenderingStateChanged();
@@ -370,16 +372,17 @@ void MediaPlayerPrivateMediaSourceAVFObjC::play()
 
 void MediaPlayerPrivateMediaSourceAVFObjC::playInternal(std::optional<MonotonicTime>&& hostTime)
 {
-    if (!m_mediaSourcePrivate)
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    if (!mediaSourcePrivate)
         return;
 
-    if (currentTime() >= m_mediaSourcePrivate->duration()) {
-        ALWAYS_LOG(LOGIDENTIFIER, "bailing, current time: ", currentTime(), " greater than duration ", m_mediaSourcePrivate->duration());
+    if (currentTime() >= mediaSourcePrivate->duration()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "bailing, current time: ", currentTime(), " greater than duration ", mediaSourcePrivate->duration());
         return;
     }
 
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_mediaSourcePrivate->flushActiveSourceBuffersIfNeeded();
+    mediaSourcePrivate->flushActiveSourceBuffersIfNeeded();
     m_isPlaying = true;
     if (!shouldBePlaying())
         return;
@@ -432,18 +435,14 @@ FloatSize MediaPlayerPrivateMediaSourceAVFObjC::naturalSize() const
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::hasVideo() const
 {
-    if (!m_mediaSourcePrivate)
-        return false;
-
-    return m_mediaSourcePrivate->hasVideo();
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate && mediaSourcePrivate->hasVideo();
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::hasAudio() const
 {
-    if (!m_mediaSourcePrivate)
-        return false;
-
-    return m_mediaSourcePrivate->hasAudio();
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate && mediaSourcePrivate->hasAudio();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
@@ -458,9 +457,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
 
         // Rendering may have been interrupted while the page was in a non-visible
         // state, which would require a flush to resume decoding.
-        if (m_mediaSourcePrivate) {
+        if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate) {
             SetForScope(m_flushingActiveSourceBuffersDueToVisibilityChange, true, false);
-            m_mediaSourcePrivate->flushActiveSourceBuffersIfNeeded();
+            mediaSourcePrivate->flushActiveSourceBuffersIfNeeded();
         }
     }
 
@@ -471,7 +470,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible(bool visible)
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::duration() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->duration() : MediaTime::zeroTime();
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate ? mediaSourcePrivate->duration() : MediaTime::zeroTime();
 }
 
 MediaTime MediaPlayerPrivateMediaSourceAVFObjC::currentTime() const
@@ -557,43 +557,46 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
     if (!m_pendingSeek)
         return;
 
-    if (!m_mediaSourcePrivate)
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    if (!mediaSourcePrivate)
         return;
 
     auto pendingSeek = std::exchange(m_pendingSeek, { }).value();
     m_lastSeekTime = pendingSeek.time;
 
     m_seekState = Seeking;
-    m_mediaSourcePrivate->waitForTarget(pendingSeek)->whenSettled(RunLoop::current(), [this, weakThis = WeakPtr { *this }] (auto&& result) mutable {
-        if (!weakThis)
+    mediaSourcePrivate->waitForTarget(pendingSeek)->whenSettled(RunLoop::protectedCurrent(), [weakThis = WeakPtr { *this }] (auto&& result) mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
-        if (m_seekState != Seeking || !result) {
-            ALWAYS_LOG(LOGIDENTIFIER, "seek Interrupted, aborting");
+        if (protectedThis->m_seekState != Seeking || !result) {
+            ALWAYS_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "seek Interrupted, aborting");
             return;
         }
         auto seekedTime = *result;
-        m_lastSeekTime = seekedTime;
+        protectedThis->m_lastSeekTime = seekedTime;
 
-        ALWAYS_LOG(LOGIDENTIFIER);
-        MediaTime synchronizerTime = PAL::toMediaTime([m_synchronizer currentTime]);
+        ALWAYS_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis));
+        MediaTime synchronizerTime = PAL::toMediaTime([protectedThis->m_synchronizer currentTime]);
 
-        m_isSynchronizerSeeking = m_isSynchronizerSeeking = std::abs((synchronizerTime - seekedTime).toMicroseconds()) > 1000;
+        protectedThis->m_isSynchronizerSeeking = protectedThis->m_isSynchronizerSeeking = std::abs((synchronizerTime - seekedTime).toMicroseconds()) > 1000;
 
-        ALWAYS_LOG(LOGIDENTIFIER, "seekedTime = ", seekedTime, ", synchronizerTime = ", synchronizerTime, "synchronizer seeking = ", m_isSynchronizerSeeking);
+        ALWAYS_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "seekedTime = ", seekedTime, ", synchronizerTime = ", synchronizerTime, "synchronizer seeking = ", protectedThis->m_isSynchronizerSeeking);
 
-        if (!m_isSynchronizerSeeking) {
+        if (!protectedThis->m_isSynchronizerSeeking) {
             // In cases where the destination seek time precisely matches the synchronizer's existing time
             // no time jumped notification will be issued. In this case, just notify the MediaPlayer that
             // the seek completed successfully.
-            maybeCompleteSeek();
+            protectedThis->maybeCompleteSeek();
             return;
         }
-        m_mediaSourcePrivate->willSeek();
-        [m_synchronizer setRate:0 time:PAL::toCMTime(seekedTime)];
+        RefPtr mediaSourcePrivate = protectedThis->m_mediaSourcePrivate;
+        mediaSourcePrivate->willSeek();
+        [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(seekedTime)];
 
-        m_mediaSourcePrivate->seekToTime(seekedTime)->whenSettled(RunLoop::current(), [this, weakThis = WTFMove(weakThis)]() mutable {
-            if (weakThis)
-                maybeCompleteSeek();
+        mediaSourcePrivate->seekToTime(seekedTime)->whenSettled(RunLoop::protectedCurrent(), [weakThis = WTFMove(weakThis)]() mutable {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->maybeCompleteSeek();
         });
     });
 }
@@ -688,6 +691,11 @@ const PlatformTimeRanges& MediaPlayerPrivateMediaSourceAVFObjC::buffered() const
     return PlatformTimeRanges::emptyRanges();
 }
 
+RefPtr<MediaSourcePrivateAVFObjC> MediaPlayerPrivateMediaSourceAVFObjC::protectedMediaSourcePrivate() const
+{
+    return m_mediaSourcePrivate;
+}
+
 void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
 {
     if (m_gapObserver) {
@@ -695,7 +703,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
         m_gapObserver = nullptr;
     }
 
-    auto ranges = m_mediaSourcePrivate->buffered();
+    auto ranges = protectedMediaSourcePrivate()->buffered();
     auto currentTime = this->currentTime();
     size_t index = ranges.find(currentTime);
     if (index == notFound)
@@ -710,19 +718,20 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
             auto logSiteIdentifier = LOGIDENTIFIER;
             UNUSED_PARAM(logSiteIdentifier);
 
-            m_gapObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[weakThis = WeakPtr { *this }, this, logSiteIdentifier, gapStart] {
-                if (!weakThis)
+            m_gapObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[weakThis = WeakPtr { *this }, logSiteIdentifier, gapStart] {
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis)
                     return;
-                if (m_mediaSourcePrivate->hasFutureTime(gapStart))
+                if (protectedThis->protectedMediaSourcePrivate()->hasFutureTime(gapStart))
                     return; // New data was added, don't stall.
-                MediaTime now = weakThis->currentTime();
-                ALWAYS_LOG(logSiteIdentifier, "boundary time observer called, now = ", now);
+                MediaTime now = protectedThis->currentTime();
+                ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
 
-                if (gapStart == duration())
-                    weakThis->pauseInternal();
+                if (gapStart == protectedThis->duration())
+                    protectedThis->pauseInternal();
                 // Experimentation shows that between the time the boundary time observer is called, the time have progressed by a few milliseconds. Re-adjust time. This seek doesn't require re-enqueuing/flushing.
-                [m_synchronizer setRate:0 time:PAL::toCMTime(gapStart)];
-                if (auto player = m_player.get())
+                [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(gapStart)];
+                if (RefPtr player = protectedThis->m_player.get())
                     player->timeChanged();
             }];
             return;
@@ -822,7 +831,8 @@ RefPtr<VideoFrame> MediaPlayerPrivateMediaSourceAVFObjC::videoFrameForCurrentTim
 DestinationColorSpace MediaPlayerPrivateMediaSourceAVFObjC::colorSpace()
 {
     updateLastImage();
-    return m_lastImage ? m_lastImage->colorSpace() : DestinationColorSpace::SRGB();
+    RefPtr lastImage = m_lastImage;
+    return lastImage ? lastImage->colorSpace() : DestinationColorSpace::SRGB();
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::hasAvailableVideoFrame() const
@@ -862,11 +872,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged()
     RefPtr renderer = layerOrVideoRenderer();
     if (willUseDecompressionSessionIfNeeded()) {
         if (renderer && !renderer->isUsingDecompressionSession()) {
-            if (m_mediaSourcePrivate)
-                m_mediaSourcePrivate->videoRendererWillReconfigure(*renderer);
+            if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+                mediaSourcePrivate->videoRendererWillReconfigure(*renderer);
             renderer->setPrefersDecompressionSession(true);
-            if (m_mediaSourcePrivate)
-                m_mediaSourcePrivate->videoRendererDidReconfigure(*renderer);
+            if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+                mediaSourcePrivate->videoRendererDidReconfigure(*renderer);
             return;
         }
         if (renderer)
@@ -1202,7 +1212,8 @@ MediaPlayerPrivateMediaSourceAVFObjC::AcceleratedVideoMode MediaPlayerPrivateMed
 bool MediaPlayerPrivateMediaSourceAVFObjC::canUseDecompressionSession() const
 {
     // FIXME: with shouldUseModernAVContentKeySession can a DecompressionSession be used so long as we have a AVSBDL considering the cryptor is now attached to the CMSampleBuffer?
-    return !m_mediaSourcePrivate || (!m_mediaSourcePrivate->cdmInstance() && !m_mediaSourcePrivate->needsVideoLayer());
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return !mediaSourcePrivate || (!mediaSourcePrivate->cdmInstance() && !mediaSourcePrivate->needsVideoLayer());
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::isUsingDecompressionSession() const
@@ -1320,10 +1331,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateAllRenderersHaveAvailableSample
 
 void MediaPlayerPrivateMediaSourceAVFObjC::durationChanged()
 {
-    if (!m_mediaSourcePrivate)
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    if (!mediaSourcePrivate)
         return;
 
-    MediaTime duration = m_mediaSourcePrivate->duration();
+    MediaTime duration = mediaSourcePrivate->duration();
     // Avoid emiting durationchanged in the case where the previous duration was unkniwn as that case is already handled
     // by the HTMLMediaElement.
     if (m_duration != duration && m_duration.isValid()) {
@@ -1344,16 +1356,17 @@ void MediaPlayerPrivateMediaSourceAVFObjC::sizeWillChangeAtTime(const MediaTime&
 {
     auto weakThis = m_sizeChangeObserverWeakPtrFactory.createWeakPtr(*this);
     NSArray* times = @[[NSValue valueWithCMTime:PAL::toCMTime(time)]];
-    RetainPtr<id> observer = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[this, weakThis = WTFMove(weakThis), size] {
-        if (!weakThis)
+    RetainPtr<id> observer = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[weakThis = WTFMove(weakThis), size] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
-        ASSERT(!m_sizeChangeObservers.isEmpty());
-        if (!m_sizeChangeObservers.isEmpty()) {
-            RetainPtr<id> observer = m_sizeChangeObservers.takeFirst();
-            [m_synchronizer removeTimeObserver:observer.get()];
+        ASSERT(!protectedThis->m_sizeChangeObservers.isEmpty());
+        if (!protectedThis->m_sizeChangeObservers.isEmpty()) {
+            RetainPtr<id> observer = protectedThis->m_sizeChangeObservers.takeFirst();
+            [protectedThis->m_synchronizer removeTimeObserver:observer.get()];
         }
-        setNaturalSize(size);
+        protectedThis->setNaturalSize(size);
     }];
     m_sizeChangeObservers.append(WTFMove(observer));
 
@@ -1397,16 +1410,14 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setCDMSession(LegacyCDMSession* sessi
 
     m_session = toCDMSessionAVContentKeySession(session);
 
-    if (!m_mediaSourcePrivate)
-        return;
-
-    m_mediaSourcePrivate->setCDMSession(session);
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->setCDMSession(session);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::keyAdded()
 {
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->keyAdded();
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->keyAdded();
 }
 
 #endif // ENABLE(LEGACY_ENCRYPTED_MEDIA)
@@ -1423,8 +1434,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::outputObscuredDueToInsufficientExtern
 {
 #if ENABLE(ENCRYPTED_MEDIA)
     ALWAYS_LOG(LOGIDENTIFIER, obscured);
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->outputObscuredDueToInsufficientExternalProtectionChanged(obscured);
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->outputObscuredDueToInsufficientExternalProtectionChanged(obscured);
 #else
     UNUSED_PARAM(obscured);
 #endif
@@ -1434,8 +1445,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::outputObscuredDueToInsufficientExtern
 void MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceAttached(CDMInstance& instance)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->cdmInstanceAttached(instance);
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->cdmInstanceAttached(instance);
 
     updateDisplayLayer();
 }
@@ -1443,8 +1454,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceAttached(CDMInstance& inst
 void MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceDetached(CDMInstance& instance)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->cdmInstanceDetached(instance);
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->cdmInstanceDetached(instance);
 
     updateDisplayLayer();
 }
@@ -1452,13 +1463,14 @@ void MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceDetached(CDMInstance& inst
 void MediaPlayerPrivateMediaSourceAVFObjC::attemptToDecryptWithInstance(CDMInstance& instance)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (m_mediaSourcePrivate)
-        m_mediaSourcePrivate->attemptToDecryptWithInstance(instance);
+    if (RefPtr mediaSourcePrivate = m_mediaSourcePrivate)
+        mediaSourcePrivate->attemptToDecryptWithInstance(instance);
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::waitingForKey() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->waitingForKey() : false;
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate && m_mediaSourcePrivate->waitingForKey();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::waitingForKeyChanged()
@@ -1635,7 +1647,8 @@ RetainPtr<PlatformLayer> MediaPlayerPrivateMediaSourceAVFObjC::createVideoFullsc
 void MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenLayer(PlatformLayer *videoFullscreenLayer, WTF::Function<void()>&& completionHandler)
 {
     updateLastImage();
-    m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), m_lastImage ? m_lastImage->platformImage() : nullptr);
+    RefPtr lastImage = m_lastImage;
+    m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), lastImage ? lastImage->platformImage() : nullptr);
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenFrame(FloatRect frame)
@@ -1675,10 +1688,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::setShouldPlayToPlaybackTarget(bool sh
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::isCurrentPlaybackTargetWireless() const
 {
-    if (!m_playbackTarget)
+    RefPtr playbackTarget = m_playbackTarget;
+    if (!playbackTarget)
         return false;
 
-    auto hasTarget = m_shouldPlayToTarget && m_playbackTarget->hasActiveRoute();
+    auto hasTarget = m_shouldPlayToTarget && playbackTarget->hasActiveRoute();
     INFO_LOG(LOGIDENTIFIER, hasTarget);
     return hasTarget;
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -95,6 +95,8 @@ private:
     void load(const URL&, const LoadOptions&) final;
     bool createResourceClient();
 
+    RefPtr<VideoMediaSampleRenderer> protectedVideoRenderer() const;
+
 #if ENABLE(MEDIA_SOURCE)
     void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) final;
 #endif
@@ -300,6 +302,7 @@ private:
     AcceleratedVideoMode acceleratedVideoMode() const;
 
     const Logger& logger() const final { return m_logger.get(); }
+    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const final { return "MediaPlayerPrivateWebM"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
@@ -335,7 +338,7 @@ private:
     RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;
     StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
-    Ref<SourceBufferParserWebM> m_parser;
+    const Ref<SourceBufferParserWebM> m_parser;
     const Ref<WTF::WorkQueue> m_appendQueue;
 
     MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
@@ -376,7 +379,7 @@ private:
     bool m_loadFinished { false };
     bool m_errored { false };
     bool m_processingInitializationSegment { false };
-    Ref<WebAVSampleBufferListener> m_listener;
+    const Ref<WebAVSampleBufferListener> m_listener;
 
     // Seek logic support
     void seekToTarget(const SeekTarget&) final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -302,7 +302,7 @@ void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer& buffer)
     SourceBufferParser::Segment segment(Ref { const_cast<SharedBuffer&>(buffer) });
     invokeAsync(m_appendQueue, [segment = WTFMove(segment), parser = m_parser]() mutable {
         return MediaPromise::createAndSettle(parser->appendData(WTFMove(segment)));
-    })->whenSettled(RunLoop::main(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+    })->whenSettled(RunLoop::protectedMain(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->appendCompleted(!!result);
     });
@@ -327,8 +327,8 @@ void MediaPlayerPrivateWebM::loadFinished()
 
 void MediaPlayerPrivateWebM::cancelLoad()
 {
-    if (m_resourceClient) {
-        m_resourceClient->stop();
+    if (RefPtr resourceClient = m_resourceClient) {
+        resourceClient->stop();
         m_resourceClient = nullptr;
     }
     setNetworkState(MediaPlayer::NetworkState::Idle);
@@ -425,36 +425,36 @@ void MediaPlayerPrivateWebM::seekInternal()
 
     m_seekState = Seeking;
 
-    seekTo(m_lastSeekTime)->whenSettled(RunLoop::main(), [weakThis = ThreadSafeWeakPtr { *this }, this](auto&& result) {
+    seekTo(m_lastSeekTime)->whenSettled(RunLoop::protectedMain(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         if (!result)
             return; // seek cancelled.
 
         if (RefPtr protectedThis = weakThis.get()) {
-            MediaTime synchronizerTime = PAL::toMediaTime([m_synchronizer currentTime]);
+            MediaTime synchronizerTime = PAL::toMediaTime([protectedThis->m_synchronizer currentTime]);
 
-            m_isSynchronizerSeeking = std::abs((synchronizerTime - m_lastSeekTime).toMicroseconds()) > 1000;
-            ALWAYS_LOG(LOGIDENTIFIER, "seekedTime = ", m_lastSeekTime, ", synchronizerTime = ", synchronizerTime, "synchronizer seeking = ", m_isSynchronizerSeeking);
+            protectedThis->m_isSynchronizerSeeking = std::abs((synchronizerTime - protectedThis->m_lastSeekTime).toMicroseconds()) > 1000;
+            ALWAYS_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "seekedTime = ", protectedThis->m_lastSeekTime, ", synchronizerTime = ", synchronizerTime, "synchronizer seeking = ", protectedThis->m_isSynchronizerSeeking);
 
-            if (!m_isSynchronizerSeeking) {
+            if (!protectedThis->m_isSynchronizerSeeking) {
                 // In cases where the destination seek time precisely matches the synchronizer's existing time
                 // no time jumped notification will be issued. In this case, just notify the MediaPlayer that
                 // the seek completed successfully.
-                maybeCompleteSeek();
+                protectedThis->maybeCompleteSeek();
                 return;
             }
 
-            flush();
-            [m_synchronizer setRate:0 time:PAL::toCMTime(m_lastSeekTime)];
+            protectedThis->flush();
+            [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(protectedThis->m_lastSeekTime)];
 
-            for (auto& trackBufferPair : m_trackBufferMap) {
+            for (auto& trackBufferPair : protectedThis->m_trackBufferMap) {
                 TrackBuffer& trackBuffer = trackBufferPair.second;
                 auto trackId = trackBufferPair.first;
 
                 trackBuffer.setNeedsReenqueueing(true);
-                reenqueueMediaForTime(trackBuffer, trackId, m_lastSeekTime, NeedsFlush::No);
+                protectedThis->reenqueueMediaForTime(trackBuffer, trackId, protectedThis->m_lastSeekTime, NeedsFlush::No);
             }
 
-            maybeCompleteSeek();
+            protectedThis->maybeCompleteSeek();
         }
     });
 }
@@ -636,10 +636,11 @@ RefPtr<NativeImage> MediaPlayerPrivateWebM::nativeImageForCurrentTime()
 
 bool MediaPlayerPrivateWebM::updateLastPixelBuffer()
 {
-    if (!m_videoRenderer)
+    RefPtr videoRenderer = m_videoRenderer;
+    if (!videoRenderer)
         return false;
 
-    auto entry = m_videoRenderer->copyDisplayedPixelBuffer();
+    auto entry = videoRenderer->copyDisplayedPixelBuffer();
     if (!entry.pixelBuffer)
         return false;
 
@@ -654,7 +655,8 @@ bool MediaPlayerPrivateWebM::updateLastImage()
     if (m_isGatheringVideoFrameMetadata) {
         if (!m_lastPixelBuffer)
             return false;
-        auto sampleCount = m_videoRenderer ? m_videoRenderer->totalDisplayedFrames() : 0;
+        RefPtr videoRenderer = m_videoRenderer;
+        auto sampleCount = videoRenderer ? videoRenderer->totalDisplayedFrames() : 0;
         if (sampleCount == m_lastConvertedSampleCount)
             return false;
         m_lastConvertedSampleCount = sampleCount;
@@ -703,7 +705,8 @@ RefPtr<VideoFrame> MediaPlayerPrivateWebM::videoFrameForCurrentTime()
 DestinationColorSpace MediaPlayerPrivateWebM::colorSpace()
 {
     updateLastImage();
-    return m_lastImage ? m_lastImage->colorSpace() : DestinationColorSpace::SRGB();
+    RefPtr lastImage = m_lastImage;
+    return lastImage ? lastImage->colorSpace() : DestinationColorSpace::SRGB();
 }
 
 void MediaPlayerPrivateWebM::setNaturalSize(FloatSize size)
@@ -769,20 +772,20 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
     DEBUG_LOG(logSiteIdentifier, duration);
     UNUSED_PARAM(logSiteIdentifier);
 
-    m_durationObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[weakThis = ThreadSafeWeakPtr { *this }, duration, logSiteIdentifier, this] {
+    m_durationObserver = [m_synchronizer addBoundaryTimeObserverForTimes:times queue:dispatch_get_main_queue() usingBlock:[weakThis = ThreadSafeWeakPtr { *this }, duration, logSiteIdentifier] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        MediaTime now = currentTime();
-        ALWAYS_LOG(logSiteIdentifier, "boundary time observer called, now = ", now);
+        MediaTime now = protectedThis->currentTime();
+        ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
 
-        pause();
+        protectedThis->pause();
         if (now < duration) {
-            ERROR_LOG(logSiteIdentifier, "ERROR: boundary time observer called before duration");
-            [m_synchronizer setRate:0 time:PAL::toCMTime(duration)];
+            ERROR_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "ERROR: boundary time observer called before duration");
+            [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(duration)];
         }
-        if (auto player = m_player.get())
+        if (auto player = protectedThis->m_player.get())
             player->timeChanged();
 
     }];
@@ -842,7 +845,8 @@ void MediaPlayerPrivateWebM::acceleratedRenderingStateChanged()
 void MediaPlayerPrivateWebM::updateDisplayLayer()
 {
     if (shouldEnsureLayerOrVideoRenderer()) {
-        auto needsRenderingModeChanged = !m_videoRenderer || m_videoRenderer->renderer() ? MediaPlayerEnums::NeedsRenderingModeChanged::No : MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
+        RefPtr videoRenderer = m_videoRenderer;
+        auto needsRenderingModeChanged = !videoRenderer || videoRenderer->renderer() ? MediaPlayerEnums::NeedsRenderingModeChanged::No : MediaPlayerEnums::NeedsRenderingModeChanged::Yes;
         ensureLayerOrVideoRenderer(needsRenderingModeChanged);
         return;
     }
@@ -857,7 +861,8 @@ RetainPtr<PlatformLayer> MediaPlayerPrivateWebM::createVideoFullscreenLayer()
 void MediaPlayerPrivateWebM::setVideoFullscreenLayer(PlatformLayer *videoFullscreenLayer, WTF::Function<void()>&& completionHandler)
 {
     updateLastImage();
-    m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), m_lastImage ? m_lastImage->platformImage() : nullptr);
+    RefPtr lastImage = m_lastImage;
+    m_videoLayerManager->setVideoFullscreenLayer(videoFullscreenLayer, WTFMove(completionHandler), lastImage ? lastImage->platformImage() : nullptr);
 }
 
 void MediaPlayerPrivateWebM::setVideoFullscreenFrame(FloatRect frame)
@@ -903,10 +908,11 @@ void MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget(bool shouldPlayToTarg
 
 bool MediaPlayerPrivateWebM::isCurrentPlaybackTargetWireless() const
 {
-    if (!m_playbackTarget)
+    RefPtr playbackTarget = m_playbackTarget;
+    if (!playbackTarget)
         return false;
 
-    auto hasTarget = m_shouldPlayToTarget && m_playbackTarget->hasActiveRoute();
+    auto hasTarget = m_shouldPlayToTarget && playbackTarget->hasActiveRoute();
     INFO_LOG(LOGIDENTIFIER, hasTarget);
     return hasTarget;
 }
@@ -944,8 +950,8 @@ void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID tr
         if (formatSize != m_naturalSize)
             setNaturalSize(formatSize);
 
-        if (m_videoRenderer)
-            m_videoRenderer->enqueueSample(sample);
+        if (RefPtr videoRenderer = m_videoRenderer)
+            videoRenderer->enqueueSample(sample);
 
         return;
     }
@@ -987,12 +993,13 @@ void MediaPlayerPrivateWebM::reenqueueMediaForTime(TrackBuffer& trackBuffer, Tra
 void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId)
 {
     if (isEnabledVideoTrackID(trackId)) {
-        if (!m_videoRenderer)
+        RefPtr videoRenderer = m_videoRenderer;
+        if (!videoRenderer)
             return;
 
-        m_videoRenderer->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, this, trackId] {
+        videoRenderer->requestMediaDataWhenReady([weakThis = ThreadSafeWeakPtr { *this }, trackId] {
             if (RefPtr protectedThis = weakThis.get())
-                didBecomeReadyForMoreSamples(trackId);
+                protectedThis->didBecomeReadyForMoreSamples(trackId);
         });
         return;
     }
@@ -1008,14 +1015,18 @@ void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId
 
 void MediaPlayerPrivateWebM::setMinimumUpcomingPresentationTime(TrackID trackId, const MediaTime& presentationTime)
 {
-    if (isEnabledVideoTrackID(trackId) && m_videoRenderer)
-        m_videoRenderer->expectMinimumUpcomingSampleBufferPresentationTime(presentationTime);
+    if (isEnabledVideoTrackID(trackId)) {
+        if (RefPtr videoRenderer = m_videoRenderer)
+            videoRenderer->expectMinimumUpcomingSampleBufferPresentationTime(presentationTime);
+    }
 }
 
 void MediaPlayerPrivateWebM::clearMinimumUpcomingPresentationTime(TrackID trackId)
 {
-    if (isEnabledVideoTrackID(trackId) && m_videoRenderer)
-        m_videoRenderer->resetUpcomingSampleBufferPresentationTimeExpectations();
+    if (isEnabledVideoTrackID(trackId)) {
+        if (RefPtr videoRenderer = m_videoRenderer)
+            videoRenderer->resetUpcomingSampleBufferPresentationTimeExpectations();
+    }
 }
 
 bool MediaPlayerPrivateWebM::isReadyForMoreSamples(TrackID trackId)
@@ -1025,7 +1036,7 @@ bool MediaPlayerPrivateWebM::isReadyForMoreSamples(TrackID trackId)
         if (m_displayLayerWasInterrupted)
             return false;
 #endif
-        return m_videoRenderer->isReadyForMoreMediaData();
+        return protectedVideoRenderer()->isReadyForMoreMediaData();
     }
 
     if (auto itAudioRenderer = m_audioRenderers.find(trackId); itAudioRenderer != m_audioRenderers.end())
@@ -1039,8 +1050,8 @@ void MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples(TrackID trackId)
     INFO_LOG(LOGIDENTIFIER, trackId);
 
     if (isEnabledVideoTrackID(trackId)) {
-        if (m_videoRenderer)
-            m_videoRenderer->stopRequestingMediaData();
+        if (RefPtr videoRenderer = m_videoRenderer)
+            videoRenderer->stopRequestingMediaData();
     } else if (auto itAudioRenderer = m_audioRenderers.find(trackId); itAudioRenderer != m_audioRenderers.end())
         [itAudioRenderer->second stopRequestingMediaData];
     else
@@ -1162,8 +1173,8 @@ void MediaPlayerPrivateWebM::trackDidChangeSelected(VideoTrackPrivate& track, bo
     if (isEnabledVideoTrackID(trackId)) {
         m_enabledVideoTrackID.reset();
         m_readyForMoreSamplesMap.erase(trackId);
-        if (m_videoRenderer)
-            m_videoRenderer->stopRequestingMediaData();
+        if (RefPtr videoRenderer = m_videoRenderer)
+            videoRenderer->stopRequestingMediaData();
     }
 }
 
@@ -1212,17 +1223,17 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
 #endif
             addTrackBuffer(track->id(), WTFMove(videoTrackInfo.description));
 
-            track->setSelectedChangedCallback([weakThis = ThreadSafeWeakPtr { *this }, this] (VideoTrackPrivate& track, bool selected) {
+            track->setSelectedChangedCallback([weakThis = ThreadSafeWeakPtr { *this }] (VideoTrackPrivate& track, bool selected) {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
 
-                auto videoTrackSelectedChanged = [weakThis, this, trackRef = Ref { track }, selected] {
+                auto videoTrackSelectedChanged = [weakThis, trackRef = Ref { track }, selected] {
                     if (RefPtr protectedThis = weakThis.get())
-                        trackDidChangeSelected(trackRef, selected);
+                        protectedThis->trackDidChangeSelected(trackRef, selected);
                 };
 
-                if (!m_processingInitializationSegment) {
+                if (!protectedThis->m_processingInitializationSegment) {
                     videoTrackSelectedChanged();
                     return;
                 }
@@ -1244,17 +1255,17 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
             auto track = static_pointer_cast<AudioTrackPrivateWebM>(audioTrackInfo.track);
             addTrackBuffer(track->id(), WTFMove(audioTrackInfo.description));
 
-            track->setEnabledChangedCallback([weakThis = ThreadSafeWeakPtr { *this }, this] (AudioTrackPrivate& track, bool enabled) {
+            track->setEnabledChangedCallback([weakThis = ThreadSafeWeakPtr { *this }] (AudioTrackPrivate& track, bool enabled) {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
 
-                auto audioTrackEnabledChanged = [weakThis, this, trackRef = Ref { track }, enabled] {
+                auto audioTrackEnabledChanged = [weakThis, trackRef = Ref { track }, enabled] {
                     if (RefPtr protectedThis = weakThis.get())
-                        trackDidChangeEnabled(trackRef, enabled);
+                        protectedThis->trackDidChangeEnabled(trackRef, enabled);
                 };
 
-                if (!m_processingInitializationSegment) {
+                if (!protectedThis->m_processingInitializationSegment) {
                     audioTrackEnabledChanged();
                     return;
                 }
@@ -1346,8 +1357,8 @@ void MediaPlayerPrivateWebM::flushIfNeeded()
     // We initiatively enqueue samples instead of waiting for the
     // media data requests from m_displayLayer.
     // In addition, we need to enqueue a sync sample (IDR video frame) first.
-    if (m_videoRenderer)
-        m_videoRenderer->stopRequestingMediaData();
+    if (RefPtr videoRenderer = m_videoRenderer)
+        videoRenderer->stopRequestingMediaData();
 
     if (m_enabledVideoTrackID)
         reenqueSamples(*m_enabledVideoTrackID);
@@ -1370,8 +1381,8 @@ void MediaPlayerPrivateWebM::flushTrack(TrackID trackId)
 void MediaPlayerPrivateWebM::flushVideo()
 {
     DEBUG_LOG(LOGIDENTIFIER);
-    if (m_videoRenderer)
-        m_videoRenderer->flush();
+    if (RefPtr videoRenderer = m_videoRenderer)
+        videoRenderer->flush();
     setHasAvailableVideoFrame(false);
 }
 
@@ -1389,7 +1400,7 @@ void MediaPlayerPrivateWebM::addTrackBuffer(TrackID trackId, RefPtr<MediaDescrip
     setHasVideo(m_hasVideo || description->isVideo());
 
     auto trackBuffer = TrackBuffer::create(WTFMove(description), discontinuityTolerance);
-    trackBuffer->setLogger(logger(), logIdentifier());
+    trackBuffer->setLogger(protectedLogger(), logIdentifier());
     m_trackBufferMap.try_emplace(trackId, WTFMove(trackBuffer));
 }
 
@@ -1585,7 +1596,7 @@ void MediaPlayerPrivateWebM::checkNewVideoFrameMetadata(const MediaTime& present
     VideoFrameMetadata metadata;
     metadata.width = m_naturalSize.width();
     metadata.height = m_naturalSize.height();
-    metadata.presentedFrames = m_videoRenderer->totalDisplayedFrames();
+    metadata.presentedFrames = protectedVideoRenderer()->totalDisplayedFrames();
     metadata.presentationTime = displayTime;
     metadata.expectedDisplayTime = displayTime;
     metadata.mediaTime = (m_lastPixelBufferPresentationTimeStamp.isValid() ? m_lastPixelBufferPresentationTimeStamp : presentationTime).toDouble();
@@ -1874,12 +1885,17 @@ void MediaPlayerPrivateWebM::invalidateVideoRenderer(VideoMediaSampleRenderer& v
     videoRenderer.stopRequestingMediaData();
     if (auto renderer = videoRenderer.renderer())
         m_listener->stopObservingVideoRenderer(renderer);
+}
 
+RefPtr<VideoMediaSampleRenderer> MediaPlayerPrivateWebM::protectedVideoRenderer() const
+{
+    return m_videoRenderer;
 }
 
 void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *renderer)
 {
-    if (m_videoRenderer && renderer == m_videoRenderer->renderer()) {
+    RefPtr videoRenderer = m_videoRenderer;
+    if (videoRenderer && renderer == videoRenderer->renderer()) {
         if (RefPtr expiringVideoRenderer = std::exchange(m_expiringVideoRenderer, nullptr))
             invalidateVideoRenderer(*expiringVideoRenderer);
         return;
@@ -1888,13 +1904,16 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
     ALWAYS_LOG(LOGIDENTIFIER, "!!renderer = ", !!renderer);
 
     // FIXME: VideoMediaSampleRenderer could be re-used, even as the renderer is changing.
-    if (m_videoRenderer)
-        invalidateVideoRenderer(*std::exchange(m_videoRenderer, nullptr));
+    if (videoRenderer) {
+        invalidateVideoRenderer(*videoRenderer);
+        m_videoRenderer = nullptr;
+    }
 
-    m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
-    m_videoRenderer->setPrefersDecompressionSession(true);
-    m_videoRenderer->setTimebase([m_synchronizer timebase]);
-    m_videoRenderer->notifyWhenDecodingErrorOccurred([weakThis = WeakPtr { *this }](OSStatus) {
+    videoRenderer = VideoMediaSampleRenderer::create(renderer);
+    m_videoRenderer = videoRenderer;
+    videoRenderer->setPrefersDecompressionSession(true);
+    videoRenderer->setTimebase([m_synchronizer timebase]);
+    videoRenderer->notifyWhenDecodingErrorOccurred([weakThis = WeakPtr { *this }](OSStatus) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -1902,7 +1921,7 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
         protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
         protectedThis->m_errored = true;
     });
-    m_videoRenderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
+    videoRenderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -1910,23 +1929,25 @@ void MediaPlayerPrivateWebM::setVideoRenderer(WebSampleBufferVideoRendering *ren
         if (protectedThis->m_isGatheringVideoFrameMetadata)
             protectedThis->checkNewVideoFrameMetadata(presentationTime, displayTime);
     });
-    configureVideoRenderer(*m_videoRenderer);
+    configureVideoRenderer(*videoRenderer);
 }
 
 void MediaPlayerPrivateWebM::stageVideoRenderer(WebSampleBufferVideoRendering *renderer)
 {
-    if (m_videoRenderer && renderer == m_videoRenderer->renderer())
+    RefPtr videoRenderer = m_videoRenderer;
+    if (videoRenderer && renderer == videoRenderer->renderer())
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, "!!renderer = ", !!renderer);
     ASSERT(!renderer || hasSelectedVideo());
 
-    if (m_expiringVideoRenderer)
-        invalidateVideoRenderer(*std::exchange(m_expiringVideoRenderer, nullptr));
+    if (RefPtr expiringVideoRenderer = std::exchange(m_expiringVideoRenderer, nullptr))
+        invalidateVideoRenderer(*expiringVideoRenderer);
 
     m_expiringVideoRenderer = std::exchange(m_videoRenderer, { });
-    m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
-    configureVideoRenderer(*m_videoRenderer);
+    videoRenderer = VideoMediaSampleRenderer::create(renderer);
+    m_videoRenderer = videoRenderer;
+    configureVideoRenderer(*videoRenderer);
     if (m_enabledVideoTrackID)
         reenqueSamples(*m_enabledVideoTrackID, NeedsFlush::No);
 }
@@ -1991,15 +2012,16 @@ void MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged(bool isInFu
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateWebM::videoPlaybackQualityMetrics()
 {
-    if (!m_videoRenderer)
+    RefPtr videoRenderer = m_videoRenderer;
+    if (!videoRenderer)
         return std::nullopt;
 
     return VideoPlaybackQualityMetrics {
-        m_videoRenderer->totalVideoFrames(),
-        m_videoRenderer->droppedVideoFrames(),
-        m_videoRenderer->corruptedVideoFrames(),
-        m_videoRenderer->totalFrameDelay().toDouble(),
-        m_videoRenderer->totalDisplayedFrames()
+        videoRenderer->totalVideoFrames(),
+        videoRenderer->droppedVideoFrames(),
+        videoRenderer->corruptedVideoFrames(),
+        videoRenderer->totalFrameDelay().toDouble(),
+        videoRenderer->totalDisplayedFrames()
     };
 }
 


### PR DESCRIPTION
#### 8d4a694143418e20d99c180345da3f928863c06a
<pre>
Fix safer C++ warnings in MediaPlayerPrivate classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=287067">https://bugs.webkit.org/show_bug.cgi?id=287067</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/LoggerHelper.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::seekToTarget):
(WebCore::MediaPlayerPrivateAVFoundation::processNewAndRemovedTextTracks):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::EffectiveRateChangedListener::effectiveRateChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::playInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::hasVideo const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::hasAudio const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPageIsVisible):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::duration const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::protectedMediaSourcePrivate const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::colorSpace):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::acceleratedRenderingStateChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::canUseDecompressionSession const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::durationChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::sizeWillChangeAtTime):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setCDMSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::keyAdded):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::outputObscuredDueToInsufficientExternalProtectionChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceAttached):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cdmInstanceDetached):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::attemptToDecryptWithInstance):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::waitingForKey const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isCurrentPlaybackTargetWireless const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
(WebCore::MediaPlayerPrivateWebM::protectedLogger const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::dataReceived):
(WebCore::MediaPlayerPrivateWebM::cancelLoad):
(WebCore::MediaPlayerPrivateWebM::seekInternal):
(WebCore::MediaPlayerPrivateWebM::updateLastPixelBuffer):
(WebCore::MediaPlayerPrivateWebM::updateLastImage):
(WebCore::MediaPlayerPrivateWebM::colorSpace):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::updateDisplayLayer):
(WebCore::MediaPlayerPrivateWebM::setVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateWebM::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::setMinimumUpcomingPresentationTime):
(WebCore::MediaPlayerPrivateWebM::clearMinimumUpcomingPresentationTime):
(WebCore::MediaPlayerPrivateWebM::isReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
(WebCore::MediaPlayerPrivateWebM::flushIfNeeded):
(WebCore::MediaPlayerPrivateWebM::flushVideo):
(WebCore::MediaPlayerPrivateWebM::addTrackBuffer):
(WebCore::MediaPlayerPrivateWebM::checkNewVideoFrameMetadata):
(WebCore::MediaPlayerPrivateWebM::invalidateVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::protectedVideoRenderer const):
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::stageVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::videoPlaybackQualityMetrics):

Canonical link: <a href="https://commits.webkit.org/289883@main">https://commits.webkit.org/289883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae13dc63e05d2f5627900a67a99086d793db280f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68061 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25786 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79792 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48430 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5975 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34201 "Found 2 new test failures: editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38082 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81022 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95023 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87000 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76923 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75648 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76167 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18971 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8421 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13789 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20711 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109493 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15154 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26330 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->