### PR TITLE
LibWebRTC HEVC parameter validation when matching video codecs is not compatible with http://play.geforcenow.com/

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/sdp_video_format.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/sdp_video_format.cc
@@ -83,6 +83,7 @@ bool AV1IsSameLevelIdx(const CodecParameterMap& left,
 }
 
 #ifdef RTC_ENABLE_H265
+#ifdef RTC_ENABLE_H265_TIGHT_CHECKS
 std::string GetH265TxModeOrDefault(const CodecParameterMap& params) {
   // If TxMode is not present, a value of "SRST" must be inferred.
   // https://tools.ietf.org/html/rfc7798@section-7.1
@@ -94,6 +95,7 @@ bool IsSameH265TxMode(const CodecParameterMap& left,
   return absl::EqualsIgnoreCase(GetH265TxModeOrDefault(left),
                                 GetH265TxModeOrDefault(right));
 }
+#endif
 #endif
 
 // Some (video) codecs are actually families of codecs and rely on parameters
@@ -119,9 +121,13 @@ bool IsSameCodecSpecific(const std::string& name1,
              AV1IsSameLevelIdx(params1, params2);
 #ifdef RTC_ENABLE_H265
     case kVideoCodecH265:
+#ifdef RTC_ENABLE_H265_TIGHT_CHECKS
       return H265IsSameProfile(params1, params2) &&
              H265IsSameTier(params1, params2) &&
              IsSameH265TxMode(params1, params2);
+#else
+      return true;
+#endif
 #endif
     default:
       return true;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/media/base/codec_comparators.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/media/base/codec_comparators.cc
@@ -95,11 +95,13 @@ std::string GetH265TxModeOrDefault(const CodecParameterMap& params) {
   return GetFmtpParameterOrDefault(params, cricket::kH265FmtpTxMode, "SRST");
 }
 
+#ifdef RTC_ENABLE_H265_TIGHT_CHECKS
 bool IsSameH265TxMode(const CodecParameterMap& left,
                       const CodecParameterMap& right) {
   return absl::EqualsIgnoreCase(GetH265TxModeOrDefault(left),
                                 GetH265TxModeOrDefault(right));
 }
+#endif
 #endif
 
 // Some (video) codecs are actually families of codecs and rely on parameters
@@ -123,11 +125,13 @@ bool IsSameCodecSpecific(const std::string& name1,
            AV1IsSameTier(params1, params2) &&
            AV1IsSameLevelIdx(params1, params2);
 #ifdef RTC_ENABLE_H265
+#ifdef RTC_ENABLE_H265_TIGHT_CHECKS
   if (either_name_matches(cricket::kH265CodecName)) {
     return H265IsSameProfile(params1, params2) &&
            H265IsSameTier(params1, params2) &&
            IsSameH265TxMode(params1, params2);
   }
+#endif
 #endif
   return true;
 }

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
@@ -128,6 +128,8 @@ ExceptionOr<void> RTCRtpTransceiver::setCodecPreferences(const Vector<RTCRtpCode
 {
     if (!m_backend)
         return { };
+
+    RELEASE_LOG_INFO(WebRTC, "RTCRtpTransceiver::setCodecPreferences");
     return m_backend->setCodecPreferences(codecs);
 }
 


### PR DESCRIPTION
#### 3e847b33c9aa193c4a1fc72e530dd3edaf4f11a2
<pre>
LibWebRTC HEVC parameter validation when matching video codecs is not compatible with <a href="http://play.geforcenow.com/">http://play.geforcenow.com/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287111">https://bugs.webkit.org/show_bug.cgi?id=287111</a>
<a href="https://rdar.apple.com/143436499">rdar://143436499</a>

Reviewed by Jean-Yves Avenard.

Libwebrtc M132 introduced tighter video codec matching.
This breaks <a href="http://play.geforcenow.com/">http://play.geforcenow.com/</a> which uses HEVC, in particular for high resolution.
This notably impacts VisionOS.

This patch disables these HEVC checks until a later release.

* Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/sdp_video_format.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/media/base/codec_comparators.cc:
* Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp:
(WebCore::RTCRtpTransceiver::setCodecPreferences):

Canonical link: <a href="https://commits.webkit.org/289918@main">https://commits.webkit.org/289918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89902a0aa313017fe2f2babdc08556b44208c231

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68131 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25852 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34305 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15493 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76246 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18776 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8530 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->