### PR TITLE
Web Inspector: support `console.profile` in `Worker`

### DIFF
--- a/LayoutTests/inspector/worker/resources/worker-timeline.js
+++ b/LayoutTests/inspector/worker/resources/worker-timeline.js
@@ -1,0 +1,35 @@
+function bar(x) {
+    return x * 10;
+}
+
+function foo() {
+    bar(42);
+}
+
+let customTarget = new EventTarget;
+customTarget.addEventListener("custom", (event) => {
+    foo();
+});
+
+function willCallFunctionTest() {
+    console.profile();
+    customTarget.dispatchEvent(new CustomEvent("custom"));
+    console.profileEnd();
+}
+
+function willEvaluateScriptTest() {
+    console.profile();
+    foo();
+    console.profileEnd();
+}
+
+self.addEventListener("message", (event) => {
+    switch (event.data) {
+    case "willCallFunctionTest":
+        willCallFunctionTest();
+        break;
+    case "willEvaluateScriptTest":
+        willEvaluateScriptTest();
+        break;
+    }
+});

--- a/LayoutTests/inspector/worker/timeline-line-column-expected.txt
+++ b/LayoutTests/inspector/worker/timeline-line-column-expected.txt
@@ -1,0 +1,140 @@
+Test that script Timeline records have column numbers in a Worker.
+
+PASS: Worker created.
+
+== Running test suite: Worker.Timeline.LineColumn
+-- Running test case: Worker.Timeline.LineColumn.willCallFunction
+Evaluating in page...
+PASS: Capturing started.
+{
+  "startTime": "<filtered>",
+  "data": {
+    "type": "custom",
+    "defaultPrevented": false
+  },
+  "children": [],
+  "endTime": "<filtered>",
+  "type": "EventDispatch"
+}
+{
+  "startTime": "<filtered>",
+  "data": {
+    "type": "custom",
+    "defaultPrevented": false
+  },
+  "children": [
+    {
+      "startTime": "<filtered>",
+      "stackTrace": {
+        "callFrames": [
+          {
+            "functionName": "dispatchEvent",
+            "url": "[native code]",
+            "scriptId": "<filtered>",
+            "lineNumber": 0,
+            "columnNumber": 0
+          },
+          {
+            "functionName": "willCallFunctionTest",
+            "url": "worker/resources/worker-timeline.js",
+            "scriptId": "<filtered>",
+            "lineNumber": 16,
+            "columnNumber": 31
+          },
+          {
+            "functionName": "",
+            "url": "worker/resources/worker-timeline.js",
+            "scriptId": "<filtered>",
+            "lineNumber": 29,
+            "columnNumber": 29
+          }
+        ]
+      },
+      "data": {
+        "scriptName": "worker/resources/worker-timeline.js",
+        "scriptLine": 10,
+        "scriptColumn": 41
+      },
+      "children": [],
+      "endTime": "<filtered>",
+      "type": "FunctionCall"
+    }
+  ],
+  "endTime": "<filtered>",
+  "type": "EventDispatch"
+}
+{
+  "startTime": "<filtered>",
+  "stackTrace": {
+    "callFrames": [
+      {
+        "functionName": "profile",
+        "url": "[native code]",
+        "scriptId": "<filtered>",
+        "lineNumber": 0,
+        "columnNumber": 0
+      },
+      {
+        "functionName": "willCallFunctionTest",
+        "url": "worker/resources/worker-timeline.js",
+        "scriptId": "<filtered>",
+        "lineNumber": 15,
+        "columnNumber": 20
+      },
+      {
+        "functionName": "",
+        "url": "worker/resources/worker-timeline.js",
+        "scriptId": "<filtered>",
+        "lineNumber": 29,
+        "columnNumber": 29
+      }
+    ]
+  },
+  "data": {
+    "title": ""
+  },
+  "children": [],
+  "endTime": "<filtered>",
+  "type": "ConsoleProfile"
+}
+PASS: Capturing stopped.
+
+-- Running test case: Worker.Timeline.LineColumn.willEvaluateScript
+Evaluating in page...
+PASS: Capturing started.
+{
+  "startTime": "<filtered>",
+  "stackTrace": {
+    "callFrames": [
+      {
+        "functionName": "profile",
+        "url": "[native code]",
+        "scriptId": "<filtered>",
+        "lineNumber": 0,
+        "columnNumber": 0
+      },
+      {
+        "functionName": "willEvaluateScriptTest",
+        "url": "worker/resources/worker-timeline.js",
+        "scriptId": "<filtered>",
+        "lineNumber": 21,
+        "columnNumber": 20
+      },
+      {
+        "functionName": "",
+        "url": "worker/resources/worker-timeline.js",
+        "scriptId": "<filtered>",
+        "lineNumber": 32,
+        "columnNumber": 31
+      }
+    ]
+  },
+  "data": {
+    "title": ""
+  },
+  "children": [],
+  "endTime": "<filtered>",
+  "type": "ConsoleProfile"
+}
+PASS: Capturing stopped.
+

--- a/LayoutTests/inspector/worker/timeline-line-column.html
+++ b/LayoutTests/inspector/worker/timeline-line-column.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script>
+let worker = new Worker("resources/worker-timeline.js");
+
+function test()
+{
+    let suite = ProtocolTest.createAsyncSuite("Worker.Timeline.LineColumn");
+
+    // To avoid flakiness print only events that we always expect.
+    const eventAllowlist = new Set(["RenderingFrame", "ConsoleProfile", "EventDispatch", "FunctionCall"]);
+
+    // The inspector injected script call frame(s) have different line numbers between release and
+    // debug builds. We only want to filter those values for those specific call frames in order to
+    // ensure other line/column numbers remain stable.
+    let functionNameLength = 0;
+    let urlLength = 0;
+
+    function replacer(key, value) {
+        if (key === "functionName") {
+            functionNameLength = value.length;
+            return value;
+        }
+
+        if (key === "children" && this.startTime)
+            return value.filter(e => eventAllowlist.has(e.type));
+        if (key === "startTime" || key === "endTime" || key === "scriptId")
+            return "<filtered>";
+        if ((key === "lineNumber" || key === "columnNumber") && !functionNameLength && !urlLength)
+            return "<filtered>";
+
+        if (key === "url")
+            urlLength = value.length;
+        if (key === "url" || key === "scriptName")
+            return value.replace(/^.+LayoutTests\/inspector\//, "");
+        return value;
+    }
+
+    const tests = [
+        {
+            name: "Worker.Timeline.LineColumn.willCallFunction",
+            description: "Test that column numbers are passed through the willCallFunction instrumentation point.",
+            expression: `worker.postMessage("willCallFunctionTest")`,
+        },
+        {
+            name: "Worker.Timeline.LineColumn.willEvaluateScript",
+            description: "Test that column numbers are passed through the willEvaluateScript instrumentation point.",
+            expression: `worker.postMessage("willEvaluateScriptTest")`,
+        },
+    ];
+
+    for (let {name, description, expression} of tests) {
+        suite.addTestCase({
+            name,
+            description,
+            test(resolve, reject) {
+                let eventNames = [];
+
+                function handleEvent(eventName, handler) {
+                    eventNames.push(eventName);
+                    InspectorProtocol.eventHandler[eventName] = handler;
+                }
+
+                handleEvent("Worker.dispatchMessageFromWorker", (event) => {
+                    InspectorProtocol.dispatchMessageFromBackend(JSON.parse(event.params.message));
+                });
+
+                handleEvent("Timeline.eventRecorded", (event) => {
+                    ProtocolTest.log(JSON.stringify(event.params.record, replacer, 2));
+                });
+
+                handleEvent("Timeline.recordingStarted", () => {
+                    ProtocolTest.pass("Capturing started.");
+                });
+
+                handleEvent("Timeline.recordingStopped", () => {
+                    ProtocolTest.pass("Capturing stopped.");
+
+                    for (let eventName of eventNames)
+                        delete InspectorProtocol.eventHandler[eventName];
+
+                    resolve();
+                });
+
+                ProtocolTest.log("Evaluating in page...");
+                ProtocolTest.evaluateInPage(expression).catch(reject);
+            },
+        });
+    }
+
+    InspectorProtocol.sendCommand("Page.enable");
+    InspectorProtocol.sendCommand("Timeline.enable");
+    InspectorProtocol.sendCommand("Worker.enable");
+    InspectorProtocol.awaitEvent({event: "Worker.workerCreated"}).then((result) => {
+        ProtocolTest.pass("Worker created.");
+
+        InspectorProtocol.sendCommand("Worker.sendMessageToWorker", {
+            workerId: result.params.workerId,
+            message: JSON.stringify({
+                id: InspectorProtocol.getNextMessageId(),
+                method: "Timeline.enable",
+            }),
+        });
+
+        suite.runTestCasesAndFinish();
+    });
+}
+
+</script>
+</head>
+<body onload="runTest()">
+    <p>Test that script Timeline records have column numbers in a Worker.</p>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -262,6 +262,7 @@ public:
     static void consoleCountReset(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label);
 
     static void takeHeapSnapshot(Frame&, const String& title);
+    static void takeHeapSnapshot(WorkerOrWorkletGlobalScope&, const String& title);
     static void startConsoleTiming(Frame&, JSC::JSGlobalObject*, const String& label);
     static void startConsoleTiming(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label);
     static void logConsoleTiming(Frame&, JSC::JSGlobalObject*, const String& label, Ref<Inspector::ScriptArguments>&&);
@@ -269,8 +270,11 @@ public:
     static void stopConsoleTiming(Frame&, JSC::JSGlobalObject*, const String& label);
     static void stopConsoleTiming(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label);
     static void consoleTimeStamp(Frame&, Ref<Inspector::ScriptArguments>&&);
+    static void consoleTimeStamp(WorkerOrWorkletGlobalScope&, Ref<Inspector::ScriptArguments>&&);
     static void startProfiling(Page&, const String& title);
+    static void startProfiling(WorkerOrWorkletGlobalScope&, const String& title);
     static void stopProfiling(Page&, const String& title);
+    static void stopProfiling(WorkerOrWorkletGlobalScope&, const String& title);
     static void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     static void consoleStopRecordingCanvas(CanvasRenderingContext&);
 
@@ -1627,6 +1631,12 @@ inline void InspectorInstrumentation::takeHeapSnapshot(Frame& frame, const Strin
         takeHeapSnapshotImpl(*agents, title);
 }
 
+inline void InspectorInstrumentation::takeHeapSnapshot(WorkerOrWorkletGlobalScope& globalScope, const String& title)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    takeHeapSnapshotImpl(instrumentingAgents(globalScope), title);
+}
+
 inline void InspectorInstrumentation::startConsoleTiming(Frame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
     if (auto* agents = instrumentingAgents(frame))
@@ -1667,16 +1677,34 @@ inline void InspectorInstrumentation::consoleTimeStamp(Frame& frame, Ref<Inspect
         consoleTimeStampImpl(*agents, WTFMove(arguments));
 }
 
+inline void InspectorInstrumentation::consoleTimeStamp(WorkerOrWorkletGlobalScope& globalScope, Ref<Inspector::ScriptArguments>&& arguments)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    consoleTimeStampImpl(instrumentingAgents(globalScope), WTFMove(arguments));
+}
+
 inline void InspectorInstrumentation::startProfiling(Page& page, const String &title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     startProfilingImpl(instrumentingAgents(page), title);
 }
 
+inline void InspectorInstrumentation::startProfiling(WorkerOrWorkletGlobalScope& globalScope, const String &title)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    startProfilingImpl(instrumentingAgents(globalScope), title);
+}
+
 inline void InspectorInstrumentation::stopProfiling(Page& page, const String &title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     stopProfilingImpl(instrumentingAgents(page), title);
+}
+
+inline void InspectorInstrumentation::stopProfiling(WorkerOrWorkletGlobalScope& globalScope, const String &title)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    stopProfilingImpl(instrumentingAgents(globalScope), title);
 }
 
 inline void InspectorInstrumentation::consoleStartRecordingCanvas(CanvasRenderingContext& context, JSC::JSGlobalObject& exec, JSC::JSObject* options)

--- a/Source/WebCore/workers/WorkerConsoleClient.cpp
+++ b/Source/WebCore/workers/WorkerConsoleClient.cpp
@@ -56,46 +56,66 @@ void WorkerConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel
 
 void WorkerConsoleClient::count(JSC::JSGlobalObject* exec, const String& label)
 {
-    // FIXME: Add support for WorkletGlobalScope.
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
     if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
         InspectorInstrumentation::consoleCount(*worker, exec, label);
 }
 
 void WorkerConsoleClient::countReset(JSC::JSGlobalObject* exec, const String& label)
 {
-    // FIXME: Add support for WorkletGlobalScope.
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
     if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
         InspectorInstrumentation::consoleCountReset(*worker, exec, label);
 }
 
 void WorkerConsoleClient::time(JSC::JSGlobalObject* exec, const String& label)
 {
-    // FIXME: Add support for WorkletGlobalScope.
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
     if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
         InspectorInstrumentation::startConsoleTiming(*worker, exec, label);
 }
 
 void WorkerConsoleClient::timeLog(JSC::JSGlobalObject* exec, const String& label, Ref<ScriptArguments>&& arguments)
 {
-    // FIXME: Add support for WorkletGlobalScope.
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
     if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
         InspectorInstrumentation::logConsoleTiming(*worker, exec, label, WTFMove(arguments));
 }
 
 void WorkerConsoleClient::timeEnd(JSC::JSGlobalObject* exec, const String& label)
 {
-    // FIXME: Add support for WorkletGlobalScope.
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
     if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
         InspectorInstrumentation::stopConsoleTiming(*worker, exec, label);
 }
 
-// FIXME: <https://webkit.org/b/153499> Web Inspector: console.profile should use the new Sampling Profiler
-void WorkerConsoleClient::profile(JSC::JSGlobalObject*, const String&) { }
-void WorkerConsoleClient::profileEnd(JSC::JSGlobalObject*, const String&) { }
+void WorkerConsoleClient::profile(JSC::JSGlobalObject*, const String& title)
+{
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
+    if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
+        InspectorInstrumentation::startProfiling(*worker, title);
+}
 
-// FIXME: <https://webkit.org/b/127634> Web Inspector: support debugging web workers
-void WorkerConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String&) { }
-void WorkerConsoleClient::timeStamp(JSC::JSGlobalObject*, Ref<ScriptArguments>&&) { }
+void WorkerConsoleClient::profileEnd(JSC::JSGlobalObject*, const String& title)
+{
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
+    if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
+        InspectorInstrumentation::stopProfiling(*worker, title);
+}
+
+void WorkerConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String& title)
+{
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
+    if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
+        InspectorInstrumentation::takeHeapSnapshot(*worker, title);
+}
+
+void WorkerConsoleClient::timeStamp(JSC::JSGlobalObject*, Ref<ScriptArguments>&& arguments)
+{
+    // FIXME: <https://webkit.org/b/217724> Add support for WorkletGlobalScope.
+    if (auto* worker = dynamicDowncast<WorkerGlobalScope>(m_globalScope))
+        InspectorInstrumentation::consoleTimeStamp(*worker, WTFMove(arguments));
+}
 
 // FIXME: <https://webkit.org/b/243362> Web Inspector: support starting/stopping recordings from the console in a Worker
 void WorkerConsoleClient::record(JSC::JSGlobalObject*, Ref<ScriptArguments>&&) { }

--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -84,16 +84,15 @@ WI.TimelineManager = class TimelineManager extends WI.Object
         if (!this._enabled)
             return;
 
-        if (target.hasDomain("Timeline")) {
-            // COMPATIBILITY (iOS 13): Timeline.enable did not exist yet.
-            if (target.hasCommand("Timeline.enable"))
-                target.TimelineAgent.enable();
+        // COMPATIBILITY (iOS 13): Timeline.enable did not exist yet.
+        // COMPATIBILITY (iOS X.Y, macOS X.Y): `Timeline.enable` did not exist yet for Worker targets.
+        if (target.hasCommand("Timeline.enable"))
+            target.TimelineAgent.enable();
 
-            this._updateAutoCaptureInstruments([target]);
+        this._updateAutoCaptureInstruments([target]);
 
-            if (target.hasCommand("Timeline.setAutoCaptureEnabled"))
-                target.TimelineAgent.setAutoCaptureEnabled(this._autoCaptureOnPageLoad);
-        }
+        if (target.hasCommand("Timeline.setAutoCaptureEnabled"))
+            target.TimelineAgent.setAutoCaptureEnabled(this._autoCaptureOnPageLoad);
     }
 
     transitionPageTarget()
@@ -271,6 +270,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
 
         for (let target of WI.targets) {
             // COMPATIBILITY (iOS 13): Timeline.disable did not exist yet.
+            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Timeline.disable` did not exist yet for Worker targets.
             if (target.hasCommand("Timeline.disable"))
                 target.TimelineAgent.disable();
         }
@@ -1425,6 +1425,7 @@ WI.TimelineManager = class TimelineManager extends WI.Object
         let enabledTimelineTypes = this.enabledTimelineTypes;
 
         for (let target of targets) {
+            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Timeline.setInstruments` did not exist yet for Worker targets.
             if (!target.hasCommand("Timeline.setInstruments"))
                 continue;
 

--- a/Source/WebInspectorUI/UserInterface/Models/Instrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Instrument.js
@@ -69,6 +69,7 @@ WI.Instrument = class Instrument
         for (let target of WI.targets) {
             if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
                 continue;
+            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Timeline.start` did not exist yet for Worker targets.
             if (target.hasDomain("Timeline"))
                 target.TimelineAgent.start();
         }
@@ -89,6 +90,7 @@ WI.Instrument = class Instrument
         for (let target of WI.targets) {
             if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
                 continue;
+            // COMPATIBILITY (iOS X.Y, macOS X.Y): `Timeline.stop` did not exist yet for Worker targets.
             if (target.hasDomain("Timeline"))
                 target.TimelineAgent.stop();
         }

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
@@ -41,6 +41,7 @@ WI.ScriptInstrument = class ScriptInstrument extends WI.Instrument
             for (let target of WI.targets) {
                 if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
                     continue;
+                // COMPATIBILITY (iOS X.Y, macOS X.Y): `ScriptProfiler.startTracking` did not exist yet in Worker targets.
                 if (target.hasDomain("ScriptProfiler"))
                     target.ScriptProfilerAgent.startTracking(includeSamples);
             }
@@ -53,6 +54,7 @@ WI.ScriptInstrument = class ScriptInstrument extends WI.Instrument
             for (let target of WI.targets) {
                 if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
                     continue;
+                // COMPATIBILITY (iOS X.Y, macOS X.Y): `ScriptProfiler.stopTracking` did not exist yet for Worker targets.
                 if (target.hasDomain("ScriptProfiler"))
                     target.ScriptProfilerAgent.stopTracking();
             }

--- a/Source/WebInspectorUI/UserInterface/Test/InspectorProtocol.js
+++ b/Source/WebInspectorUI/UserInterface/Test/InspectorProtocol.js
@@ -30,6 +30,11 @@ InspectorProtocol._placeholderRequestIds = [];
 InspectorProtocol._requestId = -1;
 InspectorProtocol.eventHandler = {};
 
+InspectorProtocol.getNextMessageId = function()
+{
+    return ++this._requestId;
+};
+
 InspectorProtocol.sendCommand = function(methodOrObject, params, handler)
 {
     // Allow new-style arguments object, as in awaitCommand.
@@ -39,7 +44,7 @@ InspectorProtocol.sendCommand = function(methodOrObject, params, handler)
     else if (!params)
         params = {};
 
-    this._dispatchTable[++this._requestId] = handler;
+    this._dispatchTable[this.getNextMessageId()] = handler;
     let messageObject = {method, params, id: this._requestId};
     this._sendMessage(messageObject);
 
@@ -49,7 +54,7 @@ InspectorProtocol.sendCommand = function(methodOrObject, params, handler)
 InspectorProtocol.awaitCommand = function(args)
 {
     let {method, params} = args;
-    let messageObject = {method, params, id: ++this._requestId};
+    let messageObject = {method, params, id: this.getNextMessageId()};
 
     return this.awaitMessage(messageObject);
 };
@@ -63,7 +68,7 @@ InspectorProtocol.awaitMessage = function(messageObject)
         // If the caller did not provide an id, then make one up so that the response
         // can be used to settle a promise.
         if (typeof requestId !== "number") {
-            requestId = ++this._requestId;
+            requestId = this.getNextMessageId();
             this._placeholderRequestIds.push(requestId);
         }
 


### PR DESCRIPTION
#### 98f9f65893366f159adec513808b596ab972a7dd
<pre>
Web Inspector: support `console.profile` in `Worker`
<a href="https://bugs.webkit.org/show_bug.cgi?id=287069">https://bugs.webkit.org/show_bug.cgi?id=287069</a>

Reviewed by BJ Burg.

* Source/WebCore/workers/WorkerConsoleClient.cpp:
(WebCore::WorkerConsoleClient::profile):
(WebCore::WorkerConsoleClient::profileEnd):
(WebCore::WorkerConsoleClient::takeHeapSnapshot):
(WebCore::WorkerConsoleClient::timeStamp):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::takeHeapSnapshot):
(WebCore::InspectorInstrumentation::consoleTimeStamp):
(WebCore::InspectorInstrumentation::startProfiling):
(WebCore::InspectorInstrumentation::stopProfiling):
Create new `InspectorInstrumentation` hooks for `WorkerGlobalScope` that mimic the behavior of the respective `Page` flow.

* LayoutTests/inspector/worker/resources/worker-timeline.js: Added.
* LayoutTests/inspector/worker/timeline-line-column.html: Added.
* LayoutTests/inspector/worker/timeline-line-column-expected.txt: Added.
Add some basic tests to ensure that `Timeline` works in a `Worker`.

* Source/WebInspectorUI/UserInterface/Test/InspectorProtocol.js:
(InspectorProtocol.getNextMessageId): Added.
(InspectorProtocol.sendCommand):
(InspectorProtocol.awaitCommand):
(InspectorProtocol.awaitMessage):
Expose the message ID for callers to craft their own properly formatted protocol messages.

* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype.initializeTarget):
(WI.TimelineManager.prototype.disable):
(WI.TimelineManager.prototype._updateAutoCaptureInstruments):
* Source/WebInspectorUI/UserInterface/Models/Instrument.js:
(WI.Instrument.startLegacyTimelineAgent):
(WI.Instrument.stopLegacyTimelineAgent):
* Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js:
(WI.ScriptInstrument.prototype.startInstrumentation):
(WI.ScriptInstrument.prototype.stopInstrumentation):

Drive-by: add missing compatibility comments.
Canonical link: <a href="https://commits.webkit.org/295189@main">https://commits.webkit.org/295189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f1c75cc6c3a9248d69af7c89d7e55df5fb78755

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14485 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/55034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32617 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/109568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/55034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107372 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/19006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/94186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/109568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/18807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/12259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54394 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/12313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111949 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31523 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/23222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/88279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/31887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/90430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87944 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22390 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/10611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/25991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36776 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/31245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/34581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/32805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->