### PR TITLE
[JSC] Handle power-of-two div / udiv in B3

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -938,7 +938,8 @@ private:
                 break;
 
             if (m_value->child(1)->hasInt()) {
-                switch (m_value->child(1)->asInt()) {
+                int64_t divisor64 = m_value->child(1)->asInt();
+                switch (divisor64) {
                 case -1:
                     // Turn this: Div(value, -1)
                     // Into this: Neg(value)
@@ -960,6 +961,16 @@ private:
                     break;
 
                 default:
+                    // Turn this: Div(value, constant)
+                    // Into this: Shr(value, log2(constant))
+                    if (divisor64 > 0 && hasOneBitSet(divisor64)) {
+                        unsigned shiftAmount = WTF::fastLog2(static_cast<uint64_t>(divisor64));
+                        replaceWithNew<Value>(
+                            SShr, m_value->origin(), m_value->child(0),
+                            m_insertionSet.insert<Const32Value>(m_index, m_value->origin(), shiftAmount));
+                        break;
+                    }
+
                     // Perform super comprehensive strength reduction of division. Currently we
                     // only do this for 32-bit divisions, since we need a high multiply
                     // operation. We emulate it using 64-bit multiply. We can't emulate 64-bit
@@ -972,7 +983,7 @@ private:
                     if (m_proc.optLevel() < 2)
                         break;
 
-                    int32_t divisor = m_value->child(1)->asInt32();
+                    int32_t divisor = static_cast<int32_t>(divisor64);
                     DivisionMagic<int32_t> magic = computeDivisionMagic(divisor);
 
                     // Perform the "high" multiplication. We do it just to get the high bits.
@@ -1025,7 +1036,8 @@ private:
                 break;
 
             if (m_value->child(1)->hasInt()) {
-                switch (m_value->child(1)->asInt()) {
+                uint64_t divisor64 = static_cast<uint64_t>(m_value->child(1)->asInt());
+                switch (divisor64) {
                 case 0:
                     // Turn this: UDiv(value, 0)
                     // Into this: 0
@@ -1040,6 +1052,19 @@ private:
                     replaceWithIdentity(m_value->child(0));
                     break;
                 default:
+                    // Turn this: UDiv(value, constant)
+                    // Into this: ZShr(value, log2(constant))
+                    if (m_value->type() == Int32)
+                        divisor64 = static_cast<uint32_t>(divisor64);
+
+                    if (hasOneBitSet(divisor64)) {
+                        unsigned shiftAmount = WTF::fastLog2(divisor64);
+                        replaceWithNew<Value>(
+                            ZShr, m_value->origin(), m_value->child(0),
+                            m_insertionSet.insert<Const32Value>(m_index, m_value->origin(), shiftAmount));
+                        break;
+                    }
+
                     // FIXME: We should do comprehensive strength reduction for unsigned numbers. Likely,
                     // we will just want copy what llvm does. https://bugs.webkit.org/show_bug.cgi?id=164809
                     break;


### PR DESCRIPTION
#### 629080edf9e278a791b39bac7083de25dbcd82e2
<pre>
[JSC] Handle power-of-two div / udiv in B3
<a href="https://bugs.webkit.org/show_bug.cgi?id=287140">https://bugs.webkit.org/show_bug.cgi?id=287140</a>
<a href="https://rdar.apple.com/144296154">rdar://144296154</a>

Reviewed by NOBODY (OOPS!).

Add simple x / 2 etc. handling in B3.

* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/629080edf9e278a791b39bac7083de25dbcd82e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68213 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38306 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81243 "Found 8 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/integer-division-neg2tothe32-by-neg1.js.layout-ftl-eager-no-cjit, microbenchmarks/integer-modulo.js.ftl-eager, microbenchmarks/integer-modulo.js.ftl-eager-no-cjit, microbenchmarks/integer-modulo.js.ftl-no-cjit-no-inline-validate, microbenchmarks/integer-modulo.js.ftl-no-cjit-no-put-stack-validate, microbenchmarks/integer-modulo.js.ftl-no-cjit-small-pool, microbenchmarks/integer-modulo.js.ftl-no-cjit-validate-sampling-profiler, stress/op_mod-VarConst.js.misc-ftl-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95244 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87220 "Found 10 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/integer-division-neg2tothe32-by-neg1.js.layout-ftl-eager-no-cjit, microbenchmarks/integer-modulo.js.bytecode-cache, microbenchmarks/integer-modulo.js.default, microbenchmarks/integer-modulo.js.ftl-eager, microbenchmarks/integer-modulo.js.ftl-eager-no-cjit, microbenchmarks/integer-modulo.js.ftl-no-cjit-no-inline-validate, microbenchmarks/integer-modulo.js.ftl-no-cjit-no-put-stack-validate, microbenchmarks/integer-modulo.js.ftl-no-cjit-small-pool, microbenchmarks/integer-modulo.js.ftl-no-cjit-validate-sampling-profiler, stress/op_mod-VarConst.js.misc-ftl-no-cjit (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15619 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11440 "Found 1 new test failure: media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77078 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76336 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8657 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20941 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109713 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15376 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26382 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->