### PR TITLE
FileSystemWritableFileStream.truncate should change the file current position if the position is greater than the truncate size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any-expected.txt
@@ -4,7 +4,7 @@ PASS truncate() to grow a file
 FAIL createWritable() fails when parent directory is removed assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS createWritable({keepExistingData: true}): atomic writable file stream initialized with source contents
 PASS createWritable({keepExistingData: false}): atomic writable file stream initialized with empty file
-FAIL cursor position: truncate size > offset assert_equals: expected "abc45" but got "12345abc"
+PASS cursor position: truncate size > offset
 PASS cursor position: truncate size < offset
 PASS commands are queued, stream is unlocked after each operation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any.worker-expected.txt
@@ -4,7 +4,7 @@ PASS truncate() to grow a file
 FAIL createWritable() fails when parent directory is removed assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS createWritable({keepExistingData: true}): atomic writable file stream initialized with source contents
 PASS createWritable({keepExistingData: false}): atomic writable file stream initialized with empty file
-FAIL cursor position: truncate size > offset assert_equals: expected "abc45" but got "12345abc"
+PASS cursor position: truncate size > offset
 PASS cursor position: truncate size < offset
 PASS commands are queued, stream is unlocked after each operation
 

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -322,7 +322,10 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::executeCommandFor
         if (!truncated)
             return FileSystemStorageError::Unknown;
 
-        FileSystem::seekFile(m_activeWritableFile.handle(), *size, FileSystem::FileSeekOrigin::Beginning);
+        auto currentOffset = FileSystem::seekFile(m_activeWritableFile.handle(), 0, FileSystem::FileSeekOrigin::Current);
+        if (currentOffset == -1 || static_cast<unsigned long long>(currentOffset) > *size)
+            FileSystem::seekFile(m_activeWritableFile.handle(), *size, FileSystem::FileSeekOrigin::Beginning);
+
         return std::nullopt;
     }
     }


### PR DESCRIPTION
#### e14ddf1849da2527e2d5f20bc5e74d89cd1a435b
<pre>
FileSystemWritableFileStream.truncate should change the file current position if the position is greater than the truncate size
<a href="https://rdar.apple.com/144247504">rdar://144247504</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287104">https://bugs.webkit.org/show_bug.cgi?id=287104</a>

Reviewed by Sihui Liu.

Implement step 3.2.5.7 of <a href="https://fs.spec.whatwg.org/#write-a-chunk.">https://fs.spec.whatwg.org/#write-a-chunk.</a>

* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemWritableFileStream.https.any.worker-expected.txt:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::executeCommandForWritableInternal):

Canonical link: <a href="https://commits.webkit.org/289920@main">https://commits.webkit.org/289920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fe4ed2fa8c79f603c79f8c5d5d28fe17c47291e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68129 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25849 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6061 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34337 "Found 60 new test failures: accessibility/placeholder.html editing/undo/redo-reapply-edit-command-crash.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/canvas/ctx.2d-canvas-style-gradient-no-document-leak.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95114 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15489 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11357 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76998 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76245 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18779 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8526 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20810 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18695 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->