### PR TITLE
[GTK][WPE] REGRESSION(289816@main) Update JSC Options test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
@@ -4470,13 +4470,21 @@ static void testsJSCOptions()
     g_assert_cmpuint(maxPerThreadStackUsage, ==, 4096);
     g_assert_true(jsc_options_set_uint("maxPerThreadStackUsage", 5242880));
 
-    gsize wasmPartialCompileLimit;
-    g_assert_true(jsc_options_get_size("wasmPartialCompileLimit", &wasmPartialCompileLimit));
-    g_assert_cmpuint(wasmPartialCompileLimit, ==, 5000);
-    g_assert_true(jsc_options_set_size("wasmPartialCompileLimit", 6000));
-    g_assert_true(jsc_options_get_size("wasmPartialCompileLimit", &wasmPartialCompileLimit));
-    g_assert_cmpuint(wasmPartialCompileLimit, ==, 6000);
-    g_assert_true(jsc_options_set_size("wasmPartialCompileLimit", 5000));
+    gsize wasmSmallPartialCompileLimit;
+    g_assert_true(jsc_options_get_size("wasmSmallPartialCompileLimit", &wasmSmallPartialCompileLimit));
+    g_assert_cmpuint(wasmSmallPartialCompileLimit, ==, 5000);
+    g_assert_true(jsc_options_set_size("wasmSmallPartialCompileLimit", 6000));
+    g_assert_true(jsc_options_get_size("wasmSmallPartialCompileLimit", &wasmSmallPartialCompileLimit));
+    g_assert_cmpuint(wasmSmallPartialCompileLimit, ==, 6000);
+    g_assert_true(jsc_options_set_size("wasmSmallPartialCompileLimit", 5000));
+
+    gsize wasmLargePartialCompileLimit;
+    g_assert_true(jsc_options_get_size("wasmLargePartialCompileLimit", &wasmLargePartialCompileLimit));
+    g_assert_cmpuint(wasmLargePartialCompileLimit, ==, 20000);
+    g_assert_true(jsc_options_set_size("wasmLargePartialCompileLimit", 25000));
+    g_assert_true(jsc_options_get_size("wasmLargePartialCompileLimit", &wasmLargePartialCompileLimit));
+    g_assert_cmpuint(wasmLargePartialCompileLimit, ==, 25000);
+    g_assert_true(jsc_options_set_size("wasmLargePartialCompileLimit", 20000));
 
     gdouble criticalGCMemoryThreshold;
     g_assert_true(jsc_options_get_double("criticalGCMemoryThreshold", &criticalGCMemoryThreshold));
@@ -4565,7 +4573,9 @@ static void testsJSCOptions()
             g_assert_true(type == JSC_OPTION_INT);
         else if (!g_strcmp0(option, "maxPerThreadStackUsage"))
             g_assert_true(type == JSC_OPTION_UINT);
-        else if (!g_strcmp0(option, "wasmPartialCompileLimit"))
+        else if (!g_strcmp0(option, "wasmSmallPartialCompileLimit"))
+            g_assert_true(type == JSC_OPTION_SIZE);
+        else if (!g_strcmp0(option, "wasmLargePartialCompileLimit"))
             g_assert_true(type == JSC_OPTION_SIZE);
         else if (!g_strcmp0(option, "smallHeapRAMFraction"))
             g_assert_true(type == JSC_OPTION_DOUBLE);
@@ -4579,7 +4589,7 @@ static void testsJSCOptions()
         (*static_cast<unsigned*>(userData))++;
         return FALSE;
     }, &optionsCount);
-    g_assert_cmpuint(optionsCount, ==, 7);
+    g_assert_cmpuint(optionsCount, ==, 8);
 
     GOptionContext* context = g_option_context_new(nullptr);
     g_option_context_add_group(context, jsc_options_get_option_group());
@@ -4588,7 +4598,7 @@ static void testsJSCOptions()
         "--jsc-useJIT=false",
         "--jsc-thresholdForJITAfterWarmUp=2000",
         "--jsc-maxPerThreadStackUsage=1024",
-        "--jsc-wasmPartialCompileLimit=4000",
+        "--jsc-wasmSmallPartialCompileLimit=4000",
         "--jsc-criticalGCMemoryThreshold=0.95",
         "--jsc-configFile=/tmp/bar",
         "--jsc-bytecodeRangeToJITCompile=100:300",
@@ -4607,8 +4617,8 @@ static void testsJSCOptions()
     g_assert_cmpint(thresholdForJITAfterWarmUp, ==, 2000);
     g_assert_true(jsc_options_get_uint("maxPerThreadStackUsage", &maxPerThreadStackUsage));
     g_assert_cmpuint(maxPerThreadStackUsage, ==, 1024);
-    g_assert_true(jsc_options_get_size("wasmPartialCompileLimit", &wasmPartialCompileLimit));
-    g_assert_cmpuint(wasmPartialCompileLimit, ==, 4000);
+    g_assert_true(jsc_options_get_size("wasmSmallPartialCompileLimit", &wasmSmallPartialCompileLimit));
+    g_assert_cmpuint(wasmSmallPartialCompileLimit, ==, 4000);
     g_assert_true(jsc_options_get_double("criticalGCMemoryThreshold", &criticalGCMemoryThreshold));
     g_assert_cmpfloat(criticalGCMemoryThreshold, ==, 0.95);
     g_assert_true(jsc_options_get_string("configFile", &configFile.outPtr()));
@@ -4622,7 +4632,7 @@ static void testsJSCOptions()
     g_assert_true(jsc_options_set_boolean(JSC_OPTIONS_USE_JIT, TRUE));
     g_assert_true(jsc_options_set_int("thresholdForJITAfterWarmUp", 500));
     g_assert_true(jsc_options_set_uint("maxPerThreadStackUsage", 5242880));
-    g_assert_true(jsc_options_set_size("wasmPartialCompileLimit", 5000));
+    g_assert_true(jsc_options_set_size("wasmSmallPartialCompileLimit", 5000));
     g_assert_true(jsc_options_set_double("smallHeapRAMFraction", 0.25));
     g_assert_true(jsc_options_set_string("configFile", nullptr));
     g_assert_true(jsc_options_set_range_string("bytecodeRangeToJITCompile", nullptr));


### PR DESCRIPTION
#### 7975f75dd31e7052a55791eef840ad289d7e248c
<pre>
[GTK][WPE] REGRESSION(289816@main) Update JSC Options test
<a href="https://bugs.webkit.org/show_bug.cgi?id=287085">https://bugs.webkit.org/show_bug.cgi?id=287085</a>

Reviewed by Michael Catanzaro.

wasmPartialCompileLimit was replaced by wasmSmallPartialCompileLimit
and wasmLargePartialCompileLimit, update test accordingly.

* Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp:
(testsJSCOptions):

Canonical link: <a href="https://commits.webkit.org/289879@main">https://commits.webkit.org/289879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5694fe0bd87e4c862fe5b9fde97b8c3239cdce4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68100 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25819 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6022 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34254 "Found 3 new test failures: accessibility/noscript-ignored.html editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38134 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81074 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95075 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87052 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15446 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76963 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20603 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8483 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13785 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15464 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109545 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15206 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26349 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->