### PR TITLE
Address or suppress smart pointer warnings in Thread

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -8,7 +8,6 @@ wtf/NativePromise.h
 wtf/ParallelHelperPool.cpp
 wtf/PrintStream.h
 wtf/ThreadGroup.cpp
-wtf/Threading.cpp
 wtf/WorkerPool.cpp
 wtf/cocoa/MainThreadCocoa.mm
 wtf/text/AtomStringImpl.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -6,8 +6,6 @@ wtf/RecursiveLockAdapter.h
 wtf/RedBlackTree.h
 wtf/Ref.h
 wtf/ThreadSafeWeakPtr.h
-wtf/Threading.cpp
-wtf/Threading.h
 wtf/posix/ThreadingPOSIX.cpp
 wtf/text/AtomStringImpl.cpp
 wtf/text/CString.cpp

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -251,9 +251,11 @@ void Thread::entryPoint(NewThreadContext* newThreadContext)
 
         Thread::initializeCurrentThreadInternal(context->name);
         function = WTFMove(context->entryPoint);
-        context->thread->initializeInThread();
 
-        Thread::initializeTLS(WTFMove(context->thread));
+        Ref thread = WTFMove(context->thread);
+        thread->initializeInThread();
+
+        Thread::initializeTLS(WTFMove(thread));
 
 #if !HAVE(STACK_BOUNDS_FOR_NEW_THREAD)
         // Ack completion of initialization to the creating thread.
@@ -387,9 +389,9 @@ unsigned Thread::numberOfThreadGroups()
 
 bool Thread::exchangeIsCompilationThread(bool newValue)
 {
-    auto& thread = Thread::current();
-    bool oldValue = thread.m_isCompilationThread;
-    thread.m_isCompilationThread = newValue;
+    Ref thread = Thread::current();
+    bool oldValue = thread->m_isCompilationThread;
+    thread->m_isCompilationThread = newValue;
     return oldValue;
 }
 

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -439,7 +439,7 @@ inline Thread& Thread::current()
     if (UNLIKELY(Thread::s_key == InvalidThreadSpecificKey))
         WTF::initialize();
 #endif
-    if (auto* thread = currentMayBeNull(); LIKELY(thread))
+    if (SUPPRESS_UNCOUNTED_LOCAL auto* thread = currentMayBeNull(); LIKELY(thread))
         return *thread;
     return initializeCurrentTLS();
 }

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -570,7 +570,7 @@ void Thread::initializeTLSKey()
 Thread& Thread::initializeTLS(Ref<Thread>&& thread)
 {
     // We leak the ref to keep the Thread alive while it is held in TLS. destructTLS will deref it later at thread destruction time.
-    auto& threadInTLS = thread.leakRef();
+    SUPPRESS_UNCOUNTED_LOCAL auto& threadInTLS = thread.leakRef();
 #if !HAVE(FAST_TLS)
     ASSERT(s_key != InvalidThreadSpecificKey);
     threadSpecificSet(s_key, &threadInTLS);


### PR DESCRIPTION
#### df2a8fd2e43ee4ecd9b93b17b7de023c21cb2f14
<pre>
Address or suppress smart pointer warnings in Thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=287100">https://bugs.webkit.org/show_bug.cgi?id=287100</a>

Reviewed by Chris Dumez.

Fixed or suppressed smart pointer static analyzer warnings in Threading.h/cpp.

* Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::entryPoint):
(WTF::Thread::exchangeIsCompilationThread):
* Source/WTF/wtf/Threading.h:
(WTF::Thread::current):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::Thread::initializeTLS):

Canonical link: <a href="https://commits.webkit.org/289917@main">https://commits.webkit.org/289917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c1c3a5a77a21b6135f95da4955810e9435980ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39073 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68141 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25857 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48510 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/87818 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38181 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81118 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95119 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87095 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76266 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8531 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13819 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15510 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20816 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109588 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15251 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26357 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18700 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->