### PR TITLE
Fix safer C++ static analysis warnings for MediaPlayerPrivateMediaStreamAVFObjC

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -114,9 +114,9 @@ public:
 
     void clear();
 
-    template<typename Predicate> iterator findIf(const Predicate&);
-    template<typename Predicate> const_iterator findIf(const Predicate&) const;
-    template<typename Predicate> bool containsIf(const Predicate& predicate) const
+    template<typename Predicate> iterator findIf(NOESCAPE const Predicate&);
+    template<typename Predicate> const_iterator findIf(NOESCAPE const Predicate&) const;
+    template<typename Predicate> bool containsIf(NOESCAPE const Predicate& predicate) const
     {
         return findIf(predicate) != end();
     }
@@ -409,14 +409,14 @@ inline void Deque<T, inlineCapacity>::clear()
 
 template<typename T, size_t inlineCapacity>
 template<typename Predicate>
-inline auto Deque<T, inlineCapacity>::findIf(const Predicate& predicate) -> iterator
+inline auto Deque<T, inlineCapacity>::findIf(NOESCAPE const Predicate& predicate) -> iterator
 {
     return std::find_if(begin(), end(), predicate);
 }
 
 template<typename T, size_t inlineCapacity>
 template<typename Predicate>
-inline auto Deque<T, inlineCapacity>::findIf(const Predicate& predicate) const -> const_iterator
+inline auto Deque<T, inlineCapacity>::findIf(NOESCAPE const Predicate& predicate) const -> const_iterator
 {
     return std::find_if(begin(), end(), predicate);
 }

--- a/Source/WTF/wtf/RefVector.h
+++ b/Source/WTF/wtf/RefVector.h
@@ -138,8 +138,8 @@ public:
     T& last() { return Base::at(Base::size() - 1).get(); }
     const T& last() const { return Base::at(Base::size() - 1).get(); }
 
-    template<typename MatchFunction> size_t findIf(const MatchFunction&) const;
-    template<typename MatchFunction> bool containsIf(const MatchFunction& matches) const { return findIf(matches) != notFound; }
+    template<typename MatchFunction> size_t findIf(NOESCAPE const MatchFunction&) const;
+    template<typename MatchFunction> bool containsIf(NOESCAPE const MatchFunction& matches) const { return findIf(matches) != notFound; }
 };
 
 template<typename T, size_t inlineCapacity>
@@ -150,7 +150,7 @@ inline RefVector<T, inlineCapacity>::RefVector(std::initializer_list<WTF::Ref<T>
 
 template<typename T, size_t inlineCapacity>
 template<typename MatchFunction>
-size_t RefVector<T, inlineCapacity>::findIf(const MatchFunction& matches) const
+size_t RefVector<T, inlineCapacity>::findIf(NOESCAPE const MatchFunction& matches) const
 {
     for (size_t i = 0; i < size(); ++i) {
         if (matches(at(i)))

--- a/Source/WTF/wtf/ReferenceWrapperVector.h
+++ b/Source/WTF/wtf/ReferenceWrapperVector.h
@@ -147,8 +147,8 @@ public:
     T& last() { return Base::at(Base::size() - 1).get(); }
     const T& last() const { return Base::at(Base::size() - 1).get(); }
 
-    template<typename MatchFunction> size_t findIf(const MatchFunction&) const;
-    template<typename MatchFunction> bool containsIf(const MatchFunction& matches) const { return findIf(matches) != notFound; }
+    template<typename MatchFunction> size_t findIf(NOESCAPE const MatchFunction&) const;
+    template<typename MatchFunction> bool containsIf(NOESCAPE const MatchFunction& matches) const { return findIf(matches) != notFound; }
 };
 
 template<typename T, size_t inlineCapacity>
@@ -159,7 +159,7 @@ inline ReferenceWrapperVector<T, inlineCapacity>::ReferenceWrapperVector(std::in
 
 template<typename T, size_t inlineCapacity>
 template<typename MatchFunction>
-size_t ReferenceWrapperVector<T, inlineCapacity>::findIf(const MatchFunction& matches) const
+size_t ReferenceWrapperVector<T, inlineCapacity>::findIf(NOESCAPE const MatchFunction& matches) const
 {
     for (size_t i = 0; i < size(); ++i) {
         if (matches(at(i)))

--- a/Source/WTF/wtf/UniqueRefVector.h
+++ b/Source/WTF/wtf/UniqueRefVector.h
@@ -135,13 +135,13 @@ public:
     T& last() { return Base::at(Base::size() - 1).get(); }
     const T& last() const { return Base::at(Base::size() - 1).get(); }
 
-    template<typename MatchFunction> size_t findIf(const MatchFunction&) const;
-    template<typename MatchFunction> bool containsIf(const MatchFunction& matches) const { return findIf(matches) != notFound; }
+    template<typename MatchFunction> size_t findIf(NOESCAPE const MatchFunction&) const;
+    template<typename MatchFunction> bool containsIf(NOESCAPE const MatchFunction& matches) const { return findIf(matches) != notFound; }
 };
 
 template<typename T, size_t inlineCapacity>
 template<typename MatchFunction>
-size_t UniqueRefVector<T, inlineCapacity>::findIf(const MatchFunction& matches) const
+size_t UniqueRefVector<T, inlineCapacity>::findIf(NOESCAPE const MatchFunction& matches) const
 {
     for (size_t i = 0; i < size(); ++i) {
         if (matches(at(i)))

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -216,7 +216,6 @@ platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -637,7 +637,6 @@ platform/graphics/WidthIterator.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
-platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -247,6 +247,8 @@ private:
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRight&&) final;
     void requestHostingContextID(LayerHostingContextIDCallback&&) final;
 
+    RefPtr<MediaStreamPrivate> protectedMediaStreamPrivate() const;
+
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     RefPtr<MediaStreamPrivate> m_mediaStreamPrivate;
     RefPtr<VideoTrackPrivateMediaStream> m_activeVideoTrack;

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -55,6 +55,7 @@ public:
     void setAudioOutputDevice(const String&);
 
     MediaStreamTrackPrivate& streamTrack() { return m_streamTrack.get(); }
+    Ref<MediaStreamTrackPrivate> protectedStreamTrack() { return m_streamTrack; }
 
     void clear();
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -511,6 +511,16 @@ const RealtimeMediaSource& MediaStreamTrackPrivate::source() const
     return m_sourceObserver->source();
 }
 
+Ref<RealtimeMediaSource> MediaStreamTrackPrivate::protectedSource()
+{
+    return source();
+}
+
+Ref<const RealtimeMediaSource> MediaStreamTrackPrivate::protectedSource() const
+{
+    return source();
+}
+
 RealtimeMediaSource& MediaStreamTrackPrivate::sourceForProcessor()
 {
     ASSERT(isOnCreationThread());

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -115,6 +115,8 @@ public:
 
     WEBCORE_EXPORT RealtimeMediaSource& source();
     const RealtimeMediaSource& source() const;
+    Ref<RealtimeMediaSource> protectedSource();
+    Ref<const RealtimeMediaSource> protectedSource() const;
     RealtimeMediaSource& sourceForProcessor();
     bool hasSource(const RealtimeMediaSource*) const;
 

--- a/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
@@ -46,6 +46,7 @@ public:
     void setTrackIndex(int index) { m_index = index; }
 
     MediaStreamTrackPrivate& streamTrack() { return m_streamTrack.get(); }
+    Ref<MediaStreamTrackPrivate> protectedStreamTrack() { return m_streamTrack; }
 
 private:
     VideoTrackPrivateMediaStream(MediaStreamTrackPrivate& track)


### PR DESCRIPTION
#### 4c63256f3747578f85c5b313993d8b1165ddb904
<pre>
Fix safer C++ static analysis warnings for MediaPlayerPrivateMediaStreamAVFObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=287129">https://bugs.webkit.org/show_bug.cgi?id=287129</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/Deque.h:
(WTF::inlineCapacity&gt;::findIf):
(WTF::inlineCapacity&gt;::findIf const):
* Source/WTF/wtf/RefVector.h:
(WTF::RefVector::containsIf const):
(WTF::inlineCapacity&gt;::findIf const):
* Source/WTF/wtf/ReferenceWrapperVector.h:
(WTF::ReferenceWrapperVector::containsIf const):
(WTF::inlineCapacity&gt;::findIf const):
* Source/WTF/wtf/UniqueRefVector.h:
(WTF::UniqueRefVector::containsIf const):
(WTF::inlineCapacity&gt;::findIf const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::~MediaPlayerPrivateMediaStreamAVFObjC):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::enqueueVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::reenqueueCurrentVideoFrameIfNeeded):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::applicationDidBecomeActive):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::flushRenderers):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::ensureLayers):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::protectedMediaStreamPrivate const):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::platformLayer const):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::currentDisplayMode const):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::updateDisplayMode):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::play):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::pause):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::currentReadyState):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::activeStatusChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::scheduleRenderingModeChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::scheduleTaskForCharacteristicsChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::readyStateChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setVideoFullscreenLayer):
(WebCore::updateTracksOfKind):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::checkSelectedVideoTrack):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::updateTracks):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::paintCurrentFrameInContext):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::colorSpace):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setBufferingPolicy):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::rootLayerBoundsDidChange):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setVideoLayerSizeFenced):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setShouldMaintainAspectRatio):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::protectedSource):
(WebCore::MediaStreamTrackPrivate::protectedSource const):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h:

Canonical link: <a href="https://commits.webkit.org/289933@main">https://commits.webkit.org/289933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9692a03617f31e07215fd18fb5e41a0422fee99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90518 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8373 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16170 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/25957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38329 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81266 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95267 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87243 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15642 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75882 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18788 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20753 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8681 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15658 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109736 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15399 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26389 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->