### PR TITLE
FileSystemWritableStream should expose the exception thrown when retrieving a blob

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt
@@ -26,5 +26,5 @@ FAIL WriteParams: truncate missing size param promise_rejects_dom: truncate with
 FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data type is invalid" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
 PASS WriteParams: write null data param
 FAIL WriteParams: seek missing position param promise_rejects_dom: seek without position function "function() { throw e }" threw object "TypeError: Required argument is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
-FAIL write() with an invalid blob to an empty file should reject promise_rejects_dom: function "function() { throw e }" threw object "TypeError: Data type is invalid" that is not a DOMException NotFoundError: property "code" is equal to undefined, expected 8
+PASS write() with an invalid blob to an empty file should reject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt
@@ -26,5 +26,5 @@ FAIL WriteParams: truncate missing size param promise_rejects_dom: truncate with
 FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data type is invalid" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
 PASS WriteParams: write null data param
 FAIL WriteParams: seek missing position param promise_rejects_dom: seek without position function "function() { throw e }" threw object "TypeError: Required argument is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
-FAIL write() with an invalid blob to an empty file should reject promise_rejects_dom: function "function() { throw e }" threw object "TypeError: Data type is invalid" that is not a DOMException NotFoundError: property "code" is equal to undefined, expected 8
+PASS write() with an invalid blob to an empty file should reject
 


### PR DESCRIPTION
#### 794627f1803fa8f6ec015ec783c2b59666153051
<pre>
FileSystemWritableStream should expose the exception thrown when retrieving a blob
<a href="https://rdar.apple.com/144243284">rdar://144243284</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287093">https://bugs.webkit.org/show_bug.cgi?id=287093</a>

Reviewed by Sihui Liu.

We pipe the exception received when retrieving blob content, if any, to the error mechanism.

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp:
(WebCore::fetchDataBytesForWrite):
(WebCore::FileSystemWritableFileStreamSink::write):

Canonical link: <a href="https://commits.webkit.org/289919@main">https://commits.webkit.org/289919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a0958d796f0fb6068e88d8cdcc7891fdd5a5d97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68123 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25851 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38165 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76238 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18780 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20628 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19045 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8515 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20799 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->