### PR TITLE
[JSC] Further optimize wasm init time

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -83,11 +83,12 @@ enum class CallRole : uint8_t {
 
 struct CallInformation {
     CallInformation() = default;
-    CallInformation(ArgumentLocation passedThisArgument, Vector<ArgumentLocation, 8>&& parameters, Vector<ArgumentLocation, 1>&& returnValues, size_t stackOffset)
+    CallInformation(ArgumentLocation passedThisArgument, Vector<ArgumentLocation, 8>&& parameters, Vector<ArgumentLocation, 1>&& returnValues, size_t stackOffset, size_t stackValues)
         : thisArgument(passedThisArgument)
         , params(WTFMove(parameters))
         , results(WTFMove(returnValues))
         , headerAndArgumentStackSizeInBytes(stackOffset)
+        , numberOfStackValues(stackValues)
     { }
 
     RegisterAtOffsetList computeResultsOffsetList()
@@ -112,6 +113,7 @@ struct CallInformation {
     Vector<ArgumentLocation, 1> results { };
     // As a callee this includes CallerFrameAndPC as a caller it does not.
     size_t headerAndArgumentStackSizeInBytes { 0 };
+    size_t numberOfStackValues { 0 };
 };
 
 class WasmCallingConvention {
@@ -313,18 +315,25 @@ public:
                 return marshallLocation(role, signature.argumentType(index), gpArgumentCount, fpArgumentCount, argStackOffset);
             });
         uint32_t stackArgs = argStackOffset - headerSize;
+        size_t stackArguments = 0;
+        if (gpArgumentCount > jsrArgs.size())
+            stackArguments += (gpArgumentCount - jsrArgs.size());
+        if (fpArgumentCount > fprArgs.size())
+            stackArguments += (fpArgumentCount - fprArgs.size());
+        ASSERT(stackArguments == numberOfStackArguments(signature));
+
         gpArgumentCount = 0;
         fpArgumentCount = 0;
-
-        uint32_t stackResults = numberOfStackResults(signature) * sizeof(Register);
-        uint32_t stackCountAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(stackArgs, stackResults));
-        size_t resultStackOffset = headerSize + stackCountAligned - stackResults;
+        size_t stackResults = numberOfStackResults(signature);
+        uint32_t stackResultsInBytes = stackResults * sizeof(Register);
+        uint32_t stackCountAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(stackArgs, stackResultsInBytes));
+        size_t resultStackOffset = headerSize + stackCountAligned - stackResultsInBytes;
         Vector<ArgumentLocation, 1> results(signature.returnCount(),
             [&](unsigned index) {
                 return marshallLocation(role, signature.returnType(index), gpArgumentCount, fpArgumentCount, resultStackOffset);
             });
 
-        return { thisArgument, WTFMove(params), WTFMove(results), std::max(argStackOffset, resultStackOffset) };
+        return { thisArgument, WTFMove(params), WTFMove(results), std::max(argStackOffset, resultStackOffset), std::max(stackArguments, stackResults) };
     }
 
     RegisterSet argumentGPRs() const { return RegisterSetBuilder::argumentGPRs(); }
@@ -398,7 +407,7 @@ public:
                 return marshallLocation(role, signature.argumentType(index), gpArgumentCount, fpArgumentCount, stackOffset);
             });
         Vector<ArgumentLocation, 1> results { ArgumentLocation { ValueLocation { JSRInfo::returnValueJSR }, Width64 } };
-        return CallInformation(thisArgument, WTFMove(params), WTFMove(results), stackOffset);
+        return { thisArgument, WTFMove(params), WTFMove(results), stackOffset, 0U };
     }
 
     const Vector<JSValueRegs> jsrArgs;
@@ -591,10 +600,12 @@ public:
                 return marshallLocation(role, argumentType, gpArgumentCount, fpArgumentCount, argStackOffset);
             });
         uint32_t stackArgs = argStackOffset - headerSize;
+        size_t stackArgsCount = numberOfStackArguments(signature);
+
         gpArgumentCount = 0;
         fpArgumentCount = 0;
-
-        uint32_t stackResults = numberOfStackResults(signature) * sizeof(Register);
+        size_t stackResultsCount = numberOfStackResults(signature);
+        uint32_t stackResults = stackResultsCount * sizeof(Register);
         uint32_t stackCountAligned = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(std::max(stackArgs, stackResults));
         size_t resultStackOffset = headerSize + stackCountAligned - stackResults;
         Vector<ArgumentLocation, 1> results(signature.returnCount(),
@@ -602,7 +613,7 @@ public:
                 ASSERT(!signature.returnType(index).isV128());
                 return marshallLocation(role, signature.returnType(index), gpArgumentCount, fpArgumentCount, resultStackOffset);
             });
-        return { thisArgument, WTFMove(params), WTFMove(results), std::max(argStackOffset, resultStackOffset) };
+        return { thisArgument, WTFMove(params), WTFMove(results), std::max(argStackOffset, resultStackOffset), std::max(stackArgsCount, stackResultsCount) };
     }
 
     const Vector<GPRReg> gprArgs;

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -66,6 +66,10 @@ struct JumpTableEntry;
     } while (false)
 
 class FunctionIPIntMetadataGenerator {
+    struct MetadataBufferMalloc final : public FastMalloc {
+        static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity) { return capacity + capacity; }
+    };
+
     WTF_MAKE_TZONE_ALLOCATED(FunctionIPIntMetadataGenerator);
     WTF_MAKE_NONCOPYABLE(FunctionIPIntMetadataGenerator);
 
@@ -96,6 +100,7 @@ public:
     unsigned addSignature(const TypeDefinition&);
 
 private:
+    using MetadataBuffer = Vector<uint8_t, 0, UnsafeVectorOverflow, 16, MetadataBufferMalloc>;
 
     inline void addBlankSpace(size_t);
     template <typename T> inline void addBlankSpace() { addBlankSpace(sizeof(T)); };
@@ -120,7 +125,7 @@ private:
     BitVector m_tailCallSuccessors;
 
     std::span<const uint8_t> m_bytecode;
-    Vector<uint8_t> m_metadata { };
+    MetadataBuffer m_metadata { };
     Vector<uint8_t, 8> m_uINTBytecode { };
     unsigned m_highestReturnStackOffset;
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -97,8 +97,8 @@ void FunctionSignature::dump(PrintStream& out) const
     }
 }
 
-FunctionSignature::FunctionSignature(Type* payload, FunctionArgCount argumentCount, FunctionArgCount returnCount)
-    : m_payload(payload)
+FunctionSignature::FunctionSignature(void* payload, FunctionArgCount argumentCount, FunctionArgCount returnCount)
+    : m_payload(static_cast<Type*>(payload))
     , m_argCount(argumentCount)
     , m_retCount(returnCount)
 { }
@@ -123,8 +123,8 @@ void StructType::dump(PrintStream& out) const
     out.print(")"_s);
 }
 
-StructType::StructType(FieldType* payload, StructFieldCount fieldCount, const FieldType* fieldTypes)
-    : m_payload(payload)
+StructType::StructType(void* payload, StructFieldCount fieldCount, const FieldType* fieldTypes)
+    : m_payload(static_cast<FieldType*>(payload))
     , m_fieldCount(fieldCount)
     , m_hasRecursiveReference(false)
 {
@@ -355,7 +355,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateFunctionSignature(FunctionArgCou
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::FunctionSignature, returnCount, argumentCount);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<FunctionSignature>, argumentCount, returnCount);
     return adoptRef(signature);
 }
 
@@ -366,7 +366,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateStructType(StructFieldCount fiel
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::StructType, fieldCount, fields);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<StructType>, fieldCount, fields);
     return adoptRef(signature);
 }
 
@@ -377,7 +377,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateArrayType()
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::ArrayType);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<ArrayType>);
     return adoptRef(signature);
 }
 
@@ -388,7 +388,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateRecursionGroup(RecursionGroupCou
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::RecursionGroup, typeCount);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<RecursionGroup>, typeCount);
     return adoptRef(signature);
 }
 
@@ -399,7 +399,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateProjection()
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::Projection);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<Projection>);
     return adoptRef(signature);
 }
 
@@ -410,7 +410,7 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateSubtype(SupertypeCount count, bo
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(TypeDefinitionKind::Subtype, count, isFinal);
+    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(std::in_place_type<Subtype>, count, isFinal);
     return adoptRef(signature);
 }
 


### PR DESCRIPTION
#### 5f50c2e0c206b7f0fe8ca5040af207298a09c399
<pre>
[JSC] Further optimize wasm init time
<a href="https://bugs.webkit.org/show_bug.cgi?id=287076">https://bugs.webkit.org/show_bug.cgi?id=287076</a>
<a href="https://rdar.apple.com/144217504">rdar://144217504</a>

Reviewed by Keith Miller.

This patch further optimizes wasm init time.

1. addCall&apos;s signature is already expanded, so we do not need to do it
   again.
2. CallInformation should hold numberOfStackValues for wasm.
3. IPIntGenerator MetadataBuffer increase policy should be 2x.
4. We introduce CallCommonData bytecode cache.
5. Use shrink(0) instead of clear() for control flow stack in IPIntGenerator.
6. Do style fix.

                                  ToT                     Patched

    hashset-wasm-load      376.2614+-1.0030     ^    318.7618+-0.6149        ^ definitely 1.1804x faster

* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::CallInformation::CallInformation):
(JSC::Wasm::WasmCallingConvention::callInformationFor const):
(JSC::Wasm::JSCallingConvention::callInformationFor const):
(JSC::Wasm::CCallingConventionArmThumb2::callInformationFor const):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::cachedCallInformationFor):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addTailCallCommonData):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::FunctionSignature::FunctionSignature):
(JSC::Wasm::StructType::StructType):
(JSC::Wasm::TypeDefinition::tryCreateFunctionSignature):
(JSC::Wasm::TypeDefinition::tryCreateStructType):
(JSC::Wasm::TypeDefinition::tryCreateArrayType):
(JSC::Wasm::TypeDefinition::tryCreateRecursionGroup):
(JSC::Wasm::TypeDefinition::tryCreateProjection):
(JSC::Wasm::TypeDefinition::tryCreateSubtype):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::ArrayType::ArrayType):
(JSC::Wasm::RecursionGroup::RecursionGroup):
(JSC::Wasm::Projection::Projection):
(JSC::Wasm::Subtype::Subtype):
(JSC::Wasm::TypeDefinition::TypeDefinition):

Canonical link: <a href="https://commits.webkit.org/289881@main">https://commits.webkit.org/289881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bac32daec619f9c45d71a7fd1590fe384ff905ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88264 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39014 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68090 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25810 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79827 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48459 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6010 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34236 "Found 60 new test failures: accessibility/negative-tabindex-does-not-expose-label.html fast/repaint/switch-overflow-vertical-rl.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38122 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81062 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95063 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76953 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75684 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76199 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20591 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8461 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13787 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15452 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20751 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109533 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15194 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26344 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->