### PR TITLE
[GStreamer] Avoid intermediate copies in GStreamerWebRTCUtils.cpp

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -428,13 +428,12 @@ static String x509Serialize(X509* x509)
     if (!PEM_write_bio_X509(bio.get(), x509))
         return { };
 
-    Vector<char> buffer;
-    buffer.reserveCapacity(4096);
-    int length = BIO_read(bio.get(), buffer.data(), 4096);
-    if (!length)
+    uint8_t* data { nullptr };
+    auto length = BIO_get_mem_data(bio.get(), &data);
+    if (length <= 0)
         return { };
 
-    return buffer.subspan(0, length);
+    return String::fromUTF8(unsafeMakeSpan(data, length));
 }
 
 static String privateKeySerialize(EVP_PKEY* privateKey)
@@ -446,13 +445,12 @@ static String privateKeySerialize(EVP_PKEY* privateKey)
     if (!PEM_write_bio_PrivateKey(bio.get(), privateKey, nullptr, nullptr, 0, nullptr, nullptr))
         return { };
 
-    Vector<char> buffer;
-    buffer.reserveCapacity(4096);
-    int length = BIO_read(bio.get(), buffer.data(), 4096);
-    if (!length)
+    uint8_t* data { nullptr };
+    auto length = BIO_get_mem_data(bio.get(), &data);
+    if (length <= 0)
         return { };
 
-    return buffer.subspan(0, length);
+    return String::fromUTF8(unsafeMakeSpan(data, length));
 }
 
 std::optional<Ref<RTCCertificate>> generateCertificate(Ref<SecurityOrigin>&& origin, const PeerConnectionBackend::CertificateInformation& info)


### PR DESCRIPTION
#### bc904f61e31309be4ea955201359de30f3df5370
<pre>
[GStreamer] Avoid intermediate copies in GStreamerWebRTCUtils.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287149">https://bugs.webkit.org/show_bug.cgi?id=287149</a>

Reviewed by Philippe Normand.

Use BIO_get_mem_data() to gain access to the underlying buffer of a BIO
created with BIO_s_mem() directly, instead of doing an additional copy
through a Vector&lt;char&gt; used as intermediary buffer with BIO_read().

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::x509Serialize):
(WebCore::privateKeySerialize):

Canonical link: <a href="https://commits.webkit.org/289953@main">https://commits.webkit.org/289953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae0fde749fb629cbde3fadd8ce668a31cefafa82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68225 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48591 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34422 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38318 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95256 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77092 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8669 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13838 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15647 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20953 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->