### PR TITLE
YouTube.com: Only Audio Resumes after Pause, Video remains still

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -301,6 +301,7 @@ platform/cocoa/CoreLocationGeolocationProvider.mm
 platform/cocoa/CoreVideoSoftLink.cpp
 platform/cocoa/DragDataCocoa.mm
 platform/cocoa/DragImageCocoa.mm
+platform/cocoa/EffectiveRateChangedListener.mm
 platform/cocoa/FileMonitorCocoa.mm
 platform/cocoa/KeyEventCocoa.mm
 platform/cocoa/LocalizedStringsCocoa.mm

--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+typedef struct OpaqueCMTimebase* CMTimebaseRef;
+OBJC_CLASS WebEffectiveRateChangedListenerObjCAdapter;
+
+namespace WebCore {
+
+class EffectiveRateChangedListener final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<EffectiveRateChangedListener> {
+public:
+    static Ref<EffectiveRateChangedListener> create(Function<void()>&& callback, CMTimebaseRef timebase)
+    {
+        return adoptRef(*new EffectiveRateChangedListener(WTFMove(callback), timebase));
+    }
+    ~EffectiveRateChangedListener();
+
+    void effectiveRateChanged();
+    void stop();
+
+private:
+    EffectiveRateChangedListener(Function<void()>&&, CMTimebaseRef);
+
+    const Function<void()> m_callback;
+    const RetainPtr<WebEffectiveRateChangedListenerObjCAdapter> m_objcAdapter;
+    RetainPtr<CMTimebaseRef> m_timebase;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "EffectiveRateChangedListener.h"
+
+#import <AVFoundation/AVFoundation.h>
+#import <CoreMedia/CMTime.h>
+#import <pal/spi/cf/CFNotificationCenterSPI.h>
+#import <wtf/Function.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
+
+#import <pal/cf/CoreMediaSoftLink.h>
+
+@interface WebEffectiveRateChangedListenerObjCAdapter : NSObject
+@property (atomic, readonly, direct) RefPtr<WebCore::EffectiveRateChangedListener> protectedListener;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithEffectiveRateChangedListener:(const WebCore::EffectiveRateChangedListener&)listener;
+@end
+
+NS_DIRECT_MEMBERS
+@implementation WebEffectiveRateChangedListenerObjCAdapter {
+    ThreadSafeWeakPtr<WebCore::EffectiveRateChangedListener> _listener;
+}
+
+- (instancetype)initWithEffectiveRateChangedListener:(const WebCore::EffectiveRateChangedListener&)listener
+{
+    if ((self = [super init]))
+        _listener = listener;
+    return self;
+}
+
+- (RefPtr<WebCore::EffectiveRateChangedListener>)protectedListener
+{
+    return _listener.get();
+}
+@end
+
+namespace WebCore {
+
+static void timebaseEffectiveRateChangedCallback(CFNotificationCenterRef, void* observer, CFNotificationName, const void*, CFDictionaryRef)
+{
+    RetainPtr adapter { dynamic_objc_cast<WebEffectiveRateChangedListenerObjCAdapter>(reinterpret_cast<id>(observer)) };
+    if (RefPtr protectedListener = [adapter protectedListener])
+        protectedListener->effectiveRateChanged();
+}
+
+EffectiveRateChangedListener::EffectiveRateChangedListener(Function<void()>&& callback, CMTimebaseRef timebase)
+    : m_callback(WTFMove(callback))
+    , m_objcAdapter(adoptNS([[WebEffectiveRateChangedListenerObjCAdapter alloc] initWithEffectiveRateChangedListener:*this]))
+    , m_timebase(timebase)
+{
+    assertIsMainThread();
+    ASSERT(timebase);
+    // Observer removed MediaPlayerPrivateMediaSourceAVFObjC destructor.
+    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), m_objcAdapter.get(), timebaseEffectiveRateChangedCallback, kCMTimebaseNotification_EffectiveRateChanged, timebase, static_cast<CFNotificationSuspensionBehavior>(_CFNotificationObserverIsObjC));
+}
+
+EffectiveRateChangedListener::~EffectiveRateChangedListener()
+{
+    stop();
+}
+
+void EffectiveRateChangedListener::effectiveRateChanged()
+{
+    m_callback();
+}
+
+void EffectiveRateChangedListener::stop()
+{
+    assertIsMainThread();
+    if (!m_timebase)
+        return;
+    CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenter(), m_objcAdapter.get(), kCMTimebaseNotification_EffectiveRateChanged, m_timebase.get());
+    m_timebase = nullptr;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -28,10 +28,10 @@
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
 
 #include "MediaPlayerPrivateAVFoundation.h"
+#include "SharedBuffer.h"
 #include "VideoFrameMetadata.h"
 #include <CoreMedia/CMTime.h>
-#include <wtf/CompletionHandler.h>
-#include <wtf/Function.h>
+#include <wtf/Forward.h>
 #include <wtf/MainThreadDispatcher.h>
 #include <wtf/Observer.h>
 #include <wtf/RobinHoodHashMap.h>
@@ -74,7 +74,6 @@ class MediaPlaybackTarget;
 class MediaSelectionGroupAVFObjC;
 class PixelBufferConformerCV;
 class QueuedVideoOutput;
-class SharedBuffer;
 class VideoLayerManagerObjC;
 class VideoTrackPrivateAVFObjC;
 class WebCoreAVFResourceLoader;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -63,8 +63,6 @@
 #import "ScriptDisallowedScope.h"
 #import "SecurityOrigin.h"
 #import "SerializedPlatformDataCueMac.h"
-#import "SharedBuffer.h"
-#import "SourceBufferParserWebM.h"
 #import "TextTrack.h"
 #import "TextTrackRepresentation.h"
 #import "UTIUtilities.h"
@@ -101,7 +99,9 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/text/TextCodecUTF8.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/FileSystem.h>
+#import <wtf/Function.h>
 #import <wtf/ListHashSet.h>
 #import <wtf/NativePromise.h>
 #import <wtf/NeverDestroyed.h>

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -49,6 +49,7 @@ class WorkQueue;
 
 namespace WebCore {
 
+class EffectiveRateChangedListener;
 class MediaSample;
 class WebCoreDecompressionSession;
 
@@ -150,6 +151,7 @@ private:
 #endif
     mutable Lock m_lock;
     TimebaseAndTimerSource m_timebaseAndTimerSource WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<EffectiveRateChangedListener> m_effectiveRateChangedListener;
     std::atomic<ssize_t> m_framesBeingDecoded { 0 };
     std::atomic<FlushId> m_flushId { 0 };
     Deque<std::pair<RetainPtr<CMSampleBufferRef>, FlushId>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -35,9 +35,11 @@
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/WTFString.h>
 
+#import <pal/cf/CoreMediaSoftLink.h>
+
 IGNORE_WARNINGS_BEGIN("nullability-completeness")
 
-SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebCore, AVKit)
+SOFTLINK_AVKIT_FRAMEWORK()
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVTouchBarMediaSelectionOption)
 
 using WebCore::MediaSelectionOption;


### PR DESCRIPTION
#### 895987c5c5acc58caebdd74f48618bba50f8d2b0
<pre>
YouTube.com: Only Audio Resumes after Pause, Video remains still
<a href="https://bugs.webkit.org/show_bug.cgi?id=287123">https://bugs.webkit.org/show_bug.cgi?id=287123</a>
<a href="https://rdar.apple.com/144274075">rdar://144274075</a>

Reviewed by Youenn Fablet.

When the timebase&apos;s rate change from 0 to 1 (or vice versa) we can observe
that sometimes the currentTime moves slightly either backward or forward.

The VideoMediaSampleRenderer sets a timer to fire at the time the next
available video frame should be displayed.
When the timebase&apos;s rate change and the time moved forward slightly, the
timer doesn&apos;t fire.
This prevented from the next video frame to be painted and another timer to
be set for the next frame making the media playing only with audio and the
last painted video frame showing forever.

To get around this, we now observe the timebase rate change and when it
changes from 0, re-schedule a purge&amp;display cycle.
Code to observe the timebase&apos;s rate change is extracted from MediaPlayerPrivateMediaSourceAVFObjC
into its own separate EffectiveRateChangedListener class.

Manually tested. Automated testing is difficult as the typical way to check
that the video frames are regularly changing would be to paint them into a canvas.
However, painting into a canvas forcibly refresh the video frame showing.
Video frames can also be dropped if they are late, which can easily happen
on a busy host, making a reftest results inconsistent.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h: Added. Code was extracted from MediaPlayerPrivateMediaSourceAVFObjC
* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm: Added.
(-[WebEffectiveRateChangedListenerObjCAdapter initWithEffectiveRateChangedListener:]):
(-[WebEffectiveRateChangedListenerObjCAdapter protectedListener]):
(WebCore::timebaseEffectiveRateChangedCallback):
(WebCore::EffectiveRateChangedListener::EffectiveRateChangedListener):
(WebCore::EffectiveRateChangedListener::~EffectiveRateChangedListener):
(WebCore::EffectiveRateChangedListener::effectiveRateChanged):
(WebCore::EffectiveRateChangedListener::stop):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h: Shuffle headers around to fix unified build.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC):
(-[WebEffectiveRateChangedListenerObjCAdapter initWithEffectiveRateChangedListener:]): Deleted.
(-[WebEffectiveRateChangedListenerObjCAdapter protectedListener]): Deleted.
(WebCore::EffectiveRateChangedListener::create): Deleted.
(WebCore::EffectiveRateChangedListener::effectiveRateChanged): Deleted.
(WebCore::timebaseEffectiveRateChangedCallback): Deleted.
(WebCore::EffectiveRateChangedListener::stop): Deleted.
(WebCore::EffectiveRateChangedListener::EffectiveRateChangedListener): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::setTimebase):
(WebCore::VideoMediaSampleRenderer::clearTimebase):
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm:

Canonical link: <a href="https://commits.webkit.org/289922@main">https://commits.webkit.org/289922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2089f76b728d746ebc2bcaf3f78a090f9dc9cd24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68209 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34405 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38300 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95238 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15613 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77074 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76332 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18782 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20722 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8651 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15629 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->