### PR TITLE
Deploy more smart pointers in NowPlayingManager

### DIFF
--- a/Source/WebCore/platform/NowPlayingManager.cpp
+++ b/Source/WebCore/platform/NowPlayingManager.cpp
@@ -130,39 +130,39 @@ void NowPlayingManager::setNowPlayingInfoPrivate(const NowPlayingInfo& nowPlayin
 
 void NowPlayingManager::setSupportsSeeking(bool supports)
 {
-    if (m_remoteCommandListener)
-        m_remoteCommandListener->setSupportsSeeking(supports);
+    if (RefPtr commandListener = m_remoteCommandListener)
+        commandListener->setSupportsSeeking(supports);
 }
 
 void NowPlayingManager::addSupportedCommand(PlatformMediaSession::RemoteControlCommandType command)
 {
-    if (m_remoteCommandListener)
-        m_remoteCommandListener->addSupportedCommand(command);
+    if (RefPtr commandListener = m_remoteCommandListener)
+        commandListener->addSupportedCommand(command);
 }
 
 void NowPlayingManager::removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType command)
 {
-    if (m_remoteCommandListener)
-        m_remoteCommandListener->removeSupportedCommand(command);
+    if (RefPtr commandListener = m_remoteCommandListener)
+        commandListener->removeSupportedCommand(command);
 }
 
 RemoteCommandListener::RemoteCommandsSet NowPlayingManager::supportedCommands() const
 {
-    if (!m_remoteCommandListener)
-        return { };
-    return m_remoteCommandListener->supportedCommands();
+    if (RefPtr commandListener = m_remoteCommandListener)
+        return commandListener->supportedCommands();
+    return { };
 }
 
 void NowPlayingManager::setSupportedRemoteCommands(const RemoteCommandListener::RemoteCommandsSet& commands)
 {
-    if (m_remoteCommandListener)
-        m_remoteCommandListener->setSupportedCommands(commands);
+    if (RefPtr commandListener = m_remoteCommandListener)
+        commandListener->setSupportedCommands(commands);
 }
 
 void NowPlayingManager::updateSupportedCommands()
 {
-    if (m_remoteCommandListener)
-        m_remoteCommandListener->updateSupportedCommands();
+    if (RefPtr commandListener = m_remoteCommandListener)
+        commandListener->updateSupportedCommands();
 }
 
 void NowPlayingManager::ensureRemoteCommandListenerCreated()


### PR DESCRIPTION
#### d69c9f92769207fed898f965a3c2c8ff4f7dd5b9
<pre>
Deploy more smart pointers in NowPlayingManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=287164">https://bugs.webkit.org/show_bug.cgi?id=287164</a>

Reviewed by Geoffrey Garen and Chris Dumez.

Addressed smart pointer static analyzer warnings.

* Source/WebCore/platform/NowPlayingManager.cpp:
(WebCore::NowPlayingManager::setSupportsSeeking):
(WebCore::NowPlayingManager::addSupportedCommand):
(WebCore::NowPlayingManager::removeSupportedCommand):
(WebCore::NowPlayingManager::supportedCommands const):
(WebCore::NowPlayingManager::setSupportedRemoteCommands):
(WebCore::NowPlayingManager::updateSupportedCommands):

Canonical link: <a href="https://commits.webkit.org/289989@main">https://commits.webkit.org/289989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebab7b1d7e8933c734a4932f3dd4257594752ba4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39265 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68288 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34475 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76389 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19202 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8725 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13864 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21010 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->