### PR TITLE
warning when building WebKit: imported declaration '_WKWebExtensionSidebar' could not be mapped to 'WKWebExtension.Sidebar'

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h
@@ -29,7 +29,6 @@
 @class WKWebExtensionContext;
 @class WKWebView;
 @protocol WKWebExtensionTab;
-@protocol WKWebExtension;
 
 #if TARGET_OS_IPHONE
 @class UIImage;
@@ -46,7 +45,6 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion When this property is `nil`, it indicates that the action is the default action and not associated with a specific tab.
  */
 WK_CLASS_AVAILABLE(macos(15.2), ios(18.2), visionos(2.2))
-NS_SWIFT_NAME(WKWebExtension.Sidebar)
 @interface _WKWebExtensionSidebar : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;


### PR DESCRIPTION
#### 4eb48cccc9769667f91d5bdcd9e59416c8e4dbda
<pre>
warning when building WebKit: imported declaration &apos;_WKWebExtensionSidebar&apos; could not be mapped to &apos;WKWebExtension.Sidebar&apos;
<a href="https://rdar.apple.com/144207409">rdar://144207409</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287094">https://bugs.webkit.org/show_bug.cgi?id=287094</a>

Reviewed by Timothy Hatcher.

This removes the Swift name for _WKWebExtensionSidebar, as we cannot fix the warning by un-prefixing the Objective-C interface until this API has stabilized.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.h: Remove NS_SWIFT_NAME(WKWebExtension.Sidebar), remove unused forward declaration

Canonical link: <a href="https://commits.webkit.org/289908@main">https://commits.webkit.org/289908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ff191e4d72952601d3dbceb38dcaba4023533ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39121 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68153 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25872 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6091 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38229 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15542 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77024 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75776 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76275 "Found 100 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/color-chooser-request, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/audio-usermedia-permission-request, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /TestWebKit:WebKit.EvaluateJavaScriptThatThrowsAnException, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/link ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20663 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8579 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13810 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15558 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->