### PR TITLE
[JSC] Make ArithNegate / ArithAbs ImpureNaN propagation more precise

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -818,13 +818,17 @@ private:
             case Floor:
             case Ceil:
             case Trunc:
-            case Abs:
-            case Neg:
             case Mul:
             case Add:
             case PurifyNaN:
                 replaceWithIdentity(m_value->child(0));
                 break;
+            case Abs:
+            case Neg: {
+                if (isARM64())
+                    replaceWithIdentity(m_value->child(0));
+                break;
+            }
             default:
                 break;
             }

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1318,6 +1318,7 @@ void testTernarySubInstructionSelection(B3::Opcode valueModifier, Type valueType
 void testNegDouble(double);
 void testNegFloat(float);
 void testNegFloatWithUselessDoubleConversion(float);
+void testImpureNaN();
 
 void addArgTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 void addBitTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -161,6 +161,7 @@ void run(const TestConfig* config)
     RUN_UNARY(testNegDouble, floatingPointOperands<double>());
     RUN_UNARY(testNegFloat, floatingPointOperands<float>());
     RUN_UNARY(testNegFloatWithUselessDoubleConversion, floatingPointOperands<float>());
+    RUN(testImpureNaN());
 
     addBitTests(config, tasks);
 

--- a/Source/JavaScriptCore/b3/testb3_2.cpp
+++ b/Source/JavaScriptCore/b3/testb3_2.cpp
@@ -3286,6 +3286,28 @@ void testNegDouble(double a)
     CHECK(isIdentical(compileAndRun<double>(proc, a), -a));
 }
 
+void testImpureNaN()
+{
+    if (isARM64()) {
+        {
+            Procedure proc;
+            BasicBlock* root = proc.addBlock();
+            auto arguments = cCallArgumentValues<double>(proc, root);
+            root->appendNewControlValue(proc, Return, Origin(), root->appendNew<Value>(proc, Neg, Origin(), arguments[0]));
+            double res = compileAndRun<double>(proc, ImpureNaN);
+            CHECK(!isImpureNaN(res));
+        }
+        {
+            Procedure proc;
+            BasicBlock* root = proc.addBlock();
+            auto arguments = cCallArgumentValues<double>(proc, root);
+            root->appendNewControlValue(proc, Return, Origin(), root->appendNew<Value>(proc, Abs, Origin(), arguments[0]));
+            double res = compileAndRun<double>(proc, ImpureNaN);
+            CHECK(!isImpureNaN(res));
+        }
+    }
+}
+
 void testNegFloat(float a)
 {
     Procedure proc;

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -853,10 +853,17 @@ SpeculatedType typeOfDoubleMinMax(SpeculatedType a, SpeculatedType b)
 
 SpeculatedType typeOfDoubleNegation(SpeculatedType value)
 {
-    // Changing bits can make pure NaN impure and vice versa:
-    // 0xefff000000000000 (pure) - 0xffff000000000000 (impure)
-    if (value & SpecDoubleNaN)
-        value |= SpecDoubleNaN;
+    if (isARM64()) {
+        // ARM64 will just use fneg, which makes impure NaN -> pure NaN.
+        // Including negation & abs.
+        if (value & SpecDoubleNaN)
+            value = (value & ~SpecDoubleNaN) | SpecDoublePureNaN;
+    } else {
+        // Changing bits can make pure NaN impure and vice versa:
+        // 0xefff000000000000 (pure) - 0xffff000000000000 (impure)
+        if (value & SpecDoubleNaN)
+            value |= SpecDoubleNaN;
+    }
     // We could get negative zero, which mixes SpecAnyIntAsDouble and SpecNotIntAsDouble.
     // We could also overflow a large negative int into something that is no longer
     // representable as an int.

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -109,6 +109,15 @@ private:
     void handleNode()
     {
         switch (m_node->op()) {
+        case ArithAbs:
+        case ArithNegate: {
+            if (isARM64()) {
+                if (foldPurifyNaNOnUnary(m_node))
+                    m_changed = true;
+            }
+            break;
+        }
+
         case Branch:
         case PurifyNaN:
         case DoubleAsInt32:
@@ -118,8 +127,6 @@ private:
         case ParseInt:
         case ToIntegerOrInfinity:
         case ToLength:
-        case ArithAbs:
-        case ArithNegate:
         case ArithFRound:
         case ArithF16Round:
         case ArithRound:

--- a/Source/JavaScriptCore/runtime/PureNaN.h
+++ b/Source/JavaScriptCore/runtime/PureNaN.h
@@ -73,6 +73,8 @@ namespace JSC {
 // never happen, but it's healthy to be paranoid.
 static constexpr uint64_t PNaNAsBits { 0x7ff8000000000000ll };
 static constexpr double PNaN { std::bit_cast<double>(PNaNAsBits) };
+static constexpr uint64_t ImpureNaNAsBits { 0xffff000000000000ULL };
+static constexpr double ImpureNaN { std::bit_cast<double>(ImpureNaNAsBits) };
 
 inline constexpr bool isImpureNaN(double value)
 {


### PR DESCRIPTION
#### 382919880a00d89bcd736751d6117a225277ebda
<pre>
[JSC] Make ArithNegate / ArithAbs ImpureNaN propagation more precise
<a href="https://bugs.webkit.org/show_bug.cgi?id=287081">https://bugs.webkit.org/show_bug.cgi?id=287081</a>
<a href="https://rdar.apple.com/144224569">rdar://144224569</a>

Reviewed by Yijia Huang.

This patch makes ArithNegate / ArithAbs ImpureNaN propagation more precise.
On ARM64, we have native instructions for them in Double, and they will
produce pure NaN for impure NaN input.

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_2.cpp:
(testImpureNaN):
* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::typeOfDoubleNegation):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/runtime/PureNaN.h:

Canonical link: <a href="https://commits.webkit.org/289880@main">https://commits.webkit.org/289880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42c7c09275413a9c45df1298cbfd449f69a30b21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39015 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68093 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25812 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79840 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48462 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6012 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-018.html imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-026.html imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-011.html imported/w3c/web-platform-tests/fetch/metadata/fetch-preflight.https.sub.any.html imported/w3c/web-platform-tests/fetch/metadata/generated/element-frame.sub.html imported/w3c/web-platform-tests/fetch/range/non-matching-range-response.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-pageshow-events-iframe-contentWindow.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34250 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38123 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81063 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95064 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87041 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15435 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76956 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75697 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76202 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8463 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13786 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20752 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109534 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15195 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26345 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->