### PR TITLE
Unreviewed, fix the internal iOS engineering build (again)

### DIFF
--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -288,7 +288,7 @@ typedef NS_ENUM(NSInteger, _UIDataOwner) {
 @end
 
 @protocol UITextInputSuggestionDelegate <UITextInputDelegate>
-- (void)setSuggestions:(NSArray <UITextSuggestion*> *)suggestions;
+- (void)setSuggestions:(NSArray<UITextSuggestion *> *)suggestions;
 @end
 
 @interface UIScrollView (SPI)

--- a/Tools/TestWebKitAPI/Tests/ios/DataListTextSuggestionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DataListTextSuggestionTests.mm
@@ -34,11 +34,10 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
 
-@interface DataListTextSuggestionInputDelegate : NSObject <UITextInputSuggestionDelegate
+@interface DataListTextSuggestionInputDelegate : NSObject
 #if USE(BROWSERENGINEKIT)
-    , BETextInputDelegate
+    <BETextInputDelegate>
 #endif
->
 @end
 
 @implementation DataListTextSuggestionInputDelegate {
@@ -151,7 +150,7 @@ TEST(DataListTextSuggestionTestView, InsertSuggestion)
         "</datalist>"];
 
     RetainPtr inputDelegate = adoptNS([[DataListTextSuggestionInputDelegate alloc] init]);
-    [[webView textInputContentView] setInputDelegate:inputDelegate.get()];
+    [[webView textInputContentView] setInputDelegate:static_cast<id<UITextInputDelegate>>(inputDelegate.get())];
 #if USE(BROWSERENGINEKIT)
     [[webView asyncTextInput] setAsyncInputDelegate:inputDelegate.get()];
 #endif


### PR DESCRIPTION
#### e683ee0e78e8bb4e1fa03d56799b4923003d34cd
<pre>
Unreviewed, fix the internal iOS engineering build (again)
<a href="https://rdar.apple.com/144232842">rdar://144232842</a>

Apply the same treatment in 289848@main to another mock object used only for API tests:
`DataListTextSuggestionInputDelegate`.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/ios/DataListTextSuggestionTests.mm:
(TestWebKitAPI::TEST(DataListTextSuggestionTestView, InsertSuggestion)):

Canonical link: <a href="https://commits.webkit.org/289868@main">https://commits.webkit.org/289868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30c232f8e6127b27eaf9f62906ed19d757dd6e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39027 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15977 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91279 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79845 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48471 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6023 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38135 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15447 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75702 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20604 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8485 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15465 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->