### PR TITLE
AX: attributed string for range truncated for list items

### DIFF
--- a/LayoutTests/accessibility/mac/line-text-marker-range-in-list-item-expected.txt
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-in-list-item-expected.txt
@@ -1,0 +1,9 @@
+This tests that fetching the string for the line range corresponding to a text marker fetches the whole string, and it doesn't get truncated due to the list marker adding extra characters
+
+stringForTextMarkerRange: • Once upon a time
+attributedStringForTextMarkerRange: Attributes in range {0, 18}: } • Once upon a time
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/line-text-marker-range-in-list-item.html
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-in-list-item.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul id="list">
+  <li id="listitem">Once upon a time</li>
+</ul>
+
+<script>
+    let output = "This tests that fetching the string for the line range corresponding to a text marker fetches the whole string, and it doesn't get truncated due to the list marker adding extra characters\n\n";
+
+if (window.accessibilityController) {
+    const list = accessibilityController.accessibleElementById("list");
+    const listitem = accessibilityController.accessibleElementById("listitem");
+    const listItemText = listitem.childAtIndex(1);  // List item marker is child 0
+    const fullRange = list.textMarkerRangeForElement(listItemText);
+    const marker = list.endTextMarkerForTextMarkerRange(fullRange);
+    const range = list.lineTextMarkerRangeForTextMarker(marker);
+    var rangeStr = (list.stringForTextMarkerRange(range) + "").trim();
+    output += `stringForTextMarkerRange: ${rangeStr}\n`;
+
+    var attrRangeStr = (list.attributedStringForTextMarkerRange(range) + "").trim();
+    // Filter out lines with AX attributes because they're not identical on all systems
+    attrRangeStr = attrRangeStr.split("\n").filter(line => line.indexOf("AX") == -1).join(" ");
+    output += `attributedStringForTextMarkerRange: ${attrRangeStr}\n`;
+
+    debug(output);
+    document.getElementById("list").hidden = true;
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1124,6 +1124,7 @@ public:
     virtual String description() const = 0;
 
     virtual std::optional<String> textContent() const = 0;
+    virtual String textContentPrefixFromListMarker() const = 0;
 #if ENABLE(AX_THREAD_TEXT_APIS)
     virtual bool hasTextRuns() = 0;
     virtual TextEmissionBehavior emitTextAfterBehavior() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1172,6 +1172,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::TagName:
         stream << "TagName";
         break;
+    case AXProperty::TextContentPrefixFromListMarker:
+        stream << "TextContentPrefixFromListMarker";
+        break;
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     case AXProperty::TextContent:
         stream << "TextContent";

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1803,6 +1803,19 @@ StringView AccessibilityObject::listMarkerTextForNodeAndPosition(Node* node, Pos
     return lineStartListMarkerText(listItem, startPosition, markerText);
 }
 
+String AccessibilityObject::textContentPrefixFromListMarker() const
+{
+    // Get the attributed string for range (0, 1) and then delete the last character,
+    // in order to extract the list marker that was added as a prefix to the text content.
+    std::optional<SimpleRange> firstCharacterRange = rangeForCharacterRange({ 0, 1 });
+    if (firstCharacterRange) {
+        String firstCharacterText = stringForRange(*firstCharacterRange);
+        if (firstCharacterText.length() > 1)
+            return firstCharacterText.left(firstCharacterText.length() - 1);
+    }
+    return { };
+}
+
 String AccessibilityObject::stringForRange(const SimpleRange& range) const
 {
     TextIterator it = textIteratorIgnoringFullSizeKana(range);

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -379,6 +379,7 @@ public:
 #if PLATFORM(COCOA)
     bool hasAttributedText() const;
 #endif
+    String textContentPrefixFromListMarker() const override;
 
     // Methods for determining accessibility text.
     bool isARIAStaticText() const { return ariaRoleAttribute() == AccessibilityRole::StaticText; }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -217,6 +217,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     setProperty(AXProperty::BrailleRoleDescription, object.brailleRoleDescription().isolatedCopy());
     setProperty(AXProperty::BrailleLabel, object.brailleLabel().isolatedCopy());
     setProperty(AXProperty::IsNonLayerSVGObject, object.isNonLayerSVGObject());
+    setProperty(AXProperty::TextContentPrefixFromListMarker, object.textContentPrefixFromListMarker());
 
     bool isWebArea = axObject->isWebArea();
     bool isScrollArea = axObject->isScrollView();
@@ -1996,6 +1997,11 @@ bool AXIsolatedObject::inheritsPresentationalRole() const
 void AXIsolatedObject::setAccessibleName(const AtomString&)
 {
     ASSERT_NOT_REACHED();
+}
+
+String AXIsolatedObject::textContentPrefixFromListMarker() const
+{
+    return propertyValue<String>(AXProperty::TextContentPrefixFromListMarker);
 }
 
 String AXIsolatedObject::titleAttributeValue() const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -493,6 +493,7 @@ private:
     bool inheritsPresentationalRole() const final;
     void setAccessibleName(const AtomString&) final;
 
+    String textContentPrefixFromListMarker() const final;
     String titleAttributeValue() const final;
     String title() const final { return stringAttributeValue(AXProperty::Title); }
     String description() const final { return stringAttributeValue(AXProperty::Description); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -272,6 +272,7 @@ enum class AXProperty : uint16_t {
     SupportsRangeValue,
     SupportsSetSize,
     TagName,
+    TextContentPrefixFromListMarker,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should
     // synthesize it on-the-fly using AXProperty::TextRuns.

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -315,6 +315,10 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
     if (!nsRange)
         return nil;
 
+    // If the range spans the beginning of the node, account for the length of the text marker prefix, if any.
+    if (!nsRange->location)
+        nsRange->length += textContentPrefixFromListMarker().length();
+
     if (!attributedStringContainsRange(attributedText.get(), *nsRange))
         return nil;
 


### PR DESCRIPTION
#### 98770472e072b7648f4324af7867c294e40f8fb0
<pre>
AX: attributed string for range truncated for list items
<a href="https://bugs.webkit.org/show_bug.cgi?id=287124">https://bugs.webkit.org/show_bug.cgi?id=287124</a>
<a href="https://rdar.apple.com/144274917">rdar://144274917</a>

Reviewed by Tyler Wilcock.

The list item&apos;s text node might consist of, say, 10 characters, but
the attributed string for the whole text element includes the list
marker character, resulting in a length of 12 total. But if you fetch
the attributed string for range with a range of (0, 10) you end up
getting the list marker, but the end of the string gets truncated.
The fix is to take the prefix from the list marker into account
when returning the attributed string for a range including the beginning
of the node.

* LayoutTests/accessibility/mac/line-text-marker-range-in-list-item-expected.txt: Added.
* LayoutTests/accessibility/mac/line-text-marker-range-in-list-item.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::textContentPrefixFromListMarker const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::textContentPrefixFromListMarker const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):

Canonical link: <a href="https://commits.webkit.org/290041@main">https://commits.webkit.org/290041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c37d0068cda620521e122519c0af5e105622169

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68436 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26122 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34693 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38628 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15941 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77298 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76578 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19388 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15955 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15696 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->