### PR TITLE
Use SyntaxError for missing parameters in FileSystemWritableFileStream.write to follow other User Agents

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt
@@ -22,9 +22,9 @@ PASS atomic writes: truncate() after close() fails
 PASS atomic writes: close() after close() fails
 PASS atomic writes: only one close() operation may succeed
 PASS getWriter() can be used
-FAIL WriteParams: truncate missing size param promise_rejects_dom: truncate without size function "function() { throw e }" threw object "TypeError: Required argument is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
-FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data type is invalid" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+PASS WriteParams: truncate missing size param
+FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
 PASS WriteParams: write null data param
-FAIL WriteParams: seek missing position param promise_rejects_dom: seek without position function "function() { throw e }" threw object "TypeError: Required argument is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+PASS WriteParams: seek missing position param
 PASS write() with an invalid blob to an empty file should reject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt
@@ -22,9 +22,9 @@ PASS atomic writes: truncate() after close() fails
 PASS atomic writes: close() after close() fails
 PASS atomic writes: only one close() operation may succeed
 PASS getWriter() can be used
-FAIL WriteParams: truncate missing size param promise_rejects_dom: truncate without size function "function() { throw e }" threw object "TypeError: Required argument is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
-FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data type is invalid" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+PASS WriteParams: truncate missing size param
+FAIL WriteParams: write missing data param promise_rejects_dom: write without data function "function() { throw e }" threw object "TypeError: Data is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
 PASS WriteParams: write null data param
-FAIL WriteParams: seek missing position param promise_rejects_dom: seek without position function "function() { throw e }" threw object "TypeError: Required argument is missing" that is not a DOMException SyntaxError: property "code" is equal to undefined, expected 12
+PASS WriteParams: seek missing position param
 PASS write() with an invalid blob to an empty file should reject
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h
@@ -41,8 +41,8 @@ public:
     using DataVariant = std::variant<RefPtr<JSC::ArrayBufferView>, RefPtr<JSC::ArrayBuffer>, RefPtr<Blob>, String>;
     struct WriteParams {
         WriteCommandType type;
-        std::optional<uint64_t> size;
-        std::optional<uint64_t> position;
+        std::optional<uint64_t> size { };
+        std::optional<uint64_t> position { };
         std::optional<DataVariant> data;
     };
 


### PR DESCRIPTION
#### 9e49f1749881fc5815b407d68df6ce03c46b9e29
<pre>
Use SyntaxError for missing parameters in FileSystemWritableFileStream.write to follow other User Agents
<a href="https://rdar.apple.com/144245491">rdar://144245491</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287097">https://bugs.webkit.org/show_bug.cgi?id=287097</a>

Reviewed by Sihui Liu.

We align with other User Agents by rejecting the promise with a SyntaxError if there are missing parameters for truncate and seek.
Small refactoring to make that easier.r

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream-write.https.any.worker-expected.txt:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp:
(WebCore::writeParamsFromChunk):
(WebCore::FileSystemWritableFileStreamSink::write):

Originally-landed-as: b9193fdd8b2d. <a href="https://rdar.apple.com/144245491">rdar://144245491</a>
Canonical link: <a href="https://commits.webkit.org/289995@main">https://commits.webkit.org/289995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c6007a25861230e3e1fd2ece7b453d17bf96dbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16388 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26069 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48748 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38547 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15860 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76070 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20912 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15876 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15617 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->