### PR TITLE
Store WeakPtr and WeakObjCPtr instead of raw pointers as members of objects

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -54,6 +54,7 @@
 #import <wtf/NakedRef.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/WeakPtr.h>
 #import <wtf/text/TextStream.h>
 
 #import "WebKitSwiftSoftLink.h"
@@ -63,7 +64,7 @@
 @end
 
 @implementation WKModelProcessModelPlayerProxyObjCAdapter {
-    NakedPtr<WebKit::ModelProcessModelPlayerProxy> _modelProcessModelPlayerProxy;
+    WeakPtr<WebKit::ModelProcessModelPlayerProxy> _modelProcessModelPlayerProxy;
 }
 
 - (instancetype)initWithModelProcessModelPlayerProxy:(NakedRef<WebKit::ModelProcessModelPlayerProxy>)modelProcessModelPlayerProxy

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -341,7 +341,7 @@ void PageClientImplCocoa::updateScreenTimeWebpageControllerURL(WKWebView *webVie
     if (!screenTimeWebpageController)
         return;
 
-    NakedPtr<WebKit::WebPageProxy> pageProxy = [webView _page];
+    RefPtr pageProxy = [webView _page].get();
     if (pageProxy && !pageProxy->preferences().screenTimeEnabled()) {
         [webView _uninstallScreenTimeWebpageController];
         return;

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -27,9 +27,10 @@
 
 #import <AppKit/AppKit.h>
 #import <wtf/CompletionHandler.h>
-#import <wtf/NakedPtr.h>
 #import <wtf/NakedRef.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebKit { 
 class LayerTreeContext;
@@ -47,8 +48,8 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 
 @interface WKFullScreenWindowController : NSWindowController<NSWindowDelegate> {
 @private
-    NSView *_webView; // Cannot be retained, see <rdar://problem/14884666>.
-    NakedPtr<WebKit::WebPageProxy> _page;
+    WeakObjCPtr<NSView> _webView; // Cannot be retained, see <rdar://problem/14884666>.
+    WeakPtr<WebKit::WebPageProxy> _page;
     RetainPtr<WebCoreFullScreenPlaceholderView> _webViewPlaceholder;
     RetainPtr<NSView> _exitPlaceholder;
     RetainPtr<NSView> _clipView;

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -266,13 +266,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _webViewPlaceholder = adoptNS([[WebCoreFullScreenPlaceholderView alloc] initWithFrame:[_webView frame]]);
     [_webViewPlaceholder setTarget:nil];
     [_webViewPlaceholder setContents:(__bridge id)webViewContents.get()];
-    [self _saveConstraintsOf:_webView.superview];
-    [self _replaceView:_webView with:_webViewPlaceholder.get()];
+    [self _saveConstraintsOf:[_webView superview]];
+    [self _replaceView:_webView.get().get() with:_webViewPlaceholder.get()];
     
     // Then insert the WebView into the full screen window
     NSView *contentView = [[self window] contentView];
-    [_clipView addSubview:_webView positioned:NSWindowBelow relativeTo:nil];
-    _webView.frame = NSInsetRect(contentView.bounds, 0, -_page->topContentInset());
+    [_clipView addSubview:_webView.get().get() positioned:NSWindowBelow relativeTo:nil];
+    [_webView setFrame:NSInsetRect(contentView.bounds, 0, -_page->topContentInset())];
 
     _savedScale = _page->pageScaleFactor();
     _page->scalePageRelativeToScrollPosition(1, { });
@@ -307,7 +307,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     NSWindow* window = self.window;
     NSWindowCollectionBehavior behavior = [window collectionBehavior];
     [window setCollectionBehavior:(behavior | NSWindowCollectionBehaviorCanJoinAllSpaces)];
-    [window makeFirstResponder:_webView];
+    [window makeFirstResponder:_webView.get().get()];
     [window makeKeyAndOrderFront:self];
     [window setCollectionBehavior:behavior];
 
@@ -358,12 +358,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _page->setSuppressVisibilityUpdates(false);
 
         NSResponder *firstResponder = [[self window] firstResponder];
-        [self _replaceView:_webViewPlaceholder.get() with:_webView];
+        [self _replaceView:_webViewPlaceholder.get() with:_webView.get().get()];
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         [NSLayoutConstraint activateConstraints:self.savedConstraints];
         END_BLOCK_OBJC_EXCEPTIONS
         self.savedConstraints = nil;
-        makeResponderFirstResponderIfDescendantOfView(_webView.window, firstResponder, _webView);
+        makeResponderFirstResponderIfDescendantOfView([_webView window], firstResponder, _webView.get().get());
         [[_webView window] makeKeyAndOrderFront:self];
 
         _page->scalePageRelativeToScrollPosition(_savedScale, { });
@@ -382,7 +382,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             eventNumber:0
             clickCount:0
             pressure:0];
-        WebKit::NativeWebMouseEvent webEvent(fakeEvent, nil, _webView);
+        WebKit::NativeWebMouseEvent webEvent(fakeEvent, nil, _webView.get().get());
         _page->handleMouseEvent(webEvent);
     }
     _page->flushDeferredResizeEvents();
@@ -518,7 +518,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [_exitPlaceholder setLayerContentsRedrawPolicy: NSViewLayerContentsRedrawNever];
     [_exitPlaceholder setFrame:[_webView frame]];
     [[_exitPlaceholder layer] setContents:(__bridge id)webViewContents.get()];
-    [[_webView superview] addSubview:_exitPlaceholder.get() positioned:NSWindowAbove relativeTo:_webView];
+    [[_webView superview] addSubview:_exitPlaceholder.get() positioned:NSWindowAbove relativeTo:_webView.get().get()];
 
     [CATransaction commit];
     [CATransaction flush];
@@ -531,13 +531,13 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [_webView removeFromSuperview];
     [_webView setFrame:[_webViewPlaceholder frame]];
     [_webView setAutoresizingMask:[_webViewPlaceholder autoresizingMask]];
-    [[_webViewPlaceholder superview] addSubview:_webView positioned:NSWindowBelow relativeTo:_webViewPlaceholder.get()];
+    [[_webViewPlaceholder superview] addSubview:_webView.get().get() positioned:NSWindowBelow relativeTo:_webViewPlaceholder.get()];
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [NSLayoutConstraint activateConstraints:self.savedConstraints];
     END_BLOCK_OBJC_EXCEPTIONS
     self.savedConstraints = nil;
-    makeResponderFirstResponderIfDescendantOfView(_webView.window, firstResponder, _webView);
+    makeResponderFirstResponderIfDescendantOfView([_webView window], firstResponder, _webView.get().get());
 
     // These messages must be sent after the swap or flashing will occur during forceRepaint:
     [self _manager]->setAnimatingFullScreen(false);

--- a/Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.h
+++ b/Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.h
@@ -23,14 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WKViewLayoutStrategy_h
-#define WKViewLayoutStrategy_h
+#pragma once
 
 #if PLATFORM(MAC)
 
 #import "WKLayoutMode.h"
-#import <wtf/NakedPtr.h>
 #import <wtf/NakedRef.h>
+#import <wtf/WeakObjCPtr.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebKit {
 class WebPageProxy;
@@ -41,9 +41,9 @@ class WebViewImpl;
 
 @interface WKViewLayoutStrategy : NSObject {
 @package
-    NakedPtr<WebKit::WebPageProxy> _page;
-    NakedPtr<WebKit::WebViewImpl> _webViewImpl;
-    NSView *_view;
+    WeakPtr<WebKit::WebPageProxy> _page;
+    WeakPtr<WebKit::WebViewImpl> _webViewImpl;
+    WeakObjCPtr<NSView> _view;
 
     WKLayoutMode _layoutMode;
 }
@@ -67,5 +67,3 @@ class WebViewImpl;
 @end
 
 #endif // PLATFORM(MAC)
-
-#endif // WKViewLayoutStrategy_h

--- a/Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.mm
+++ b/Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.mm
@@ -132,7 +132,7 @@
 {
     if (_webViewImpl->clipsToVisibleRect())
         _webViewImpl->updateViewExposedRect();
-    _webViewImpl->setDrawingAreaSize(NSSizeToCGSize(_view.frame.size));
+    _webViewImpl->setDrawingAreaSize(NSSizeToCGSize(_view.get().get().frame.size));
 }
 
 - (void)willChangeLayoutStrategy
@@ -198,7 +198,8 @@
 - (void)updateLayout
 {
     CGFloat inverseScale = 1 / _page->viewScaleFactor();
-    _webViewImpl->setFixedLayoutSize(CGSizeMake(_view.frame.size.width * inverseScale, _view.frame.size.height * inverseScale));
+    RetainPtr view = _view.get();
+    _webViewImpl->setFixedLayoutSize(CGSizeMake(view.get().frame.size.width * inverseScale, view.get().frame.size.height * inverseScale));
 }
 
 - (void)didChangeViewScale

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -30,6 +30,7 @@
 #import <wtf/Lock.h>
 #import <wtf/NakedPtr.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/WeakPtr.h>
 
 namespace WebKit {
 class WebPage;
@@ -40,7 +41,7 @@ class AXCoreObject;
 }
 
 @interface WKAccessibilityWebPageObjectBase : NSObject {
-    NakedPtr<WebKit::WebPage> m_page;
+    WeakPtr<WebKit::WebPage> m_page;
     Markable<WebCore::PageIdentifier> m_pageID;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     Lock m_cacheLock;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -125,7 +125,7 @@ namespace ax = WebCore::Accessibility;
 {
     ASSERT(isMainRunLoop());
 
-    m_page = page;
+    m_page = page.get();
 
     if (page) {
         m_pageID = page->identifier();


### PR DESCRIPTION
#### 9bc59f671b1e20027a4d2ea65613c05623f844db
<pre>
Store WeakPtr and WeakObjCPtr instead of raw pointers as members of objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=287121">https://bugs.webkit.org/show_bug.cgi?id=287121</a>
<a href="https://rdar.apple.com/144268261">rdar://144268261</a>

Reviewed by Chris Dumez.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::updateScreenTimeWebpageControllerURL):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:completionHandler:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
* Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.h:
* Source/WebKit/UIProcess/mac/WKViewLayoutStrategy.mm:
(-[WKViewLayoutStrategy didChangeFrameSize]):
(-[WKViewDynamicSizeComputedFromViewScaleLayoutStrategy updateLayout]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase setWebPage:]):

Canonical link: <a href="https://commits.webkit.org/289909@main">https://commits.webkit.org/289909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abe138ac177ddd6015f9a4c95635b18ca2a5b746

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39134 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68163 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25880 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48531 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6100 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38242 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95180 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15555 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77030 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76283 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20670 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13811 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15571 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->