### PR TITLE
Support sideways-lr coordinate conversion for carets and selection

### DIFF
--- a/LayoutTests/editing/caret/caret-position-sideways-lr-expected.txt
+++ b/LayoutTests/editing/caret/caret-position-sideways-lr-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 62,44,20,1
+Click at 5, 5 for left above first line : 17,21,25,1
+Click at 5, 275 for right above first line : 17,21,25,1
+Click at 25, 5 for left of first line : 17,21,25,1
+Click at 25, 275 for right of first line : 17,237,25,1
+Click at 45, 5 for left of second line : 42,21,20,1
+Click at 45, 275 for right of second line : 42,248,20,1
+Click at 65, 5 for left of third line : 62,21,20,1
+Click at 65, 275 for right of third line : 62,176,20,1
+Click at 85, 5 for left of fourth line : 82,21,20,1
+Click at 85, 275 for right of fourth line : 82,262,20,1
+Click at 105, 5 for left of fifth line : 102,21,19,1
+Click at 105, 275 for right of fifth line : 102,68,19,1
+Click at 125, 5 for left of sixth line : 121,21,20,1
+Click at 125, 275 for right of sixth line : 121,260,20,1
+Click at 145, 5 for left of seventh line : 141,21,20,1
+Click at 145, 275 for right of seventh line : 141,200,20,1
+Click at 170, 5 for left below last line : 141,200,20,1
+Click at 170, 275 for right below last line : 141,200,20,1
+Click at 25, 30 for inside first root inline fragment : 17,32,25,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 121,32,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 42,32,20,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 62,32,20,1
+Click at 85, 220 for inside unfragmented non-root inline : 82,225,20,1

--- a/LayoutTests/editing/caret/caret-position-sideways-lr.html
+++ b/LayoutTests/editing/caret/caret-position-sideways-lr.html
@@ -1,0 +1,125 @@
+<html>
+<style>
+#test {
+    writing-mode: sideways-lr;
+    /* If this test ends up being flaky, consider using Ahem. But it's more rigorous not to. */
+    outline: solid gray 1px;
+    padding: 1em;
+    width: 10em;
+    height: 20ch;
+    font: 20px/1 monospace;
+    background: /* Create a 10px grid to help with debugging. */
+        repeating-linear-gradient(transparent 0em 9px, #FC88 9px 10px),
+        repeating-linear-gradient(to left, transparent 0px 9px, #FC88 9px 10px);
+}
+span {
+    border: 1px solid aqua;
+}
+</style>
+
+<div id=test contenteditable>
+This is a test <span id=first>of writingsideways in vertical text</span><br>
+with multiline <span id=second>text</span> and alongwordthat'slong andanotherword.
+</div>
+
+<hr>
+
+<ul id="console"></ul>
+
+<script src="../../resources/ui-helper.js"></script>
+<script>
+
+var test = document.getElementById('test');
+var first = document.getElementById('first');
+var second = document.getElementById('second');
+
+var testLeftEdge = test.offsetLeft;
+var testTopEdge = test.offsetTop;
+var testBottomEdge = test.offsetTop + test.offsetHeight;
+var measure = test.offsetHeight;
+
+function stringifyCaret(caretRect) {
+    // Convert to LTR-relative coords and stringify
+    return (caretRect.x - testLeftEdge) + ","
+        + -(caretRect.y - testBottomEdge) + ","
+        + caretRect.width + ","
+        + caretRect.height;
+}
+
+function log(str) {
+    var li = document.createElement("li");
+    li.appendChild(document.createTextNode(str));
+    var console = document.getElementById("console");
+    console.appendChild(li);
+}
+
+function testCaretPosition(testID, element)
+{
+    element.focus();
+    var caretRect = window.internals.absoluteCaretBounds();
+    log(testID + " : " + stringifyCaret(caretRect));
+}
+
+async function clickInTest(target, blockCoord, inlineCoord)
+{
+    if (window.eventSender) {
+        await UIHelper.activateAt(testLeftEdge + blockCoord, testBottomEdge - inlineCoord);
+    }
+    else {
+        log("FAIL: could not send click event");
+    }
+}
+
+// To make it easier to reason about individual tests, this test method
+// accepts click coordinates in LTR-relative terms. See helper functions for conversion.
+async function testCaretClick(testID, blockCoord, inlineCoord, element)
+{
+    await clickInTest(element, blockCoord, inlineCoord);
+    testCaretPosition("Click at " + blockCoord + ", " + inlineCoord + " for " + testID, element);
+}
+
+async function runTest()
+{
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    // Tests for bugs that are oddly specific and hard to describe
+    window.getSelection().collapse(first.firstChild, 24);
+    await testCaretPosition("Bug 286961", first);
+
+    // Check caret insertion
+    await testCaretClick("left above first line", 5, 5, test);
+    await testCaretClick("right above first line", 5, measure - 5, test);
+
+    await testCaretClick("left of first line", 25, 5, test);
+    await testCaretClick("right of first line", 25, measure - 5, test);
+    await testCaretClick("left of second line", 45, 5, test);
+    await testCaretClick("right of second line", 45, measure - 5, test);
+    await testCaretClick("left of third line", 65, 5, test);
+    await testCaretClick("right of third line", 65, measure - 5, test);
+    await testCaretClick("left of fourth line", 85, 5, test);
+    await testCaretClick("right of fourth line", 85, measure - 5, test);
+    await testCaretClick("left of fifth line", 105, 5, test);
+    await testCaretClick("right of fifth line", 105, measure - 5, test);
+    await testCaretClick("left of sixth line", 125, 5, test);
+    await testCaretClick("right of sixth line", 125, measure - 5, test);
+    await testCaretClick("left of seventh line", 145, 5, test);
+    await testCaretClick("right of seventh line", 145, measure - 5, test);
+
+    await testCaretClick("left below last line", 170, 5, test);
+    await testCaretClick("right below last line", 170, measure - 5, test);
+
+    await testCaretClick("inside first root inline fragment", 25, 30, test);
+    await testCaretClick("inside middle fragment of root inline fragment", 125, 30, test);
+    await testCaretClick("inside middle fragment of non-root inline fragment", 45, 30, first);
+    await testCaretClick("inside last fragment of non-root inline fragment", 65, 30, first);
+    await testCaretClick("inside unfragmented non-root inline", 85, measure - 60, second);
+
+    testRunner.notifyDone();
+}
+
+runTest();
+
+</script>

--- a/LayoutTests/platform/ios/editing/caret/caret-position-sideways-lr-expected.txt
+++ b/LayoutTests/platform/ios/editing/caret/caret-position-sideways-lr-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 61,45,20,2
+Click at 5, 5 for left above first line : 18,22,23,2
+Click at 5, 275 for right above first line : 18,22,23,2
+Click at 25, 5 for left of first line : 18,22,23,2
+Click at 25, 275 for right of first line : 41,22,20,2
+Click at 45, 5 for left of second line : 41,22,20,2
+Click at 45, 275 for right of second line : 61,22,20,2
+Click at 65, 5 for left of third line : 61,22,20,2
+Click at 65, 275 for right of third line : 61,177,20,2
+Click at 85, 5 for left of fourth line : 81,22,20,2
+Click at 85, 275 for right of fourth line : 81,263,20,2
+Click at 105, 5 for left of fifth line : 101,22,19,2
+Click at 105, 275 for right of fifth line : 120,22,20,2
+Click at 125, 5 for left of sixth line : 120,22,20,2
+Click at 125, 275 for right of sixth line : 140,22,20,2
+Click at 145, 5 for left of seventh line : 140,22,20,2
+Click at 145, 275 for right of seventh line : 140,201,20,2
+Click at 170, 5 for left below last line : 140,201,20,2
+Click at 170, 275 for right below last line : 140,201,20,2
+Click at 25, 30 for inside first root inline fragment : 18,22,23,2
+Click at 125, 30 for inside middle fragment of root inline fragment : -8,288,0,0
+Click at 45, 30 for inside middle fragment of non-root inline fragment : -8,288,0,0
+Click at 65, 30 for inside last fragment of non-root inline fragment : -8,288,0,0
+Click at 85, 220 for inside unfragmented non-root inline : 81,251,20,2

--- a/LayoutTests/platform/mac-ventura/editing/caret/caret-position-sideways-lr-expected.txt
+++ b/LayoutTests/platform/mac-ventura/editing/caret/caret-position-sideways-lr-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 62,44,20,1
+Click at 5, 5 for left above first line : 17,21,25,1
+Click at 5, 275 for right above first line : 17,21,25,1
+Click at 25, 5 for left of first line : 17,21,25,1
+Click at 25, 275 for right of first line : 17,237,25,1
+Click at 45, 5 for left of second line : 42,21,20,1
+Click at 45, 275 for right of second line : 42,248,20,1
+Click at 65, 5 for left of third line : 62,21,20,1
+Click at 65, 275 for right of third line : 62,176,20,1
+Click at 85, 5 for left of fourth line : 82,21,20,1
+Click at 85, 275 for right of fourth line : 82,262,20,1
+Click at 105, 5 for left of fifth line : 102,21,19,1
+Click at 105, 275 for right of fifth line : 102,68,19,1
+Click at 125, 5 for left of sixth line : 121,21,20,1
+Click at 125, 275 for right of sixth line : 121,260,20,1
+Click at 145, 5 for left of seventh line : 141,21,20,1
+Click at 145, 275 for right of seventh line : 141,200,20,1
+Click at 170, 5 for left below last line : 141,200,20,1
+Click at 170, 275 for right below last line : 141,200,20,1
+Click at 25, 30 for inside first root inline fragment : 17,32,25,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 121,32,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 42,32,20,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 62,32,20,1
+Click at 85, 220 for inside unfragmented non-root inline : 82,225,20,1

--- a/LayoutTests/platform/mac/editing/caret/caret-position-sideways-lr-expected.txt
+++ b/LayoutTests/platform/mac/editing/caret/caret-position-sideways-lr-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 62,45,20,2
+Click at 5, 5 for left above first line : 17,22,25,2
+Click at 5, 275 for right above first line : 17,22,25,2
+Click at 25, 5 for left of first line : 17,22,25,2
+Click at 25, 275 for right of first line : 17,238,25,2
+Click at 45, 5 for left of second line : 42,22,20,2
+Click at 45, 275 for right of second line : 42,249,20,2
+Click at 65, 5 for left of third line : 62,22,20,2
+Click at 65, 275 for right of third line : 62,177,20,2
+Click at 85, 5 for left of fourth line : 82,22,20,2
+Click at 85, 275 for right of fourth line : 82,263,20,2
+Click at 105, 5 for left of fifth line : 102,22,19,2
+Click at 105, 275 for right of fifth line : 102,69,19,2
+Click at 125, 5 for left of sixth line : 121,22,20,2
+Click at 125, 275 for right of sixth line : 121,261,20,2
+Click at 145, 5 for left of seventh line : 141,22,20,2
+Click at 145, 275 for right of seventh line : 141,201,20,2
+Click at 170, 5 for left below last line : 141,201,20,2
+Click at 170, 275 for right below last line : 141,201,20,2
+Click at 25, 30 for inside first root inline fragment : 17,33,25,2
+Click at 125, 30 for inside middle fragment of root inline fragment : 121,33,20,2
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 42,33,20,2
+Click at 65, 30 for inside last fragment of non-root inline fragment : 62,33,20,2
+Click at 85, 220 for inside unfragmented non-root inline : 82,226,20,2

--- a/LayoutTests/platform/win/editing/caret/caret-position-sideways-lr-expected.txt
+++ b/LayoutTests/platform/win/editing/caret/caret-position-sideways-lr-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 62,44,20,1
+Click at 5, 5 for left above first line : 17,21,25,1
+Click at 5, 275 for right above first line : 17,237,25,1
+Click at 25, 5 for left of first line : 17,21,25,1
+Click at 25, 275 for right of first line : 17,237,25,1
+Click at 45, 5 for left of second line : 42,21,20,1
+Click at 45, 275 for right of second line : 42,248,20,1
+Click at 65, 5 for left of third line : 62,21,20,1
+Click at 65, 275 for right of third line : 62,176,20,1
+Click at 85, 5 for left of fourth line : 82,21,20,1
+Click at 85, 275 for right of fourth line : 82,262,20,1
+Click at 105, 5 for left of fifth line : 102,21,19,1
+Click at 105, 275 for right of fifth line : 102,68,19,1
+Click at 125, 5 for left of sixth line : 121,21,20,1
+Click at 125, 275 for right of sixth line : 121,260,20,1
+Click at 145, 5 for left of seventh line : 141,21,20,1
+Click at 145, 275 for right of seventh line : 141,200,20,1
+Click at 170, 5 for left below last line : 141,21,20,1
+Click at 170, 275 for right below last line : 141,200,20,1
+Click at 25, 30 for inside first root inline fragment : 17,32,25,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 121,32,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 42,32,20,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 62,32,20,1
+Click at 85, 220 for inside unfragmented non-root inline : 82,225,20,1

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -69,8 +69,10 @@ public:
     inline float logicalBottom() const;
     inline float logicalHeight() const;
     inline float logicalWidth() const;
+    inline float logicalLeft() const;
+    inline float logicalRight() const;
 
-    // Return visual left/right coords in inline direction (they are still considered logical values as there's no flip for writing mode).
+    // Return line-relative left/right coords (they are still considered logical values as there's no flip for writing mode).
     inline float logicalLeftIgnoringInlineDirection() const;
     inline float logicalRightIgnoringInlineDirection() const;
 
@@ -81,9 +83,11 @@ public:
     unsigned leftmostCaretOffset() const { return isLeftToRightDirection() ? minimumCaretOffset() : maximumCaretOffset(); }
     unsigned rightmostCaretOffset() const { return isLeftToRightDirection() ? maximumCaretOffset() : minimumCaretOffset(); }
 
+    // isLeftToRightDirection() here is not the same as writingMode().isBidiLTR().
     unsigned char bidiLevel() const;
     TextDirection direction() const { return bidiLevel() % 2 ? TextDirection::RTL : TextDirection::LTR; }
     bool isLeftToRightDirection() const { return direction() == TextDirection::LTR; }
+    bool isInlineFlipped() const { return !(isLeftToRightDirection() == writingMode().isLogicalLeftLineLeft()); }
 
     RenderObject::HighlightState selectionState() const;
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h
@@ -38,6 +38,9 @@ inline float Box::logicalRightIgnoringInlineDirection() const { return logicalRe
 inline float Box::logicalTop() const { return logicalRectIgnoringInlineDirection().y(); }
 inline float Box::logicalWidth() const { return logicalRectIgnoringInlineDirection().width(); }
 
+inline float Box::logicalLeft() const { return isHorizontal() ? visualRect().x() : visualRect().y(); }
+inline float Box::logicalRight() const { return logicalLeft() + logicalWidth(); }
+
 inline bool Box::isHorizontal() const
 {
     return WTF::switchOn(m_pathVariant, [](auto& path) {
@@ -74,6 +77,34 @@ inline LeafBoxIterator Box::nextLogicalLeftwardOnLineIgnoringLineBreak() const
 {
     return writingMode().isLogicalLeftLineLeft()
         ? nextLineLeftwardOnLineIgnoringLineBreak() : nextLineRightwardOnLineIgnoringLineBreak();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalRightwardOnLine()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineRightwardOnLine()
+        : traverseLineLeftwardOnLine();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalLeftwardOnLine()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineLeftwardOnLine()
+        : traverseLineRightwardOnLine();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalRightwardOnLineIgnoringLineBreak()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineRightwardOnLineIgnoringLineBreak()
+        : traverseLineLeftwardOnLineIgnoringLineBreak();
+}
+
+inline LeafBoxIterator& LeafBoxIterator::traverseLogicalLeftwardOnLineIgnoringLineBreak()
+{
+    return m_box.writingMode().isLogicalLeftLineLeft()
+        ? traverseLineLeftwardOnLineIgnoringLineBreak()
+        : traverseLineRightwardOnLineIgnoringLineBreak();
 }
 
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "InlineIteratorLineBox.h"
+#include "InlineIteratorLineBoxInlines.h"
 
 #include "InlineIteratorBoxInlines.h"
 #include "LayoutIntegrationLineLayout.h"
@@ -130,29 +131,29 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
         return box && box->renderer().node() && box->renderer().node()->hasEditableStyle();
     };
 
-    auto firstBox = lineBox.lineLeftmostLeafBox();
-    auto lastBox = lineBox.lineRightmostLeafBox();
+    auto firstBox = lineBox.logicalLeftmostLeafBox();
+    auto lastBox = lineBox.logicalRightmostLeafBox();
 
     if (firstBox != lastBox) {
         if (firstBox->isLineBreak())
-            firstBox = firstBox->nextLineRightwardOnLineIgnoringLineBreak();
+            firstBox = firstBox->nextLogicalRightwardOnLineIgnoringLineBreak();
         else if (lastBox->isLineBreak())
-            lastBox = lastBox->nextLineLeftwardOnLineIgnoringLineBreak();
+            lastBox = lastBox->nextLogicalLeftwardOnLineIgnoringLineBreak();
     }
 
     if (firstBox == lastBox && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (firstBox && horizontalPosition <= firstBox->logicalLeftIgnoringInlineDirection() && !firstBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(firstBox)))
+    if (firstBox && horizontalPosition <= firstBox->logicalLeft() && !firstBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (lastBox && horizontalPosition >= lastBox->logicalRightIgnoringInlineDirection() && !lastBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(lastBox)))
+    if (lastBox && horizontalPosition >= lastBox->logicalRight() && !lastBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(lastBox)))
         return lastBox;
 
     auto closestBox = lastBox;
-    for (auto box = firstBox; box; box = box.traverseLineRightwardOnLineIgnoringLineBreak()) {
+    for (auto box = firstBox; box; box = box.traverseLogicalRightwardOnLineIgnoringLineBreak()) {
         if (!box->renderer().isRenderListMarker() && (!editableOnly || isEditable(box))) {
-            if (horizontalPosition < box->logicalRightIgnoringInlineDirection())
+            if (horizontalPosition < box->logicalRight())
                 return box;
             closestBox = box;
         }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -88,8 +88,12 @@ public:
     bool isFirst() const;
     bool isFirstAfterPageBreak() const;
 
+    // Text-relative left/right
     LeafBoxIterator lineLeftmostLeafBox() const;
     LeafBoxIterator lineRightmostLeafBox() const;
+    // Coordinate-relative left/right
+    inline LeafBoxIterator logicalLeftmostLeafBox() const;
+    inline LeafBoxIterator logicalRightmostLeafBox() const;
 
     LineBoxIterator next() const;
     LineBoxIterator previous() const;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h
@@ -43,5 +43,19 @@ inline float contentStartInBlockDirection(const LineBox& lineBox)
     return std::min(lineBox.contentLogicalBottom(), lineBox.contentLogicalBottomAdjustedForFollowingLineBox());
 }
 
+inline LeafBoxIterator LineBox::logicalLeftmostLeafBox() const
+{
+    return formattingContextRoot().writingMode().isLogicalLeftLineLeft()
+        ? lineLeftmostLeafBox()
+        : lineRightmostLeafBox();
+}
+
+inline LeafBoxIterator LineBox::logicalRightmostLeafBox() const
+{
+    return formattingContextRoot().writingMode().isLogicalLeftLineLeft()
+        ? lineRightmostLeafBox()
+        : lineLeftmostLeafBox();
+}
+
 }
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -63,18 +63,25 @@ public:
 
     float contentLogicalTopAdjustedForPrecedingLineBox() const
     {
-        if (formattingContextRoot().style().writingMode().isLineInverted() || !m_lineIndex)
+        if (formattingContextRoot().writingMode().isLineInverted() || !m_lineIndex)
             return contentLogicalTop();
         return LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex - 1 }.contentLogicalBottom();
     }
     float contentLogicalBottomAdjustedForFollowingLineBox() const
     {
-        if (!formattingContextRoot().style().writingMode().isLineInverted() || m_lineIndex == lines().size() - 1)
+        if (!formattingContextRoot().writingMode().isLineInverted() || m_lineIndex == lines().size() - 1)
             return contentLogicalBottom();
         return LineBoxIteratorModernPath { *m_inlineContent, m_lineIndex + 1 }.contentLogicalTop();
     }
 
-    float contentLogicalLeft() const { return line().lineBoxLeft() + line().contentLogicalLeftIgnoringInlineDirection(); }
+    float contentLogicalLeft() const
+    {
+        auto writingMode = formattingContextRoot().writingMode();
+        if (writingMode.isLogicalLeftLineLeft())
+            return line().lineBoxLeft() + line().contentLogicalLeftIgnoringInlineDirection();
+        ASSERT(writingMode.isVertical()); // Currently only sideways-lr gets this far.
+        return line().bottom() - (line().contentLogicalLeftIgnoringInlineDirection() + line().contentLogicalWidth());
+    }
     float contentLogicalRight() const { return contentLogicalLeft() + line().contentLogicalWidth(); }
     bool isHorizontal() const { return line().isHorizontal(); }
     FontBaseline baselineType() const { return line().baselineType(); }

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -194,11 +194,17 @@ LayoutRect LegacyInlineTextBox::localSelectionRect(unsigned startPos, unsigned e
         return { };
 
     TextRun textRun = createTextRun();
+    auto writingMode = renderer().writingMode();
+    auto width = LayoutUnit { logicalWidth() };
 
-    LayoutRect selectionRect { LayoutUnit(logicalLeft()), this->selectionTop(), LayoutUnit(logicalWidth()), this->selectionHeight() };
+    LayoutRect selectionRect { 0, this->selectionTop(), width, this->selectionHeight() };
     // Avoid measuring the text when the entire line box is selected as an optimization.
     if (clampedStart || clampedEnd != textRun.length())
         lineFont().adjustSelectionRectForText(renderer().canUseSimplifiedTextMeasuring().value_or(false), textRun, selectionRect, clampedStart, clampedEnd);
+
+    if (!writingMode.isLogicalLeftLineLeft())
+        selectionRect.setX(width - selectionRect.x());
+    selectionRect.move(logicalLeft(), 0);
     // FIXME: The computation of the snapped selection rect differs from the computation of this rect
     // in paintMarkedTextBackground(). See <https://bugs.webkit.org/show_bug.cgi?id=138913>.
     return snappedSelectionRect(selectionRect, logicalRight(), renderer().writingMode());


### PR DESCRIPTION
#### 12e65d787eb09add291c21e11858bf6d4d7bef5c
<pre>
Support sideways-lr coordinate conversion for carets and selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=286961">https://bugs.webkit.org/show_bug.cgi?id=286961</a>
<a href="https://rdar.apple.com/144117372">rdar://144117372</a>

Reviewed by Alan Baradlay.

In sideways-lr mode (uniquely), LTR text progresses in the direction opposite
to the direction our inline coordinates increase. Update caret and selection
coordinate computations, comparisons, and box traversals to handle this mismatch.

This commit introduces two cosmetic changes for consistency with introduced code:
- Drop the style() in formattingContext().style().writingMode() in two places
- Rename pointLineDirection and pointBlockDirection to logicalPoint.x()/y()

* LayoutTests/editing/caret/caret-position-sideways-lr-expected.txt: Added.
* LayoutTests/editing/caret/caret-position-sideways-lr.html: Added.
* LayoutTests/platform/ios/editing/caret/caret-position-sideways-lr-expected.txt: Added.
* LayoutTests/platform/mac-ventura/editing/caret/caret-position-sideways-lr-expected.txt: Added.
* LayoutTests/platform/mac/editing/caret/caret-position-sideways-lr-expected.txt: Added.
* LayoutTests/platform/win/editing/caret/caret-position-sideways-lr-expected.txt: Added.
* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
(WebCore::InlineIterator::Box::isInlineFlipped const): Introduce new convenience method.
* Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h:
(WebCore::InlineIterator::Box::logicalLeft const): Provide Render tree logical coords.
(WebCore::InlineIterator::Box::logicalRight const): Provide Render tree logical coords.
(WebCore::InlineIterator::LeafBoxIterator::traverseLogicalRightwardOnLine): Add coordinate-relative traversal methods.
(WebCore::InlineIterator::LeafBoxIterator::traverseLogicalLeftwardOnLine): Add coordinate-relative traversal methods.
(WebCore::InlineIterator::LeafBoxIterator::traverseLogicalRightwardOnLineIgnoringLineBreak): Add coordinate-relative traversal methods.
(WebCore::InlineIterator::LeafBoxIterator::traverseLogicalLeftwardOnLineIgnoringLineBreak): Add coordinate-relative traversal methods.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp:
(WebCore::InlineIterator::closestBoxForHorizontalPosition): Update to coordinate flow traversal.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h:
(WebCore::InlineIterator::LineBox::logicalLeftmostLeafBox const): Add coordinate-relative traversal methods.
(WebCore::InlineIterator::LineBox::logicalRightmostLeafBox const): Add coordinate-relative traversal methods.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::contentLogicalTopAdjustedForPrecedingLineBox const): Tweak for consistency.
(WebCore::InlineIterator::LineBoxIteratorModernPath::contentLogicalBottomAdjustedForFollowingLineBox const): Tweak for consistency.
(WebCore::InlineIterator::LineBoxIteratorModernPath::contentLogicalLeft const): Add support for sideways-lr coordinates.
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForText): Separate out getting the textRun offset from adding the box edge offset, and perform coordinate conversion on the former only.
(WebCore::computeCaretRectForEmptyElement): Update caret alignment to support sideways-lr.
(WebCore::computeCaretRectForLinePosition): Update caret alignment to support sideways-lr.
(WebCore::computeCaretRectForLineBreak):
(WebCore::computeCaretRectForSVGInlineText): Incorporate sideways-lr logic into inline direction check.
(WebCore::computeCaretRectForBox): Incorporate sideways-lr logic into inline direction check.
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::localSelectionRect const): Separate out getting the textRun offset from adding the box edge offset, and perform coordinate conversion on the former only.
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::selectionRectForTextBox): Separate out getting the textRun offset from adding the box edge offset, and perform coordinate conversion on the former only.
(WebCore::offsetForPositionInRun): Incorporate sidways-lr logic into inline direction checks, and convert sideways-lr coordinates appropriately.
(WebCore::lineDirectionPointFitsInBox): Perform coordinate comparisons in the correct coordinate system, using coordinate-relative traversal methods.
(WebCore::RenderText::positionForPoint): Perform coordinate comparisons in the correct coordinate system. Rename local variables accordingly.

Canonical link: <a href="https://commits.webkit.org/290387@main">https://commits.webkit.org/290387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76bfee0f20705e1c3025355e9aaa63a2d33ed9e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69084 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26708 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49450 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7103 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35830 "Found 1 new test failure: media/modern-media-controls/invalid-placard/invalid-placard-constrained-metrics.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39598 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96522 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77279 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10054 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14113 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22213 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->