### PR TITLE
[web-animations] update effect stack membership when animation relevance changes

### DIFF
--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -72,10 +72,8 @@ void AnimationTimeline::removeAnimation(WebAnimation& animation)
     ASSERT(!animation.timeline() || animation.timeline() == this);
     m_animations.remove(animation);
     if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animation.effect())) {
-        if (auto styleable = keyframeEffect->targetStyleable()) {
+        if (auto styleable = keyframeEffect->targetStyleable())
             styleable->animationWasRemoved(animation);
-            styleable->ensureKeyframeEffectStack().removeEffect(*keyframeEffect);
-        }
     }
 }
 

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -134,7 +134,6 @@ public:
     OptionSet<AnimationImpact> apply(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds> = std::nullopt);
     void invalidate();
 
-    void animationTimingDidChange();
     void animationRelevancyDidChange();
     void transformRelatedPropertyDidChange();
     enum class RecomputationReason : uint8_t { LogicalPropertyChange, Other };

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -55,6 +55,8 @@ bool KeyframeEffectStack::addEffect(KeyframeEffect& effect)
     if (!effect.targetStyleable() || !effect.animation() || !effect.animation()->timeline() || !effect.animation()->isRelevant())
         return false;
 
+    ASSERT(!m_effects.contains(&effect));
+
     m_effects.append(effect);
     m_isSorted = false;
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -100,7 +100,7 @@ public:
 
     enum class ReplaceState : uint8_t { Active, Removed, Persisted };
     ReplaceState replaceState() const { return m_replaceState; }
-    void setReplaceState(ReplaceState replaceState) { m_replaceState = replaceState; }
+    void setReplaceState(ReplaceState);
 
     bool pending() const { return hasPendingPauseTask() || hasPendingPlayTask(); }
 

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -239,8 +239,18 @@ bool Styleable::isRunningAcceleratedTransformAnimation() const
 
 bool Styleable::hasRunningAcceleratedAnimations() const
 {
-    if (auto* effectStack = keyframeEffectStack())
-        return effectStack->hasAcceleratedEffects(element.document().settings());
+    if (auto* effectStack = keyframeEffectStack()) {
+        if (effectStack->hasAcceleratedEffects(element.document().settings()))
+            return true;
+    }
+
+    for (RefPtr animation : WebAnimation::instances()) {
+        if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect())) {
+            if (keyframeEffect->isRunningAccelerated() && keyframeEffect->targetStyleable() == *this)
+                return true;
+        }
+    }
+
     return false;
 }
 


### PR DESCRIPTION
#### e81cfc86cc3bc48022f3e3c436c47447ade7a2df
<pre>
[web-animations] update effect stack membership when animation relevance changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=287087">https://bugs.webkit.org/show_bug.cgi?id=287087</a>

Reviewed by Tim Nguyen.

We used to update an effect&apos;s membership in the effect stack in various places. But since
effect stack membership is only determined by the associated animation&apos;s relevance, we should
tie membership updates to animation relevancy changes. Since we already have a method called
when animation relevancy changes, `KeyframeEffect::animationRelevancyDidChange()`, we centralize
effect membership updates there and remove all other calls to `KeyframeEffectStack::removeEffect()`
and `KeyframeEffectStack::addEffect()` besides those in `KeyframeEffect::didChangeTargetStyleable()`
used to transition an effect from one effect stack to another.

This refactoring should have no observable effect but it did break the test
webanimations/accelerated-translate-animation-additional-animation-added-in-flight.html. Indeed,
this test checks that an animation target&apos;s layer remains composited as that animation&apos;s `finished`
promise is resolved upon completion, where other tests check that the layer is no longer composited
in the next rendering frame.

To make this test pass still, we needed to make a couple of additional changes. The method used
to determine whether a running animation should trigger a compositing layer in this case is
`RenderLayerCompositor::requiresCompositingForAnimation()`. That method calls into
`Styleable::hasRunningAcceleratedAnimations()`, which queries the associated effect stack for
effects that are running accelerated. However, the other changes in this patch now more reliably
update the effect stack as soon as animation relevancy changes, and in that test&apos;s case as soon
as we determine the animation has completed, which is to say when we&apos;ll resolve the `finished`
promise, we remove the animation effect from the associated effect stack and the method
`Styleable::hasRunningAcceleratedAnimations()` will return `false` immediately.

So we now add another check in `Styleable::hasRunningAcceleratedAnimations()` where we query
all known animations in case we didn&apos;t find an accelerated effect in the effect stack.

Another required changes was to add a check for whether an animation was associated with an effect
in `KeyframeEffect::canBeAccelerated()`, which ought to always have been there from the start.

This refactoring effort will help us fix a number of `timeline-scope` going forwards where we
dynamically update timelines.

* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::removeAnimation):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationTimelineDidChange):
(WebCore::KeyframeEffect::animationRelevancyDidChange):
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::wasRemovedFromEffectStack):
(WebCore::KeyframeEffect::animationTimingDidChange): We no longer need this method since its sole
purpose was to call `updateEffectStackMembership()`, but we now do so under `animationRelevancyDidChange()`
which will be called under `WebAnimation::timingDidChange()` through `updateFinishedState()`.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::addEffect):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setEffectInternal):
(WebCore::WebAnimation::timingDidChange):
(WebCore::WebAnimation::persist):
(WebCore::WebAnimation::setReplaceState):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::setReplaceState): Deleted.
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::hasRunningAcceleratedAnimations const):

Canonical link: <a href="https://commits.webkit.org/289928@main">https://commits.webkit.org/289928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df25cfaad4de6fe6eaa9a8d7238f1ab0ac109e46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42905 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93423 "Failed to checkout and rebase branch from PR 40054") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16168 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/93423 "Failed to checkout and rebase branch from PR 40054") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91467 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/93423 "Failed to checkout and rebase branch from PR 40054") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/38327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/95265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15640 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/95265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15896 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/75870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/95265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/20745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13822 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15656 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15397 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->