### PR TITLE
[JSC] Enable Allocation Sinking for NewArrayWithConstantSize

### DIFF
--- a/JSTests/microbenchmarks/loop-unrolling-4.js
+++ b/JSTests/microbenchmarks/loop-unrolling-4.js
@@ -11,15 +11,14 @@ function test(s) {
     for (var i = 0; i < len; i++) {
         a[i] = s[i];
     }
-    // FIXME: why read a[0] is not eliminated but a[1] does?
     s[0] = a[0] ^ a[1];
     return s;
 }
 noInline(test);
 
 let expected;
-for (let i = 0; i < 1e5; i++) {
-    let a = [0, 0];
+for (let i = 0; i < 1e6; i++) {
+    let a = [0, 0, 0, 0];
     let res = test(a);
     if (i == 0)
         expected = res;

--- a/JSTests/microbenchmarks/loop-unrolling-5.js
+++ b/JSTests/microbenchmarks/loop-unrolling-5.js
@@ -1,0 +1,35 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function test(s) {
+    var a = new Array(4);
+    for (var i = 0; i < 4; i++) {
+        a[i] = s[i] & 0x80;
+    }
+
+    s[0] = a[0] ^ a[1] ^ a[2];
+    s[1] = a[1] ^ a[2] ^ a[3];
+    s[2] = a[2] ^ a[3] ^ a[0];
+    s[3] = a[3] ^ a[0] ^ a[1];
+
+    s[4] = a[0] ^ a[1] ^ a[2];
+    s[5] = a[1] ^ a[2] ^ a[3];
+    s[6] = a[2] ^ a[3] ^ a[0];
+    s[7] = a[3] ^ a[0] ^ a[1];
+    return s;
+}
+noInline(test);
+
+let expected;
+for (let i = 0; i < 1e5; i++) {
+    let a = [1, 2, 3, 4, 5, 6, 7, 8];
+    let res = test(a);
+    if (i == 0)
+        expected = res;
+    assert(res, expected);
+}
+

--- a/JSTests/stress/array-allocation-sink.js
+++ b/JSTests/stress/array-allocation-sink.js
@@ -1,0 +1,180 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function run(func, a) {
+    let expected;
+    for (let i = 0; i < 1e5; i++) {
+        if (a == undefined)
+            a = [1, 2];
+        let res = func(a);
+        if (i == 0)
+            expected = res;
+        assert(res, expected);
+    }
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 43; // ArrayWithInt32
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = s[1] & 0x8; // ArrayWithInt32
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = s[1]; // ArrayWithContiguous
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = s[1]; // ArrayWithDouble
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test, [0.1, 0.2]);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = { f: 10 }; // ArrayWithContiguous
+        s[0] = a[0];
+
+        var q = { f: s[1] ? a : 42 }; // MaterializeNewArrayWithConstantSize
+        return s;
+    }
+    noInline(test);
+    run(test, [0.1, 0.2]);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        a.length = 10; // escape
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 42;
+        s[1] = a.length;
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 42;
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        Array[Symbol.species] = 99; // FIXME: Maybe we should not sink
+        let a = new Array(4); // NewArrayWithConstantSize | sink
+        a[0] = 42;
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        s[0] = a[0];
+        globalThis.ref = a; // escape
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        Array.prototype[2] = 99; // ArrayPrototypeChainIsSaneWatchpoint = IsInvalidated
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        s[0] = a[2];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[0] = 42;
+        s[0] = a[0];
+        let sliced = a.slice();  // escape
+        let mapped = a.map(x => x * 2);  // escape
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+{
+    function test(s) {
+        let a = new Array(4); // NewArrayWithConstantSize | no sink
+        a[10] = 42;  // Out of bounds
+        s[0] = a[0];
+        return s;
+    }
+    noInline(test);
+    run(test);
+}
+
+

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3456,6 +3456,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case NewArrayWithConstantSize:
+    case MaterializeNewArrayWithConstantSize:
         setForNode(node, m_graph.globalObjectFor(node->origin.semantic)->arrayStructureForIndexingTypeDuringAllocation(node->indexingMode()));
         break;
 
@@ -3713,6 +3714,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case PhantomNewObject:
+    case PhantomNewArrayWithConstantSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1740,6 +1740,8 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case NewArrayWithConstantSize:
+    case PhantomNewArrayWithConstantSize:
+    case MaterializeNewArrayWithConstantSize:
         read(HeapObjectCount);
         write(HeapObjectCount);
         def(HeapLocation(ArrayLengthLoc, Butterfly_publicLength, node), LazyNode(graph.freeze(jsNumber(node->newArraySize()))));

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1012,18 +1012,11 @@ private:
                 if (m_graph.isWatchingHavingABadTimeWatchpoint(node)) {
                     if (node->child1().useKind() == Int32Use && node->child1()->isInt32Constant()) {
                         int32_t length = node->child1()->asInt32();
-                        if (length >= 0 && length < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH) {
-                            switch (node->indexingType()) {
-                            case ALL_DOUBLE_INDEXING_TYPES:
-                            case ALL_INT32_INDEXING_TYPES:
-                            case ALL_CONTIGUOUS_INDEXING_TYPES: {
+                        if (length >= 0
+                            && length < MIN_ARRAY_STORAGE_CONSTRUCTION_LENGTH
+                            && isNewArrayWithConstantSizeIndexingType(node->indexingType())) {
                                 node->convertToNewArrayWithConstantSize(m_graph, length);
                                 changed = true;
-                                break;
-                            }
-                            default:
-                                break;
-                            }
                         }
                     }
                 }
@@ -1501,6 +1494,7 @@ private:
             }
 
             case PhantomNewObject:
+            case PhantomNewArrayWithConstantSize:
             case PhantomNewFunction:
             case PhantomNewGeneratorFunction:
             case PhantomNewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -224,6 +224,7 @@ bool doesGC(Graph& graph, Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
+    case PhantomNewArrayWithConstantSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -430,6 +431,7 @@ bool doesGC(Graph& graph, Node* node)
     case EnumeratorNextUpdatePropertyName:
     case EnumeratorNextUpdateIndexAndMode:
     case MaterializeNewObject:
+    case MaterializeNewArrayWithConstantSize:
     case MaterializeNewInternalFieldObject:
     case MaterializeCreateActivation:
     case SetFunctionName:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2502,6 +2502,7 @@ private:
         case Identity: // This should have been cleaned up.
         case BooleanToNumber:
         case PhantomNewObject:
+        case PhantomNewArrayWithConstantSize:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -2523,6 +2524,7 @@ private:
         case CheckStructureOrEmpty:
         case CheckArrayOrEmpty:
         case MaterializeNewObject:
+        case MaterializeNewArrayWithConstantSize:
         case MaterializeCreateActivation:
         case MaterializeNewInternalFieldObject:
         case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGInsertionSet.h
+++ b/Source/JavaScriptCore/dfg/DFGInsertionSet.h
@@ -130,6 +130,11 @@ public:
     
     size_t execute(BasicBlock* block);
 
+    bool isEmpty()
+    {
+        return m_insertions.isEmpty();
+    }
+
 private:
     void insertSlow(const Insertion&);
     

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -71,6 +71,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case BottomValue:
     case PutHint:
     case PhantomNewObject:
+    case PhantomNewArrayWithConstantSize:
     case PhantomNewInternalFieldObject:
     case PutStack:
     case KillStack:
@@ -145,6 +146,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case CreateActivation:
     case MaterializeCreateActivation:
     case MaterializeNewObject:
+    case MaterializeNewArrayWithConstantSize:
     case MaterializeNewInternalFieldObject:
     case NewFunction:
     case NewGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -415,6 +415,8 @@ namespace JSC { namespace DFG {
     \
     macro(Spread, NodeResultJS | NodeMustGenerate) \
     /* Support for allocation sinking. */\
+    macro(PhantomNewArrayWithConstantSize, NodeResultJS | NodeMustGenerate) \
+    macro(MaterializeNewArrayWithConstantSize, NodeResultJS | NodeHasVarArgs) \
     macro(PhantomNewObject, NodeResultJS | NodeMustGenerate) \
     macro(PutHint, NodeMustGenerate) \
     macro(CheckStructureImmediate, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -145,13 +145,15 @@ public:
     // once it is escaped if it still has pointers to it in order to
     // replace any use of those pointers by the corresponding
     // materialization
-    enum class Kind { Escaped, Object, Activation, Function, GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, InternalFieldObject, RegExpObject };
+    enum class Kind { Escaped, Array, Object, Activation, Function, GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, InternalFieldObject, RegExpObject };
 
     using Fields = UncheckedKeyHashMap<PromotedLocationDescriptor, Node*>;
 
-    explicit Allocation(Node* identifier = nullptr, Kind kind = Kind::Escaped)
+    explicit Allocation(Node* identifier = nullptr, Kind kind = Kind::Escaped, IndexingType indexingType = 0, unsigned length = 0)
         : m_identifier(identifier)
         , m_kind(kind)
+        , m_indexingType(indexingType)
+        , m_length(length)
     {
     }
 
@@ -186,6 +188,16 @@ public:
     void remove(PromotedLocationDescriptor descriptor)
     {
         set(descriptor, nullptr);
+    }
+
+    IndexingType indexingType()
+    {
+        return m_indexingType;
+    }
+
+    unsigned length()
+    {
+        return m_length;
     }
 
     bool hasStructures() const
@@ -244,6 +256,11 @@ public:
         return kind() == Kind::Escaped;
     }
 
+    bool isArrayAllocation() const
+    {
+        return m_kind == Kind::Array;
+    }
+
     bool isObjectAllocation() const
     {
         return m_kind == Kind::Object;
@@ -279,6 +296,10 @@ public:
     void dumpInContext(PrintStream& out, DumpContext* context) const
     {
         switch (m_kind) {
+        case Kind::Array:
+            out.print("Array"_s);
+            break;
+
         case Kind::Escaped:
             out.print("Escaped"_s);
             break;
@@ -330,6 +351,8 @@ private:
     Node* m_identifier; // This is the actual node that created the allocation
     Kind m_kind;
     Fields m_fields;
+    IndexingType m_indexingType { NoIndexingShape };
+    unsigned m_length { 0 };
 
     // This set of structures is the intersection of structures seen at control flow edges. It's used
     // for checks and speculation since it can't be widened.
@@ -342,11 +365,11 @@ private:
 
 class LocalHeap {
 public:
-    Allocation& newAllocation(Node* node, Allocation::Kind kind)
+    Allocation& newAllocation(Node* node, Allocation::Kind kind, IndexingType indexingType = NoIndexingShape, unsigned length = 0)
     {
         ASSERT(!m_pointers.contains(node) && !isAllocation(node));
         m_pointers.add(node, node);
-        return m_allocations.set(node, Allocation(node, kind)).iterator->value;
+        return m_allocations.set(node, Allocation(node, kind, indexingType, length)).iterator->value;
     }
 
     bool isAllocation(Node* identifier) const
@@ -786,6 +809,7 @@ public:
         , m_pointerSSA(graph)
         , m_allocationSSA(graph)
         , m_insertionSet(graph)
+        , m_rootInsertionSet(graph)
     {
     }
 
@@ -797,7 +821,7 @@ public:
         if (!performSinking())
             return false;
 
-        if (DFGObjectAllocationSinkingPhaseInternal::verbose) {
+        if constexpr (DFGObjectAllocationSinkingPhaseInternal::verbose) {
             dataLog("Graph after elimination:\n");
             m_graph.dump();
         }
@@ -822,17 +846,18 @@ private:
             graphBeforeSinking = out.toCString();
         }
 
-        if (DFGObjectAllocationSinkingPhaseInternal::verbose) {
+        if constexpr (DFGObjectAllocationSinkingPhaseInternal::verbose) {
             dataLog("Graph before elimination:\n");
             m_graph.dump();
         }
 
         performAnalysis();
+        ASSERT(m_rootInsertionSet.isEmpty());
 
         if (!determineSinkCandidates())
             return false;
 
-        if (DFGObjectAllocationSinkingPhaseInternal::verbose) {
+        if constexpr (DFGObjectAllocationSinkingPhaseInternal::verbose) {
             for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
                 dataLog("Heap at head of ", *block, ": \n", m_heapAtHead[block]);
                 dataLog("Heap at tail of ", *block, ": \n", m_heapAtTail[block]);
@@ -854,8 +879,7 @@ private:
 
         bool changed;
         do {
-            if (DFGObjectAllocationSinkingPhaseInternal::verbose)
-                dataLog("Doing iteration of escape analysis.\n");
+            dataLogLnIf(DFGObjectAllocationSinkingPhaseInternal::verbose, "Doing iteration of escape analysis.");
             changed = false;
 
             for (BasicBlock* block : m_graph.blocksInPreOrder()) {
@@ -906,6 +930,8 @@ private:
                 }
             }
         } while (changed);
+
+        m_rootInsertionSet.execute(m_graph.block(0));
     }
 
     template<typename InternalFieldClass>
@@ -919,6 +945,13 @@ private:
             writes.add(PromotedLocationDescriptor(InternalFieldObjectPLoc, index), LazyNode(m_graph.freeze(initialValues[index])));
 
         return result;
+    }
+
+    Node* ensureConstant(unsigned constant)
+    {
+        return m_constants.ensure(constant, [&]() {
+            return m_rootInsertionSet.insertConstant(0, m_graph.block(0)->at(0)->origin, jsNumber(constant));
+        }).iterator->value;
     }
 
     template<typename WriteFunctor, typename ResolveFunctor>
@@ -935,6 +968,124 @@ private:
         PromotedLocationDescriptor exactRead;
 
         switch (node->op()) {
+        case NewArrayWithConstantSize:
+            //    D@1 Array()
+            //    D@2 GetButterfly(D@1)
+            //    D@3 GetArrayLength(D@1, D@2) <- others
+            //    D@4 CheckInBounds(@index, D@3)
+            //    D@5 PutByVal(D@1, @index, @value, D@2, D@4)
+            //    D@6 GetByVal(D@1, @index, D@2, D@4)
+            //
+            //               D@1
+            //        -----------------
+            //         ^      ^      ^
+            //         |      |      |
+            //         |     D@2 <- D@3 <- others
+            //         |      ^      ^
+            //         |      |      |
+            //         |      |     D@4
+            //         |      |      ^
+            //         |      |      |
+            //        -----------------
+            //            D@5   D@6
+            //
+            // This is the dependency graph for an array with common usage patterns in the wild.
+            // Before converting D@1 (NewArrayWithConstantSize) into a phantom node, we must
+            // first lower its dependent nodes to ensure correctness.
+            //
+            // 1. D@5 (PutByVal) and D@6 (GetByVal) are leaf nodes and the only ones that reference
+            //    D@2 (GetButterfly) and D@4 (CheckInBounds). These must be lowered first.
+            //    - For the first implementation, we only handle in-bounds reads and writes with constant
+            //      index access, since these guarantee no array hole accesses.
+            //    - Every in-bounds read with a constant index can be safely replaced with its resolved value.
+            //
+            // 2. Since only D@5 and D@6 reference D@4, D@4 (CheckInBounds) must be removed when lowering them.
+            //
+            // 3. D@3 (GetArrayLength) may be referenced by other nodes, so we replace it with a constant size node.
+            //    - This is valid because we only sink arrays where all accesses are in-bounds,
+            //      ensuring that the array size remains a known constant.
+            //
+            // 4. Since D@2 (GetButterfly) is only referenced by D@5 and D@6, it will be eliminated
+            //    once those nodes are lowered.
+            //
+            // 5. Once all dependent nodes have been properly handled, D@1 can be safely converted
+            //    into a phantom node.
+            //
+            // 6. **If any other node in the program uses D@1 as an input (other than the cases listed above),**
+            //    **sinking will be disabled.** This ensures that no other operation:
+            //    - Adds new properties to the array.
+            //    - Modifies the array’s length.
+            //    - Updates any existing fields in a way that would break our assumptions about the array.
+            //    If such an operation exists, we **must not** sink the allocation, as it would lead to
+            //    incorrect behavior.
+            if (Options::useArrayAllocationSinking()) {
+                if (!m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node))
+                    goto escapeChildren;
+                unsigned arraySize = node->newArraySize();
+                target = &m_heap.newAllocation(node, Allocation::Kind::Array, node->indexingType(), arraySize);
+                writes.add(PromotedLocationDescriptor(ArrayLengthPropertyPLoc), LazyNode(ensureConstant(arraySize)));
+            } else
+                goto escapeChildren;
+            break;
+
+        case GetButterfly:
+        case GetArrayLength: {
+            Node* base = node->child1().node();
+            target = m_heap.onlyLocalAllocation(base);
+            if (target && target->isArrayAllocation()) {
+                // No special handling is required for GetButterfly because:
+                // 1. If the array is a sink candidate, then all referrers of GetButterfly (i.e., GetArrayLength,
+                //    PutByVal, and GetByVal) will be eliminated. Consequently, GetButterfly itself
+                //    will have zero references and will be removed in a later phase.
+                // 2. If the array is not a sink candidate, then at least one node (GetByVal or PutByVal)
+                //    must have caused the array to escape.
+                if (node->op() == GetArrayLength)
+                    exactRead = PromotedLocationDescriptor(ArrayLengthPropertyPLoc);
+            } else
+                goto escapeChildren;
+            break;
+        }
+
+        case GetByVal:
+        case PutByVal: {
+            ArrayMode arrayMode = node->arrayMode();
+            Node* base = m_graph.varArgChild(node, 0).node();
+            Node* index = m_graph.varArgChild(node, 1).node();
+            target = m_heap.onlyLocalAllocation(base);
+
+            auto matchesIndexingTypeWithArrayMode = [&](IndexingType indexingType, Array::Type type) {
+                switch (indexingType) {
+                case ALL_DOUBLE_INDEXING_TYPES:
+                    return type == Array::Double;
+                case ALL_INT32_INDEXING_TYPES:
+                    return type == Array::Int32;
+                case ALL_CONTIGUOUS_INDEXING_TYPES: {
+                    return type == Array::Contiguous;
+                }
+                default:
+                    return false;
+                }
+            };
+
+            auto isWithinBounds = [&](int32_t index, unsigned length) {
+                return index >= 0 && static_cast<unsigned>(index) < length;
+            };
+
+            if (target && target->isArrayAllocation()
+                && arrayMode.isInBounds()
+                && matchesIndexingTypeWithArrayMode(target->indexingType(), arrayMode.type())
+                && index->isInt32Constant()
+                && isWithinBounds(index->asInt32(), target->length())) {
+                if (node->op() == PutByVal) {
+                    Edge value = m_graph.varArgChild(node, 2);
+                    writes.add(PromotedLocationDescriptor(ArrayIndexedPropertyPLoc, index->asInt32()), LazyNode(value.node()));
+                } else
+                    exactRead = PromotedLocationDescriptor(ArrayIndexedPropertyPLoc, index->asInt32());
+            } else
+                goto escapeChildren;
+            break;
+        }
+
         case NewObject:
             target = &m_heap.newAllocation(node, Allocation::Kind::Object);
             target->setStructures(node->structure());
@@ -1253,6 +1404,7 @@ private:
             break;
 
         default:
+escapeChildren:
             m_graph.doToChildren(
                 node,
                 [&] (Edge edge) {
@@ -1449,8 +1601,7 @@ private:
         if (m_sinkCandidates.isEmpty())
             return hasUnescapedReads;
 
-        if (DFGObjectAllocationSinkingPhaseInternal::verbose)
-            dataLog("Candidates: ", listDump(m_sinkCandidates), "\n");
+        dataLogLnIf(DFGObjectAllocationSinkingPhaseInternal::verbose, "Candidates: ", listDump(m_sinkCandidates));
 
         // Create the materialization nodes.
         forEachEscapee([&] (UncheckedKeyHashMap<Node*, Allocation>& escapees, Node* where) {
@@ -1684,6 +1835,17 @@ private:
         // fact that an allocation's identifier is indeed the node
         // that created the allocation.
         switch (allocation.kind()) {
+        case Allocation::Kind::Array: {
+            Node* node = allocation.identifier();
+            ObjectMaterializationData* data = m_graph.m_objectMaterializationData.add();
+            data->m_newArraySize = node->newArraySize();
+
+            return m_graph.addNode(
+                node->prediction(), Node::VarArg, MaterializeNewArrayWithConstantSize,
+                where->origin.withSemantic(node->origin.semantic),
+                OpInfo(node->indexingType()), OpInfo(data), 0, 0);
+        }
+
         case Allocation::Kind::Object: {
             ObjectMaterializationData* data = m_graph.m_objectMaterializationData.add();
 
@@ -1830,7 +1992,7 @@ private:
                 // Some named properties can be added conditionally,
                 // and that would necessitate bottoms
                 for (PromotedHeapLocation location : m_locationsForAllocation.get(node)) {
-                    if (location.kind() != NamedPropertyPLoc)
+                    if (location.kind() != NamedPropertyPLoc && location.kind() != ArrayIndexedPropertyPLoc)
                         continue;
 
                     SSACalculator::Variable* variable = m_locationToVariable.get(location);
@@ -1993,7 +2155,7 @@ private:
                 }
             }
 
-            if (DFGObjectAllocationSinkingPhaseInternal::verbose) {
+            if constexpr (DFGObjectAllocationSinkingPhaseInternal::verbose) {
                 dataLog("Local mapping at ", pointerDump(block), ": ", mapDump(m_localMapping), "\n");
                 dataLog("Local materializations at ", pointerDump(block), ": ", mapDump(m_escapeeToMaterialization), "\n");
             }
@@ -2003,14 +2165,13 @@ private:
                 bool canExit = true;
                 bool nextCanExit = node->origin.exitOK;
                 for (PromotedHeapLocation location : m_locationsForAllocation.get(node)) {
-                    if (location.kind() != NamedPropertyPLoc)
+                    if (location.kind() != NamedPropertyPLoc && location.kind() != ArrayIndexedPropertyPLoc)
                         continue;
 
                     m_localMapping.set(location, m_bottom);
 
                     if (m_sinkCandidates.contains(node)) {
-                        if (DFGObjectAllocationSinkingPhaseInternal::verbose)
-                            dataLog("For sink candidate ", node, " found location ", location, "\n");
+                        dataLogLnIf(DFGObjectAllocationSinkingPhaseInternal::verbose, "For sink candidate ", node, " found location ", location);
                         m_insertionSet.insert(
                             nodeIndex + 1,
                             location.createHint(
@@ -2024,8 +2185,7 @@ private:
                     populateMaterialization(block, materialization, escapee);
                     m_escapeeToMaterialization.set(escapee, materialization);
                     m_insertionSet.insert(nodeIndex, materialization);
-                    if (DFGObjectAllocationSinkingPhaseInternal::verbose)
-                        dataLog("Materializing ", escapee, " => ", materialization, " at ", node, "\n");
+                    dataLogLnIf(DFGObjectAllocationSinkingPhaseInternal::verbose, "Materializing ", escapee, " => ", materialization, " at ", node);
                 }
 
                 for (PromotedHeapLocation location : m_materializationSiteToRecoveries.get(node))
@@ -2079,12 +2239,16 @@ private:
 
                         doLower = true;
 
-                        if (DFGObjectAllocationSinkingPhaseInternal::verbose)
-                            dataLog("Creating hint with value ", nodeValue, " before ", node, "\n");
+                        dataLogLnIf(DFGObjectAllocationSinkingPhaseInternal::verbose, "Creating hint with value ", nodeValue, " before ", node);
                         m_insertionSet.insert(
                             nodeIndex + 1,
                             location.createHint(
                                 m_graph, node->origin.takeValidExit(nextCanExit), nodeValue));
+
+                        if (node->op() == PutByVal) {
+                            Edge value = m_graph.varArgChild(node, 2);
+                            m_insertionSet.insertNode(nodeIndex + 1, SpecNone, Check, node->origin, Edge(value.node(), value.useKind()));
+                        }
                     },
                     [&] (PromotedHeapLocation location) -> Node* {
                         return resolve(block, location);
@@ -2098,6 +2262,10 @@ private:
 
                 if (m_sinkCandidates.contains(node) || doLower) {
                     switch (node->op()) {
+                    case NewArrayWithConstantSize:
+                        node->convertToPhantomNewArrayWithConstantSize();
+                        break;
+
                     case NewObject:
                         node->convertToPhantomNewObject();
                         break;
@@ -2232,7 +2400,7 @@ private:
 
     void insertOSRHintsForUpdate(unsigned nodeIndex, NodeOrigin origin, bool& canExit, AvailabilityMap& availability, Node* escapee, Node* materialization)
     {
-        if (DFGObjectAllocationSinkingPhaseInternal::verbose) {
+        if constexpr (DFGObjectAllocationSinkingPhaseInternal::verbose) {
             dataLog("Inserting OSR hints at ", origin, ":\n");
             dataLog("    Escapee: ", escapee, "\n");
             dataLog("    Materialization: ", materialization, "\n");
@@ -2292,6 +2460,48 @@ private:
     {
         Allocation& allocation = m_heap.getAllocation(escapee);
         switch (node->op()) {
+        case MaterializeNewArrayWithConstantSize: {
+            ObjectMaterializationData& data = node->objectMaterializationData();
+            unsigned firstChild = m_graph.m_varArgChildren.size();
+
+            auto useKind = [&](IndexingType indexingType) {
+                switch (indexingType) {
+                case ALL_DOUBLE_INDEXING_TYPES:
+                    return DoubleRepRealUse;
+                case ALL_INT32_INDEXING_TYPES:
+                    return Int32Use;
+                default:
+                    return UntypedUse;
+                }
+            };
+
+            Vector<PromotedHeapLocation> locations = m_locationsForAllocation.get(escapee);
+            for (PromotedHeapLocation location : locations) {
+                switch (location.kind()) {
+                case ArrayIndexedPropertyPLoc: {
+                    ASSERT(location.base() == allocation.identifier());
+                    data.m_properties.append(location.descriptor());
+                    Node* value = resolve(block, location);
+                    if (m_sinkCandidates.contains(value))
+                        m_graph.m_varArgChildren.append(m_bottom);
+                    else
+                        m_graph.m_varArgChildren.append(Edge(value, useKind(node->indexingType())));
+                    break;
+                }
+                case ArrayLengthPropertyPLoc:
+                    // No need to do anything here since it's used for read only.
+                    break;
+                default:
+                    DFG_CRASH(m_graph, node, "Bad location kind");
+                }
+            }
+
+            node->children = AdjacencyList(
+                AdjacencyList::Variable,
+                firstChild, m_graph.m_varArgChildren.size() - firstChild);
+            break;
+        }
+
         case MaterializeNewObject: {
             ObjectMaterializationData& data = node->objectMaterializationData();
             unsigned firstChild = m_graph.m_varArgChildren.size();
@@ -2462,16 +2672,14 @@ private:
 
     Node* createRecovery(BasicBlock* block, PromotedHeapLocation location, Node* where, bool& canExit)
     {
-        if (DFGObjectAllocationSinkingPhaseInternal::verbose)
-            dataLog("Recovering ", location, " at ", where, "\n");
+        dataLogLnIf(DFGObjectAllocationSinkingPhaseInternal::verbose, "Recovering ", location, " at ", where);
         ASSERT(location.base()->isPhantomAllocation());
         Node* base = getMaterialization(block, location.base());
         Node* value = resolve(block, location);
 
         NodeOrigin origin = where->origin.withSemantic(base->origin.semantic);
 
-        if (DFGObjectAllocationSinkingPhaseInternal::verbose)
-            dataLog("Base is ", base, " and value is ", value, "\n");
+        dataLogLnIf(DFGObjectAllocationSinkingPhaseInternal::verbose, "Base is ", base, " and value is ", value);
 
         if (base->isPhantomAllocation()) {
             return PromotedHeapLocation(base, location.descriptor()).createHint(
@@ -2640,6 +2848,7 @@ private:
     UncheckedKeyHashMap<PromotedHeapLocation, Node*> m_localMapping;
     UncheckedKeyHashMap<Node*, Node*> m_escapeeToMaterialization;
     InsertionSet m_insertionSet;
+    InsertionSet m_rootInsertionSet;
     CombinedLiveness m_combinedLiveness;
 
     UncheckedKeyHashMap<JSCell*, bool> m_validInferredValues;
@@ -2651,11 +2860,13 @@ private:
 
     UncheckedKeyHashMap<Node*, Vector<PromotedHeapLocation>> m_locationsForAllocation;
 
+    UncheckedKeyHashMap<unsigned, Node*, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_constants;
+
     BlockMap<LocalHeap> m_heapAtHead;
     BlockMap<LocalHeap> m_heapAtTail;
     LocalHeap m_heap;
 
-    Node* m_bottom = nullptr;
+    Node* m_bottom { nullptr };
 };
 
 }

--- a/Source/JavaScriptCore/dfg/DFGObjectMaterializationData.h
+++ b/Source/JavaScriptCore/dfg/DFGObjectMaterializationData.h
@@ -38,7 +38,7 @@ namespace JSC { namespace DFG {
 struct ObjectMaterializationData {
     // Determines the meaning of the passed nodes.
     Vector<PromotedLocationDescriptor> m_properties;
-    
+    unsigned m_newArraySize { 0 };
     void dump(PrintStream&) const;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1566,6 +1566,7 @@ private:
         case Identity:
         case BooleanToNumber:
         case PhantomNewObject:
+        case PhantomNewArrayWithConstantSize:
         case PhantomNewFunction:
         case PhantomNewGeneratorFunction:
         case PhantomNewAsyncGeneratorFunction:
@@ -1586,6 +1587,7 @@ private:
         case CheckStructureOrEmpty:
         case CheckArrayOrEmpty:
         case MaterializeNewObject:
+        case MaterializeNewArrayWithConstantSize:
         case MaterializeCreateActivation:
         case MaterializeNewInternalFieldObject:
         case PutStack:

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.cpp
@@ -91,6 +91,18 @@ void printInternal(PrintStream& out, PromotedLocationKind kind)
         out.print("ArgumentsCalleePLoc");
         return;
 
+    case ArrayPLoc:
+        out.print("ArrayPLoc");
+        return;
+
+    case ArrayLengthPropertyPLoc:
+        out.print("ArrayLengthPropertyPLoc");
+        return;
+
+    case ArrayIndexedPropertyPLoc:
+        out.print("ArrayIndexedPropertyPLoc");
+        return;
+
     case FunctionExecutablePLoc:
         out.print("FunctionExecutablePLoc");
         return;

--- a/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h
@@ -47,12 +47,15 @@ struct Node;
 
 enum PromotedLocationKind {
     InvalidPromotedLocationKind,
-    
+
     ActivationScopePLoc,
     ActivationSymbolTablePLoc,
     ArgumentCountPLoc,
     ArgumentPLoc,
     ArgumentsCalleePLoc,
+    ArrayPLoc,
+    ArrayLengthPropertyPLoc,
+    ArrayIndexedPropertyPLoc,
     ClosureVarPLoc,
     InternalFieldObjectPLoc,
     FunctionActivationPLoc,

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -713,6 +713,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case MultiDeleteByOffset:
     case GetPropertyEnumerator:
     case PhantomNewObject:
+    case PhantomNewArrayWithConstantSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:
@@ -722,6 +723,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case PhantomNewRegexp:
     case PutHint:
     case MaterializeNewObject:
+    case MaterializeNewArrayWithConstantSize:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PhantomDirectArguments:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1713,6 +1713,7 @@ public:
     void compileSetRegExpObjectLastIndex(Node*);
     void compileLazyJSConstant(Node*);
     void compileMaterializeNewObject(Node*);
+    void compileMaterializeNewArrayWithConstantSize(Node*);
     void compileRecordRegExpCachedResult(Node*);
     void compileToObjectOrCallObjectConstructor(Node*);
     void compileResolveScope(Node*);
@@ -1759,6 +1760,7 @@ public:
     void compileStrCat(Node*);
     void compileNewArrayBuffer(Node*);
     void compileNewArrayWithSize(Node*);
+    void compileNewArrayWithConstantSizeImpl(Node*, GPRReg, GPRReg);
     void compileNewArrayWithConstantSize(Node*);
     void compileNewArrayWithSpecies(Node*);
     void compileNewArrayWithSizeAndStructure(Node*);
@@ -1893,10 +1895,10 @@ public:
     void speculateCellType(Edge, GPRReg cellGPR, SpeculatedType, JSType);
     
     void speculateInt32(Edge);
+    void speculateInt32(Edge, JSValueRegs);
 #if USE(JSVALUE64)
     void convertAnyInt(Edge, GPRReg resultGPR);
     void speculateAnyInt(Edge);
-    void speculateInt32(Edge, JSValueRegs);
     void speculateDoubleRepAnyInt(Edge);
 #endif // USE(JSVALUE64)
 #if USE(BIGINT32)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -1032,10 +1032,11 @@ GPRReg SpeculativeJIT::fillSpeculateInt32Internal(Edge edge, DataFormat& returnF
         // Check the value is an integer.
         GPRReg tagGPR = info.tagGPR();
         GPRReg payloadGPR = info.payloadGPR();
+        JSValueRegs valueRegs = JSValueRegs(tagGPR, payloadGPR);
         m_gprs.lock(tagGPR);
         m_gprs.lock(payloadGPR);
         if (type & ~SpecInt32Only)
-            speculationCheck(BadType, JSValueRegs(tagGPR, payloadGPR), edge, branchIfNotInt32(tagGPR));
+            speculateInt32(edge, valueRegs);
         m_gprs.unlock(tagGPR);
         m_gprs.release(tagGPR);
         m_gprs.release(payloadGPR);
@@ -4259,6 +4260,10 @@ void SpeculativeJIT::compile(Node* node)
         compileMaterializeNewObject(node);
         break;
 
+    case MaterializeNewArrayWithConstantSize:
+        compileMaterializeNewArrayWithConstantSize(node);
+        break;
+
     case PutDynamicVar: {
         compilePutDynamicVar(node);
         break;
@@ -4348,6 +4353,7 @@ void SpeculativeJIT::compile(Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
+    case PhantomNewArrayWithConstantSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:
@@ -5383,6 +5389,11 @@ void SpeculativeJIT::cachedPutById(Node* node, CodeOrigin codeOrigin, GPRReg bas
 
     addPutById(gen, slowPath.get());
     addSlowPathGenerator(WTFMove(slowPath));
+}
+
+void SpeculativeJIT::speculateInt32(Edge edge, JSValueRegs regs)
+{
+    speculationCheck(BadType, regs, edge, branchIfNotInt32(regs.tagGPR()));
 }
 
 #endif

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5884,6 +5884,10 @@ void SpeculativeJIT::compile(Node* node)
         compileMaterializeNewObject(node);
         break;
 
+    case MaterializeNewArrayWithConstantSize:
+        compileMaterializeNewArrayWithConstantSize(node);
+        break;
+
     case CallDOM:
         compileCallDOM(node);
         break;
@@ -6472,6 +6476,7 @@ void SpeculativeJIT::compile(Node* node)
     case CheckBadValue:
     case BottomValue:
     case PhantomNewObject:
+    case PhantomNewArrayWithConstantSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncFunction:

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -394,6 +394,7 @@ private:
             case NewSet:
             case NewSymbol:
             case MaterializeNewObject:
+            case MaterializeNewArrayWithConstantSize:
             case MaterializeCreateActivation:
             case MakeRope:
             case MakeAtomString:

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -364,6 +364,9 @@ public:
                         VALIDATE((node), !hasAnyArrayStorage(structure->indexingType()));
                     }
                     break;
+                case MaterializeNewArrayWithConstantSize:
+                    VALIDATE((node), isNewArrayWithConstantSizeIndexingType(node->indexingType()));
+                    break;
                 case DoubleConstant:
                 case Int52Constant:
                     VALIDATE((node), node->isNumberConstant());
@@ -675,6 +678,7 @@ private:
                 case CheckInBounds:
                 case CheckInBoundsInt52:
                 case PhantomNewObject:
+                case PhantomNewArrayWithConstantSize:
                 case PhantomNewFunction:
                 case PhantomNewGeneratorFunction:
                 case PhantomNewAsyncFunction:
@@ -895,6 +899,7 @@ private:
                     continue;
                 switch (node->op()) {
                 case PhantomNewObject:
+                case PhantomNewArrayWithConstantSize:
                 case PhantomNewFunction:
                 case PhantomNewGeneratorFunction:
                 case PhantomNewAsyncFunction:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -336,6 +336,7 @@ inline CapabilityLevel canCompile(Node* node)
     case EnumeratorPutByVal:
     case BottomValue:
     case PhantomNewObject:
+    case PhantomNewArrayWithConstantSize:
     case PhantomNewFunction:
     case PhantomNewGeneratorFunction:
     case PhantomNewAsyncGeneratorFunction:
@@ -346,6 +347,7 @@ inline CapabilityLevel canCompile(Node* node)
     case PutHint:
     case CheckStructureImmediate:
     case MaterializeNewObject:
+    case MaterializeNewArrayWithConstantSize:
     case MaterializeCreateActivation:
     case MaterializeNewInternalFieldObject:
     case PhantomDirectArguments:

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
@@ -34,8 +34,10 @@ namespace JSC { namespace FTL {
 
 using namespace JSC::DFG;
 
-ExitTimeObjectMaterialization::ExitTimeObjectMaterialization(NodeType type, CodeOrigin codeOrigin)
-    : m_type(type)
+ExitTimeObjectMaterialization::ExitTimeObjectMaterialization(Node* node, CodeOrigin codeOrigin)
+    : m_type(node->op())
+    , m_indexingType(node->op() == DFG::PhantomNewArrayWithConstantSize ? node->indexingType() : NoIndexingShape)
+    , m_size(node->op() == DFG::PhantomNewArrayWithConstantSize ? node->newArraySize() : 0)
     , m_origin(codeOrigin)
 {
 }

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.h
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.h
@@ -41,12 +41,14 @@ namespace FTL {
 class ExitTimeObjectMaterialization {
     WTF_MAKE_NONCOPYABLE(ExitTimeObjectMaterialization)
 public:
-    ExitTimeObjectMaterialization(DFG::NodeType, CodeOrigin);
+    ExitTimeObjectMaterialization(DFG::Node*, CodeOrigin);
     ~ExitTimeObjectMaterialization();
     
     void add(DFG::PromotedLocationDescriptor, const ExitValue&);
-    
+
     DFG::NodeType type() const { return m_type; }
+    IndexingType indexingType() const { return m_indexingType; }
+    size_t size() const { return m_size; }
     CodeOrigin origin() const { return m_origin; }
     
     ExitValue get(DFG::PromotedLocationDescriptor) const;
@@ -60,6 +62,8 @@ public:
     
 private:
     DFG::NodeType m_type;
+    IndexingType m_indexingType;
+    size_t m_size;
     CodeOrigin m_origin;
     Vector<ExitPropertyValue> m_properties;
 };

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -210,6 +210,19 @@ inline unsigned arrayIndexFromIndexingType(IndexingType indexingType)
     return (indexingType & IndexingShapeMask) >> IndexingShapeShift;
 }
 
+inline bool isNewArrayWithConstantSizeIndexingType(IndexingType indexingType)
+{
+    switch (indexingType) {
+    case ALL_DOUBLE_INDEXING_TYPES:
+    case ALL_INT32_INDEXING_TYPES:
+    case ALL_CONTIGUOUS_INDEXING_TYPES: {
+        return true;
+    }
+    default:
+        return false;
+    }
+}
+
 inline IndexingType indexingTypeForValue(JSValue value)
 {
     if (value.isInt32())

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -602,6 +602,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     v(Bool, useOMGInlining, true, Normal, "Use OMG inlining"_s) \
     v(Bool, freeRetiredWasmCode, true, Normal, "free BBQ/OMG-OSR wasm code once it's no longer reachable."_s) \
+    v(Bool, useArrayAllocationSinking, true, Normal, "free BBQ/OMG-OSR wasm code once it's no longer reachable."_s) \
     \
     /* Feature Flags */\
     \


### PR DESCRIPTION
#### 3353f1290c6aa2eebdd48c99c539a6a0858c8ab1
<pre>
[JSC] Enable Allocation Sinking for NewArrayWithConstantSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=287731">https://bugs.webkit.org/show_bug.cgi?id=287731</a>
<a href="https://rdar.apple.com/144885784">rdar://144885784</a>

Reviewed by Yusuke Suzuki.

This patch enables allocation sinking for NewArrayWithConstantSize, allowing
the DFG JIT to eliminate unnecessary array allocations when safe. This
optimization removes dead allocations and materializes them only if needed,
reducing memory overhead and improving execution efficiency. See the comments
in DFGObjectAllocationSinkingPhase.cpp for details.

Changes:
1. Introduced PhantomNewArrayWithConstantSize and MaterializeNewArrayWithConstantSize
   nodes for sinking and materializing arrays.
2. Tracked array allocations and indexed properties using ArrayIndexedPropertyPLoc
   and ArrayLengthPropertyPLoc.
3. Eliminated redundant bounds checks with removeCheckInBoundsIfNeeded.
4. Implemented JIT and FTL support for materializing sunken arrays.
5. Guarded sinking with isWatchingArrayPrototypeChainIsSaneWatchpoint, isInBounds,
   and constant index access to ensure deoptimization safety.
6. Added Options::useArrayAllocationSinking for runtime control.

* JSTests/microbenchmarks/loop-unrolling-4.js:
(test):
* JSTests/microbenchmarks/loop-unrolling-5.js: Added.
(assert):
(test):
* JSTests/stress/array-allocation-sink.js: Added.
(assert):
(run):
(assert.test):
(run.test):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToPhantomNewArrayWithConstantSize):
(JSC::DFG::Node::hasNewArraySize):
(JSC::DFG::Node::newArraySize):
(JSC::DFG::Node::hasIndexingType):
(JSC::DFG::Node::hasObjectMaterializationData):
(JSC::DFG::Node::isPhantomAllocation):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGObjectMaterializationData.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/dfg/DFGPromotedHeapLocation.h:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp:
(JSC::FTL::ExitTimeObjectMaterialization::ExitTimeObjectMaterialization):
* Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.h:
(JSC::FTL::ExitTimeObjectMaterialization::indexingType const):
(JSC::FTL::ExitTimeObjectMaterialization::size const):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileNewArrayWithConstantSizeImpl):
(JSC::FTL::DFG::LowerDFGToB3::compileNewArrayWithConstantSize):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/runtime/IndexingType.h:
(JSC::isNewArrayWithConstantSizeIndexingType):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/290691@main">https://commits.webkit.org/290691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/488c182dc5d172b005d27a6b513c751c1e91ebc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41498 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27341 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36642 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40627 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83544 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97557 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89492 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17907 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78030 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21088 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14312 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23259 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111981 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17655 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->