### PR TITLE
Send correct encodedDataLength on NetworkResourceLoader

### DIFF
--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -178,7 +178,7 @@ void BackgroundFetchLoad::didReceiveResponse(ResourceResponse&& response, Negoti
     m_client->didReceiveResponse(WTFMove(response));
 }
 
-void BackgroundFetchLoad::didReceiveData(const SharedBuffer& data)
+void BackgroundFetchLoad::didReceiveData(const SharedBuffer& data, uint64_t)
 {
     BGLOAD_RELEASE_LOG("didReceiveData");
     m_client->didReceiveResponseBodyChunk(data);

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -72,7 +72,7 @@ private:
     void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) final;
     void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) final;
     void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&) final;
-    void didReceiveData(const WebCore::SharedBuffer&) final;
+    void didReceiveData(const WebCore::SharedBuffer&, uint64_t encodedDataLength) final;
     void didCompleteWithError(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&) final;
     void didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend) final;
     void wasBlocked() final;

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -131,7 +131,7 @@ void NetworkCORSPreflightChecker::didReceiveResponse(WebCore::ResourceResponse&&
     completionHandler(PolicyAction::Use);
 }
 
-void NetworkCORSPreflightChecker::didReceiveData(const WebCore::SharedBuffer&)
+void NetworkCORSPreflightChecker::didReceiveData(const WebCore::SharedBuffer&, uint64_t)
 {
     CORS_CHECKER_RELEASE_LOG("didReceiveData");
 }

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h
@@ -85,7 +85,7 @@ private:
     void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) final;
     void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) final;
     void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&) final;
-    void didReceiveData(const WebCore::SharedBuffer&) final;
+    void didReceiveData(const WebCore::SharedBuffer&, uint64_t encodedDataLength) final;
     void didCompleteWithError(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&) final;
     void didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend) final;
     void wasBlocked() final;

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -67,7 +67,7 @@ public:
     virtual void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) = 0;
     virtual void didReceiveInformationalResponse(WebCore::ResourceResponse&&) { };
     virtual void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&) = 0;
-    virtual void didReceiveData(const WebCore::SharedBuffer&) = 0;
+    virtual void didReceiveData(const WebCore::SharedBuffer&, uint64_t encodedDataLength) = 0;
     virtual void didCompleteWithError(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&) = 0;
     virtual void didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend) = 0;
     virtual void wasBlocked() = 0;

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -396,7 +396,7 @@ void NetworkDataTaskBlob::consumeData(std::span<const uint8_t> data)
                 return;
         } else {
             ASSERT(m_client);
-            m_client->didReceiveData(SharedBuffer::create(data));
+            m_client->didReceiveData(SharedBuffer::create(data), 0);
         }
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -273,10 +273,9 @@ void NetworkLoad::notifyDidReceiveResponse(ResourceResponse&& response, Negotiat
     m_client.get().didReceiveResponse(WTFMove(response), privateRelayed, WTFMove(completionHandler));
 }
 
-void NetworkLoad::didReceiveData(const WebCore::SharedBuffer& buffer)
+void NetworkLoad::didReceiveData(const WebCore::SharedBuffer& buffer, uint64_t encodedDataLength)
 {
-    // FIXME: This should be the encoded data length, not the decoded data length.
-    m_client.get().didReceiveBuffer(buffer, buffer.size());
+    m_client.get().didReceiveBuffer(buffer, encodedDataLength);
 }
 
 void NetworkLoad::didCompleteWithError(const ResourceError& error, const WebCore::NetworkLoadMetrics& networkLoadMetrics)

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -105,7 +105,7 @@ private:
     void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) final;
     void didReceiveInformationalResponse(WebCore::ResourceResponse&&) final;
     void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&) final;
-    void didReceiveData(const WebCore::SharedBuffer&) final;
+    void didReceiveData(const WebCore::SharedBuffer&, uint64_t encodedDataLength) final;
     void didCompleteWithError(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&) final;
     void didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend) final;
     void wasBlocked() final;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1139,10 +1139,8 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLo
     if (isSynchronous())
         sendReplyToSynchronousRequest(*m_synchronousLoadData, m_bufferedData.get().get(), networkLoadMetrics);
     else {
-        if (!m_bufferedData.isEmpty()) {
-            // FIXME: Pass a real value or remove the encoded data size feature.
-            sendBuffer(*m_bufferedData.get(), -1);
-        }
+        if (!m_bufferedData.isEmpty())
+            sendBuffer(*m_bufferedData.get(), 0);
 #if ENABLE(CONTENT_FILTERING)
         if (m_contentFilter) {
             if (!m_contentFilter->continueAfterNotifyFinished(m_parameters.request.url()))
@@ -1726,7 +1724,7 @@ void NetworkResourceLoader::sendResultForCacheEntry(std::unique_ptr<NetworkCache
 #endif
 
     RefPtr buffer = entry->protectedBuffer();
-    sendBuffer(*buffer, buffer->size());
+    sendBuffer(*buffer, 0);
 #if ENABLE(CONTENT_FILTERING)
     if (m_contentFilter) {
         m_contentFilter->continueAfterNotifyFinished(m_parameters.request.url());

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -174,7 +174,7 @@ void PingLoad::didReceiveResponse(ResourceResponse&& response, NegotiatedLegacyT
     didFinish({ }, response);
 }
 
-void PingLoad::didReceiveData(const SharedBuffer&)
+void PingLoad::didReceiveData(const SharedBuffer&, uint64_t)
 {
     PING_RELEASE_LOG("didReceiveData");
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/NetworkProcess/PingLoad.h
+++ b/Source/WebKit/NetworkProcess/PingLoad.h
@@ -74,7 +74,7 @@ private:
     void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) final;
     void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) final;
     void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&) final;
-    void didReceiveData(const WebCore::SharedBuffer&) final;
+    void didReceiveData(const WebCore::SharedBuffer&, uint64_t encodedDataLength) final;
     void didCompleteWithError(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&) final;
     void didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend) final;
     void wasBlocked() final;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -65,7 +65,7 @@ public:
     void didNegotiateModernTLS(const URL&);
     void didCompleteWithError(const WebCore::ResourceError&, const WebCore::NetworkLoadMetrics&);
     void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&);
-    void didReceiveData(const WebCore::SharedBuffer&);
+    void didReceiveData(const WebCore::SharedBuffer&, uint64_t encodedDataLength);
 
     void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&);
     void transferSandboxExtensionToDownload(Download&);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -393,12 +393,12 @@ void NetworkDataTaskCocoa::didCompleteWithError(const WebCore::ResourceError& er
         m_client->didCompleteWithError(error, networkLoadMetrics);
 }
 
-void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
+void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data, uint64_t encodedDataLength)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "received %zd bytes", data.size());
 
     if (m_client)
-        m_client->didReceiveData(data);
+        m_client->didReceiveData(data, encodedDataLength);
 }
 
 void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS negotiatedLegacyTLS, PrivateRelayed privateRelayed, WebKit::ResponseCompletionHandler&& completionHandler)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1161,7 +1161,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
     if (auto networkDataTask = [self existingTask:dataTask])
-        networkDataTask->didReceiveData(WebCore::SharedBuffer::create(data));
+        networkDataTask->didReceiveData(WebCore::SharedBuffer::create(data), data.length);
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
@@ -2044,7 +2044,7 @@ private:
         });
     }
 
-    void didReceiveData(const WebCore::SharedBuffer& buffer)
+    void didReceiveData(const WebCore::SharedBuffer& buffer, uint64_t)
     {
         if (!m_connection)
             return;
@@ -2107,7 +2107,7 @@ void NetworkSessionCocoa::loadImageForDecoding(WebCore::ResourceRequest&& reques
         {
             completionHandler(WebCore::PolicyAction::Use);
         }
-        void didReceiveData(const WebCore::SharedBuffer& buffer) final
+        void didReceiveData(const WebCore::SharedBuffer& buffer, uint64_t) final
         {
             m_buffer.append(buffer);
             if (m_buffer.size() > m_maximumBytesFromNetwork)

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -211,7 +211,7 @@ void NetworkDataTaskCurl::curlDidReceiveData(CurlRequest&, Ref<SharedBuffer>&& b
         return;
     }
 
-    m_client->didReceiveData(buffer.get());
+    m_client->didReceiveData(buffer.get(), buffer->size());
 }
 
 void NetworkDataTaskCurl::curlDidComplete(CurlRequest&, NetworkLoadMetrics&& networkLoadMetrics)

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1048,7 +1048,7 @@ void NetworkDataTaskSoup::didRead(gssize bytesRead)
         writeDownload();
     } else {
         ASSERT(m_client);
-        m_client->didReceiveData(SharedBuffer::create(WTFMove(m_readBuffer)));
+        m_client->didReceiveData(SharedBuffer::create(WTFMove(m_readBuffer)), bytesRead);
         read();
     }
 }


### PR DESCRIPTION
#### bc3abaa9166e77458b279d4d496916d9957a4b53
<pre>
Send correct encodedDataLength on NetworkResourceLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=287135">https://bugs.webkit.org/show_bug.cgi?id=287135</a>

Reviewed by NOBODY (OOPS!).

True to its name, the parameter `encodedDataLength` of  WebResourceLoader::DidReceiveData message from
NetworkResourceLoader to WebResourceLoader should be the actual size of network transferred size, not the
decoded size.

* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
(WebKit::BackgroundFetchLoad::didReceiveData):
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h:
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
(WebKit::NetworkCORSPreflightChecker::didReceiveData):
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::consumeData):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::didReceiveData):
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::sendResultForCacheEntry):
* Source/WebKit/NetworkProcess/PingLoad.cpp:
(WebKit::PingLoad::didReceiveData):
* Source/WebKit/NetworkProcess/PingLoad.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didReceiveData):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveData:]):
(WebKit::NetworkSessionCocoa::loadImageForDecoding):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::curlDidReceiveData):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::didRead):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc3abaa9166e77458b279d4d496916d9957a4b53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39218 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68232 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25955 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6177 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95264 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15639 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11464 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77097 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76357 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20749 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19170 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20963 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15396 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->