### PR TITLE
Deploy more smart pointers in NetworkDataTask/NetworkDataTaskCocoa

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -122,21 +122,25 @@ void NetworkDataTask::scheduleFailure(FailureType type)
     m_failureScheduled = true;
     RunLoop::protectedMain()->dispatch([weakThis = ThreadSafeWeakPtr { *this }, type] {
         auto protectedThis = weakThis.get();
-        if (!protectedThis || !protectedThis->m_client)
+        if (!protectedThis)
+            return;
+
+        RefPtr client = protectedThis->m_client.get();
+        if (!client)
             return;
 
         switch (type) {
         case FailureType::Blocked:
-            protectedThis->m_client->wasBlocked();
+            client->wasBlocked();
             return;
         case FailureType::InvalidURL:
-            protectedThis->m_client->cannotShowURL();
+            client->cannotShowURL();
             return;
         case FailureType::RestrictedURL:
-            protectedThis->m_client->wasBlockedByRestrictions();
+            client->wasBlockedByRestrictions();
             return;
         case FailureType::FTPDisabled:
-            protectedThis->m_client->wasBlockedByDisabledFTP();
+            client->wasBlockedByDisabledFTP();
         }
     });
 }
@@ -155,8 +159,8 @@ void NetworkDataTask::didReceiveResponse(ResourceResponse&& response, Negotiated
         if (port && !WTF::isDefaultPortForProtocol(port.value(), url.protocol())) {
             completionHandler(PolicyAction::Ignore);
             cancel();
-            if (m_client)
-                m_client->didCompleteWithError({ String(), 0, url, makeString("Cancelled load from '"_s, url.stringCenterEllipsizedToLength(), "' because it is using HTTP/0.9."_s) });
+            if (RefPtr client = m_client.get())
+                client->didCompleteWithError({ String(), 0, url, makeString("Cancelled load from '"_s, url.stringCenterEllipsizedToLength(), "' because it is using HTTP/0.9."_s) });
             return;
         }
     }
@@ -169,8 +173,8 @@ void NetworkDataTask::didReceiveResponse(ResourceResponse&& response, Negotiated
         if (resolvedIPAddress && !resolvedIPAddress->isLoopback()) {
             completionHandler(PolicyAction::Ignore);
             cancel();
-            if (m_client)
-                m_client->didCompleteWithError({ String(), 0, url, makeString("Cancelled load from '"_s, url.stringCenterEllipsizedToLength(), "' because localhost did not resolve to a loopback address."_s) });
+            if (RefPtr client = m_client.get())
+                client->didCompleteWithError({ String(), 0, url, makeString("Cancelled load from '"_s, url.stringCenterEllipsizedToLength(), "' because localhost did not resolve to a loopback address."_s) });
             return;
         }
     }
@@ -181,8 +185,8 @@ void NetworkDataTask::didReceiveResponse(ResourceResponse&& response, Negotiated
     if (privateRelayed == PrivateRelayed::Yes)
         response.setWasPrivateRelayed(WasPrivateRelayed::Yes);
 
-    if (m_client)
-        m_client->didReceiveResponse(WTFMove(response), negotiatedLegacyTLS, privateRelayed, WTFMove(completionHandler));
+    if (RefPtr client = m_client.get())
+        client->didReceiveResponse(WTFMove(response), negotiatedLegacyTLS, privateRelayed, WTFMove(completionHandler));
     else
         completionHandler(PolicyAction::Ignore);
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -360,8 +360,8 @@ void NetworkDataTaskCocoa::didSendData(uint64_t totalBytesSent, uint64_t totalBy
 {
     WTFEmitSignpost(m_task.get(), DataTask, "sent %llu bytes (expected %llu bytes)", totalBytesSent, totalBytesExpectedToSend);
 
-    if (m_client)
-        m_client->didSendData(totalBytesSent, totalBytesExpectedToSend);
+    if (RefPtr client = m_client.get())
+        client->didSendData(totalBytesSent, totalBytesExpectedToSend);
 }
 
 void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler)
@@ -371,8 +371,8 @@ void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&
     if (tryPasswordBasedAuthentication(challenge, completionHandler))
         return;
 
-    if (m_client)
-        m_client->didReceiveChallenge(WTFMove(challenge), negotiatedLegacyTLS, WTFMove(completionHandler));
+    if (RefPtr client = m_client.get())
+        client->didReceiveChallenge(WTFMove(challenge), negotiatedLegacyTLS, WTFMove(completionHandler));
     else {
         ASSERT_NOT_REACHED();
         completionHandler(AuthenticationChallengeDisposition::PerformDefaultHandling, { });
@@ -381,24 +381,24 @@ void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&
 
 void NetworkDataTaskCocoa::didNegotiateModernTLS(const URL& url)
 {
-    if (m_client)
-        m_client->didNegotiateModernTLS(url);
+    if (RefPtr client = m_client.get())
+        client->didNegotiateModernTLS(url);
 }
 
 void NetworkDataTaskCocoa::didCompleteWithError(const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics& networkLoadMetrics)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "completed with error: %d", !error.isNull());
 
-    if (m_client)
-        m_client->didCompleteWithError(error, networkLoadMetrics);
+    if (RefPtr client = m_client.get())
+        client->didCompleteWithError(error, networkLoadMetrics);
 }
 
 void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "received %zd bytes", data.size());
 
-    if (m_client)
-        m_client->didReceiveData(data);
+    if (RefPtr client = m_client.get())
+        client->didReceiveData(data);
 }
 
 void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS negotiatedLegacyTLS, PrivateRelayed privateRelayed, WebKit::ResponseCompletionHandler&& completionHandler)
@@ -486,9 +486,10 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler({ });
-        if (!protectedThis->m_client)
+        RefPtr client = protectedThis->m_client.get();
+        if (!client)
             return completionHandler({ });
-        protectedThis->m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), weakThis] (WebCore::ResourceRequest&& request) mutable {
+        client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), weakThis] (WebCore::ResourceRequest&& request) mutable {
             auto protectedThis = weakThis.get();
             if (!protectedThis || !protectedThis->m_session)
                 return completionHandler({ });

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -9,7 +9,6 @@ NetworkProcess/Downloads/DownloadManager.cpp
 NetworkProcess/Downloads/PendingDownload.cpp
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
 NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
-NetworkProcess/NetworkDataTask.cpp
 NetworkProcess/NetworkDataTaskBlob.cpp
 NetworkProcess/NetworkLoad.cpp
 NetworkProcess/NetworkSession.cpp
@@ -26,7 +25,6 @@ NetworkProcess/cache/NetworkCacheEntry.cpp
 NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
 NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
 NetworkProcess/cache/NetworkCacheStorage.cpp
-NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
 NetworkProcess/mac/SecItemShim.cpp
 NetworkProcess/storage/BackgroundFetchStoreImpl.cpp


### PR DESCRIPTION
#### ea39de014864091982cb00f3effd083eb5f37bb3
<pre>
Deploy more smart pointers in NetworkDataTask/NetworkDataTaskCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=287106">https://bugs.webkit.org/show_bug.cgi?id=287106</a>

Reviewed by NOBODY (OOPS!).

Addressed smart pointer static analyzer warnings in NetworkDataTask.cpp and NetworkDataTaskCocoa.mm.

* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::scheduleFailure):
(WebKit::NetworkDataTask::didReceiveResponse):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didSendData):
(WebKit::NetworkDataTaskCocoa::didReceiveChallenge):
(WebKit::NetworkDataTaskCocoa::didNegotiateModernTLS):
(WebKit::NetworkDataTaskCocoa::didCompleteWithError):
(WebKit::NetworkDataTaskCocoa::didReceiveData):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea39de014864091982cb00f3effd083eb5f37bb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39179 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68201 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25916 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91427 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6368 "Found 7 new test failures: fast/forms/ios/file-upload-panel.html http/tests/contentfiltering/block-after-redirect.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79978 "2 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48567 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6140 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox-redirects-cuts-opener.https.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/resource-timing/redirects.html imported/w3c/web-platform-tests/resource-timing/redirects.sub.html imported/w3c/web-platform-tests/xhr/access-control-and-redirects.any.html (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38287 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76517 "Found 1 new API test failure: TestWebKitAPI.ContentFiltering.LoadAlternateAfterRedirectWK2 (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35277 "Found 10 new test failures: http/tests/contentfiltering/block-after-redirect.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox-redirects-cuts-opener.https.html imported/w3c/web-platform-tests/resource-timing/redirects.html imported/w3c/web-platform-tests/resource-timing/redirects.sub.html imported/w3c/web-platform-tests/xhr/access-control-and-redirects.any.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95225 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15600 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11430 "Found 15 new test failures: http/tests/contentfiltering/block-after-redirect.html http/tests/security/xss-DENIED-xsl-document-securityOrigin.xml http/tests/security/xss-DENIED-xsl-external-entity-xslt-docloader.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync-double.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75834 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76322 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/color-chooser-request, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/audio-usermedia-permission-request, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /TestWebKit:WebKit.EvaluateJavaScriptThatThrowsAnException, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/link ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20710 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19131 "Found 10 new test failures: http/tests/contentfiltering/block-after-redirect.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox-redirects-cuts-opener.https.html imported/w3c/web-platform-tests/resource-timing/redirects.html imported/w3c/web-platform-tests/resource-timing/redirects.sub.html imported/w3c/web-platform-tests/xhr/access-control-and-redirects.any.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8637 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20922 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->