### PR TITLE
Trusted Types default callback allows Attr node in multiple Elements at once

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback-expected.txt
@@ -7,4 +7,6 @@ PASS Ensure the deleted attributes is modified (setAttributeNS).
 PASS Ensure toggleAttribute results in an empty attribute.
 PASS Ensure setAttribute results in right attribute value.
 PASS Ensure setAttributeNS results in right attribute value.
+PASS Ensure setAttributeNode throws InUseAttributeError when callback assigns attributes.
+PASS Ensure setAttributeNodeNS throws InUseAttributeError when callback assigns attributes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html
@@ -13,6 +13,11 @@
   // The test should hold true for any browser that supports Trusted Types.
 
   let iframeAttributeRemovedInCallback = null;
+
+  let attr = document.createAttribute('onclick');
+  attr.value = 'setAttributeNode';
+  let createScriptCalledForOnClickAttrNode = false;
+
   trustedTypes.createPolicy("default", {
     createHTML: (s, _, sink) => {
       if (iframeAttributeRemovedInCallback) {
@@ -26,7 +31,17 @@
         return s;
       }
 
-      div.setAttribute('onmouseover', 'accepted');
+      if (createScriptCalledForOnClickAttrNode && s === 'setAttributeNode') {
+          return s;
+      }
+
+      if (s === 'setAttributeNode') {
+        createScriptCalledForOnClickAttrNode = true;
+        document.documentElement.setAttributeNode(attr);
+      } else {
+        div.setAttribute('onmouseover', 'accepted');
+      }
+
       return s;
     }
   });
@@ -76,7 +91,18 @@
   }, "Ensure the deleted attributes is modified (setAttributeNS).");
 
   function cleanUpDivTest() {
-    div.removeAttribute('onmouseover');
+      div.removeAttribute('onmouseover');
+      try {
+          div.removeAttributeNode(attr);
+      } catch (e) {
+
+      }
+      try {
+          document.documentElement.removeAttributeNode(attr);
+      } catch (e) {
+
+      }
+      createScriptCalledForOnClickAttrNode = false;
   }
   const expectedAttributeCount = 2; // id and onmouseover.
 
@@ -100,5 +126,29 @@
     assert_equals(div.attributes.length, expectedAttributeCount);
     assert_equals(div.attributes.onmouseover.value, 'foo');
   }, "Ensure setAttributeNS results in right attribute value.");
+
+  test(t => {
+    t.add_cleanup(cleanUpDivTest);
+    let exception = null;
+    try {
+        div.setAttributeNode(attr);
+    } catch (e) {
+        exception = e;
+    }
+    assert_true(exception instanceof DOMException, `DOMException exception reported`);
+    assert_equals(exception?.name, 'InUseAttributeError', `DOMException name is InUseAttributeError`);
+  }, "Ensure setAttributeNode throws InUseAttributeError when callback assigns attributes.");
+
+  test(t => {
+    t.add_cleanup(cleanUpDivTest);
+    let exception = null;
+    try {
+        div.setAttributeNodeNS(attr);
+    } catch (e) {
+        exception = e;
+    }
+    assert_true(exception instanceof DOMException, `DOMException exception reported`);
+    assert_equals(exception?.name, 'InUseAttributeError', `DOMException name is InUseAttributeError`);
+  }, "Ensure setAttributeNodeNS throws InUseAttributeError when callback assigns attributes.");
 
 </script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3639,6 +3639,9 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
         if (attributeNodeValue.hasException())
             return attributeNodeValue.releaseException();
         attrNodeValue = AtomString(attributeNodeValue.releaseReturnValue());
+
+        if (!attributeTypeAndSink.attributeType.isNull() && attrNode.ownerElement() && attrNode.ownerElement() != this)
+            return Exception { ExceptionCode::InUseAttributeError };
     }
 
     auto existingAttributeIndex = elementData.findAttributeIndexByName(attrNode.qualifiedName());
@@ -3689,6 +3692,9 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNodeNS(Attr& attrNode)
         if (attributeNodeValue.hasException())
             return attributeNodeValue.releaseException();
         attrNodeValue = AtomString(attributeNodeValue.releaseReturnValue());
+
+        if (!attributeTypeAndSink.attributeType.isNull() && attrNode.ownerElement() && attrNode.ownerElement() != this)
+            return Exception { ExceptionCode::InUseAttributeError };
     }
 
     {


### PR DESCRIPTION
#### 4dad722e68b54ae7d38cd91dac521310e18417a8
<pre>
Trusted Types default callback allows Attr node in multiple Elements at once
<a href="https://bugs.webkit.org/show_bug.cgi?id=287158">https://bugs.webkit.org/show_bug.cgi?id=287158</a>

Reviewed by Anne van Kesteren.

This patch addresses this issue by re-validating that the Attr node
isn&apos;t on an element, or is on the correct element, after default callback is called.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/modify-attributes-in-callback.html:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setAttributeNode):
(WebCore::Element::setAttributeNodeNS):

Canonical link: <a href="https://commits.webkit.org/290543@main">https://commits.webkit.org/290543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b0b2f43f4e925a2236bede6a474f50b56bbb2ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41141 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69564 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27142 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93366 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36345 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40272 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97207 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17553 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78561 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77781 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22227 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10819 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17563 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22895 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->