### PR TITLE
Re-import command/command-for WPTs

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2951,6 +2951,7 @@ http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-css-i
 imported/w3c/web-platform-tests/css/css-text/text-spacing-trim [ Skip ]
 
 # command/commandfor future: These tests cover additions to the command invokers API which aren't specced yet
+imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-behavior.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-invalid-behavior.tentative.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative-expected.txt
@@ -1,6 +1,7 @@
 
 
-PASS event dispatches on click
+PASS event dispatches on click with addEventListener
+FAIL event dispatches on click with oncommand property assert_true: event is CommandEvent expected true got false
 PASS setting custom command property to --foo (must include dash) sets event command
 PASS setting custom command attribute to --foo (must include dash) sets event command
 PASS setting custom command property to --foo- (must include dash) sets event command

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html
@@ -38,7 +38,24 @@
     assert_equals(event.command, "--custom-command", "command");
     assert_equals(event.target, invokee, "target");
     assert_equals(event.source, invokerbutton, "source");
-  }, "event dispatches on click");
+  }, "event dispatches on click with addEventListener");
+
+  promise_test(async function (t) {
+    let event = null;
+    t.add_cleanup(() => {
+        invokee.oncommand = null;
+    });
+    invokee.oncommand = (e) => (event = e);
+    await clickOn(invokerbutton);
+    assert_true(event instanceof CommandEvent, "event is CommandEvent");
+    assert_equals(event.type, "command", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, true, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.command, "--custom-command", "command");
+    assert_equals(event.target, invokee, "target");
+    assert_equals(event.source, invokerbutton, "source");
+  }, "event dispatches on click with oncommand property");
 
   // valid custom invokeactions
   ["--foo", "--foo-", "--cAsE-cArRiEs", "--", "--a-", "--a-b", "---", "--show-picker"].forEach(

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8" />
 <meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<meta name="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" />
 <meta name="timeout" content="long">
 <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
 <script src="/resources/testharness.js"></script>
@@ -9,9 +10,10 @@
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="resources/invoker-utils.js"></script>
+<!-- Merge the following tests into the main test file when the feature is stable -->
 
 <dialog id="invokee">
-  <button id="containedinvoker" commandfor="invokee" command="close"></button>
+  <button id="containedinvoker" commandfor="invokee" command="request-close"></button>
 </dialog>
 <button id="invokerbutton" commandfor="invokee" command="show-modal"></button>
 
@@ -22,82 +24,13 @@
     invokee.removeAttribute("popover");
     invokee.returnValue = '';
     invokerbutton.setAttribute("command", "show-modal");
-    containedinvoker.setAttribute("command", "close");
+    containedinvoker.setAttribute("command", "request-close");
     containedinvoker.removeAttribute("value");
   }
 
-  // opening a dialog
+  // request to close an already open dialog
 
-  ["show-modal", /* test case sensitivity */ "sHoW-mOdAl"].forEach(
-    (command) => {
-      ["property", "attribute"].forEach((setType) => {
-        promise_test(
-          async function (t) {
-            t.add_cleanup(resetState);
-            assert_false(invokee.open, "invokee.open");
-            assert_false(invokee.matches(":modal"), "invokee :modal");
-            if (setType === "property") {
-              invokerbutton.command = command;
-            } else {
-              invokerbutton.setAttribute("command", command);
-            }
-            await clickOn(invokerbutton);
-            assert_true(invokee.open, "invokee.open");
-            assert_true(invokee.matches(":modal"), "invokee :modal");
-          },
-          `invoking (with command ${setType} as ${command}) closed dialog opens as modal`,
-        );
-
-        promise_test(
-          async function (t) {
-            t.add_cleanup(resetState);
-            assert_false(invokee.open, "invokee.open");
-            assert_false(invokee.matches(":modal"), "invokee :modal");
-            invokee.addEventListener("command", (e) => e.preventDefault(), {
-              once: true,
-            });
-            if (setType === "property") {
-              invokerbutton.command = command;
-            } else {
-              invokerbutton.setAttribute("command", command);
-            }
-            await clickOn(invokerbutton);
-            assert_false(invokee.open, "invokee.open");
-            assert_false(invokee.matches(":modal"), "invokee :modal");
-          },
-          `invoking (with command ${setType} as ${command}) closed dialog with preventDefault is noop`,
-        );
-
-        promise_test(
-          async function (t) {
-            t.add_cleanup(resetState);
-            assert_false(invokee.open, "invokee.open");
-            assert_false(invokee.matches(":modal"), "invokee :modal");
-            invokee.addEventListener(
-              "command",
-              (e) => {
-                invokerbutton.setAttribute("command", "close");
-              },
-              { once: true },
-            );
-            if (setType === "property") {
-              invokerbutton.command = command;
-            } else {
-              invokerbutton.setAttribute("command", command);
-            }
-            await clickOn(invokerbutton);
-            assert_true(invokee.open, "invokee.open");
-            assert_true(invokee.matches(":modal"), "invokee :modal");
-          },
-          `invoking (with command ${setType} as ${command}) while changing command still opens as modal`,
-        );
-      });
-    },
-  );
-
-  // closing an already open dialog
-
-  ["close", /* test case sensitivity */ "cLoSe"].forEach((command) => {
+  ["request-close", /* test case sensitivity */ "reQuEst-Close"].forEach((command) => {
     ["property", "attribute"].forEach((setType) => {
       promise_test(
         async function (t) {
@@ -115,7 +48,7 @@
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with command ${setType} as ${command}) open dialog closes`,
+        `invoking to request-close (with command ${setType} as ${command}) open dialog closes`,
       );
 
       promise_test(
@@ -135,7 +68,7 @@
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with command ${setType} as ${command}) open dialog closes and sets returnValue`,
+        `invoking to request-close with value (with command ${setType} as ${command}) open dialog closes and sets returnValue`,
       );
 
       promise_test(
@@ -158,7 +91,7 @@
           assert_true(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with command ${setType} as ${command}) open dialog with preventDefault is no-op`,
+        `invoking to request-close (with command ${setType} as ${command}) open dialog with preventDefault is no-op`,
       );
 
       promise_test(
@@ -179,7 +112,7 @@
           assert_true(invokee.open, "invokee.open");
           assert_true(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with command ${setType} as ${command}) open modal dialog with preventDefault is no-op`,
+        `invoking to request-close (with command ${setType} as ${command}) open modal dialog with preventDefault is no-op`,
       );
 
       promise_test(
@@ -204,7 +137,7 @@
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with command ${setType} as ${command}) open dialog while changing command still closes`,
+        `invoking to request-close (with command ${setType} as ${command}) open dialog while changing command still closes`,
       );
 
       promise_test(
@@ -229,67 +162,25 @@
           assert_false(invokee.open, "invokee.open");
           assert_false(invokee.matches(":modal"), "invokee :modal");
         },
-        `invoking to close (with command ${setType} as ${command}) open modal dialog while changing command still closes`,
+        `invoking to request-close (with command ${setType} as ${command}) open modal dialog while changing command still closes`,
       );
     });
   });
 
-  // show-modal explicit behaviours
+  // request-close explicit behaviours
 
   promise_test(async function (t) {
     t.add_cleanup(resetState);
-    containedinvoker.setAttribute("command", "show-Modal");
-    invokee.show();
-    assert_true(invokee.open, "invokee.open");
-    assert_false(invokee.matches(":modal"), "invokee :modal");
-    await clickOn(containedinvoker);
-    assert_true(invokee.open, "invokee.open");
-    assert_false(invokee.matches(":modal"), "invokee :modal");
-  }, "invoking (as show-modal) open dialog is noop");
-
-  promise_test(async function (t) {
-    t.add_cleanup(resetState);
-    containedinvoker.setAttribute("command", "show-modal");
-    invokee.showModal();
-    assert_true(invokee.open, "invokee.open");
-    assert_true(invokee.matches(":modal"), "invokee :modal");
-    invokee.addEventListener(
-      "command",
-      (e) => {
-        containedinvoker.setAttribute("command", "close");
-      },
-      { once: true },
-    );
-    await clickOn(invokerbutton);
-    assert_true(invokee.open, "invokee.open");
-    assert_true(invokee.matches(":modal"), "invokee :modal");
-  }, "invoking (as show-modal) open modal, while changing command still a no-op");
-
-  promise_test(async function (t) {
-    t.add_cleanup(resetState);
-    invokerbutton.setAttribute("command", "show-modal");
-    assert_false(invokee.open, "invokee.open");
-    assert_false(invokee.matches(":modal"), "invokee :modal");
-    invokee.setAttribute("popover", "auto");
-    await clickOn(invokerbutton);
-    assert_true(invokee.open, "invokee.open");
-    assert_true(invokee.matches(":modal"), "invokee :modal");
-  }, "invoking (as show-modal) closed popover dialog opens as modal");
-
-  // close explicit behaviours
-
-  promise_test(async function (t) {
-    t.add_cleanup(resetState);
-    invokerbutton.setAttribute("command", "close");
+    invokerbutton.setAttribute("command", "request-close");
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
     await clickOn(containedinvoker);
     assert_false(invokee.open, "invokee.open");
     assert_false(invokee.matches(":modal"), "invokee :modal");
-  }, "invoking (as close) already closed dialog is noop");
+  }, "invoking (as request-close) already closed dialog is noop");
 
   // Open Popovers using Dialog actions
-  ["show-modal", "close"].forEach((command) => {
+  ["request-close"].forEach((command) => {
     ["manual", "auto"].forEach((popoverState) => {
       promise_test(
         async function (t) {
@@ -320,7 +211,7 @@
   });
 
   // Elements being disconnected during invoke steps
-  ["show-modal", "close"].forEach((command) => {
+  ["request-close"].forEach((command) => {
     promise_test(
       async function (t) {
         t.add_cleanup(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative-expected.txt
@@ -13,21 +13,25 @@ PASS invoking (with command attribute as sHoW-mOdAl) closed dialog opens as moda
 PASS invoking (with command attribute as sHoW-mOdAl) closed dialog with preventDefault is noop
 PASS invoking (with command attribute as sHoW-mOdAl) while changing command still opens as modal
 PASS invoking to close (with command property as close) open dialog closes
+FAIL invoking to close (with command property as close) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
 PASS invoking to close (with command property as close) open dialog with preventDefault is no-op
 PASS invoking to close (with command property as close) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command property as close) open dialog while changing command still closes
 PASS invoking to close (with command property as close) open modal dialog while changing command still closes
 PASS invoking to close (with command attribute as close) open dialog closes
+FAIL invoking to close (with command attribute as close) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
 PASS invoking to close (with command attribute as close) open dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as close) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as close) open dialog while changing command still closes
 PASS invoking to close (with command attribute as close) open modal dialog while changing command still closes
 PASS invoking to close (with command property as cLoSe) open dialog closes
+FAIL invoking to close (with command property as cLoSe) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
 PASS invoking to close (with command property as cLoSe) open dialog with preventDefault is no-op
 PASS invoking to close (with command property as cLoSe) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command property as cLoSe) open dialog while changing command still closes
 PASS invoking to close (with command property as cLoSe) open modal dialog while changing command still closes
 PASS invoking to close (with command attribute as cLoSe) open dialog closes
+FAIL invoking to close (with command attribute as cLoSe) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
 PASS invoking to close (with command attribute as cLoSe) open dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as cLoSe) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as cLoSe) open dialog while changing command still closes

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
@@ -25,6 +25,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-invalid-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-details-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-details-invalid-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-input-number.tentative.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -4205,6 +4205,9 @@
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-details-invalid-behavior.tentative.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 46df61a59e02437af6481d4e2d8082403e8ec4db
<pre>
Re-import command/command-for WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=287146">https://bugs.webkit.org/show_bug.cgi?id=287146</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/952bb9eb3645f9aecf17a0d988e1447680602a36">https://github.com/web-platform-tests/wpt/commit/952bb9eb3645f9aecf17a0d988e1447680602a36</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative.html.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/289943@main">https://commits.webkit.org/289943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e16a49f8c8d9edc60cd44e67d35c4adbbf9572a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39209 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68224 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6168 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38317 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95255 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77090 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15886 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76349 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20738 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15646 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->