### PR TITLE
Prevent Yarr::Interpreter's evaluation stack from growing unboundedly.

### DIFF
--- a/JSTests/stress/regexp-huge-oom.js
+++ b/JSTests/stress/regexp-huge-oom.js
@@ -22,12 +22,16 @@ function shouldThrow(run, errorType)
     if (!hadError)
         throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
     if (!(actual instanceof errorType))
-        throw new Error("Expeced " + run + "() to throw " + errorType.name + " , but threw '" + actual + "'");
+        throw new Error("Expected " + run + "() to throw " + errorType.name + " , but threw '" + actual + "'");
 }
 
 // This should throw during pattern compilation.
 shouldThrow(() => RegExp('a?'.repeat(2**19) + 'b').exec('x'), SyntaxError);
 
-// This test should fail execution in the JIT'ed code and then fall back to the interpreter ans succeed.
-shouldBe(RegExp('a?'.repeat(2**19)).exec('x')[0], "");
+// This should fail during pattern evaluation, and be treated as NO match i.e. returning null.
+var r1 = RegExp('a?'.repeat(2**19));
+shouldBe(r1.exec('x'), null);
+
+// Run it again to confirm no deadlock in the implementation. This caught a bug before.
+shouldBe(r1.exec('x'), null);
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -367,6 +367,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Double, minHeapUtilization, 0.8, Normal, nullptr) \
     v(Double, minMarkedBlockUtilization, 0.9, Normal, nullptr) \
     v(Unsigned, slowPathAllocsBetweenGCs, 0, Normal, "force a GC on every Nth slow path alloc, where N is specified by this option"_s) \
+    v(Unsigned, maxRegExpStackSize, 4 * MB, Normal, nullptr) \
     \
     v(Double, percentCPUPerMBForFullTimer, 0.0003125, Normal, nullptr) \
     v(Double, percentCPUPerMBForEdenTimer, 0.0025, Normal, nullptr) \

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +39,8 @@ ASCIILiteral errorMessage(ErrorCode error)
     // The order of this array must match the ErrorCode enum.
     static const ASCIILiteral errorMessages[] = {
         { },                                                                          // NoError
+
+        // The following are hard errors.
         REGEXP_ERROR_PREFIX "regular expression too large"_s,                         // PatternTooLarge
         REGEXP_ERROR_PREFIX "numbers out of order in {} quantifier"_s,                // QuantifierOutOfOrder
         REGEXP_ERROR_PREFIX "nothing to repeat"_s,                                    // QuantifierWithoutAtom
@@ -63,12 +66,14 @@ ASCIILiteral errorMessage(ErrorCode error)
         REGEXP_ERROR_PREFIX "invalid octal escape for Unicode pattern"_s,             // InvalidOctalEscape
         REGEXP_ERROR_PREFIX "invalid \\c escape for Unicode pattern"_s,               // InvalidControlLetterEscape
         REGEXP_ERROR_PREFIX "invalid property expression"_s,                          // InvalidUnicodePropertyExpression
-        REGEXP_ERROR_PREFIX "too many nested disjunctions"_s,                         // TooManyDisjunctions
         REGEXP_ERROR_PREFIX "pattern exceeds string length limits"_s,                 // OffsetTooLarge
         REGEXP_ERROR_PREFIX "invalid flags"_s,                                        // InvalidRegularExpressionFlags
         REGEXP_ERROR_PREFIX "invalid operation in class set"_s,                       // InvalidClassSetOperation
         REGEXP_ERROR_PREFIX "negated class set may contain strings"_s,                // NegatedClassSetMayContainStrings
-        REGEXP_ERROR_PREFIX "invalid class set character"_s                           // InvalidClassSetCharacter
+        REGEXP_ERROR_PREFIX "invalid class set character"_s,                          // InvalidClassSetCharacter
+
+        // The following are NOT hard errors.
+        REGEXP_ERROR_PREFIX "too many nested disjunctions"_s,                         // TooManyDisjunctions
     };
 
     return errorMessages[static_cast<unsigned>(error)];

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.h
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +38,13 @@ namespace Yarr {
 
 enum class ErrorCode : uint8_t {
     NoError = 0,
+
+    // A hard error means that no matter what string the RegExp is evaluated on, it will
+    // always fail. A SyntaxError is a hard error because the RegExp will never succeed no
+    // matter what string it is run on. An OOME is not a hard error because the RegExp may
+    // succeed when run on a different string.
+
+    // The following are hard errors.
     PatternTooLarge,
     QuantifierOutOfOrder,
     QuantifierWithoutAtom,
@@ -62,12 +70,14 @@ enum class ErrorCode : uint8_t {
     InvalidOctalEscape,
     InvalidControlLetterEscape,
     InvalidUnicodePropertyExpression,
-    TooManyDisjunctions,
     OffsetTooLarge,
     InvalidRegularExpressionFlags,
     InvalidClassSetOperation,
     NegatedClassSetMayContainStrings,
     InvalidClassSetCharacter,
+
+    // The following are NOT hard errors.
+    TooManyDisjunctions, // we ran out stack compiling.
 };
 
 JS_EXPORT_PRIVATE ASCIILiteral errorMessage(ErrorCode);
@@ -78,9 +88,8 @@ inline bool hasError(ErrorCode errorCode)
 
 inline bool hasHardError(ErrorCode errorCode)
 {
-    // TooManyDisjunctions means that we ran out stack compiling.
-    // All other errors are due to problems in the expression.
-    return hasError(errorCode) && errorCode != ErrorCode::TooManyDisjunctions;
+    // See comment in the enum class ErrorCode above for the definition of hard errors.
+    return hasError(errorCode) && errorCode < ErrorCode::TooManyDisjunctions;
 }
 JS_EXPORT_PRIVATE JSObject* errorToThrow(JSGlobalObject*, ErrorCode);
 

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Peter Varga (pvarga@inf.u-szeged.hu), University of Szeged
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "YarrInterpreter.h"
 
+#include "ConcurrentJSLock.h"
 #include "Options.h"
 #include "SuperSampler.h"
 #include "Yarr.h"
@@ -124,19 +125,30 @@ public:
         int term { 0 };
         unsigned matchBegin;
         unsigned matchEnd;
+#if ASSERT_ENABLED
+        constexpr static uint64_t magicNumber = 0x01aabbccddeeff01;
+        uint64_t m_magicNumber { magicNumber };
+#endif
         uintptr_t frame[1];
     };
 
     DisjunctionContext* allocDisjunctionContext(ByteDisjunction* disjunction)
     {
         size_t size = DisjunctionContext::allocationSize(disjunction->m_frameSize);
-        allocatorPool = allocatorPool->ensureCapacity(size);
-        RELEASE_ASSERT(allocatorPool);
+        auto* newAllocatorPool = allocatorPool->ensureCapacity(size);
+        if (UNLIKELY(!newAllocatorPool))
+            return nullptr;
+        allocatorPool = newAllocatorPool;
         return new (allocatorPool->alloc(size)) DisjunctionContext();
     }
 
     void freeDisjunctionContext(DisjunctionContext* context)
     {
+#if ASSERT_ENABLED
+        ASSERT(context->m_magicNumber == DisjunctionContext::magicNumber);
+        context->m_magicNumber = 0;
+#endif
+        static_assert(std::is_trivially_destructible_v<DisjunctionContext>);
         allocatorPool = allocatorPool->dealloc(context);
     }
 
@@ -215,6 +227,10 @@ public:
         unsigned m_numNestedSubpatterns;
         size_t m_numBackupIds;
         BitVector m_duplicateNamedGroups;
+#if ASSERT_ENABLED
+        constexpr static uint64_t magicNumber = 0x02aabbccddeeff02;
+        uint64_t m_magicNumber { magicNumber };
+#endif
         unsigned subpatternAndGroupIdBackup[1];
     };
 
@@ -237,13 +253,20 @@ public:
         }
 
         size_t size = Checked<size_t>(ParenthesesDisjunctionContext::allocationSize(numNestedSubpatterns, numDuplicateNamedGroups)) + DisjunctionContext::allocationSize(disjunction->m_frameSize);
-        allocatorPool = allocatorPool->ensureCapacity(size);
-        RELEASE_ASSERT(allocatorPool);
+        auto* newAllocatorPool = allocatorPool->ensureCapacity(size);
+        if (UNLIKELY(!newAllocatorPool))
+            return nullptr;
+        allocatorPool = newAllocatorPool;
         return new (allocatorPool->alloc(size)) ParenthesesDisjunctionContext(pattern, output, term, numDuplicateNamedGroups, duplicateNamedCaptureGroups);
     }
 
     void freeParenthesesDisjunctionContext(ParenthesesDisjunctionContext* context)
     {
+#if ASSERT_ENABLED
+        ASSERT(context->m_magicNumber == ParenthesesDisjunctionContext::magicNumber);
+        context->m_magicNumber = 0;
+#endif
+        context->~ParenthesesDisjunctionContext();
         allocatorPool = allocatorPool->dealloc(context);
     }
 
@@ -1396,6 +1419,8 @@ public:
             while (backTrack->matchAmount < minimumMatchCount) {
                 // Try to do a match, and it it succeeds, add it to the list.
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+                if (UNLIKELY(!context))
+                    return JSRegExpResult::ErrorNoMemory;
                 fixedMatchResult = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (fixedMatchResult == JSRegExpResult::Match)
                     appendParenthesesDisjunctionContext(backTrack, context);
@@ -1425,6 +1450,8 @@ public:
         case QuantifierType::Greedy: {
             while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+                if (UNLIKELY(!context))
+                    return JSRegExpResult::ErrorNoMemory;
                 JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (result == JSRegExpResult::Match)
                     appendParenthesesDisjunctionContext(backTrack, context);
@@ -1485,6 +1512,8 @@ public:
             while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 // Try to do a match, and it it succeeds, add it to the list.
                 context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+                if (UNLIKELY(!context))
+                    return JSRegExpResult::ErrorNoMemory;
                 result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
 
                 if (result == JSRegExpResult::Match)
@@ -1517,6 +1546,8 @@ public:
             if (result == JSRegExpResult::Match) {
                 while (backTrack->matchAmount < term.atom.quantityMaxCount) {
                     ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+                    if (UNLIKELY(!context))
+                        return JSRegExpResult::ErrorNoMemory;
                     JSRegExpResult parenthesesResult = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                     if (parenthesesResult == JSRegExpResult::Match)
                         appendParenthesesDisjunctionContext(backTrack, context);
@@ -1562,6 +1593,8 @@ public:
             // If we've not reached the limit, try to add one more match.
             if (backTrack->matchAmount < term.atom.quantityMaxCount) {
                 ParenthesesDisjunctionContext* context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+                if (UNLIKELY(!context))
+                    return JSRegExpResult::ErrorNoMemory;
                 JSRegExpResult result = matchNonZeroDisjunction(disjunctionBody, context->getDisjunctionContext());
                 if (result == JSRegExpResult::Match) {
                     appendParenthesesDisjunctionContext(backTrack, context);
@@ -2168,19 +2201,20 @@ public:
         if (!input.isAvailableInput(0))
             return offsetNoMatch;
 
-        if (pattern->m_lock)
-            pattern->m_lock->lock();
-        
+        ConcurrentJSLocker locker(pattern->m_lock);
+
         for (unsigned i = 0; i < pattern->m_body->m_numSubpatterns + 1; ++i)
             output[i << 1] = offsetNoMatch;
 
         for (unsigned i = pattern->m_offsetVectorBaseForNamedCaptures; i < pattern->m_offsetsSize; ++i)
             output[i] = 0;
 
-        allocatorPool = pattern->m_allocator->startAllocator();
+        allocatorPool = pattern->m_allocator->startAllocator(Options::maxRegExpStackSize());
         RELEASE_ASSERT(allocatorPool);
 
         DisjunctionContext* context = allocDisjunctionContext(pattern->m_body.get());
+        if (UNLIKELY(!context))
+            return offsetNoMatch;
 
         dataLogLnIf(verbose, "  Interpret input: ", input, "\n  Matching");
 
@@ -2196,9 +2230,6 @@ public:
 
         ASSERT((result == JSRegExpResult::Match) == (output[0] != offsetNoMatch));
 
-        if (pattern->m_lock)
-            pattern->m_lock->unlock();
-        
         return output[0];
     }
 
@@ -3176,18 +3207,6 @@ unsigned interpret(BytecodePattern* bytecode, StringView input, unsigned start, 
     if (input.is8Bit())
         return Interpreter<LChar>(bytecode, output, input.span8(), start).interpret();
     return Interpreter<UChar>(bytecode, output, input.span16(), start).interpret();
-}
-
-unsigned interpret(BytecodePattern* bytecode, std::span<const LChar> input, unsigned start, unsigned* output)
-{
-    SuperSamplerScope superSamplerScope(false);
-    return Interpreter<LChar>(bytecode, output, input, start).interpret();
-}
-
-unsigned interpret(BytecodePattern* bytecode, std::span<const UChar> input, unsigned start, unsigned* output)
-{
-    SuperSamplerScope superSamplerScope(false);
-    return Interpreter<UChar>(bytecode, output, input, start).interpret();
 }
 
 // These should be the same for both UChar & LChar.

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -536,7 +536,5 @@ private:
 
 JS_EXPORT_PRIVATE std::unique_ptr<BytecodePattern> byteCompile(YarrPattern&, BumpPointerAllocator*, ErrorCode&, ConcurrentJSLock* = nullptr);
 JS_EXPORT_PRIVATE unsigned interpret(BytecodePattern*, StringView input, unsigned start, unsigned* output);
-unsigned interpret(BytecodePattern*, std::span<const LChar> input, unsigned start, unsigned* output);
-unsigned interpret(BytecodePattern*, std::span<const UChar> input, unsigned start, unsigned* output);
 
 } } // namespace JSC::Yarr

--- a/Tools/TestWebKitAPI/Tests/WTF/BumpPointerAllocator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BumpPointerAllocator.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,13 +25,14 @@
 
 #include "config.h"
 #include <wtf/BumpPointerAllocator.h>
+#include <wtf/StdLibExtras.h>
 
 namespace TestWebKitAPI {
 
 TEST(WTF_BumpPointerAllocator, AllocationWithOnlySmallerPoolsAvailable)
 {
     WTF::BumpPointerAllocator allocator;
-    WTF::BumpPointerPool* pool = allocator.startAllocator();
+    WTF::BumpPointerPool* pool = allocator.startAllocator(4 * MB);
 
     pool = pool->ensureCapacity(0x2000);
     void* a = pool->alloc(0x2000);


### PR DESCRIPTION
#### 424c8d8832690078419ba0586eb81416d7f16f9d
<pre>
Prevent Yarr::Interpreter&apos;s evaluation stack from growing unboundedly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287074">https://bugs.webkit.org/show_bug.cgi?id=287074</a>
<a href="https://rdar.apple.com/143786123">rdar://143786123</a>

Reviewed by Keith Miller and Michael Saboff.

Currently, Yarr::Interpreter&apos;s evaluation stack (see BytecodePattern::m_allocator) is allowed
to grow unboundedly until we exhaust all memory.  We should bound it instead to a max capacity
limit.

1. The evaluation stack uses the BumpPointerAllocator class.  We enhanced BumpPointerAllocator&apos;s
   startAllocator() to take a maxCapacity value.  This maxCapacity value is used internally
   to compute a remainingCapacity value.

   The BumpPointerAllocator works by creating a link list of BumpPointerPools.  Each BumpPointerPool
   will now track the remainingCapacity should it needs to allocate the next BumpPointerPool in
   the link.  The size of the current BumpPointerPool will be deducted from remainingCapacity.
   When requested growth exceeds the remainingCapacity, BumpPointerPool::create() will fail to
   create another pool.

2. Introduced JSC::Options::maxRegExpStackSize() to define the max capacity.  The current default
   for this option value is 4M.

3. Yarr::interpret() has always returned offsetNoMatch if any errors occur during evaluation.
   When we encounter this new error condition where we&apos;ve exhausted the evaluation stack, we&apos;ll
   do the same thing.

4. Fixed a potential memory leak in freeParenthesesDisjunctionContext().  It was freeing the
   ParenthesesDisjunctionContext memory without calling its destructor.  This used to be fine
   because ParenthesesDisjunctionContext used to be trivially destructible.  That is no longer
   the case since a BitVector field got added into it.  Hence, we fixed
   freeParenthesesDisjunctionContext() to also call ~ParenthesesDisjunctionContext() before
   we dealloc its memory.

5. Also removed 2 unused variants of the Yarr::interpret() method.

* JSTests/stress/regexp-huge-oom.js:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
* Source/JavaScriptCore/yarr/YarrErrorCode.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::allocDisjunctionContext):
(JSC::Yarr::Interpreter::freeDisjunctionContext):
(JSC::Yarr::Interpreter::allocParenthesesDisjunctionContext):
(JSC::Yarr::Interpreter::freeParenthesesDisjunctionContext):
(JSC::Yarr::Interpreter::matchParentheses):
(JSC::Yarr::Interpreter::backtrackParentheses):
(JSC::Yarr::interpret):
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
* Source/WTF/wtf/BumpPointerAllocator.h:
(WTF::BumpPointerPool::BumpPointerPool):
(WTF::BumpPointerPool::create):
(WTF::BumpPointerPool::ensureCapacityCrossPool):
(WTF::BumpPointerAllocator::startAllocator):
* Tools/TestWebKitAPI/Tests/WTF/BumpPointerAllocator.cpp:
(TestWebKitAPI::TEST(WTF_BumpPointerAllocator, AllocationWithOnlySmallerPoolsAvailable)):

Canonical link: <a href="https://commits.webkit.org/290198@main">https://commits.webkit.org/290198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61d12b6f69e0154477a23bc7f9993184e75ae5e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89225 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68744 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26419 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92227 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7007 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6756 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39093 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77117 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96040 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88001 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16405 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77622 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16661 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76916 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21331 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9523 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13991 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21730 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110494 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16160 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26513 "Found 9 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->