### PR TITLE
Make CString explicit about its lack of encoding safety

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -80,7 +80,7 @@ void RemoteInspector::sendWebInspectorEvent(const String& event)
     if (!m_clientConnection)
         return;
 
-    send(m_clientConnection.value(), event.utf8().span());
+    send(m_clientConnection.value(), byteCast<uint8_t>(event.utf8().span()));
 }
 
 void RemoteInspector::start()

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2100,7 +2100,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWriteFile, (JSGlobalObject* globalObject, CallF
 
     int size = std::visit(WTF::makeVisitor([&](const String& string) {
         CString utf8 = string.utf8();
-        return FileSystem::writeToFile(handle, utf8.span());
+        return FileSystem::writeToFile(handle, byteCast<uint8_t>(utf8.span()));
     }, [&] (const std::span<const uint8_t>& data) {
         return FileSystem::writeToFile(handle, data);
     }), data);

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -417,7 +417,8 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
         return value;
     };
 
-    double value = parseDateImpl(expectedString.value().span());
+    // FIXME: expectedString is UTF-8 but parseDateImpl requires Latin1. Which is correct?
+    double value = parseDateImpl(byteCast<LChar>(expectedString.value().span()));
     m_cachedDateString = date;
     m_cachedDateStringValue = value;
     return value;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -472,7 +472,7 @@ JSC_DEFINE_HOST_FUNCTION(dumpAndClearSamplingProfilerSamples, (JSGlobalObject* g
 
         CString utf8String = jsonData.utf8();
 
-        FileSystem::writeToFile(fileHandle, utf8String.span());
+        FileSystem::writeToFile(fileHandle, byteCast<uint8_t>(utf8String.span()));
         FileSystem::closeFile(fileHandle);
         dataLogLn("Dumped sampling profiler samples to ", tempFilePath);
     }

--- a/Source/WTF/wtf/SHA1.h
+++ b/Source/WTF/wtf/SHA1.h
@@ -67,7 +67,7 @@ public:
 
     void addBytes(const CString& input)
     {
-        addBytes(input.span());
+        addBytes(std::as_bytes(input.span()));
     }
 
     WTF_EXPORT_PRIVATE void addUTF8Bytes(StringView);

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2480,6 +2480,7 @@ std::optional<URLParser::IPv6Address> URLParser::parseIPv6Host(CodePointIterator
     return address;
 }
 
+// FIXME: This function should take span<const char8_t>, since it requires UTF-8.
 template<typename CharacterType>
 URLParser::LCharBuffer URLParser::percentDecode(std::span<const LChar> input, const CodePointIterator<CharacterType>& iteratorForSyntaxViolationPosition)
 {
@@ -2896,7 +2897,7 @@ std::optional<String> URLParser::formURLDecode(StringView input)
     auto utf8 = input.utf8(StrictConversion);
     if (utf8.isNull())
         return std::nullopt;
-    auto percentDecoded = percentDecode(utf8.span());
+    auto percentDecoded = percentDecode(byteCast<LChar>(utf8.span()));
     return String::fromUTF8ReplacingInvalidSequences(percentDecoded.span());
 }
 

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -61,7 +61,7 @@ RetainPtr<CFURLRef> URL::createCFURL() const
     } else {
         CString utf8 = m_string.utf8();
         auto utf8Span = utf8.span();
-        result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, utf8Span.data(), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
+        result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(utf8Span.data()), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
     }
 
     // This additional check is only needed for invalid URLs, for which we've already returned null with new SDKs.

--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -60,7 +60,7 @@ void Coder<CString>::encodeForPersistence(Encoder& encoder, const CString& strin
 
     uint32_t length = string.length();
     encoder << length;
-    encoder.encodeFixedLengthData(string.span());
+    encoder.encodeFixedLengthData(byteCast<uint8_t>(string.span()));
 }
 
 std::optional<CString> Coder<CString>::decodeForPersistence(Decoder& decoder)

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -114,7 +114,7 @@ inline String base64EncodeToStringReturnNullIfOverflow(std::span<const uint8_t> 
 
 inline String base64EncodeToStringReturnNullIfOverflow(const CString& input, OptionSet<Base64EncodeOption> options)
 {
-    return base64EncodeToStringReturnNullIfOverflow(input.span(), options);
+    return base64EncodeToStringReturnNullIfOverflow(std::as_bytes(input.span()), options);
 }
 
 inline std::optional<Vector<uint8_t>> base64Decode(std::span<const uint8_t> input, OptionSet<Base64DecodeOption> options)

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -138,7 +138,7 @@ bool operator==(const CString& a, const CString& b)
         return false;
     if (a.length() != b.length())
         return false;
-    return equal(a.span().data(), b.span());
+    return equal(byteCast<LChar>(a.span()).data(), byteCast<LChar>(b.span()));
 }
 
 unsigned CString::hash() const

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
@@ -42,7 +42,7 @@ ClipboardItem::~ClipboardItem() = default;
 
 Ref<Blob> ClipboardItem::blobFromString(ScriptExecutionContext* context, const String& stringData, const String& type)
 {
-    return Blob::create(context, Vector(stringData.utf8().span()), Blob::normalizedContentType(type));
+    return Blob::create(context, Vector(byteCast<uint8_t>(stringData.utf8().span())), Blob::normalizedContentType(type));
 }
 
 static ClipboardItem::PresentationStyle clipboardItemPresentationStyle(const PasteboardItemInfo& info)

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
@@ -97,7 +97,7 @@ static void fetchDataBytesForWrite(const FileSystemWritableFileStream::DataVaria
             completionHandler(buffer->span());
         });
     }, [&](const String& string) {
-        completionHandler(string.utf8().span());
+        completionHandler(byteCast<uint8_t>(string.utf8().span()));
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
@@ -102,7 +102,7 @@ bool RTCDataChannelRemoteHandler::sendStringData(const CString& text)
         m_pendingMessages.append(Message { false, SharedBuffer::create(text.span()) });
         return true;
     }
-    m_connection->sendData(m_remoteIdentifier, false, text.span());
+    m_connection->sendData(m_remoteIdentifier, false, byteCast<uint8_t>(text.span()));
     return true;
 }
 

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -44,7 +44,7 @@ Vector<uint8_t> produceRpIdHash(const String& rpId)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto rpIdUTF8 = rpId.utf8();
-    crypto->addBytes(rpIdUTF8.span());
+    crypto->addBytes(byteCast<uint8_t>(rpIdUTF8.span()));
     return crypto->computeHash();
 }
 
@@ -174,7 +174,7 @@ Ref<ArrayBuffer> buildClientDataJson(ClientDataType type, const BufferSource& ch
     if (!topOrigin.isNull())
         object->setString("topOrigin"_s, topOrigin);
 
-    return ArrayBuffer::create(object->toJSONString().utf8().span());
+    return ArrayBuffer::create(byteCast<uint8_t>(object->toJSONString().utf8().span()));
 }
 
 Vector<uint8_t> buildClientDataJsonHash(const ArrayBuffer& clientDataJson)

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -268,7 +268,7 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
 
     // The following calculates a SHA-256 digest of the PIN, and shrink to the left 16 bytes.
     crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(pin.span());
+    crypto->addBytes(byteCast<uint8_t>(pin.span()));
     auto pinHash = crypto->computeHash();
     pinHash.shrink(16);
 

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -559,7 +559,7 @@ void WebSocket::didReceiveMessage(String&& message)
         if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
             if (auto* inspector = m_channel->channelInspector()) {
                 auto utf8Message = message.utf8();
-                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(utf8Message.span(), WebSocketFrame::OpCode::OpCodeText));
+                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(byteCast<uint8_t>(utf8Message.span()), WebSocketFrame::OpCode::OpCodeText));
             }
         }
         ASSERT(scriptExecutionContext());

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -95,7 +95,8 @@ bool WebSocketExtensionDispatcher::processHeaderValue(const String& headerValue)
     }
 
     const CString headerValueData = headerValue.utf8();
-    WebSocketExtensionParser parser(headerValueData.span());
+    // FIXME: Is UTF-8 the encoding that WebSocketExtensionParser expects? It doesn't specify.
+    WebSocketExtensionParser parser(byteCast<uint8_t>(headerValueData.span()));
     while (!parser.finished()) {
         String extensionToken;
         HashMap<String, String> extensionParameters;

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.h
@@ -38,12 +38,15 @@ namespace WebCore {
 
 class WebSocketExtensionParser {
 public:
+    // FIXME: What character encoding are we parsing? Specify LChar, char8_t, UChar, or something else here.
     explicit WebSocketExtensionParser(std::span<const uint8_t> data)
         : m_data(data)
     {
     }
     bool finished();
     bool parsedSuccessfully();
+
+    // FIXME: What character encoding are we parsing? Specify LChar, char8_t, UChar, or something else here.
     bool parseExtension(String& extensionToken, HashMap<String, String>& parameters);
 
 private:

--- a/Source/WebCore/bindings/js/GCController.cpp
+++ b/Source/WebCore/bindings/js/GCController.cpp
@@ -164,7 +164,7 @@ void GCController::dumpHeapForVM(VM& vm)
 
     CString utf8String = jsonData.utf8();
 
-    FileSystem::writeToFile(fileHandle, utf8String.span());
+    FileSystem::writeToFile(fileHandle, byteCast<uint8_t>(utf8String.span()));
     FileSystem::closeFile(fileHandle);
     WTFLogAlways("Dumped GC heap to %s%s", tempFilePath.utf8().data(), isMainThread() ? "" : " for Worker");
 }

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp
@@ -249,8 +249,9 @@ auto DFABytecodeInterpreter::interpret(const String& urlString, ResourceFlags fl
     if (LIKELY(urlString.is8Bit()))
         url = urlString.span8();
     else {
+        // FIXME: Stuffing a UTF-8 string into a Latin1 buffer seems wrong.
         urlCString = urlString.utf8();
-        url = urlCString.span();
+        url = byteCast<LChar>(urlCString.span());
     }
     ASSERT(url.data());
     

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -571,7 +571,7 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
             subframeMainResource.releaseNonNull(), subframeArchive.copyRef() };
         auto subframeMarkup = sanitizeMarkupWithArchive(frame, destinationDocument, subframeContent, MSOListQuirks::Disabled, canShowMIMETypeAsHTML);
 
-        auto blob = Blob::create(&destinationDocument, Vector(subframeMarkup.utf8().span()), type);
+        auto blob = Blob::create(&destinationDocument, Vector(byteCast<uint8_t>(subframeMarkup.utf8().span())), type);
 
         String subframeBlobURL = DOMURL::createObjectURL(destinationDocument, blob);
         blobURLMap.set(AtomString { subframeURL.string() }, AtomString { subframeBlobURL });

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -96,7 +96,7 @@ void DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL(const Str
         }
 
         if (RefPtr parser = frame->document()->parser())
-            parser->appendBytes(*this, source.utf8().span());
+            parser->appendBytes(*this, byteCast<uint8_t>(source.utf8().span()));
     }
 
     end();

--- a/Source/WebCore/page/Base64Utilities.cpp
+++ b/Source/WebCore/page/Base64Utilities.cpp
@@ -38,7 +38,7 @@ ExceptionOr<String> Base64Utilities::btoa(const String& stringToEncode)
     if (!stringToEncode.containsOnlyLatin1())
         return Exception { ExceptionCode::InvalidCharacterError };
 
-    return base64EncodeToString(stringToEncode.latin1().span());
+    return base64EncodeToString(byteCast<uint8_t>(stringToEncode.latin1().span()));
 }
 
 ExceptionOr<String> Base64Utilities::atob(const String& encodedString)

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -276,7 +276,7 @@ static void showText(CGContextRef context, float x, float y, CGColorRef color, c
     auto attributes = adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     CString cstr = text.ascii();
     auto cstrSpan = cstr.span();
-    auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, cstrSpan.data(), cstrSpan.size(), kCFStringEncodingASCII, false, kCFAllocatorNull));
+    auto string = adoptCF(CFStringCreateWithBytesNoCopy(kCFAllocatorDefault, byteCast<UInt8>(cstrSpan.data()), cstrSpan.size(), kCFStringEncodingASCII, false, kCFAllocatorNull));
     auto attributedString = adoptCF(CFAttributedStringCreate(kCFAllocatorDefault, string.get(), attributes.get()));
     auto line = adoptCF(CTLineCreateWithAttributedString(attributedString.get()));
     CGContextSetTextPosition(context, x, y);

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -407,7 +407,7 @@ static Vector<ContentSecurityPolicyHash> generateHashesForContent(const StringVi
     CString utf8Content = content.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
     Vector<ContentSecurityPolicyHash> hashes;
     for (auto algorithm : algorithms) {
-        auto hash = cryptographicDigestForBytes(algorithm, utf8Content.span());
+        auto hash = cryptographicDigestForBytes(algorithm, byteCast<uint8_t>(utf8Content.span()));
         hashes.append(hash);
     }
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -1155,7 +1155,7 @@ void showGraphicsLayerTree(const WebCore::GraphicsLayer* layer)
     // to a file in case we don't have easy access to stderr.
     auto [tempFilePath, fileHandle] = FileSystem::openTemporaryFile("GraphicsLayerTree"_s);
     if (FileSystem::isHandleValid(fileHandle)) {
-        FileSystem::writeToFile(fileHandle, output.utf8().span());
+        FileSystem::writeToFile(fileHandle, byteCast<uint8_t>(output.utf8().span()));
         FileSystem::closeFile(fileHandle);
         WTFLogAlways("Saved GraphicsLayer Tree to %s", tempFilePath.utf8().data());
     } else

--- a/Source/WebCore/platform/network/CredentialBase.cpp
+++ b/Source/WebCore/platform/network/CredentialBase.cpp
@@ -99,7 +99,7 @@ bool CredentialBase::compare(const Credential& a, const Credential& b)
 String CredentialBase::serializationForBasicAuthorizationHeader() const
 {
     auto credentialStringData = makeString(m_user, ':', m_password).utf8();
-    return makeString("Basic "_s, base64Encoded(credentialStringData.span()));
+    return makeString("Basic "_s, base64Encoded(byteCast<uint8_t>(credentialStringData.span())));
 }
 
 auto CredentialBase::nonPlatformData() const -> NonPlatformData

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -64,7 +64,7 @@ Ref<FormData> FormData::create(std::span<const uint8_t> data)
 
 Ref<FormData> FormData::create(const CString& string)
 {
-    return create(string.span());
+    return create(byteCast<uint8_t>(string.span()));
 }
 
 Ref<FormData> FormData::create(Vector<uint8_t>&& vector)

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -323,7 +323,8 @@ static String trimInputSample(std::span<const CharType> input)
 
 std::optional<WallTime> parseHTTPDate(const String& value)
 {
-    double dateInMillisecondsSinceEpoch = parseDate(value.utf8().span());
+    // FIXME: parseDate() requires Latin1, but we're passing it UTF-8.
+    double dateInMillisecondsSinceEpoch = parseDate(byteCast<LChar>(value.utf8().span()));
     if (!std::isfinite(dateInMillisecondsSinceEpoch))
         return std::nullopt;
     // This assumes system_clock epoch equals Unix epoch which is true for all implementations but unspecified.

--- a/Source/WebCore/platform/network/cf/ResourceRequestCFNet.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequestCFNet.h
@@ -122,7 +122,7 @@ inline RetainPtr<CFStringRef> httpHeaderValueUsingSuitableEncoding(HTTPHeaderMap
         auto utf8Value = header.value.utf8();
         auto utf8ValueSpan = utf8Value.span();
         // Constructing a string with the UTF-8 bytes but claiming that it’s Latin-1 is the way to get CFNetwork to put those UTF-8 bytes on the wire.
-        return adoptCF(CFStringCreateWithBytes(nullptr, utf8ValueSpan.data(), utf8ValueSpan.size(), kCFStringEncodingISOLatin1, false));
+        return adoptCF(CFStringCreateWithBytes(nullptr, byteCast<UInt8>(utf8ValueSpan.data()), utf8ValueSpan.size(), kCFStringEncodingISOLatin1, false));
     }
     return header.value.createCFString();
 }

--- a/Source/WebCore/platform/network/curl/CookieUtil.cpp
+++ b/Source/WebCore/platform/network/curl/CookieUtil.cpp
@@ -130,7 +130,8 @@ static void parseCookieAttributes(const String& attribute, bool& hasMaxAge, Cook
             result.expires = std::nullopt;
         }
     } else if (equalLettersIgnoringASCIICase(attributeName, "expires"_s) && !hasMaxAge) {
-        if (auto expiryTime = parseExpiresMS(attributeValue.utf8().span())) {
+        // FIXME: This code passes a UTF-8 buffer to a function that expects to parse Latin1.
+        if (auto expiryTime = parseExpiresMS(byteCast<LChar>(attributeValue.utf8().span()))) {
             result.expires = expiryTime.value();
             result.session = false;
         } else if (!hasMaxAge) {

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -150,7 +150,7 @@ String SQLiteFileSystem::computeHashForFileName(StringView fileName)
 {
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8FileName = fileName.utf8();
-    cryptoDigest->addBytes(utf8FileName.span());
+    cryptoDigest->addBytes(byteCast<uint8_t>(utf8FileName.span()));
     return cryptoDigest->toHexString();
 }
 

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -92,7 +92,7 @@ String encodeSecurityOriginForFileName(FileSystem::Salt salt, const SecurityOrig
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto originString = origin.toString().utf8();
-    crypto->addBytes(originString.span());
+    crypto->addBytes(byteCast<uint8_t>(originString.span()));
     crypto->addBytes(salt);
     return base64URLEncodeToString(crypto->computeHash());
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5499,8 +5499,7 @@ String Internals::createTemporaryFile(const String& name, const String& contents
     if (!FileSystem::isHandleValid(file))
         return nullString();
 
-    auto contentsUTF8 = contents.utf8();
-    FileSystem::writeToFile(file, contentsUTF8.span());
+    FileSystem::writeToFile(file, byteCast<uint8_t>(contents.utf8().span()));
 
     FileSystem::closeFile(file);
 

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -70,10 +70,8 @@ void ServiceWorkerInternals::schedulePushEvent(const String& message, RefPtr<Def
     m_pushEventPromises.add(counter, WTFMove(promise));
 
     std::optional<Vector<uint8_t>> data;
-    if (!message.isNull()) {
-        auto utf8 = message.utf8();
-        data = Vector(utf8.span());
-    }
+    if (!message.isNull())
+        data = Vector(byteCast<uint8_t>(message.utf8().span()));
     callOnMainThread([identifier = m_identifier, data = WTFMove(data), weakThis = WeakPtr { *this }, counter]() mutable {
         SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), std::nullopt, [identifier, weakThis = WTFMove(weakThis), counter](bool result, std::optional<NotificationPayload>&&) mutable {
             if (auto* proxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier)) {

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -56,7 +56,7 @@ String SWScriptStorage::sha2Hash(const String& input) const
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(m_salt);
     auto inputUTF8 = input.utf8();
-    crypto->addBytes(inputUTF8.span());
+    crypto->addBytes(byteCast<uint8_t>(inputUTF8.span()));
     return base64URLEncodeToString(crypto->computeHash());
 }
 

--- a/Source/WebDriver/socket/HTTPServerSocket.cpp
+++ b/Source/WebDriver/socket/HTTPServerSocket.cpp
@@ -107,7 +107,7 @@ void HTTPRequestHandler::didReceive(RemoteInspectorSocketEndpoint&, ConnectionID
 void HTTPRequestHandler::sendResponse(HTTPRequestHandler::Response&& response)
 {
     auto& endpoint = RemoteInspectorSocketEndpoint::singleton();
-    endpoint.send(m_client.value(), packHTTPMessage(WTFMove(response)).utf8().span());
+    endpoint.send(m_client.value(), byteCast<uint8_t>(packHTTPMessage(WTFMove(response)).utf8().span()));
     reset();
 }
 

--- a/Source/WebDriver/socket/SessionHostSocket.cpp
+++ b/Source/WebDriver/socket/SessionHostSocket.cpp
@@ -63,7 +63,7 @@ void SessionHost::sendWebInspectorEvent(const String& event)
     if (!m_clientID)
         return;
 
-    send(m_clientID.value(), event.utf8().span());
+    send(m_clientID.value(), byteCast<uint8_t>(event.utf8().span()));
 }
 
 #if PLATFORM(WIN)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -121,7 +121,7 @@ void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore
         request.get().HTTPMethod = @"POST";
         [request setValue:WebCore::HTTPHeaderValues::applicationJSONContentType() forHTTPHeaderField:@"Content-Type"];
         auto body = jsonPayload->toJSONString().utf8();
-        request.get().HTTPBody = toNSData(body.span()).get();
+        request.get().HTTPBody = toNSData(byteCast<uint8_t>(body.span())).get();
     }
 
     setPCMDataCarriedOnRequest(pcmDataCarried, request.get());

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -695,7 +695,7 @@ void Cache::dumpContentsToFile()
                 "\"averageWorth\": "_s, totals.count ? totals.worth / totals.count : 0, "\n"
                 "}\n}\n"_s
             ).utf8();
-            writeToFile(fd, writeData.span());
+            writeToFile(fd, byteCast<uint8_t>(writeData.span()));
             closeFile(fd);
             return;
         }
@@ -709,7 +709,7 @@ void Cache::dumpContentsToFile()
         StringBuilder json;
         entry->asJSON(json, info);
         json.append(",\n"_s);
-        writeToFile(fd, json.toString().utf8().span());
+        writeToFile(fd, byteCast<uint8_t>(json.toString().utf8().span()));
     });
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
@@ -79,7 +79,7 @@ void BlobStorage::synchronize()
 String BlobStorage::blobPathForHash(const SHA1::Digest& hash) const
 {
     auto hashAsString = SHA1::hexDigest(hash);
-    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), StringView::fromLatin1(hashAsString.span()));
+    return FileSystem::pathByAppendingComponent(blobDirectoryPathIsolatedCopy(), StringView::fromLatin1(byteCast<LChar>(hashAsString.span())));
 }
 
 BlobStorage::Blob BlobStorage::add(const String& path, const Data& data)

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -172,7 +172,7 @@ void WebSocketTask::close(int32_t code, const String& reason)
     if (code == WebCore::ThreadableWebSocketChannel::CloseEventCodeNotSpecified)
         code = NSURLSessionWebSocketCloseCodeInvalid;
     auto utf8 = reason.utf8();
-    RetainPtr nsData = toNSData(utf8.span());
+    RetainPtr nsData = toNSData(byteCast<uint8_t>(utf8.span()));
     if ([m_task respondsToSelector:@selector(_sendCloseCode:reason:)]) {
         [m_task _sendCloseCode:(NSURLSessionWebSocketCloseCode)code reason:nsData.get()];
         return;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -145,7 +145,7 @@ static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)
 
     auto sizeFilePath = FileSystem::pathByAppendingComponent(sizeDirectoryPath, sizeFileName);
     auto value = String::number(size).utf8();
-    return FileSystem::overwriteEntireFile(sizeFilePath, value.span()) != -1;
+    return FileSystem::overwriteEntireFile(sizeFilePath, byteCast<uint8_t>(value.span())) != -1;
 }
 
 static String saltFilePath(const String& saltDirectory)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -90,7 +90,7 @@ static String encode(const String& string, FileSystem::Salt salt)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8String = string.utf8();
-    crypto->addBytes(utf8String.span());
+    crypto->addBytes(byteCast<uint8_t>(utf8String.span()));
     crypto->addBytes(salt);
     return base64URLEncodeToString(crypto->computeHash());
 }

--- a/Source/WebKit/Shared/API/c/cf/WKURLCF.mm
+++ b/Source/WebKit/Shared/API/c/cf/WKURLCF.mm
@@ -65,5 +65,5 @@ CFURLRef WKURLCopyCFURL(CFAllocatorRef allocatorRef, WKURLRef URLRef)
 
     auto buffer = string.utf8();
     auto bufferSpan = buffer.span();
-    return CFURLCreateAbsoluteURLWithBytes(nullptr, bufferSpan.data(), bufferSpan.size(), kCFStringEncodingUTF8, nullptr, true);
+    return CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(bufferSpan.data()), bufferSpan.size(), kCFStringEncodingUTF8, nullptr, true);
 }

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -78,7 +78,7 @@ bool SandboxExtensionImpl::invalidate()
 std::span<const uint8_t> SandboxExtensionImpl::getSerializedFormat()
 {
     ASSERT(m_token.length());
-    return m_token.span();
+    return byteCast<uint8_t>(m_token.span());
 }
 
 char* SandboxExtensionImpl::sandboxExtensionForType(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -28,7 +28,7 @@ webkit_platform_headers: "StreamConnectionEncoder.h"
 
 header: <wtf/text/CString.h>
 [CustomHeader, WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::CString {
-   std::span<const uint8_t> span()
+   std::span<const char> span()
 }
 
 [AdditionalEncoder=StreamConnectionEncoder] class WTF::MediaTime {

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -146,7 +146,7 @@ void WebMemorySampler::initializeSandboxedLogFile(SandboxExtension::Handle&& sam
 void WebMemorySampler::writeHeaders()
 {
     auto processDetails = makeString("Process: "_s, processName(), " Pid: "_s, getCurrentProcessID(), '\n').utf8();
-    FileSystem::writeToFile(m_sampleLogFile, processDetails.span());
+    FileSystem::writeToFile(m_sampleLogFile, byteCast<uint8_t>(processDetails.span()));
 }
 
 void WebMemorySampler::sampleTimerFired()
@@ -180,7 +180,7 @@ void WebMemorySampler::appendCurrentMemoryUsageToFile(FileSystem::PlatformFileHa
     statString.append('\n');
 
     CString utf8String = statString.toString().utf8();
-    FileSystem::writeToFile(m_sampleLogFile, utf8String.span());
+    FileSystem::writeToFile(m_sampleLogFile, byteCast<uint8_t>(utf8String.span()));
 }
 
 }

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -129,7 +129,7 @@ void RemoteInspectorClient::sendWebInspectorEvent(const String& event)
 {
     ASSERT(isMainRunLoop());
     ASSERT(m_connectionID);
-    send(m_connectionID.value(), event.utf8().span());
+    send(m_connectionID.value(), byteCast<uint8_t>(event.utf8().span()));
 }
 
 HashMap<String, Inspector::RemoteInspectorConnectionClient::CallHandler>& RemoteInspectorClient::dispatchMap()
@@ -211,7 +211,7 @@ void RemoteInspectorClient::setBackendCommands(const Event& event)
     if (!event.message || event.message->isEmpty())
         return;
 
-    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(event.message->utf8().span()));
+    m_backendCommandsURL = makeString("data:text/javascript;base64,"_s, base64Encoded(byteCast<uint8_t>(event.message->utf8().span())));
 }
 
 void RemoteInspectorClient::setTargetList(const Event& event)

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -110,7 +110,7 @@ void WebInspectorUIProxy::showSavePanelForSingleFile(HWND parentWindow, Vector<W
 
         auto content = saveDatas[0].content.utf8();
         auto contentSize = content.length();
-        auto bytesWritten = FileSystem::writeToFile(fd, content.span());
+        auto bytesWritten = FileSystem::writeToFile(fd, byteCast<uint8_t>(content.span()));
         if (bytesWritten == -1 || static_cast<size_t>(bytesWritten) != contentSize) {
             auto message = systemErrorMessage(GetLastError());
             if (message.isEmpty())

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -64,8 +64,8 @@ NetworkSendQueue WebSocketChannel::createMessageQueue(Document& document, WebSoc
 {
     return { document, [&channel](auto& utf8String) {
         auto data = utf8String.span();
-        channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeText, data);
-        channel.sendMessageInternal(Messages::NetworkSocketChannel::SendString { data }, utf8String.length());
+        channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeText, byteCast<uint8_t>(data));
+        channel.sendMessageInternal(Messages::NetworkSocketChannel::SendString { byteCast<uint8_t>(data) }, utf8String.length());
     }, [&channel](auto span) {
         channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeBinary, span);
         channel.sendMessageInternal(Messages::NetworkSocketChannel::SendData { span }, span.size());

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -226,7 +226,7 @@ void RTCDataChannelRemoteManager::RemoteSourceConnection::didChangeReadyState(We
 void RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveStringData(WebCore::RTCDataChannelIdentifier identifier, const String& string)
 {
     auto text = string.utf8();
-    m_connection->send(Messages::RTCDataChannelRemoteManagerProxy::ReceiveData { identifier, false, text.span() }, 0);
+    m_connection->send(Messages::RTCDataChannelRemoteManagerProxy::ReceiveData { identifier, false, byteCast<uint8_t>(text.span()) }, 0);
 }
 
 void RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveRawData(WebCore::RTCDataChannelIdentifier identifier, std::span<const uint8_t> data)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4661,7 +4661,7 @@ void WebPage::getAccessibilityTreeData(CompletionHandler<void(const std::optiona
         auto writeTreeToStream = [&stream](auto& tree) {
             auto utf8 = tree.utf8();
             auto utf8Span = utf8.span();
-            CFWriteStreamWrite(stream.get(), utf8Span.data(), utf8Span.size());
+            CFWriteStreamWrite(stream.get(), byteCast<UInt8>(utf8Span.data()), utf8Span.size());
         };
         writeTreeToStream(treeData->liveTree);
         writeTreeToStream(treeData->isolatedTree);

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -465,9 +465,9 @@ void WebPushDaemon::injectPushMessageForTesting(PushClientConnection& connection
     PushSubscriptionSetIdentifier identifier { .bundleIdentifier = message.targetAppCodeSigningIdentifier, .pushPartition = message.pushPartitionString, .dataStoreIdentifier = connection.dataStoreIdentifier() };
     auto data = message.payload.utf8();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    WebKit::WebPushMessage pushMessage { Vector(data.span()), message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) };
+    WebKit::WebPushMessage pushMessage { Vector(byteCast<uint8_t>(data.span())), message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) };
 #else
-    WebKit::WebPushMessage pushMessage { Vector(data.span()), message.pushPartitionString, message.registrationURL, { } };
+    WebKit::WebPushMessage pushMessage { Vector(byteCast<uint8_t>(data.span())), message.pushPartitionString, message.registrationURL, { } };
 #endif
 
     WEBPUSHDAEMON_RELEASE_LOG(Push, "Injected a test push message for %{public}s at %{public}s with %zu pending messages, payload: %{public}s", message.targetAppCodeSigningIdentifier.utf8().data(), message.registrationURL.string().utf8().data(), m_pendingPushMessages.size(), message.payload.utf8().data());
@@ -488,8 +488,7 @@ void WebPushDaemon::injectEncryptedPushMessageForTesting(PushClientConnection& c
         if (!m_pushService)
             return replySender(false);
 
-        auto bytes = message.utf8();
-        RetainPtr data = toNSData(bytes.span());
+        RetainPtr data = toNSData(byteCast<uint8_t>(message.utf8().span()));
 
         id obj = [NSJSONSerialization JSONObjectWithData:data.get() options:0 error:nullptr];
         if (!obj || ![obj isKindOfClass:[NSDictionary class]])

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
@@ -60,7 +60,7 @@ void SocketStreamHandle::sendHandshake(CString&& handshake, std::optional<Cookie
 {
     if (m_state == Connecting || m_state == Closing)
         return completionHandler(false, false);
-    platformSendHandshake(handshake.span(), WTFMove(headerFieldProxy), WTFMove(completionHandler));
+    platformSendHandshake(byteCast<uint8_t>(handshake.span()), WTFMove(headerFieldProxy), WTFMove(completionHandler));
 }
 
 void SocketStreamHandle::close()

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -770,7 +770,7 @@ void WebSocketChannel::processOutgoingFrameQueue()
         auto frame = m_outgoingFrameQueue.takeFirst();
         switch (frame->frameType) {
         case QueuedFrameTypeString: {
-            sendFrame(frame->opCode, frame->stringData.span(), [this, protectedThis = Ref { *this }] (bool success) {
+            sendFrame(frame->opCode, byteCast<uint8_t>(frame->stringData.span()), [this, protectedThis = Ref { *this }] (bool success) {
                 if (!success)
                     fail("Failed to send WebSocket frame."_s);
             });

--- a/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
@@ -50,7 +50,7 @@ static void expect(PAL::CryptoDigest::Algorithm algorithm, const CString& input,
     auto cryptoDigest = PAL::CryptoDigest::create(algorithm);
 
     for (int i = 0; i < repeat; ++i)
-        cryptoDigest->addBytes(input.span());
+        cryptoDigest->addBytes(byteCast<uint8_t>(input.span()));
 
     CString actual = toHex(cryptoDigest->computeHash());
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -60,7 +60,7 @@ public:
         auto handle = result.second;
         ASSERT_NE(handle, FileSystem::invalidPlatformFileHandle);
 
-        int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().span());
+        int rc = FileSystem::writeToFile(handle, byteCast<uint8_t>(FileMonitorTestData.utf8().span()));
         ASSERT_NE(rc, -1);
         
         FileSystem::closeFile(handle);
@@ -348,7 +348,7 @@ TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)
         auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate);
         ASSERT_NE(handle, FileSystem::invalidPlatformFileHandle);
 
-        int rc = FileSystem::writeToFile(handle, FileMonitorTestData.utf8().span());
+        int rc = FileSystem::writeToFile(handle, byteCast<uint8_t>(FileMonitorTestData.utf8().span()));
         ASSERT_NE(rc, -1);
 
         auto firstCommand = createCommand(tempFilePath(), FileMonitorRevisedData);


### PR DESCRIPTION
#### b5cddddc947c75a0675855fd6f322dd21e9320ea
<pre>
Make CString explicit about its lack of encoding safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=287131">https://bugs.webkit.org/show_bug.cgi?id=287131</a>
<a href="https://rdar.apple.com/144279558">rdar://144279558</a>

Reviewed by Darin Adler and Chris Dumez.

In a recent patch I made some mistakes with CString encoding.

This is a follow-up to clarify some details that confused me:

1. Added documentation explaining that CString has agnostic encoding

2. Changed the return type of CString::span from LChar to char. LChar indicates
Latin1 encoding, but CString offers no such guarantee.

This created a long tail of new explicit casts, and some FIXMEs about some
apparent encoding conflicts in the tree.

Chris is planning to add CString encoding safety in a future patch. In theory,
these explicit casts all facilitate that effort.

* Source/JavaScriptCore/jsc.cpp:(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::parseDate):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/SHA1.h:
(WTF::SHA1::addBytes):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::formURLDecode):
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL const):
* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::Coder&lt;CString&gt;::encodeForPersistence):
* Source/WTF/wtf/text/Base64.h:
(WTF::base64EncodeToStringReturnNullIfOverflow):
* Source/WTF/wtf/text/CString.cpp:
(WTF::operator==):
* Source/WTF/wtf/text/CString.h:
(WTF::CString::span const):
* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
(WebCore::ClipboardItem::blobFromString):
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp:
(WebCore::fetchDataBytesForWrite):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp:
(WebCore::RTCDataChannelRemoteHandler::sendStringData):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::produceRpIdHash):
(WebCore::buildClientDataJson):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::TokenRequest::tryCreate):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::didReceiveMessage):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
(WebCore::WebSocketExtensionDispatcher::processHeaderValue):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.h:
* Source/WebCore/bindings/js/GCController.cpp:
(WebCore::GCController::dumpHeapForVM):
* Source/WebCore/contentextensions/DFABytecodeInterpreter.cpp:
(WebCore::ContentExtensions::DFABytecodeInterpreter::interpret):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::sanitizeMarkupWithArchive):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL):
* Source/WebCore/page/Base64Utilities.cpp:
(WebCore::Base64Utilities::btoa):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::showText):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::generateHashesForContent):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(showGraphicsLayerTree):
* Source/WebCore/platform/network/CredentialBase.cpp:
(WebCore::CredentialBase::serializationForBasicAuthorizationHeader const):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::create):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseHTTPDate):
* Source/WebCore/platform/network/cf/ResourceRequestCFNet.h:
(WebCore::httpHeaderValueUsingSuitableEncoding):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::computeHashForFileName):
* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::encodeSecurityOriginForFileName):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::createTemporaryFile):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::schedulePushEvent):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::sha2Hash const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(WebKit::PCM::NetworkLoader::start):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::dumpContentsToFile):
* Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp:
(WebKit::NetworkCache::BlobStorage::blobPathForHash const):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::close):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::writeSizeFile):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::encode):
* Source/WebKit/Shared/API/c/cf/WKURLCF.mm:
(WKURLCopyCFURL):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::getSerializedFormat):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::writeHeaders):
(WebKit::WebMemorySampler::appendCurrentMemoryUsageToFile):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::createMessageQueue):
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveStringData):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getAccessibilityTreeData):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::injectEncryptedPushMessageForTesting):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp:
(WebCore::SocketStreamHandle::sendHandshake):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::processOutgoingFrameQueue):
* Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp:
(TestWebKitAPI::TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)):

Canonical link: <a href="https://commits.webkit.org/290024@main">https://commits.webkit.org/290024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e81eb192490bbce0079165f33b7c72b8478f3dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88721 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16426 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68405 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26099 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6609 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6364 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38583 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81520 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76735 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95522 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87497 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15896 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77273 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16152 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76566 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20943 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13882 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15912 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109990 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15653 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26423 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->