### PR TITLE
Move logic of network usage monitoring to NetworkProcess

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/blob-resource-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/blob-resource-expected.txt
@@ -1,0 +1,11 @@
+Test iframe with large Blob usage is not handled as network usage.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result is true
+PASS document.querySelector('iframe[name=frame1]').srcdoc is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/blob-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/blob-resource.html
@@ -7,8 +7,9 @@
 <body>
 <script>
 
-description("Test iframe with huge resource usage is unloaded.");
+description("Test iframe with large Blob usage is not handled as network usage.");
 window.jsTestIsAsync = true;
+var result;
 
 onload = async () => {
     if (!await setup()) {
@@ -21,14 +22,17 @@ onload = async () => {
     const base = 'http://localhost:8080/iframe-monitor/resources';
 
     stage.innerHTML = `
-        <iframe name="frame1" src="http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html"></iframe>
+        <iframe name="frame1" src="${base}/--eligible--/blob.html"></iframe>
     `;
 
-    await waitUntilUnload('frame1');
+    window.addEventListener('message', async (event) => {
+        await pause(100);
+        result = event.data;
 
-    shouldNotBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
-
-    finishJSTest();
+        shouldBeTrue('result');
+        shouldBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+        finishJSTest();
+    });
 }
 </script>
 

--- a/LayoutTests/http/tests/iframe-monitor/cached-resource-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/cached-resource-expected.txt
@@ -1,0 +1,11 @@
+Cached huge resource is not handled as network usage.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result is 20480
+PASS document.querySelector('iframe[name=frame1]').srcdoc is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/cached-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/cached-resource.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="./resources/monitor-setup.js"></script>
+</head>
+<body>
+<script>
+
+description("Cached huge resource is not handled as network usage.");
+window.jsTestIsAsync = true;
+var result;
+
+onload = async () => {
+    if (!await setup()) {
+        finishJSTest();
+        return;
+    }
+
+    // Make sure iframe load is done after rule is set correctly.
+    const stage = document.querySelector('#stage');
+    const base = '/iframe-monitor/resources';
+
+    // fetch the resource which can be in disk cache first.
+    await fetch(`${base}/generate-byte.py?size=20480&seed=cached-resource.html`);
+
+    // use same resource in the iframe.
+    stage.innerHTML = `
+        <iframe name="frame1" src="${base}/--eligible--/cached.html"></iframe>
+    `;
+
+    window.addEventListener('message', async (event) => {
+        await pause(100);
+        result = event.data;
+
+        shouldBe('result', '20480');
+        shouldBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+        finishJSTest();
+    });
+}
+</script>
+
+<div id="stage"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/iframe-monitor/dark-mode.html
+++ b/LayoutTests/http/tests/iframe-monitor/dark-mode.html
@@ -27,13 +27,13 @@ onload = async () => {
                 footer { color-scheme: dark; }
             </style>
             <header>
-                <iframe name="frame1" src="./resources/iframe--eligible--.html"></iframe>
+                <iframe name="frame1" src="./resources/--eligible--/iframe.html"></iframe>
             </header>
             <main>
-                <iframe name="frame2" src="./resources/iframe--eligible--.html"></iframe>
+                <iframe name="frame2" src="./resources/--eligible--/iframe.html"></iframe>
             </main>
             <footer>
-                <iframe name="frame3" src="./resources/iframe--eligible--.html"></iframe>
+                <iframe name="frame3" src="./resources/--eligible--/iframe.html"></iframe>
             </footer>
         `;
 

--- a/LayoutTests/http/tests/iframe-monitor/data-url-resource-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/data-url-resource-expected.txt
@@ -1,0 +1,11 @@
+Test iframe with large Blob usage is not handled as network usage.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result is true
+PASS document.querySelector('iframe[name=frame1]').srcdoc is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/data-url-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/data-url-resource.html
@@ -7,8 +7,9 @@
 <body>
 <script>
 
-description("Test iframe with huge resource usage is unloaded.");
+description("Test iframe with large Blob usage is not handled as network usage.");
 window.jsTestIsAsync = true;
+var result;
 
 onload = async () => {
     if (!await setup()) {
@@ -21,14 +22,17 @@ onload = async () => {
     const base = 'http://localhost:8080/iframe-monitor/resources';
 
     stage.innerHTML = `
-        <iframe name="frame1" src="http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html"></iframe>
+        <iframe name="frame1" src="${base}/--eligible--/data-url.html"></iframe>
     `;
 
-    await waitUntilUnload('frame1');
+    window.addEventListener('message', async (event) => {
+        await pause(100);
+        result = event.data;
 
-    shouldNotBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
-
-    finishJSTest();
+        shouldBeTrue('result');
+        shouldBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+        finishJSTest();
+    });
 }
 </script>
 

--- a/LayoutTests/http/tests/iframe-monitor/eligibility.html
+++ b/LayoutTests/http/tests/iframe-monitor/eligibility.html
@@ -26,8 +26,8 @@ onload = async () => {
         <iframe name="frame2" src="${base}/iframe-not-eligible2.html"></iframe>
 
         <!-- these frames are elegible for resource monitoring -->
-        <iframe name="frame3" src="${base}/iframe--eligible--.html"></iframe>
-        <iframe name="frame4" src="${base}/iframe--eligible--2.html"></iframe>
+        <iframe name="frame3" src="${base}/--eligible--/iframe.html"></iframe>
+        <iframe name="frame4" src="${base}/--eligible--/iframe2.html"></iframe>
     `;
 
     await waitUntilUnload('frame3');

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/blob.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/blob.html
@@ -1,0 +1,16 @@
+Using significant resources and eligible for resource monitoring.
+Resource is created as Blob and shouldn't treat as network usage.
+
+<script>
+    const size = 20 * 1024;
+    const body = new Uint8Array(size);
+    body.fill(42);
+
+    const blob = new Blob(body, { type: "application/octet-stream" });
+    const url = URL.createObjectURL(blob);
+
+    fetch(url).then(async (response) => {
+        const body = await response.blob();
+        parent.postMessage(true, "*");
+    });
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/cached.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/cached.html
@@ -1,0 +1,9 @@
+Using significant resources and eligible for resource monitoring.
+Resource is cached in disk cache so there's no network usage.
+
+<script>
+    fetch(`../generate-byte.py?size=20480&seed=cached-resource.html`).then(async (response) => {
+        const body = await response.blob();
+        parent.postMessage(body.size, "*");
+    });
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/data-url.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/data-url.html
@@ -1,0 +1,24 @@
+Using significant resources and eligible for resource monitoring.
+Resource is accessed as data url and shouldn't treat as network usage.
+
+<script>
+    const size = 20 * 1024;
+    const body = new Uint8Array(size);
+    body.fill(42);
+
+    const blob = new Blob(body, { type: "text/plain" });
+
+    blobToDataURL(blob).then(async (url) => {
+        const response = await fetch(url);
+        const body = await response.blob();
+        parent.postMessage(true, "*");
+    });
+
+    async function blobToDataURL(blob) {
+        return new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(reader.result);
+            reader.readAsDataURL(blob);
+        });
+    }
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe.html
@@ -7,5 +7,5 @@ Using significant resources and eligible for resource monitoring.
     };
 
     const size = 20 * 1024;
-    fetch(`./generate-byte.py?size=${size}`);
+    fetch(`../generate-byte.py?size=${size}`);
 </script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe2.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe2.html
@@ -7,5 +7,5 @@ Using very little resources but still eligible for resource monitoring.
     };
 
     const size = 1 * 1024;
-    fetch(`./generate-byte.py?size=${size}`);
+    fetch(`../generate-byte.py?size=${size}`);
 </script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe3.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe3.html
@@ -3,7 +3,7 @@ It will post message to the parent when finished.
 
 <script>
     const size = 20 * 1024;
-    fetch(`./generate-byte.py?size=${size}`).then(async (response) => {
+    fetch(`../generate-byte.py?size=${size}`).then(async (response) => {
         const body = await response.blob();
         parent.postMessage(true, "*");
     });

--- a/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
+++ b/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
@@ -9,7 +9,7 @@ async function setup() {
         // Lower the threshold to 10k
         internals.setResourceMonitorNetworkUsageThreshold(10 * 1024, 0.001);
 
-        // Skip throttling of unloading.
+        // Skip throttling of unloading or not.
         internals.shouldSkipResourceMonitorThrottling = false;
 
         return true;

--- a/LayoutTests/http/tests/iframe-monitor/throttler.html
+++ b/LayoutTests/http/tests/iframe-monitor/throttler.html
@@ -22,7 +22,7 @@ onload = async () => {
 
     for (let no = 1; no <= 5; no++) {
         stage.innerHTML = `
-            <iframe name="frame${no}" src="http://localhost:8080/iframe-monitor/resources/iframe--eligible--.html"></iframe>
+            <iframe name="frame${no}" src="http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html"></iframe>
         `;
 
         await waitUntilUnload(`frame${no}`);
@@ -32,7 +32,7 @@ onload = async () => {
     // Then load another one which will send a message after the fetch.
     // Throttler should prevent this iframe unloaded.
     stage.innerHTML = `
-        <iframe name="frame6" src="http://localhost:8080/iframe-monitor/resources/iframe--eligible--3.html"></iframe>
+        <iframe name="frame6" src="http://localhost:8080/iframe-monitor/resources/--eligible--/iframe3.html"></iframe>
     `;
 
     window.addEventListener('message', async (event) => {

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -662,11 +662,6 @@ void ResourceLoader::didReceiveBuffer(const FragmentedSharedBuffer& buffer, long
     RefPtr frameLoader = this->frameLoader();
     if (m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks && frame && frameLoader)
         frameLoader->notifier().didReceiveData(this, buffer.makeContiguous(), static_cast<int>(encodedDataLength));
-
-#if ENABLE(CONTENT_EXTENSIONS)
-    if (RefPtr monitor = resourceMonitorIfExists())
-        monitor->addNetworkUsage(encodedDataLength > 0 ? static_cast<size_t>(encodedDataLength) : buffer.size());
-#endif
 }
 
 void ResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMetrics)

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -174,6 +174,10 @@ public:
 
     bool isPDFJSResourceLoad() const;
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    WEBCORE_EXPORT ResourceMonitor* resourceMonitorIfExists();
+#endif
+
 protected:
     ResourceLoader(LocalFrame&, ResourceLoaderOptions);
 
@@ -229,10 +233,6 @@ private:
     void receivedCancellation(ResourceHandle*, const AuthenticationChallenge& challenge) override { receivedCancellation(challenge); }
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<CFDictionaryRef> connectionProperties(ResourceHandle*) override;
-#endif
-
-#if ENABLE(CONTENT_EXTENSIONS)
-    ResourceMonitor* resourceMonitorIfExists();
 #endif
 
 #if USE(SOUP)

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -46,7 +46,7 @@ public:
 
     void setDocumentURL(URL&&);
     void didReceiveResponse(const URL&, OptionSet<ContentExtensions::ResourceType>);
-    void addNetworkUsage(size_t);
+    WEBCORE_EXPORT void addNetworkUsage(size_t);
 
 private:
     explicit ResourceMonitor(LocalFrame&);

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -242,4 +242,14 @@ PendingDownload* NetworkDataTask::pendingDownload() const
     return m_pendingDownload.get();
 }
 
+size_t NetworkDataTask::calculateBytesTransferredOverNetworkDelta()
+{
+    if (m_totalBytesTransferredOverNetwork <= m_bytesTransferredOverNetworkReported)
+        return 0;
+
+    size_t delta = m_totalBytesTransferredOverNetwork - m_bytesTransferredOverNetworkReported;
+    m_bytesTransferredOverNetworkReported = m_totalBytesTransferredOverNetwork;
+    return delta;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -150,6 +150,9 @@ public:
 
     virtual void setTimingAllowFailedFlag() { }
 
+    size_t calculateBytesTransferredOverNetworkDelta();
+    size_t totalBytesTransferredOverNetwork() const { return m_totalBytesTransferredOverNetwork; }
+
 protected:
     NetworkDataTask(NetworkSession&, NetworkDataTaskClient&, const WebCore::ResourceRequest&, WebCore::StoredCredentialsPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool dataTaskIsForMainFrameNavigation);
 
@@ -162,6 +165,7 @@ protected:
     void scheduleFailure(FailureType);
 
     void restrictRequestReferrerToOriginIfNeeded(WebCore::ResourceRequest&);
+    void setTotalBytesTransferredOverNetwork(size_t bytes) { m_totalBytesTransferredOverNetwork = bytes; }
 
     WeakPtr<NetworkSession> m_session;
     WeakPtr<NetworkDataTaskClient> m_client;
@@ -176,8 +180,10 @@ protected:
     String m_pendingDownloadLocation;
     WebCore::ResourceRequest m_firstRequest;
     WebCore::ResourceRequest m_previousRequest;
-    bool m_shouldClearReferrerOnHTTPSToHTTPRedirect { true };
     String m_suggestedFilename;
+    size_t m_totalBytesTransferredOverNetwork { 0 };
+    size_t m_bytesTransferredOverNetworkReported { 0 };
+    bool m_shouldClearReferrerOnHTTPSToHTTPRedirect { true };
     bool m_dataTaskIsForMainFrameNavigation { false };
     bool m_failureScheduled { false };
 };

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -357,4 +357,11 @@ RefPtr<NetworkDataTask> NetworkLoad::protectedTask()
     return m_task;
 }
 
+size_t NetworkLoad::bytesTransferredOverNetworkDelta() const
+{
+    if (RefPtr task = m_task)
+        return task->calculateBytesTransferredOverNetworkDelta();
+    return 0;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -90,6 +90,8 @@ public:
     std::optional<WebCore::PageIdentifier> webPageID() const;
     Ref<NetworkProcess> networkProcess();
 
+    size_t bytesTransferredOverNetworkDelta() const;
+
 private:
     NetworkLoad(NetworkLoadClient&, NetworkLoadParameters&&, NetworkSession&);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -284,6 +284,8 @@ private:
 
     bool shouldSendResourceLoadMessages() const;
 
+    uint64_t bytesTransferredOverNetworkDelta() const;
+
     NetworkResourceLoadParameters m_parameters;
 
     Ref<NetworkConnectionToWebProcess> m_connection;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -300,7 +300,7 @@ void ServiceWorkerFetchTask::didReceiveData(const IPC::SharedBufferReference& da
     if (!protectedLoader()->continueAfterServiceWorkerReceivedData(*buffer, encodedDataLength))
         return;
 #endif
-    sendToClient(Messages::WebResourceLoader::DidReceiveData { IPC::SharedBufferReference(data), encodedDataLength });
+    sendToClient(Messages::WebResourceLoader::DidReceiveData { IPC::SharedBufferReference(data), encodedDataLength, 0 });
 }
 
 void ServiceWorkerFetchTask::didReceiveDataFromPreloader(const WebCore::FragmentedSharedBuffer& data, uint64_t encodedDataLength)
@@ -317,7 +317,7 @@ void ServiceWorkerFetchTask::didReceiveDataFromPreloader(const WebCore::Fragment
     if (!protectedLoader()->continueAfterServiceWorkerReceivedData(*buffer, encodedDataLength))
         return;
 #endif
-    sendToClient(Messages::WebResourceLoader::DidReceiveData { IPC::SharedBufferReference(data), encodedDataLength });
+    sendToClient(Messages::WebResourceLoader::DidReceiveData { IPC::SharedBufferReference(data), encodedDataLength, 0 });
 }
 
 void ServiceWorkerFetchTask::didReceiveFormData(const IPC::FormDataReference& formData)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -397,6 +397,8 @@ void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "received %zd bytes", data.size());
 
+    setTotalBytesTransferredOverNetwork(totalBytesTransferredOverNetwork() + data.size());
+
     if (m_client)
         m_client->didReceiveData(data);
 }

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -211,6 +211,9 @@ void NetworkDataTaskCurl::curlDidReceiveData(CurlRequest&, Ref<SharedBuffer>&& b
         return;
     }
 
+    // FIXME: This should be exact network transferred size rather than decoded bytes.
+    setTotalBytesTransferredOverNetwork(totalBytesTransferredOverNetwork() + buffer->size());
+
     m_client->didReceiveData(buffer.get());
 }
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1048,6 +1048,10 @@ void NetworkDataTaskSoup::didRead(gssize bytesRead)
         writeDownload();
     } else {
         ASSERT(m_client);
+
+        // FIXME: This should be exact network transferred size rather than decoded bytes.
+        setTotalBytesTransferredOverNetwork(totalBytesTransferredOverNetwork() + bytesRead);
+
         m_client->didReceiveData(SharedBuffer::create(WTFMove(m_readBuffer)));
         read();
     }

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -88,7 +88,7 @@ private:
     void willSendRequest(WebCore::ResourceRequest&&, IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&&, CompletionHandler<void(WebCore::ResourceRequest&&, bool)>&&);
     void didSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent);
     void didReceiveResponse(WebCore::ResourceResponse&&, PrivateRelayed, bool needsContinueDidReceiveResponseMessage, std::optional<WebCore::NetworkLoadMetrics>&&);
-    void didReceiveData(IPC::SharedBufferReference&& data, uint64_t encodedDataLength);
+    void didReceiveData(IPC::SharedBufferReference&& data, uint64_t encodedDataLength, uint64_t bytesTransferredOverNetwork);
     void didFinishResourceLoad(WebCore::NetworkLoadMetrics&&);
     void didFailResourceLoad(const WebCore::ResourceError&);
     void didFailServiceWorkerLoad(const WebCore::ResourceError&);

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in
@@ -29,7 +29,7 @@ messages -> WebResourceLoader {
     SetWorkerStart(MonotonicTime value)
     DidSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent)
     DidReceiveResponse(WebCore::ResourceResponse response, enum:bool WebKit::PrivateRelayed privateRelayed, bool needsContinueDidReceiveResponseMessage, std::optional<WebCore::NetworkLoadMetrics> optionalNetworkLoadMetrics)
-    DidReceiveData(IPC::SharedBufferReference data, uint64_t encodedDataLength)
+    DidReceiveData(IPC::SharedBufferReference data, uint64_t encodedDataLength, uint64_t bytesTransferredOverNetwork)
     DidFinishResourceLoad(WebCore::NetworkLoadMetrics networkLoadMetrics)
     DidFailResourceLoad(WebCore::ResourceError error)
     DidFailServiceWorkerLoad(WebCore::ResourceError error)


### PR DESCRIPTION
#### 65e37ab3fc65158cc79798546f7aa56753112d0a
<pre>
Move logic of network usage monitoring to NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=287120">https://bugs.webkit.org/show_bug.cgi?id=287120</a>
<a href="https://rdar.apple.com/144241587">rdar://144241587</a>

Reviewed by Ben Nham.

Currently the source of network usage for ResourceMonitor is in ResourceLoader in Web Process. We need to move
this into Network Process to improve the quality of monitoring which allows:

1. Avoid counting the resources comes from the cache.
2. Avoid counting blob and data urls.
3. Not the decoded size after network load but the actual bytes before decoding. (i.e. gzip a.k.a deflate)

To achieve this, a new parameter `bytesTransferredOverNetwork` is added to WebResourceLoader message and Network
Process try to send correct network usage of the request. This number is still decoded buffer size in this patch
and will be implemented in the following patch.

* LayoutTests/http/tests/iframe-monitor/blob-resource-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/blob-resource.html: Copied from LayoutTests/http/tests/iframe-monitor/iframe-unload.html.
* LayoutTests/http/tests/iframe-monitor/cached-resource-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/cached-resource.html: Added.
* LayoutTests/http/tests/iframe-monitor/dark-mode.html:
* LayoutTests/http/tests/iframe-monitor/data-url-resource-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/data-url-resource.html: Copied from LayoutTests/http/tests/iframe-monitor/iframe-unload.html.
* LayoutTests/http/tests/iframe-monitor/eligibility.html:
* LayoutTests/http/tests/iframe-monitor/iframe-unload.html:
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/blob.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/cached.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/data-url.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe.html: Renamed from LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--.html.
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe2.html: Renamed from LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--2.html.
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/iframe3.html: Renamed from LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--3.html.
* LayoutTests/http/tests/iframe-monitor/resources/generate-byte.py:
* LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js:
(async setup):
* LayoutTests/http/tests/iframe-monitor/throttler.html:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::didReceiveBuffer):
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/ResourceMonitor.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::calculateBytesTransferredOverNetworkDelta):
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::totalBytesTransferredOverNetwork const):
(WebKit::NetworkDataTask::setTotalBytesTransferredOverNetwork):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::bytesTransferredOverNetworkDelta const):
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::bufferingTimerFired):
(WebKit::NetworkResourceLoader::sendBuffer):
(WebKit::NetworkResourceLoader::dataReceivedThroughContentFilter):
(WebKit::NetworkResourceLoader::bytesTransferredOverNetworkDelta const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::didReceiveData):
(WebKit::ServiceWorkerFetchTask::didReceiveDataFromPreloader):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didReceiveData):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::curlDidReceiveData):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::didRead):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::didReceiveData):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Network/WebResourceLoader.messages.in:

Canonical link: <a href="https://commits.webkit.org/290164@main">https://commits.webkit.org/290164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67d3c301ac1ac1e5c419ca9ac88655464b50522e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39864 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68655 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26327 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35230 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38971 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95916 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16283 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11923 "Found 5 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77532 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76823 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18948 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9375 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21608 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16038 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->