### PR TITLE
Mark a couple of traverse functions functor parameters as NOESCAPE

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
@@ -53,7 +53,7 @@
 namespace WebKit {
 namespace NetworkCache {
 
-void traverseDirectory(const String& path, const Function<void (const String&, DirectoryEntryType)>& function)
+void traverseDirectory(const String& path, NOESCAPE const Function<void (const String&, DirectoryEntryType)>& function)
 {
     auto entries = FileSystem::listDirectory(path);
     for (auto& entry : entries) {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.h
@@ -31,7 +31,7 @@ namespace WebKit {
 namespace NetworkCache {
 
 enum class DirectoryEntryType { Directory, File };
-void traverseDirectory(const String& path, const Function<void (const String& fileName, DirectoryEntryType)>&);
+void traverseDirectory(const String& path, NOESCAPE const Function<void (const String& fileName, DirectoryEntryType)>&);
 
 struct FileTimes {
     WallTime creation;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -360,7 +360,7 @@ RefPtr<Storage> Storage::open(const String& baseCachePath, Mode mode, size_t cap
 }
 
 using RecordFileTraverseFunction = Function<void (const String& fileName, const String& hashString, const String& type, bool isBlob, const String& recordDirectoryPath)>;
-static void traverseRecordsFiles(const String& recordsPath, const String& expectedType, const RecordFileTraverseFunction& function)
+static void traverseRecordsFiles(const String& recordsPath, const String& expectedType, NOESCAPE const RecordFileTraverseFunction& function)
 {
     traverseDirectory(recordsPath, [&](const String& partitionName, DirectoryEntryType entryType) {
         if (entryType != DirectoryEntryType::Directory)


### PR DESCRIPTION
#### d08ef24fbdb043433dd2526f39faa225dee35b84
<pre>
Mark a couple of traverse functions functor parameters as NOESCAPE
<a href="https://bugs.webkit.org/show_bug.cgi?id=287083">https://bugs.webkit.org/show_bug.cgi?id=287083</a>

Reviewed by Chris Dumez.

These functions don&apos;t run anything asynchronously, so their
functor parameters can be marked as NOESCAPE. This should get
rid of a few uncounted lambda captures warnings.

* Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp:
(WebKit::NetworkCache::traverseDirectory):
* Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::traverseRecordsFiles):

Canonical link: <a href="https://commits.webkit.org/289887@main">https://commits.webkit.org/289887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8789997af88910a795697bb1eee92040123ba0e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39021 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68097 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79837 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48465 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6017 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95070 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15441 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11323 "Found 3 new test failures: http/tests/pdf/linearized-pdf-in-iframe.html http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76959 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75694 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76205 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20598 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8477 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13792 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15459 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20758 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->