### PR TITLE
Address safer C++ static analysis warnings in ContentFilter classes

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -920,7 +920,6 @@ layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
 loader/ApplicationManifestLoader.cpp
-loader/ContentFilter.cpp
 loader/CrossOriginAccessControl.cpp
 loader/CrossOriginOpenerPolicy.cpp
 loader/CrossOriginPreflightChecker.cpp
@@ -1558,8 +1557,6 @@ svg/properties/SVGValuePropertyListAnimatorImpl.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
 testing/LegacyMockCDM.cpp
-testing/MockContentFilter.cpp
-testing/MockContentFilterManager.cpp
 testing/MockMediaSessionCoordinator.cpp
 testing/MockPageOverlay.cpp
 testing/MockPageOverlayClient.cpp

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -359,7 +359,7 @@ void ContentFilter::handleProvisionalLoadFailure(const ResourceError& error)
 void ContentFilter::deliverStoredResourceData()
 {
     for (auto& buffer : m_buffers)
-        deliverResourceData(*buffer.buffer, buffer.encodedDataLength);
+        deliverResourceData(Ref { *buffer.buffer }, buffer.encodedDataLength);
     m_buffers.clear();
 }
 

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -54,14 +54,9 @@ void MockContentFilter::ensureInstalled()
     });
 }
 
-static inline MockContentFilterSettings& settings()
-{
-    return MockContentFilterSettings::singleton();
-}
-
 bool MockContentFilter::enabled()
 {
-    bool enabled = settings().enabled();
+    bool enabled = MockContentFilterSettings::singleton().enabled();
     LOG(ContentFiltering, "MockContentFilter is %s.\n", enabled ? "enabled" : "not enabled");
     return enabled;
 }
@@ -86,7 +81,7 @@ void MockContentFilter::willSendRequest(ResourceRequest& request, const Resource
     if (m_state == State::Filtering)
         return;
 
-    String modifiedRequestURLString { settings().modifiedRequestURL() };
+    String modifiedRequestURLString { MockContentFilterSettings::singleton().modifiedRequestURL() };
     if (modifiedRequestURLString.isEmpty())
         return;
 
@@ -127,9 +122,9 @@ ContentFilterUnblockHandler MockContentFilter::unblockHandler() const
 
     return ContentFilterUnblockHandler {
         MockContentFilterSettings::unblockURLHost(), [](DecisionHandlerFunction decisionHandler) {
-            bool shouldAllow { settings().unblockRequestDecision() == Decision::Allow };
+            bool shouldAllow { MockContentFilterSettings::singleton().unblockRequestDecision() == Decision::Allow };
             if (shouldAllow)
-                settings().setDecision(Decision::Allow);
+                MockContentFilterSettings::singleton().setDecision(Decision::Allow);
             LOG(ContentFiltering, "MockContentFilter %s the unblock request.\n", shouldAllow ? "allowed" : "did not allow");
             decisionHandler(shouldAllow);
         }
@@ -143,16 +138,16 @@ String MockContentFilter::unblockRequestDeniedScript() const
 
 void MockContentFilter::maybeDetermineStatus(DecisionPoint decisionPoint)
 {
-    if (m_state != State::Filtering || decisionPoint != settings().decisionPoint())
+    if (m_state != State::Filtering || decisionPoint != MockContentFilterSettings::singleton().decisionPoint())
         return;
 
     LOG(ContentFiltering, "MockContentFilter stopped buffering with state %u at decision point %hhu.\n", enumToUnderlyingType(m_state), enumToUnderlyingType(decisionPoint));
 
-    m_state = settings().decision() == Decision::Allow ? State::Allowed : State::Blocked;
+    m_state = MockContentFilterSettings::singleton().decision() == Decision::Allow ? State::Allowed : State::Blocked;
     if (m_state != State::Blocked)
         return;
 
-    m_replacementData = settings().blockedString().utf8().span();
+    m_replacementData = MockContentFilterSettings::singleton().blockedString().utf8().span();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockContentFilterManager.cpp
+++ b/Source/WebCore/testing/MockContentFilterManager.cpp
@@ -41,8 +41,8 @@ void MockContentFilterManager::setClient(RefPtr<MockContentFilterSettingsClient>
     
 void MockContentFilterManager::notifySettingsChanged(WebCore::MockContentFilterSettings& settings) const
 {
-    if (m_client)
-        m_client->mockContentFilterSettingsChanged(settings);
+    if (RefPtr client = m_client)
+        client->mockContentFilterSettingsChanged(settings);
 }
 
 };


### PR DESCRIPTION
#### a9dcf79fcce5719204410add04cb4f751a3640fb
<pre>
Address safer C++ static analysis warnings in ContentFilter classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=287133">https://bugs.webkit.org/show_bug.cgi?id=287133</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::deliverStoredResourceData):
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::enabled):
(WebCore::MockContentFilter::willSendRequest):
(WebCore::MockContentFilter::unblockHandler const):
(WebCore::MockContentFilter::maybeDetermineStatus):
(WebCore::settings): Deleted.
* Source/WebCore/testing/MockContentFilterManager.cpp:
(WebCore::MockContentFilterManager::notifySettingsChanged const):

Canonical link: <a href="https://commits.webkit.org/289936@main">https://commits.webkit.org/289936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/722ddb5bbdeb052188307dc76df24756e71d3215

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16172 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25953 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6178 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38331 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95269 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18790 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20751 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8683 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15660 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18850 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->