### PR TITLE
AX: rename existing Mac accessibility constants to be consistent

### DIFF
--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -146,7 +146,7 @@ void attributedStringSetNeedsSpellCheck(NSMutableAttributedString *string, const
         return;
 
     // Inform the AT that we want it to spell-check for us by setting AXDidSpellCheck to @NO.
-    attributedStringSetNumber(string, AXDidSpellCheckAttribute, @NO, NSMakeRange(0, string.length));
+    attributedStringSetNumber(string, NSAccessibilityDidSpellCheckAttribute, @NO, NSMakeRange(0, string.length));
 }
 
 void attributedStringSetElement(NSMutableAttributedString *string, NSString *attribute, const AXCoreObject& object, const NSRange& range)

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -329,14 +329,14 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
     auto resultRange = NSMakeRange(0, result.length);
     // The AttributedString is cached with spelling info. If the caller does not request spelling info, we have to remove it before returning.
     if (spellCheck == SpellCheck::No) {
-        [result removeAttribute:AXDidSpellCheckAttribute range:resultRange];
+        [result removeAttribute:NSAccessibilityDidSpellCheckAttribute range:resultRange];
         [result removeAttribute:NSAccessibilityMisspelledTextAttribute range:resultRange];
         [result removeAttribute:NSAccessibilityMarkedMisspelledTextAttribute range:resultRange];
     } else if (AXObjectCache::shouldSpellCheck()) {
         // For ITM, we should only ever eagerly spellcheck for testing purposes.
         ASSERT(_AXGetClientForCurrentRequestUntrusted() == kAXClientTypeWebKitTesting);
         // We're going to spellcheck, so remove AXDidSpellCheck: NO.
-        [result removeAttribute:AXDidSpellCheckAttribute range:resultRange];
+        [result removeAttribute:NSAccessibilityDidSpellCheckAttribute range:resultRange];
         performFunctionOnMainThreadAndWait([result = retainPtr(result), &resultRange] (AccessibilityObject* axObject) {
             if (auto* node = axObject->node())
                 attributedStringSetSpelling(result.get(), *node, String { [result string] }, resultRange);

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -332,19 +332,19 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         macNotification = (id)kAXMenuOpenedNotification;
         break;
     case AXNotification::DraggingStarted:
-        macNotification = (id)kAXDraggingSourceDragBeganNotification;
+        macNotification = (id)NSAccessibilityDraggingSourceDragBeganNotification;
         break;
     case AXNotification::DraggingEnded:
-        macNotification = (id)kAXDraggingSourceDragEndedNotification;
+        macNotification = (id)NSAccessibilityDraggingSourceDragEndedNotification;
         break;
     case AXNotification::DraggingEnteredDropZone:
-        macNotification = (id)kAXDraggingDestinationDropAllowedNotification;
+        macNotification = (id)NSAccessibilityDraggingDestinationDropAllowedNotification;
         break;
     case AXNotification::DraggingDropped:
-        macNotification = (id)kAXDraggingDestinationDragAcceptedNotification;
+        macNotification = (id)NSAccessibilityDraggingDestinationDragAcceptedNotification;
         break;
     case AXNotification::DraggingExitedDropZone:
-        macNotification = (id)kAXDraggingDestinationDragNotAcceptedNotification;
+        macNotification = (id)NSAccessibilityDraggingDestinationDragNotAcceptedNotification;
         break;
     case AXNotification::TextCompositionBegan:
         macNotification = NSAccessibilityTextInputMarkingSessionBeganNotification;
@@ -492,7 +492,7 @@ void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject*
     }
     if (!selection.isNone()) {
         if (auto textMarkerRange = textMarkerRangeFromVisiblePositions(this, selection.visibleStart(), selection.visibleEnd()))
-            [userInfo setObject:(id)textMarkerRange forKey:AXSelectedTextMarkerRangeAttribute];
+            [userInfo setObject:(id)textMarkerRange forKey:NSAccessibilitySelectedTextMarkerRangeAttribute];
     }
 
     if (id wrapper = object->wrapper()) {

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -32,11 +32,6 @@
 // Attributes
 //
 
-#define AXEndTextMarkerAttribute @"AXEndTextMarker"
-#define AXHasDocumentRoleAncestorAttribute @"AXHasDocumentRoleAncestor"
-#define AXHasWebApplicationAncestorAttribute @"AXHasWebApplicationAncestor"
-#define AXSelectedTextMarkerRangeAttribute @"AXSelectedTextMarkerRange"
-#define AXStartTextMarkerAttribute @"AXStartTextMarker"
 #define NSAccessibilityARIAAtomicAttribute @"AXARIAAtomic"
 #define NSAccessibilityARIAColumnCountAttribute @"AXARIAColumnCount"
 #define NSAccessibilityARIAColumnIndexAttribute @"AXARIAColumnIndex"
@@ -61,10 +56,13 @@
 #define NSAccessibilityEditableAncestorAttribute @"AXEditableAncestor"
 #define NSAccessibilityElementBusyAttribute @"AXElementBusy"
 #define NSAccessibilityEmbeddedImageDescriptionAttribute @"AXEmbeddedImageDescription"
+#define NSAccessibilityEndTextMarkerAttribute @"AXEndTextMarker"
 #define NSAccessibilityExpandedTextValueAttribute @"AXExpandedTextValue"
 #define NSAccessibilityFocusableAncestorAttribute @"AXFocusableAncestor"
 #define NSAccessibilityGrabbedAttribute @"AXGrabbed"
+#define NSAccessibilityHasDocumentRoleAncestorAttribute @"AXHasDocumentRoleAncestor"
 #define NSAccessibilityHasPopupAttribute @"AXHasPopup"
+#define NSAccessibilityHasWebApplicationAncestorAttribute @"AXHasWebApplicationAncestor"
 #define NSAccessibilityHighestEditableAncestorAttribute @"AXHighestEditableAncestor"
 #define NSAccessibilityImageOverlayElementsAttribute @"AXImageOverlayElements"
 #define NSAccessibilityInlineTextAttribute @"AXInlineText"
@@ -80,7 +78,8 @@
 #define NSAccessibilityPrimaryScreenHeightAttribute @"_AXPrimaryScreenHeight"
 #define NSAccessibilityRelativeFrameAttribute @"AXRelativeFrame"
 #define NSAccessibilitySelectedCellsAttribute @"AXSelectedCells"
-#define NSAccessibilityTextCompletionAttribute @"AXTextCompletion"
+#define NSAccessibilitySelectedTextMarkerRangeAttribute @"AXSelectedTextMarkerRange"
+#define NSAccessibilityStartTextMarkerAttribute @"AXStartTextMarker"
 #define NSAccessibilityTextInputMarkedRangeAttribute @"AXTextInputMarkedRange"
 #define NSAccessibilityTextInputMarkedTextMarkerRangeAttribute @"AXTextInputMarkedTextMarkerRange"
 #define NSAccessibilityValueAutofillAvailableAttribute @"AXValueAutofillAvailable"
@@ -90,45 +89,44 @@
 // Parameterized Attributes
 //
 
-#define AXAttributedStringForTextMarkerRangeAttribute @"AXAttributedStringForTextMarkerRange"
-#define AXAttributedStringForTextMarkerRangeWithOptionsAttribute @"AXAttributedStringForTextMarkerRangeWithOptions"
-#define AXBoundsForTextMarkerRangeAttribute @"AXBoundsForTextMarkerRange"
-#define AXEndTextMarkerForBoundsAttribute @"AXEndTextMarkerForBounds"
-#define AXIndexForTextMarkerAttribute @"AXIndexForTextMarker"
-#define AXLeftLineTextMarkerRangeForTextMarkerAttribute @"AXLeftLineTextMarkerRangeForTextMarker"
-#define AXLeftWordTextMarkerRangeForTextMarkerAttribute @"AXLeftWordTextMarkerRangeForTextMarker"
-#define AXLengthForTextMarkerRangeAttribute @"AXLengthForTextMarkerRange"
-#define AXLineForTextMarkerAttribute @"AXLineForTextMarker"
-#define AXLineTextMarkerRangeForTextMarkerAttribute @"AXLineTextMarkerRangeForTextMarker"
-#define AXMisspellingTextMarkerRangeAttribute @"AXMisspellingTextMarkerRange"
-#define AXNextLineEndTextMarkerForTextMarkerAttribute @"AXNextLineEndTextMarkerForTextMarker"
-#define AXNextParagraphEndTextMarkerForTextMarkerAttribute @"AXNextParagraphEndTextMarkerForTextMarker"
-#define AXNextSentenceEndTextMarkerForTextMarkerAttribute @"AXNextSentenceEndTextMarkerForTextMarker"
-#define AXNextTextMarkerForTextMarkerAttribute @"AXNextTextMarkerForTextMarker"
-#define AXNextWordEndTextMarkerForTextMarkerAttribute @"AXNextWordEndTextMarkerForTextMarker"
-#define AXParagraphTextMarkerRangeForTextMarkerAttribute @"AXParagraphTextMarkerRangeForTextMarker"
-#define AXPreviousLineStartTextMarkerForTextMarkerAttribute @"AXPreviousLineStartTextMarkerForTextMarker"
-#define AXPreviousParagraphStartTextMarkerForTextMarkerAttribute @"AXPreviousParagraphStartTextMarkerForTextMarker"
-#define AXPreviousSentenceStartTextMarkerForTextMarkerAttribute @"AXPreviousSentenceStartTextMarkerForTextMarker"
-#define AXPreviousTextMarkerForTextMarkerAttribute @"AXPreviousTextMarkerForTextMarker"
-#define AXPreviousWordStartTextMarkerForTextMarkerAttribute @"AXPreviousWordStartTextMarkerForTextMarker"
-#define AXRightLineTextMarkerRangeForTextMarkerAttribute @"AXRightLineTextMarkerRangeForTextMarker"
-#define AXRightWordTextMarkerRangeForTextMarkerAttribute @"AXRightWordTextMarkerRangeForTextMarker"
-#define AXSentenceTextMarkerRangeForTextMarkerAttribute @"AXSentenceTextMarkerRangeForTextMarker"
-#define AXStartTextMarkerForBoundsAttribute @"AXStartTextMarkerForBounds"
-#define AXStringForTextMarkerRangeAttribute @"AXStringForTextMarkerRange"
-#define AXStyleTextMarkerRangeForTextMarkerAttribute @"AXStyleTextMarkerRangeForTextMarker"
-#define AXTextMarkerForIndexAttribute @"AXTextMarkerForIndex"
-#define AXTextMarkerForPositionAttribute @"AXTextMarkerForPosition" // FIXME: should be AXTextMarkerForPoint.
-#define AXTextMarkerIsValidAttribute @"AXTextMarkerIsValid"
-#define AXTextMarkerRangeForLineAttribute @"AXTextMarkerRangeForLine"
-#define AXTextMarkerRangeForTextMarkersAttribute @"AXTextMarkerRangeForTextMarkers"
-#define AXTextMarkerRangeForUIElementAttribute @"AXTextMarkerRangeForUIElement"
-#define AXTextMarkerRangeForUnorderedTextMarkersAttribute @"AXTextMarkerRangeForUnorderedTextMarkers"
-#define AXUIElementForTextMarkerAttribute @"AXUIElementForTextMarker"
+#define NSAccessibilityAttributedStringForTextMarkerRangeAttribute @"AXAttributedStringForTextMarkerRange"
+#define NSAccessibilityAttributedStringForTextMarkerRangeWithOptionsAttribute @"AXAttributedStringForTextMarkerRangeWithOptions"
+#define NSAccessibilityBoundsForTextMarkerRangeAttribute @"AXBoundsForTextMarkerRange"
+#define NSAccessibilityConvertRelativeFrameParameterizedAttribute @"AXConvertRelativeFrame"
+#define NSAccessibilityEndTextMarkerForBoundsAttribute @"AXEndTextMarkerForBounds"
+#define NSAccessibilityIndexForTextMarkerAttribute @"AXIndexForTextMarker"
+#define NSAccessibilityLeftLineTextMarkerRangeForTextMarkerAttribute @"AXLeftLineTextMarkerRangeForTextMarker"
+#define NSAccessibilityLeftWordTextMarkerRangeForTextMarkerAttribute @"AXLeftWordTextMarkerRangeForTextMarker"
+#define NSAccessibilityLengthForTextMarkerRangeAttribute @"AXLengthForTextMarkerRange"
+#define NSAccessibilityLineForTextMarkerAttribute @"AXLineForTextMarker"
+#define NSAccessibilityLineTextMarkerRangeForTextMarkerAttribute @"AXLineTextMarkerRangeForTextMarker"
+#define NSAccessibilityMisspellingTextMarkerRangeAttribute @"AXMisspellingTextMarkerRange"
+#define NSAccessibilityNextLineEndTextMarkerForTextMarkerAttribute @"AXNextLineEndTextMarkerForTextMarker"
+#define NSAccessibilityNextParagraphEndTextMarkerForTextMarkerAttribute @"AXNextParagraphEndTextMarkerForTextMarker"
+#define NSAccessibilityNextSentenceEndTextMarkerForTextMarkerAttribute @"AXNextSentenceEndTextMarkerForTextMarker"
+#define NSAccessibilityNextTextMarkerForTextMarkerAttribute @"AXNextTextMarkerForTextMarker"
+#define NSAccessibilityNextWordEndTextMarkerForTextMarkerAttribute @"AXNextWordEndTextMarkerForTextMarker"
+#define NSAccessibilityParagraphTextMarkerRangeForTextMarkerAttribute @"AXParagraphTextMarkerRangeForTextMarker"
+#define NSAccessibilityPreviousLineStartTextMarkerForTextMarkerAttribute @"AXPreviousLineStartTextMarkerForTextMarker"
+#define NSAccessibilityPreviousParagraphStartTextMarkerForTextMarkerAttribute @"AXPreviousParagraphStartTextMarkerForTextMarker"
+#define NSAccessibilityPreviousSentenceStartTextMarkerForTextMarkerAttribute @"AXPreviousSentenceStartTextMarkerForTextMarker"
+#define NSAccessibilityPreviousTextMarkerForTextMarkerAttribute @"AXPreviousTextMarkerForTextMarker"
+#define NSAccessibilityPreviousWordStartTextMarkerForTextMarkerAttribute @"AXPreviousWordStartTextMarkerForTextMarker"
+#define NSAccessibilityRightLineTextMarkerRangeForTextMarkerAttribute @"AXRightLineTextMarkerRangeForTextMarker"
+#define NSAccessibilityRightWordTextMarkerRangeForTextMarkerAttribute @"AXRightWordTextMarkerRangeForTextMarker"
+#define NSAccessibilitySentenceTextMarkerRangeForTextMarkerAttribute @"AXSentenceTextMarkerRangeForTextMarker"
+#define NSAccessibilityStartTextMarkerForBoundsAttribute @"AXStartTextMarkerForBounds"
+#define NSAccessibilityStringForTextMarkerRangeAttribute @"AXStringForTextMarkerRange"
+#define NSAccessibilityStyleTextMarkerRangeForTextMarkerAttribute @"AXStyleTextMarkerRangeForTextMarker"
+#define NSAccessibilityTextMarkerForIndexAttribute @"AXTextMarkerForIndex"
+#define NSAccessibilityTextMarkerForPositionAttribute @"AXTextMarkerForPosition" // FIXME: should be AXTextMarkerForPoint.
+#define NSAccessibilityTextMarkerIsValidAttribute @"AXTextMarkerIsValid"
+#define NSAccessibilityTextMarkerRangeForLineAttribute @"AXTextMarkerRangeForLine"
+#define NSAccessibilityTextMarkerRangeForTextMarkersAttribute @"AXTextMarkerRangeForTextMarkers"
+#define NSAccessibilityTextMarkerRangeForUIElementAttribute @"AXTextMarkerRangeForUIElement"
+#define NSAccessibilityTextMarkerRangeForUnorderedTextMarkersAttribute @"AXTextMarkerRangeForUnorderedTextMarkers"
+#define NSAccessibilityUIElementForTextMarkerAttribute @"AXUIElementForTextMarker"
 #define NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute @"AXUIElementsForSearchPredicate"
-
-#define kAXConvertRelativeFrameParameterizedAttribute @"AXConvertRelativeFrame"
 
 //
 // Actions
@@ -140,24 +138,24 @@
 // Attributed string attribute names
 //
 
-#define AXDidSpellCheckAttribute @"AXDidSpellCheck"
+#define NSAccessibilityDidSpellCheckAttribute @"AXDidSpellCheck"
+#define NSAccessibilityTextCompletionAttribute @"AXTextCompletion"
 
 //
 // Notifications
 //
 
 #define NSAccessibilityCurrentStateChangedNotification @"AXCurrentStateChanged"
+#define NSAccessibilityDraggingDestinationDragAcceptedNotification CFSTR("AXDraggingDestinationDragAccepted")
+#define NSAccessibilityDraggingDestinationDragNotAcceptedNotification CFSTR("AXDraggingDestinationDragNotAccepted")
+#define NSAccessibilityDraggingDestinationDropAllowedNotification CFSTR("AXDraggingDestinationDropAllowed")
+#define NSAccessibilityDraggingDestinationDropNotAllowedNotification CFSTR("AXDraggingDestinationDropNotAllowed")
+#define NSAccessibilityDraggingSourceDragBeganNotification CFSTR("AXDraggingSourceDragBegan")
+#define NSAccessibilityDraggingSourceDragEndedNotification CFSTR("AXDraggingSourceDragEnded")
 #define NSAccessibilityLiveRegionChangedNotification @"AXLiveRegionChanged"
 #define NSAccessibilityLiveRegionCreatedNotification @"AXLiveRegionCreated"
 #define NSAccessibilityTextInputMarkingSessionBeganNotification @"AXTextInputMarkingSessionBegan"
 #define NSAccessibilityTextInputMarkingSessionEndedNotification @"AXTextInputMarkingSessionEnded"
-
-#define kAXDraggingDestinationDragAcceptedNotification CFSTR("AXDraggingDestinationDragAccepted")
-#define kAXDraggingDestinationDragNotAcceptedNotification CFSTR("AXDraggingDestinationDragNotAccepted")
-#define kAXDraggingDestinationDropAllowedNotification CFSTR("AXDraggingDestinationDropAllowed")
-#define kAXDraggingDestinationDropNotAllowedNotification CFSTR("AXDraggingDestinationDropNotAllowed")
-#define kAXDraggingSourceDragBeganNotification CFSTR("AXDraggingSourceDragBegan")
-#define kAXDraggingSourceDragEndedNotification CFSTR("AXDraggingSourceDragEnded")
 
 //
 // Additional attributes in text change notifications
@@ -181,8 +179,11 @@
 
 #define NSAccessibilityIntersectionWithSelectionRangeAttribute @"AXIntersectionWithSelectionRange"
 #define NSAccessibilitySelectTextActivity @"AXSelectTextActivity"
+#define NSAccessibilitySelectTextActivityFindAndCapitalize @"AXSelectTextActivityFindAndCapitalize"
+#define NSAccessibilitySelectTextActivityFindAndLowercase @"AXSelectTextActivityFindAndLowercase"
 #define NSAccessibilitySelectTextActivityFindAndReplace @"AXSelectTextActivityFindAndReplace"
 #define NSAccessibilitySelectTextActivityFindAndSelect @"AXSelectTextActivityFindAndSelect"
+#define NSAccessibilitySelectTextActivityFindAndUppercase @"AXSelectTextActivityFindAndUppercase"
 #define NSAccessibilitySelectTextAmbiguityResolution @"AXSelectTextAmbiguityResolution"
 #define NSAccessibilitySelectTextAmbiguityResolutionClosestAfterSelection @"AXSelectTextAmbiguityResolutionClosestAfterSelection"
 #define NSAccessibilitySelectTextAmbiguityResolutionClosestBeforeSelection @"AXSelectTextAmbiguityResolutionClosestBeforeSelection"
@@ -190,10 +191,6 @@
 #define NSAccessibilitySelectTextReplacementString @"AXSelectTextReplacementString"
 #define NSAccessibilitySelectTextSearchStrings @"AXSelectTextSearchStrings"
 #define NSAccessibilitySelectTextWithCriteriaParameterizedAttribute @"AXSelectTextWithCriteria"
-
-#define kAXSelectTextActivityFindAndCapitalize @"AXSelectTextActivityFindAndCapitalize"
-#define kAXSelectTextActivityFindAndLowercase @"AXSelectTextActivityFindAndLowercase"
-#define kAXSelectTextActivityFindAndUppercase @"AXSelectTextActivityFindAndUppercase"
 
 //
 // Text search

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -247,11 +247,11 @@ static std::pair<AccessibilitySearchTextCriteria, AccessibilityTextOperation> ac
     if ([activityParameter isKindOfClass:[NSString class]]) {
         if ([activityParameter isEqualToString:NSAccessibilitySelectTextActivityFindAndReplace])
             operation.type = AccessibilityTextOperationType::Replace;
-        else if ([activityParameter isEqualToString:kAXSelectTextActivityFindAndCapitalize])
+        else if ([activityParameter isEqualToString:NSAccessibilitySelectTextActivityFindAndCapitalize])
             operation.type = AccessibilityTextOperationType::Capitalize;
-        else if ([activityParameter isEqualToString:kAXSelectTextActivityFindAndLowercase])
+        else if ([activityParameter isEqualToString:NSAccessibilitySelectTextActivityFindAndLowercase])
             operation.type = AccessibilityTextOperationType::Lowercase;
-        else if ([activityParameter isEqualToString:kAXSelectTextActivityFindAndUppercase])
+        else if ([activityParameter isEqualToString:NSAccessibilitySelectTextActivityFindAndUppercase])
             operation.type = AccessibilityTextOperationType::Uppercase;
     }
 
@@ -585,8 +585,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [[self attachmentView] accessibilityAttributeNames];
 
     static NeverDestroyed<RetainPtr<NSArray>> attributes = @[
-        AXHasDocumentRoleAncestorAttribute,
-        AXHasWebApplicationAncestorAttribute,
+        NSAccessibilityHasDocumentRoleAncestorAttribute,
+        NSAccessibilityHasWebApplicationAncestorAttribute,
         NSAccessibilityRoleAttribute,
         NSAccessibilitySubroleAttribute,
         NSAccessibilityRoleDescriptionAttribute,
@@ -602,9 +602,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         NSAccessibilityFocusedAttribute,
         NSAccessibilityEnabledAttribute,
         NSAccessibilityWindowAttribute,
-        AXSelectedTextMarkerRangeAttribute,
-        AXStartTextMarkerAttribute,
-        AXEndTextMarkerAttribute,
+        NSAccessibilitySelectedTextMarkerRangeAttribute,
+        NSAccessibilityStartTextMarkerAttribute,
+        NSAccessibilityEndTextMarkerAttribute,
         @"AXVisited",
         NSAccessibilityLinkedUIElementsAttribute,
         NSAccessibilitySelectedAttribute,
@@ -1592,10 +1592,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (backingObject->isList() && [attributeName isEqualToString:NSAccessibilityOrientationAttribute])
         return NSAccessibilityVerticalOrientationValue;
 
-    if ([attributeName isEqualToString:AXSelectedTextMarkerRangeAttribute])
+    if ([attributeName isEqualToString:NSAccessibilitySelectedTextMarkerRangeAttribute])
         return (id)[self selectedTextMarkerRange];
 
-    if ([attributeName isEqualToString:AXStartTextMarkerAttribute]) {
+    if ([attributeName isEqualToString:NSAccessibilityStartTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             if (RefPtr tree = std::get<RefPtr<AXIsolatedTree>>(axTreeForID(backingObject->treeID())))
@@ -1611,7 +1611,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attributeName isEqualToString:AXEndTextMarkerAttribute]) {
+    if ([attributeName isEqualToString:NSAccessibilityEndTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             if (RefPtr tree = std::get<RefPtr<AXIsolatedTree>>(axTreeForID(backingObject->treeID())))
@@ -1810,10 +1810,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString:NSAccessibilityKeyShortcutsAttribute])
         return backingObject->keyShortcuts();
 
-    if ([attributeName isEqualToString:AXHasDocumentRoleAncestorAttribute])
+    if ([attributeName isEqualToString:NSAccessibilityHasDocumentRoleAncestorAttribute])
         return [NSNumber numberWithBool:backingObject->hasDocumentRoleAncestor()];
 
-    if ([attributeName isEqualToString:AXHasWebApplicationAncestorAttribute])
+    if ([attributeName isEqualToString:NSAccessibilityHasWebApplicationAncestorAttribute])
         return [NSNumber numberWithBool:backingObject->hasWebApplicationAncestor()];
 
     if ([attributeName isEqualToString:@"AXIsInDescriptionListDetail"])
@@ -2127,7 +2127,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (!backingObject)
         return NO;
 
-    if ([attributeName isEqualToString:AXSelectedTextMarkerRangeAttribute])
+    if ([attributeName isEqualToString:NSAccessibilitySelectedTextMarkerRangeAttribute])
         return YES;
 
     if ([attributeName isEqualToString: NSAccessibilityFocusedAttribute])
@@ -2194,41 +2194,41 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     static NSArray *webAreaParamAttrs;
     if (paramAttrs == nil) {
         paramAttrs = [[NSArray alloc] initWithObjects:
-            AXUIElementForTextMarkerAttribute,
-            AXTextMarkerRangeForUIElementAttribute,
-            AXLineForTextMarkerAttribute,
-            AXTextMarkerRangeForLineAttribute,
-            AXStringForTextMarkerRangeAttribute,
-            AXTextMarkerForPositionAttribute,
-            AXBoundsForTextMarkerRangeAttribute,
-            AXAttributedStringForTextMarkerRangeAttribute,
-            AXAttributedStringForTextMarkerRangeWithOptionsAttribute,
-            AXTextMarkerRangeForTextMarkersAttribute,
-            AXTextMarkerRangeForUnorderedTextMarkersAttribute,
-            AXNextTextMarkerForTextMarkerAttribute,
-            AXPreviousTextMarkerForTextMarkerAttribute,
-            AXLeftWordTextMarkerRangeForTextMarkerAttribute,
-            AXRightWordTextMarkerRangeForTextMarkerAttribute,
-            AXLeftLineTextMarkerRangeForTextMarkerAttribute,
-            AXRightLineTextMarkerRangeForTextMarkerAttribute,
-            AXSentenceTextMarkerRangeForTextMarkerAttribute,
-            AXParagraphTextMarkerRangeForTextMarkerAttribute,
-            AXNextWordEndTextMarkerForTextMarkerAttribute,
-            AXPreviousWordStartTextMarkerForTextMarkerAttribute,
-            AXNextLineEndTextMarkerForTextMarkerAttribute,
-            AXPreviousLineStartTextMarkerForTextMarkerAttribute,
-            AXNextSentenceEndTextMarkerForTextMarkerAttribute,
-            AXPreviousSentenceStartTextMarkerForTextMarkerAttribute,
-            AXNextParagraphEndTextMarkerForTextMarkerAttribute,
-            AXPreviousParagraphStartTextMarkerForTextMarkerAttribute,
-            AXStyleTextMarkerRangeForTextMarkerAttribute,
-            AXLengthForTextMarkerRangeAttribute,
+            NSAccessibilityUIElementForTextMarkerAttribute,
+            NSAccessibilityTextMarkerRangeForUIElementAttribute,
+            NSAccessibilityLineForTextMarkerAttribute,
+            NSAccessibilityTextMarkerRangeForLineAttribute,
+            NSAccessibilityStringForTextMarkerRangeAttribute,
+            NSAccessibilityTextMarkerForPositionAttribute,
+            NSAccessibilityBoundsForTextMarkerRangeAttribute,
+            NSAccessibilityAttributedStringForTextMarkerRangeAttribute,
+            NSAccessibilityAttributedStringForTextMarkerRangeWithOptionsAttribute,
+            NSAccessibilityTextMarkerRangeForTextMarkersAttribute,
+            NSAccessibilityTextMarkerRangeForUnorderedTextMarkersAttribute,
+            NSAccessibilityNextTextMarkerForTextMarkerAttribute,
+            NSAccessibilityPreviousTextMarkerForTextMarkerAttribute,
+            NSAccessibilityLeftWordTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilityRightWordTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilityLeftLineTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilityRightLineTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilitySentenceTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilityParagraphTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilityNextWordEndTextMarkerForTextMarkerAttribute,
+            NSAccessibilityPreviousWordStartTextMarkerForTextMarkerAttribute,
+            NSAccessibilityNextLineEndTextMarkerForTextMarkerAttribute,
+            NSAccessibilityPreviousLineStartTextMarkerForTextMarkerAttribute,
+            NSAccessibilityNextSentenceEndTextMarkerForTextMarkerAttribute,
+            NSAccessibilityPreviousSentenceStartTextMarkerForTextMarkerAttribute,
+            NSAccessibilityNextParagraphEndTextMarkerForTextMarkerAttribute,
+            NSAccessibilityPreviousParagraphStartTextMarkerForTextMarkerAttribute,
+            NSAccessibilityStyleTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilityLengthForTextMarkerRangeAttribute,
             NSAccessibilityBoundsForRangeParameterizedAttribute,
             NSAccessibilityStringForRangeParameterizedAttribute,
             NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute,
-            AXEndTextMarkerForBoundsAttribute,
-            AXStartTextMarkerForBoundsAttribute,
-            AXLineTextMarkerRangeForTextMarkerAttribute,
+            NSAccessibilityEndTextMarkerForBoundsAttribute,
+            NSAccessibilityStartTextMarkerForBoundsAttribute,
+            NSAccessibilityLineTextMarkerRangeForTextMarkerAttribute,
             NSAccessibilitySelectTextWithCriteriaParameterizedAttribute,
             NSAccessibilitySearchTextWithCriteriaParameterizedAttribute,
             NSAccessibilityTextOperationParameterizedAttribute,
@@ -2255,9 +2255,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
     if (!webAreaParamAttrs) {
         auto tempArray = adoptNS([[NSMutableArray alloc] initWithArray:paramAttrs]);
-        [tempArray addObject:AXTextMarkerForIndexAttribute];
-        [tempArray addObject:AXTextMarkerIsValidAttribute];
-        [tempArray addObject:AXIndexForTextMarkerAttribute];
+        [tempArray addObject:NSAccessibilityTextMarkerForIndexAttribute];
+        [tempArray addObject:NSAccessibilityTextMarkerIsValidAttribute];
+        [tempArray addObject:NSAccessibilityIndexForTextMarkerAttribute];
         webAreaParamAttrs = [[NSArray alloc] initWithArray:tempArray.get()];
     }
 
@@ -2278,7 +2278,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     // The object that serves up the remote frame also is the one that does the frame conversion.
     if (backingObject->hasRemoteFrameChild())
-        return [paramAttrs arrayByAddingObject:kAXConvertRelativeFrameParameterizedAttribute];
+        return [paramAttrs arrayByAddingObject:NSAccessibilityConvertRelativeFrameParameterizedAttribute];
 
     return paramAttrs;
 }
@@ -2507,7 +2507,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         array = value;
 
     // handle the command
-    if ([attributeName isEqualToString:AXSelectedTextMarkerRangeAttribute]) {
+    if ([attributeName isEqualToString:NSAccessibilitySelectedTextMarkerRangeAttribute]) {
         ASSERT(textMarkerRange);
         Accessibility::performFunctionOnMainThread([textMarkerRange = retainPtr(textMarkerRange), protectedSelf = retainPtr(self)] {
             if (RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject)
@@ -3031,7 +3031,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     // TextMarker attributes.
 
-    if ([attribute isEqualToString:AXEndTextMarkerForBoundsAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityEndTextMarkerForBoundsAttribute]) {
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([&rect, protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
             RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
             if (!backingObject)
@@ -3048,7 +3048,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXStartTextMarkerForBoundsAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityStartTextMarkerForBoundsAttribute]) {
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([&rect, protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
             RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
             if (!backingObject)
@@ -3066,10 +3066,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     // TextMarkerRange attributes.
-    if ([attribute isEqualToString:AXLineTextMarkerRangeForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityLineTextMarkerRangeForTextMarkerAttribute])
         return [self lineTextMarkerRangeForTextMarker:textMarker forUnit:TextUnit::Line];
 
-    if ([attribute isEqualToString:AXMisspellingTextMarkerRangeAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityMisspellingTextMarkerRangeAttribute]) {
         return (id)Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRangeRef>([&dictionary, protectedSelf = retainPtr(self)] () -> RetainPtr<AXTextMarkerRangeRef> {
             RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
             if (!backingObject)
@@ -3095,10 +3095,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXTextMarkerIsValidAttribute])
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerIsValidAttribute])
         return [NSNumber numberWithBool:AXTextMarker(textMarker).isValid()];
 
-    if ([attribute isEqualToString:AXIndexForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityIndexForTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis())
             return [NSNumber numberWithUnsignedInt:AXTextMarker { textMarker }.offsetFromRoot()];
@@ -3106,7 +3106,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [NSNumber numberWithInteger:[self _indexForTextMarker:textMarker]];
     }
 
-    if ([attribute isEqualToString:AXTextMarkerForIndexAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerForIndexAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             long index = [number longValue];
@@ -3124,7 +3124,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return (id)[self _textMarkerForIndex:[number integerValue]];
     }
 
-    if ([attribute isEqualToString:AXUIElementForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityUIElementForTextMarkerAttribute]) {
         AXTextMarker marker { textMarker };
         RefPtr object = marker.object();
         if (!object)
@@ -3141,7 +3141,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return wrapper;
     }
 
-    if ([attribute isEqualToString:AXTextMarkerRangeForUIElementAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerRangeForUIElementAttribute]) {
         if (uiElement) {
             if (auto markerRange = uiElement->textMarkerRange())
                 return markerRange.platformData().bridgingAutorelease();
@@ -3149,7 +3149,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return nil;
     }
 
-    if ([attribute isEqualToString:AXLineForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityLineForTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis())
             return @(AXTextMarker { textMarker }.lineIndex());
@@ -3164,7 +3164,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return @(result);
     }
 
-    if ([attribute isEqualToString:AXTextMarkerRangeForLineAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerRangeForLineAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             // Unfortunately, the main-thread version of this function expects a 1-indexed line, so callers pass it that way.
@@ -3193,7 +3193,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXStringForTextMarkerRangeAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityStringForTextMarkerRangeAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             AXTextMarkerRange range = { textMarkerRange };
@@ -3211,7 +3211,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXTextMarkerForPositionAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerForPositionAttribute]) {
         if (!pointSet)
             return nil;
         IntPoint webCorePoint = IntPoint(point);
@@ -3225,7 +3225,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXBoundsForTextMarkerRangeAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityBoundsForTextMarkerRangeAttribute]) {
         NSRect rect = Accessibility::retrieveValueFromMainThread<NSRect>([textMarkerRange = retainPtr(textMarkerRange), protectedSelf = retainPtr(self)] () -> NSRect {
             auto* backingObject = protectedSelf.get().axBackingObject;
             if (!backingObject)
@@ -3281,10 +3281,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXAttributedStringForTextMarkerRangeAttribute])
+    if ([attribute isEqualToString:NSAccessibilityAttributedStringForTextMarkerRangeAttribute])
         return attributedStringForTextMarkerRange(*backingObject, textMarkerRange, AXCoreObject::SpellCheck::Yes);
 
-    if ([attribute isEqualToString:AXAttributedStringForTextMarkerRangeWithOptionsAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityAttributedStringForTextMarkerRangeWithOptionsAttribute]) {
         if (textMarkerRange)
             return attributedStringForTextMarkerRange(*backingObject, textMarkerRange, AXCoreObject::SpellCheck::No);
 
@@ -3304,8 +3304,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return nil;
     }
 
-    if ([attribute isEqualToString:AXTextMarkerRangeForTextMarkersAttribute]
-        || [attribute isEqualToString:AXTextMarkerRangeForUnorderedTextMarkersAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerRangeForTextMarkersAttribute]
+        || [attribute isEqualToString:NSAccessibilityTextMarkerRangeForUnorderedTextMarkersAttribute]) {
         if (array.count < 2
             || !AXObjectIsTextMarker([array objectAtIndex:0])
             || !AXObjectIsTextMarker([array objectAtIndex:1]))
@@ -3314,7 +3314,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return AXTextMarkerRange { { (AXTextMarkerRef)[array objectAtIndex:0] }, { (AXTextMarkerRef)[array objectAtIndex:1] } }.platformData().bridgingAutorelease();
     }
 
-    if ([attribute isEqualToString:AXNextTextMarkerForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityNextTextMarkerForTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             AXTextMarker inputMarker { textMarker };
@@ -3333,7 +3333,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXPreviousTextMarkerForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityPreviousTextMarkerForTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             AXTextMarker inputMarker { textMarker };
@@ -3352,31 +3352,31 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXLeftWordTextMarkerRangeForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityLeftWordTextMarkerRangeForTextMarkerAttribute])
         return (id)[self textMarkerRangeAtTextMarker:textMarker forUnit:TextUnit::LeftWord];
 
-    if ([attribute isEqualToString:AXRightWordTextMarkerRangeForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityRightWordTextMarkerRangeForTextMarkerAttribute])
         return (id)[self textMarkerRangeAtTextMarker:textMarker forUnit:TextUnit::RightWord];
 
-    if ([attribute isEqualToString:AXLeftLineTextMarkerRangeForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityLeftLineTextMarkerRangeForTextMarkerAttribute])
         return [self lineTextMarkerRangeForTextMarker:textMarker forUnit:TextUnit::LeftLine];
 
-    if ([attribute isEqualToString:AXRightLineTextMarkerRangeForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityRightLineTextMarkerRangeForTextMarkerAttribute])
         return [self lineTextMarkerRangeForTextMarker:textMarker forUnit:TextUnit::RightLine];
 
-    if ([attribute isEqualToString:AXSentenceTextMarkerRangeForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilitySentenceTextMarkerRangeForTextMarkerAttribute])
         return (id)[self textMarkerRangeAtTextMarker:textMarker forUnit:TextUnit::Sentence];
 
-    if ([attribute isEqualToString:AXParagraphTextMarkerRangeForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityParagraphTextMarkerRangeForTextMarkerAttribute])
         return (id)[self textMarkerRangeAtTextMarker:textMarker forUnit:TextUnit::Paragraph];
 
-    if ([attribute isEqualToString:AXNextWordEndTextMarkerForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityNextWordEndTextMarkerForTextMarkerAttribute])
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::NextWordEnd];
 
-    if ([attribute isEqualToString:AXPreviousWordStartTextMarkerForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityPreviousWordStartTextMarkerForTextMarkerAttribute])
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::PreviousWordStart];
 
-    if ([attribute isEqualToString:AXNextLineEndTextMarkerForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityNextLineEndTextMarkerForTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             AXTextMarker inputMarker { textMarker };
@@ -3386,7 +3386,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::NextLineEnd];
     }
 
-    if ([attribute isEqualToString:AXPreviousLineStartTextMarkerForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityPreviousLineStartTextMarkerForTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             AXTextMarker inputMarker { textMarker };
@@ -3396,19 +3396,19 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::PreviousLineStart];
     }
 
-    if ([attribute isEqualToString:AXNextSentenceEndTextMarkerForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityNextSentenceEndTextMarkerForTextMarkerAttribute])
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::NextSentenceEnd];
 
-    if ([attribute isEqualToString:AXPreviousSentenceStartTextMarkerForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityPreviousSentenceStartTextMarkerForTextMarkerAttribute])
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::PreviousSentenceStart];
 
-    if ([attribute isEqualToString:AXNextParagraphEndTextMarkerForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityNextParagraphEndTextMarkerForTextMarkerAttribute])
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::NextParagraphEnd];
 
-    if ([attribute isEqualToString:AXPreviousParagraphStartTextMarkerForTextMarkerAttribute])
+    if ([attribute isEqualToString:NSAccessibilityPreviousParagraphStartTextMarkerForTextMarkerAttribute])
         return (id)[self textMarkerForTextMarker:textMarker atUnit:TextUnit::PreviousParagraphStart];
 
-    if ([attribute isEqualToString:AXStyleTextMarkerRangeForTextMarkerAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityStyleTextMarkerRangeForTextMarkerAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis())
             return AXTextMarker { textMarker }.rangeWithSameStyle().platformData().bridgingAutorelease();
@@ -3422,7 +3422,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         });
     }
 
-    if ([attribute isEqualToString:AXLengthForTextMarkerRangeAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityLengthForTextMarkerRangeAttribute]) {
 #if ENABLE(AX_THREAD_TEXT_APIS)
         if (AXObjectCache::useAXThreadTextApis()) {
             AXTextMarkerRange range = { textMarkerRange };
@@ -3519,7 +3519,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         }
     }
 
-    if ([attribute isEqualToString:kAXConvertRelativeFrameParameterizedAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityConvertRelativeFrameParameterizedAttribute]) {
         auto* parent = backingObject->parentObject();
         return parent ? [NSValue valueWithRect:parent->convertFrameToSpace(FloatRect(rect), AccessibilityConversionSpace::Page)] : nil;
     }


### PR DESCRIPTION
#### ae477a5d87f21f691956152d8a33cc23fb9893f4
<pre>
AX: rename existing Mac accessibility constants to be consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=287161">https://bugs.webkit.org/show_bug.cgi?id=287161</a>
<a href="https://rdar.apple.com/144314708">rdar://144314708</a>

Reviewed by Chris Fleizach.

We have some with an AX prefix, some with NSAccessibility, and so on.

We should make them all consistent with an NSAccessibility prefix
and a suffix like Role, Attribute, etc. indicating the type of constant.

* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::attributedStringSetNeedsSpellCheck):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformNotification):
(WebCore::AXObjectCache::postTextStateChangePlatformNotification):
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(accessibilityTextCriteriaForParameterizedAttribute):
(-[WebAccessibilityObjectWrapper ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(-[WebAccessibilityObjectWrapper accessibilityIsAttributeSettable:]):
(-[WebAccessibilityObjectWrapper _accessibilitySetValue:forAttribute:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/290058@main">https://commits.webkit.org/290058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/072ad9255a442672391ea219297512afe83c667e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68421 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26104 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91738 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6632 "Found 1 new test failure: fast/forms/switch/click-animation-twice-fast.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34674 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38598 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95537 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15911 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11647 "Found 5 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77284 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8981 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15927 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->