### PR TITLE
Fix multi-column layout in sideways-lr writing mode

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5454,7 +5454,6 @@ imported/w3c/web-platform-tests/css/css-multicol/spanner-in-opacity.html [ Image
 imported/w3c/web-platform-tests/css/css-multicol/subpixel-column-rule-width.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/table/table-cell-multicol-nested-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-multicol/column-pseudo-background-color.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-multicol/multicol-span-all-rule-002.html [ ImageOnlyFailure ]
 
 # Crashes
 webkit.org/b/279421 [ Debug ] imported/w3c/web-platform-tests/css/css-multicol/crashtests/inline-float-parallel-flow.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/getclientrects-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/getclientrects-001-expected.txt
@@ -12,11 +12,11 @@
 PASS horizontal-tb ltr
 PASS vertical-lr ltr
 PASS vertical-rl ltr
-FAIL sideways-lr ltr assert_equals: expected 260 but got 60
+PASS sideways-lr ltr
 PASS sideways-rl ltr
 PASS horizontal-tb rtl
 PASS vertical-lr rtl
 PASS vertical-rl rtl
-FAIL sideways-lr rtl assert_equals: expected 50 but got 250
+PASS sideways-lr rtl
 PASS sideways-rl rtl
 

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -477,7 +477,7 @@ LayoutUnit RenderMultiColumnSet::columnLogicalLeft(unsigned index) const
     bool progressionInline = multiColumnFlow()->progressionIsInline();
 
     if (progressionInline) {
-        if (writingMode().isBidiLTR() ^ progressionReversed)
+        if (writingMode().isLogicalLeftInlineStart() ^ progressionReversed)
             colLogicalLeft += index * (colLogicalWidth + colGap);
         else
             colLogicalLeft += contentBoxLogicalWidth() - colLogicalWidth - index * (colLogicalWidth + colGap);
@@ -596,8 +596,8 @@ LayoutRect RenderMultiColumnSet::fragmentedFlowPortionOverflowRect(const LayoutR
 
     bool isFirstColumn = !index;
     bool isLastColumn = index == colCount - 1;
-    bool isLeftmostColumn = writingMode().isBidiLTR() ^ progressionReversed ? isFirstColumn : isLastColumn;
-    bool isRightmostColumn = writingMode().isBidiLTR() ^ progressionReversed ? isLastColumn : isFirstColumn;
+    bool isLeftmostColumn = writingMode().isLogicalLeftInlineStart() ^ progressionReversed ? isFirstColumn : isLastColumn;
+    bool isRightmostColumn = writingMode().isLogicalLeftInlineStart() ^ progressionReversed ? isLastColumn : isFirstColumn;
 
     // Calculate the overflow rectangle, based on the flow thread's, clipped at column logical
     // top/bottom unless it's the first/last column.
@@ -643,18 +643,18 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
     bool antialias = BorderPainter::shouldAntialiasLines(paintInfo.context());
 
     if (fragmentedFlow->progressionIsInline()) {
-        bool leftToRight = writingMode().isBidiLTR() ^ fragmentedFlow->progressionIsReversed();
-        LayoutUnit currLogicalLeftOffset = leftToRight ? 0_lu : contentBoxLogicalWidth();
+        bool isLogicalLeftInlineStart = writingMode().isLogicalLeftInlineStart() ^ fragmentedFlow->progressionIsReversed();
+        LayoutUnit currLogicalLeftOffset = isLogicalLeftInlineStart ? 0_lu : contentBoxLogicalWidth();
         LayoutUnit ruleAdd = logicalLeftOffsetForContent();
-        LayoutUnit ruleLogicalLeft = leftToRight ? 0_lu : contentBoxLogicalWidth();
+        LayoutUnit ruleLogicalLeft = isLogicalLeftInlineStart ? 0_lu : contentBoxLogicalWidth();
         LayoutUnit inlineDirectionSize = computedColumnWidth();
         BoxSide boxSide = isHorizontalWritingMode()
-            ? leftToRight ? BoxSide::Left : BoxSide::Right
-            : leftToRight ? BoxSide::Top : BoxSide::Bottom;
+            ? isLogicalLeftInlineStart ? BoxSide::Left : BoxSide::Right
+            : isLogicalLeftInlineStart ? BoxSide::Top : BoxSide::Bottom;
 
         for (unsigned i = 0; i < colCount; i++) {
             // Move to the next position.
-            if (leftToRight) {
+            if (isLogicalLeftInlineStart) {
                 ruleLogicalLeft += inlineDirectionSize + colGap / 2;
                 currLogicalLeftOffset += inlineDirectionSize + colGap;
             } else {
@@ -865,8 +865,8 @@ void RenderMultiColumnSet::collectLayerFragments(LayerFragments& fragments, cons
         LayoutSize translationOffset;
         LayoutUnit inlineOffset = progressionIsInline ? i * (colLogicalWidth + colGap) : 0_lu;
         
-        bool leftToRight = writingMode().isBidiLTR() ^ progressionReversed;
-        if (!leftToRight) {
+        bool isLogicalLeftInlineStart = writingMode().isLogicalLeftInlineStart() ^ progressionReversed;
+        if (!isLogicalLeftInlineStart) {
             inlineOffset = -inlineOffset;
             if (progressionReversed)
                 inlineOffset += contentBoxLogicalWidth() - colLogicalWidth;


### PR DESCRIPTION
#### 5c5eacfa2fae910834716d98bacecf16c8178def
<pre>
Fix multi-column layout in sideways-lr writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=287143">https://bugs.webkit.org/show_bug.cgi?id=287143</a>
<a href="https://rdar.apple.com/144307524">rdar://144307524</a>

Reviewed by Alan Baradlay.

We were previously only drawing one column in sideways-lr writing mode.

Update `isBidiLTR()` checks to instead use `isLogicalLeftInlineStart()` since the text direction isn&apos;t
what matters in this context.

Rebaseline WPTs added by Chromium: <a href="https://github.com/chromium/chromium/commit/81c84c0838e3b3d868d38fc202c06a6c0fc8d5ab">https://github.com/chromium/chromium/commit/81c84c0838e3b3d868d38fc202c06a6c0fc8d5ab</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/getclientrects-001-expected.txt:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::columnLogicalLeft const):
(WebCore::RenderMultiColumnSet::fragmentedFlowPortionOverflowRect const):
(WebCore::RenderMultiColumnSet::paintColumnRules):
(WebCore::RenderMultiColumnSet::collectLayerFragments):

Canonical link: <a href="https://commits.webkit.org/289947@main">https://commits.webkit.org/289947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36d517a83be1967c0a99f78313edd38b8686a816

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68242 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25959 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48608 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95276 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15651 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77105 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76366 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8690 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/13835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15667 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/20975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->