### PR TITLE
Crash in com.apple.WebKit.WebContent at com.apple.WebKit: WebKit::WebExtensionAPIEvent::removeAllListeners

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -99,11 +99,12 @@ void WebExtensionAPIEvent::addListener(WebCore::FrameIdentifier frameIdentifier,
     m_frameIdentifier = frameIdentifier;
     m_listeners.append(listener);
 
-    RefPtr webFrame = WebProcess::singleton().webFrame(frameIdentifier);
-    RefPtr webExtensionControllerProxy = webFrame->page()->webExtensionControllerProxy();
-
     if (!hasExtensionContext()) {
-        if (webExtensionControllerProxy->inTestingMode()) {
+        RefPtr webFrame = WebProcess::singleton().webFrame(m_frameIdentifier);
+        RefPtr webPage = webFrame ? webFrame->page() : nullptr;
+        RefPtr webExtensionControllerProxy = webPage ? webPage->webExtensionControllerProxy() : nullptr;
+
+        if (webExtensionControllerProxy && webExtensionControllerProxy->inTestingMode()) {
             for (Ref extensionContext : webExtensionControllerProxy->extensionContexts()) {
                 extensionContext->addFrameWithExtensionContent(*webFrame);
                 WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(*m_frameIdentifier, m_type, contentWorldType()), extensionContext->identifier());
@@ -127,11 +128,12 @@ void WebExtensionAPIEvent::removeListener(WebCore::FrameIdentifier frameIdentifi
 
     ASSERT(frameIdentifier == m_frameIdentifier);
 
-    RefPtr webFrame = WebProcess::singleton().webFrame(frameIdentifier);
-    RefPtr webExtensionControllerProxy = webFrame->page()->webExtensionControllerProxy();
-
     if (!hasExtensionContext()) {
-        if (webExtensionControllerProxy->inTestingMode()) {
+        RefPtr webFrame = WebProcess::singleton().webFrame(m_frameIdentifier);
+        RefPtr webPage = webFrame ? webFrame->page() : nullptr;
+        RefPtr webExtensionControllerProxy = webPage ? webPage->webExtensionControllerProxy() : nullptr;
+
+        if (webExtensionControllerProxy && webExtensionControllerProxy->inTestingMode()) {
             for (Ref extensionContext : webExtensionControllerProxy->extensionContexts())
                 WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), removedCount), extensionContext->identifier());
         }
@@ -157,11 +159,12 @@ void WebExtensionAPIEvent::removeAllListeners()
     auto removedCount = m_listeners.size();
     m_listeners.clear();
 
-    RefPtr webFrame = WebProcess::singleton().webFrame(m_frameIdentifier);
-    RefPtr webExtensionControllerProxy = webFrame->page()->webExtensionControllerProxy();
-
     if (!hasExtensionContext()) {
-        if (webExtensionControllerProxy->inTestingMode()) {
+        RefPtr webFrame = WebProcess::singleton().webFrame(m_frameIdentifier);
+        RefPtr webPage = webFrame ? webFrame->page() : nullptr;
+        RefPtr webExtensionControllerProxy = webPage ? webPage->webExtensionControllerProxy() : nullptr;
+
+        if (webExtensionControllerProxy && webExtensionControllerProxy->inTestingMode()) {
             for (Ref extensionContext : webExtensionControllerProxy->extensionContexts())
                 WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, m_type, contentWorldType(), removedCount), extensionContext->identifier());
         }


### PR DESCRIPTION
#### 7f8613c028df85e2bde63c58c44a492061879148
<pre>
Crash in com.apple.WebKit.WebContent at com.apple.WebKit: WebKit::WebExtensionAPIEvent::removeAllListeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=287095">https://bugs.webkit.org/show_bug.cgi?id=287095</a>
<a href="https://rdar.apple.com/144211832">rdar://144211832</a>

Reviewed by Timothy Hatcher and Brian Weinstein.

This patch is a speculative fix for a crash introduced by 289222@main, as I
have been unable to reproduce the problem.

The crash is almost certainly happening because we&apos;re dereferencing a nullptr,
so the fix is to simply add null checks prior to dereferencing.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::addListener):
(WebKit::WebExtensionAPIEvent::removeListener):
(WebKit::WebExtensionAPIEvent::removeAllListeners):

Canonical link: <a href="https://commits.webkit.org/289898@main">https://commits.webkit.org/289898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bd9be3f7aece383bdec27fe7c840adea8ce3b69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93263 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39060 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68126 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25846 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48494 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6058 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38168 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95106 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76992 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75729 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76239 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8518 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13803 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15497 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18687 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->