### PR TITLE
[macOS] Refactor top content inset logic to account for content insets on all rect edges

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1800,6 +1800,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/AbortableTaskQueue.h
     platform/AudioSampleFormat.h
+    platform/BoxExtents.h
     platform/BoxSides.h
     platform/CaretAnimator.h
     platform/CPUMonitor.h

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -60,17 +60,19 @@ int FrameView::footerHeight() const
     return page ? page->footerHeight() : 0;
 }
 
-float FrameView::topContentInset(TopContentInsetType contentInsetTypeToReturn) const
+FloatBoxExtent FrameView::obscuredContentInsets(InsetType type) const
 {
-    if (platformWidget() && contentInsetTypeToReturn == TopContentInsetType::WebCoreOrPlatformContentInset)
-        return platformTopContentInset();
+    if (platformWidget() && type == InsetType::WebCoreOrPlatformInset)
+        return platformContentInsets();
 
     Ref frame = this->frame();
     if (!frame->isMainFrame())
-        return 0;
+        return { };
 
-    Page* page = frame->page();
-    return page ? page->topContentInset() : 0;
+    if (RefPtr page = frame->page())
+        return page->obscuredContentInsets();
+
+    return { };
 }
 
 float FrameView::visibleContentScaleFactor() const

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -45,7 +45,7 @@ public:
     WEBCORE_EXPORT int headerHeight() const final;
     WEBCORE_EXPORT int footerHeight() const final;
 
-    WEBCORE_EXPORT float topContentInset(TopContentInsetType = TopContentInsetType::WebCoreContentInset) const final;
+    WEBCORE_EXPORT FloatBoxExtent obscuredContentInsets(InsetType = InsetType::WebCoreInset) const final;
 
     float visibleContentScaleFactor() const final;
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -367,14 +367,14 @@ public:
     
     WEBCORE_EXPORT static LayoutPoint computeLayoutViewportOrigin(const LayoutRect& visualViewport, const LayoutPoint& stableLayoutViewportOriginMin, const LayoutPoint& stableLayoutViewportOriginMax, const LayoutRect& layoutViewport, ScrollBehaviorForFixedElements);
 
-    // These layers are positioned differently when there is a topContentInset, a header, or a footer. These value need to be computed
+    // These layers are positioned differently when there is a top inset, a header, or a footer. These value need to be computed
     // on both the main thread and the scrolling thread.
-    static float yPositionForInsetClipLayer(const FloatPoint& scrollPosition, float topContentInset);
-    WEBCORE_EXPORT static FloatPoint positionForRootContentLayer(const FloatPoint& scrollPosition, const FloatPoint& scrollOrigin, float topContentInset, float headerHeight);
+    static float yPositionForInsetClipLayer(const FloatPoint& scrollPosition, float topInset);
+    WEBCORE_EXPORT static FloatPoint positionForRootContentLayer(const FloatPoint& scrollPosition, const FloatPoint& scrollOrigin, float topInset, float headerHeight);
     WEBCORE_EXPORT FloatPoint positionForRootContentLayer() const;
 
-    WEBCORE_EXPORT static float yPositionForHeaderLayer(const FloatPoint& scrollPosition, float topContentInset);
-    WEBCORE_EXPORT static float yPositionForFooterLayer(const FloatPoint& scrollPosition, float topContentInset, float totalContentsHeight, float footerHeight);
+    WEBCORE_EXPORT static float yPositionForHeaderLayer(const FloatPoint& scrollPosition, float topInset);
+    WEBCORE_EXPORT static float yPositionForFooterLayer(const FloatPoint& scrollPosition, float topInset, float totalContentsHeight, float footerHeight);
 
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT LayoutRect viewportConstrainedObjectsRect() const;
@@ -621,7 +621,7 @@ public:
 
     LayoutPoint scrollPositionRespectingCustomFixedPosition() const;
 
-    void topContentInsetDidChange(float newTopContentInset);
+    void obscuredContentInsetsDidChange(const FloatBoxExtent&);
 
     void topContentDirectionDidChange();
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1871,15 +1871,15 @@ void Page::setOutsideViewportThrottlingEnabledForTesting(bool isEnabled)
     m_throttlingReasons.remove(ThrottlingReason::OutsideViewport);
 }
 
-void Page::setTopContentInset(float contentInset)
+void Page::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInsets)
 {
-    if (m_topContentInset == contentInset)
+    if (m_obscuredContentInsets == obscuredContentInsets)
         return;
-    
-    m_topContentInset = contentInset;
+
+    m_obscuredContentInsets = obscuredContentInsets;
     RefPtr localMainFrame = this->localMainFrame();
     if (RefPtr view = localMainFrame ? localMainFrame->view() : nullptr)
-        view->topContentInsetDidChange(m_topContentInset);
+        view->obscuredContentInsetsDidChange(obscuredContentInsets);
 }
 
 void Page::setShouldSuppressScrollbarAnimations(bool suppressAnimations)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -23,6 +23,7 @@
 #include "ActivityState.h"
 #include "AnimationFrameRate.h"
 #include "BackForwardItemIdentifier.h"
+#include "BoxExtents.h"
 #include "Color.h"
 #include "FindOptions.h"
 #include "FrameLoaderTypes.h"
@@ -623,12 +624,6 @@ public:
     WEBCORE_EXPORT std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond(OptionSet<PreferredRenderingUpdateOption> = allPreferredRenderingUpdateOptions) const;
     WEBCORE_EXPORT Seconds preferredRenderingUpdateInterval() const;
 
-    float topContentInset() const { return m_topContentInset; }
-    WEBCORE_EXPORT void setTopContentInset(float);
-
-    const FloatBoxExtent& obscuredInsets() const { return m_obscuredInsets; }
-    void setObscuredInsets(const FloatBoxExtent& obscuredInsets) { m_obscuredInsets = obscuredInsets; }
-
     const FloatBoxExtent& contentInsets() const { return m_contentInsets; }
     void setContentInsets(const FloatBoxExtent& insets) { m_contentInsets = insets; }
 
@@ -638,7 +633,13 @@ public:
 #if PLATFORM(IOS_FAMILY)
     bool enclosedInScrollableAncestorView() const { return m_enclosedInScrollableAncestorView; }
     void setEnclosedInScrollableAncestorView(bool f) { m_enclosedInScrollableAncestorView = f; }
+
+    const FloatBoxExtent& obscuredInsets() const { return m_obscuredInsets; }
+    void setObscuredInsets(const FloatBoxExtent& insets) { m_obscuredInsets = insets; }
 #endif
+
+    const FloatBoxExtent& obscuredContentInsets() const { return m_obscuredContentInsets; }
+    WEBCORE_EXPORT void setObscuredContentInsets(const FloatBoxExtent&);
 
     WEBCORE_EXPORT void useSystemAppearanceChanged();
 
@@ -1449,14 +1450,14 @@ private:
     float m_deviceScaleFactor { 1 };
     float m_viewScaleFactor { 1 };
 
-    float m_topContentInset { 0 };
-    FloatBoxExtent m_obscuredInsets;
+    FloatBoxExtent m_obscuredContentInsets;
     FloatBoxExtent m_contentInsets;
     FloatBoxExtent m_unobscuredSafeAreaInsets;
     FloatBoxExtent m_fullscreenInsets;
     Seconds m_fullscreenAutoHideDuration { 0_s };
 
 #if PLATFORM(IOS_FAMILY)
+    FloatBoxExtent m_obscuredInsets;
     bool m_enclosedInScrollableAncestorView { false };
     bool m_canShowWhileLocked { false };
 #endif

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -120,10 +120,9 @@ bool ResourceUsageOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent& ev
             newFrame.moveBy(IntPoint(-m_dragPoint.x(), -m_dragPoint.y()));
 
             // Force the frame to stay inside the viewport entirely.
-            if (newFrame.x() < 0)
-                newFrame.setX(0);
-            if (newFrame.y() < page->topContentInset())
-                newFrame.setY(page->topContentInset());
+            auto obscuredContentInsets = page->obscuredContentInsets();
+            newFrame.setX(static_cast<int>(std::max<float>(obscuredContentInsets.left(), newFrame.x())));
+            newFrame.setY(static_cast<int>(std::max<float>(obscuredContentInsets.top(), newFrame.y())));
             auto& frameView = *page->mainFrame().virtualView();
             if (newFrame.maxX() > frameView.width())
                 newFrame.setX(frameView.width() - newFrame.width());

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -384,7 +384,7 @@ void ServicesOverlayController::buildPhoneNumberHighlights()
         // Convert to the main document's coordinate space.
         // FIXME: It's a little crazy to call contentsToWindow and then windowToContents in order to get the right coordinate space.
         // We should consider adding conversion functions to ScrollView for contentsToDocument(). Right now, contentsToRootView() is
-        // not equivalent to what we need when you have a topContentInset or a header banner.
+        // not equivalent to what we need when you have a content inset or a header banner.
         auto* viewForRange = range.start.document().view();
         if (!viewForRange)
             continue;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -791,16 +791,16 @@ void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameVie
 
     ASSERT(frameView.scrollPosition() == roundedIntPoint(scrollPosition));
     LayoutPoint scrollPositionForFixed = frameView.scrollPositionForFixedPosition();
-    float topContentInset = frameView.topContentInset();
+    auto obscuredContentInsets = frameView.obscuredContentInsets();
 
     FloatPoint positionForInsetClipLayer;
     if (insetClipLayer)
-        positionForInsetClipLayer = FloatPoint(insetClipLayer->position().x(), LocalFrameView::yPositionForInsetClipLayer(scrollPosition, topContentInset));
+        positionForInsetClipLayer = FloatPoint(insetClipLayer->position().x(), LocalFrameView::yPositionForInsetClipLayer(scrollPosition, obscuredContentInsets.top()));
     FloatPoint positionForContentsLayer = frameView.positionForRootContentLayer();
     
-    FloatPoint positionForHeaderLayer = FloatPoint(scrollPositionForFixed.x(), LocalFrameView::yPositionForHeaderLayer(scrollPosition, topContentInset));
+    FloatPoint positionForHeaderLayer = FloatPoint(scrollPositionForFixed.x(), LocalFrameView::yPositionForHeaderLayer(scrollPosition, obscuredContentInsets.top()));
     FloatPoint positionForFooterLayer = FloatPoint(scrollPositionForFixed.x(),
-        LocalFrameView::yPositionForFooterLayer(scrollPosition, topContentInset, frameView.totalContentsSize().height(), frameView.footerHeight()));
+        LocalFrameView::yPositionForFooterLayer(scrollPosition, obscuredContentInsets.top(), frameView.totalContentsSize().height(), frameView.footerHeight()));
 
     if (scrollType == ScrollType::Programmatic || scrollingLayerPositionAction == ScrollingLayerPositionAction::Set) {
         reconcileScrollPosition(frameView, ScrollingLayerPositionAction::Set);
@@ -1001,7 +1001,7 @@ void AsyncScrollingCoordinator::setFrameScrollingNodeState(ScrollingNodeID nodeI
     frameScrollingNode->setFrameScaleFactor(frameView.frame().frameScaleFactor());
     frameScrollingNode->setHeaderHeight(frameView.headerHeight());
     frameScrollingNode->setFooterHeight(frameView.footerHeight());
-    frameScrollingNode->setTopContentInset(frameView.topContentInset());
+    frameScrollingNode->setObscuredContentInsets(frameView.obscuredContentInsets());
     frameScrollingNode->setLayoutViewport(frameView.layoutViewportRect());
     frameScrollingNode->setAsyncFrameOrOverflowScrollingEnabled(settings.asyncFrameScrollingEnabled() || settings.asyncOverflowScrollingEnabled());
     frameScrollingNode->setScrollingPerformanceTestingEnabled(settings.scrollingPerformanceTestingEnabled());

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -77,7 +77,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     int headerHeight,
     int footerHeight,
     ScrollBehaviorForFixedElements&& scrollBehaviorForFixedElements,
-    float topContentInset,
+    FloatBoxExtent&& obscuredContentInsets,
     bool visualViewportIsSmallerThanLayoutViewport,
     bool asyncFrameOrOverflowScrollingEnabled,
     bool wheelEventGesturesBecomeNonBlocking,
@@ -129,7 +129,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     , m_maxLayoutViewportOrigin(maxLayoutViewportOrigin)
     , m_overrideVisualViewportSize(overrideVisualViewportSize)
     , m_frameScaleFactor(frameScaleFactor)
-    , m_topContentInset(topContentInset)
+    , m_obscuredContentInsets(obscuredContentInsets)
     , m_headerHeight(headerHeight)
     , m_footerHeight(footerHeight)
     , m_behaviorForFixed(WTFMove(scrollBehaviorForFixedElements))
@@ -157,7 +157,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(const Scrolli
     , m_maxLayoutViewportOrigin(stateNode.maxLayoutViewportOrigin())
     , m_overrideVisualViewportSize(stateNode.overrideVisualViewportSize())
     , m_frameScaleFactor(stateNode.frameScaleFactor())
-    , m_topContentInset(stateNode.topContentInset())
+    , m_obscuredContentInsets(stateNode.obscuredContentInsets())
     , m_headerHeight(stateNode.headerHeight())
     , m_footerHeight(stateNode.footerHeight())
     , m_behaviorForFixed(stateNode.scrollBehaviorForFixedElements())
@@ -207,7 +207,7 @@ OptionSet<ScrollingStateNode::Property> ScrollingStateFrameScrollingNode::applic
         Property::HeaderLayer,
         Property::FooterLayer,
         Property::BehaviorForFixedElements,
-        Property::TopContentInset,
+        Property::ObscuredContentInsets,
         Property::VisualViewportIsSmallerThanLayoutViewport,
         Property::AsyncFrameOrOverflowScrollingEnabled,
         Property::WheelEventGesturesBecomeNonBlocking,
@@ -306,13 +306,13 @@ void ScrollingStateFrameScrollingNode::setFooterHeight(int footerHeight)
     setPropertyChanged(Property::FooterHeight);
 }
 
-void ScrollingStateFrameScrollingNode::setTopContentInset(float topContentInset)
+void ScrollingStateFrameScrollingNode::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInsets)
 {
-    if (m_topContentInset == topContentInset)
+    if (m_obscuredContentInsets == obscuredContentInsets)
         return;
 
-    m_topContentInset = topContentInset;
-    setPropertyChanged(Property::TopContentInset);
+    m_obscuredContentInsets = obscuredContentInsets;
+    setPropertyChanged(Property::ObscuredContentInsets);
 }
 
 void ScrollingStateFrameScrollingNode::setRootContentsLayer(const LayerRepresentation& layerRepresentation)
@@ -440,8 +440,14 @@ void ScrollingStateFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<
 
     if (m_frameScaleFactor != 1)
         ts.dumpProperty("frame scale factor", m_frameScaleFactor);
-    if (m_topContentInset)
-        ts.dumpProperty("top content inset", m_topContentInset);
+    if (m_obscuredContentInsets.top())
+        ts.dumpProperty("top content inset", m_obscuredContentInsets.top());
+    if (m_obscuredContentInsets.bottom())
+        ts.dumpProperty("bottom content inset", m_obscuredContentInsets.bottom());
+    if (m_obscuredContentInsets.left())
+        ts.dumpProperty("left content inset", m_obscuredContentInsets.left());
+    if (m_obscuredContentInsets.right())
+        ts.dumpProperty("right content inset", m_obscuredContentInsets.right());
     if (m_headerHeight)
         ts.dumpProperty("header height", m_headerHeight);
     if (m_footerHeight)

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(ASYNC_SCROLLING)
 
+#include "BoxExtents.h"
 #include "EventTrackingRegions.h"
 #include "ScrollTypes.h"
 #include "ScrollbarThemeComposite.h"
@@ -74,8 +75,8 @@ public:
     int footerHeight() const { return m_footerHeight; }
     WEBCORE_EXPORT void setFooterHeight(int);
 
-    float topContentInset() const { return m_topContentInset; }
-    WEBCORE_EXPORT void setTopContentInset(float);
+    FloatBoxExtent obscuredContentInsets() const { return m_obscuredContentInsets; }
+    WEBCORE_EXPORT void setObscuredContentInsets(const FloatBoxExtent&);
 
     const LayerRepresentation& rootContentsLayer() const { return m_rootContentsLayer; }
     WEBCORE_EXPORT void setRootContentsLayer(const LayerRepresentation&);
@@ -85,8 +86,8 @@ public:
     WEBCORE_EXPORT void setCounterScrollingLayer(const LayerRepresentation&);
 
     // This is a clipping layer that will scroll with the page for all y-delta scroll values between 0
-    // and topContentInset(). Once the y-deltas get beyond the content inset point, this layer no longer
-    // needs to move. If the topContentInset() is 0, this layer does not need to move at all. This is
+    // and obscuredInset().top. Once the y-deltas get beyond the content inset point, this layer no longer
+    // needs to move. If the obscuredInset().top is 0, this layer does not need to move at all. This is
     // only used on the Mac.
     const LayerRepresentation& insetClipLayer() const { return m_insetClipLayer; }
     WEBCORE_EXPORT void setInsetClipLayer(const LayerRepresentation&);
@@ -164,7 +165,7 @@ private:
         int headerHeight,
         int footerHeight,
         ScrollBehaviorForFixedElements&&,
-        float topContentInset,
+        FloatBoxExtent&& obscuredContentInsets,
         bool visualViewportIsSmallerThanLayoutViewport,
         bool asyncFrameOrOverflowScrollingEnabled,
         bool wheelEventGesturesBecomeNonBlocking,
@@ -196,7 +197,7 @@ private:
     std::optional<FloatSize> m_overrideVisualViewportSize;
 
     float m_frameScaleFactor { 1 };
-    float m_topContentInset { 0 };
+    FloatBoxExtent m_obscuredContentInsets;
     int m_headerHeight { 0 };
     int m_footerHeight { 0 };
     ScrollBehaviorForFixedElements m_behaviorForFixed { ScrollBehaviorForFixedElements::StickToDocumentBounds };

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -241,8 +241,8 @@ enum class ScrollingStateNodeProperty : uint64_t {
     HeaderLayer                                 = 1LLU << 50, // Not serialized
     FooterLayer                                 = 1LLU << 43, // Not serialized
     BehaviorForFixedElements                    = FooterHeight << 1,
-    TopContentInset                             = BehaviorForFixedElements << 1,
-    VisualViewportIsSmallerThanLayoutViewport   = TopContentInset << 1,
+    ObscuredContentInsets                               = BehaviorForFixedElements << 1,
+    VisualViewportIsSmallerThanLayoutViewport   = ObscuredContentInsets << 1,
     AsyncFrameOrOverflowScrollingEnabled        = VisualViewportIsSmallerThanLayoutViewport << 1,
     WheelEventGesturesBecomeNonBlocking         = AsyncFrameOrOverflowScrollingEnabled << 1,
     ScrollingPerformanceTestingEnabled          = WheelEventGesturesBecomeNonBlocking << 1,

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -653,10 +653,12 @@ void ScrollingTree::clearLatchedNode()
     m_latchingController.clearLatchedNode();
 }
 
-float ScrollingTree::mainFrameTopContentInset() const
+FloatBoxExtent ScrollingTree::mainFrameObscuredContentInsets() const
 {
     Locker locker { m_treeStateLock };
-    return m_rootNode ? m_rootNode->topContentInset() : 0;
+    if (m_rootNode)
+        return m_rootNode->obscuredContentInsets();
+    return { };
 }
 
 FloatPoint ScrollingTree::mainFrameScrollPosition() const

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -227,7 +227,7 @@ public:
 
     virtual void removePendingScrollAnimationForNode(ScrollingNodeID) { }
 
-    WEBCORE_EXPORT float mainFrameTopContentInset() const;
+    WEBCORE_EXPORT FloatBoxExtent mainFrameObscuredContentInsets() const;
 
     WEBCORE_EXPORT FloatPoint mainFrameScrollPosition() const;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
@@ -69,8 +69,8 @@ bool ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(const ScrollingS
     if (state->hasChangedProperty(ScrollingStateNode::Property::BehaviorForFixedElements))
         m_behaviorForFixed = state->scrollBehaviorForFixedElements();
 
-    if (state->hasChangedProperty(ScrollingStateNode::Property::TopContentInset))
-        m_topContentInset = state->topContentInset();
+    if (state->hasChangedProperty(ScrollingStateNode::Property::ObscuredContentInsets))
+        m_obscuredContentInsets = state->obscuredContentInsets();
 
     if (state->hasChangedProperty(ScrollingStateNode::Property::VisualViewportIsSmallerThanLayoutViewport))
         m_visualViewportIsSmallerThanLayoutViewport = state->visualViewportIsSmallerThanLayoutViewport();
@@ -137,7 +137,8 @@ FloatRect ScrollingTreeFrameScrollingNode::layoutViewportRespectingRubberBanding
 
 FloatSize ScrollingTreeFrameScrollingNode::viewToContentsOffset(const FloatPoint& scrollPosition) const
 {
-    return toFloatSize(scrollPosition) - FloatSize(0, headerHeight() + topContentInset());
+    auto obscuredContentInsets = this->obscuredContentInsets();
+    return toFloatSize(scrollPosition) - FloatSize(obscuredContentInsets.left(), headerHeight() + obscuredContentInsets.top());
 }
 
 void ScrollingTreeFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
@@ -154,8 +155,15 @@ void ScrollingTreeFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<S
 
     if (m_frameScaleFactor != 1)
         ts.dumpProperty("frame scale factor", m_frameScaleFactor);
-    if (m_topContentInset)
-        ts.dumpProperty("top content inset", m_topContentInset);
+
+    if (m_obscuredContentInsets.top())
+        ts.dumpProperty("top content inset", m_obscuredContentInsets.top());
+    if (m_obscuredContentInsets.bottom())
+        ts.dumpProperty("bottom content inset", m_obscuredContentInsets.bottom());
+    if (m_obscuredContentInsets.left())
+        ts.dumpProperty("left content inset", m_obscuredContentInsets.left());
+    if (m_obscuredContentInsets.right())
+        ts.dumpProperty("right content inset", m_obscuredContentInsets.right());
 
     if (m_headerHeight)
         ts.dumpProperty("header height", m_headerHeight);

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -54,7 +54,7 @@ public:
     float frameScaleFactor() const { return m_frameScaleFactor; }
     int headerHeight() const { return m_headerHeight; }
     int footerHeight() const { return m_footerHeight; }
-    float topContentInset() const { return m_topContentInset; }
+    FloatBoxExtent obscuredContentInsets() const { return m_obscuredContentInsets; }
     virtual void viewWillStartLiveResize() { }
     virtual void viewWillEndLiveResize() { }
     virtual void viewSizeDidChange() { }
@@ -79,7 +79,7 @@ private:
     std::optional<FloatSize> m_overrideVisualViewportSize;
     
     float m_frameScaleFactor { 1 };
-    float m_topContentInset { 0 };
+    FloatBoxExtent m_obscuredContentInsets;
 
     int m_headerHeight { 0 };
     int m_footerHeight { 0 };

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
@@ -127,7 +127,7 @@ void ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers()
     if (m_counterScrollingLayer)
         m_counterScrollingLayer->setPositionForScrolling(layoutViewport.location());
 
-    float topContentInset = this->topContentInset();
+    float topContentInset = obscuredContentInsets().top();
     if (m_insetClipLayer && m_rootContentsLayer) {
         FloatPoint insetClipPosition;
         {

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -196,10 +196,10 @@ void ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers()
     if (m_counterScrollingLayer)
         m_counterScrollingLayer.get().position = layoutViewport.location();
 
-    float topContentInset = this->topContentInset();
+    auto obscuredContentInsets = this->obscuredContentInsets();
     if (m_insetClipLayer && m_rootContentsLayer) {
-        m_insetClipLayer.get().position = FloatPoint(m_insetClipLayer.get().position.x, LocalFrameView::yPositionForInsetClipLayer(scrollPosition, topContentInset));
-        m_rootContentsLayer.get().position = LocalFrameView::positionForRootContentLayer(scrollPosition, scrollOrigin(), topContentInset, headerHeight());
+        m_insetClipLayer.get().position = FloatPoint(m_insetClipLayer.get().position.x, LocalFrameView::yPositionForInsetClipLayer(scrollPosition, obscuredContentInsets.top()));
+        m_rootContentsLayer.get().position = LocalFrameView::positionForRootContentLayer(scrollPosition, scrollOrigin(), obscuredContentInsets.top(), headerHeight());
         if (m_contentShadowLayer)
             m_contentShadowLayer.get().position = m_rootContentsLayer.get().position;
     }
@@ -210,10 +210,10 @@ void ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers()
         // then we should recompute layoutViewport.x() for the banner with a scale factor of 1.
         float horizontalScrollOffsetForBanner = layoutViewport.x();
         if (m_headerLayer)
-            m_headerLayer.get().position = FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForHeaderLayer(scrollPosition, topContentInset));
+            m_headerLayer.get().position = FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForHeaderLayer(scrollPosition, obscuredContentInsets.top()));
 
         if (m_footerLayer)
-            m_footerLayer.get().position = FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForFooterLayer(scrollPosition, topContentInset, totalContentsSize().height(), footerHeight()));
+            m_footerLayer.get().position = FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForFooterLayer(scrollPosition, obscuredContentInsets.top(), totalContentsSize().height(), footerHeight()));
     }
     END_BLOCK_OBJC_EXCEPTIONS
 

--- a/Source/WebCore/platform/BoxExtents.h
+++ b/Source/WebCore/platform/BoxExtents.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,16 +23,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "_WKThumbnailView.h"
+#pragma once
 
-#if PLATFORM(MAC)
+#include "LayoutUnit.h"
+#include "RectEdges.h"
 
-@interface _WKThumbnailView ()
+namespace WebCore {
 
-@property (nonatomic, assign, setter=_setThumbnailLayer:) CALayer *_thumbnailLayer;
-@property (nonatomic, assign, setter=_setWaitingForSnapshot:) BOOL _waitingForSnapshot;
-@property (nonatomic, assign, setter=_setSublayerTranslation:) CGPoint _sublayerTranslation;
+using FloatBoxExtent = RectEdges<float>;
+using IntBoxExtent = RectEdges<int>;
+using LayoutBoxExtent = RectEdges<LayoutUnit>;
 
-@end
-
-#endif // PLATFORM(MAC)
+} // namespace WebCore

--- a/Source/WebCore/platform/LengthBox.h
+++ b/Source/WebCore/platform/LengthBox.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include "BoxExtents.h"
 #include "Length.h"
-#include "RectEdges.h"
 #include "WritingMode.h"
 
 namespace WebCore {
@@ -62,10 +62,6 @@ public:
         return top().isZero() && right().isZero() && bottom().isZero() && left().isZero();
     }
 };
-
-using LayoutBoxExtent = RectEdges<LayoutUnit>;
-using FloatBoxExtent = RectEdges<float>;
-using IntBoxExtent = RectEdges<int>;
 
 using IntOutsets = IntBoxExtent;
 using LayoutOptionalOutsets = RectEdges<std::optional<LayoutUnit>>;

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -176,13 +176,14 @@ public:
     void setCanBlitOnScroll(bool);
     bool canBlitOnScroll() const;
 
-    // There are at least three types of contentInset. Usually we just care about WebCoreContentInset, which is the inset
+    // There are at least three types of contentInset. Usually we just care about WebCoreInset, which is the inset
     // that is set on a Page that requires WebCore to move its layers to accomodate the inset. However, there are platform
     // concepts that are similar on both iOS and Mac when there is a platformWidget(). Sometimes we need the Mac platform value
-    // for topContentInset, so when the TopContentInsetType is WebCoreOrPlatformContentInset, platformTopContentInset()
+    // for content insets, so when the inset type is WebCoreOrPlatformInset, platformContentInsets()
     // will be returned instead of the value set on Page.
-    enum class TopContentInsetType { WebCoreContentInset, WebCoreOrPlatformContentInset };
-    virtual float topContentInset(TopContentInsetType = TopContentInsetType::WebCoreContentInset) const { return 0; }
+    // FIXME: Note that WebCoreOrPlatformInset may return either WebCore obscured insets or platform content insets.
+    enum class InsetType : bool { WebCoreInset, WebCoreOrPlatformInset };
+    virtual FloatBoxExtent obscuredContentInsets(InsetType = InsetType::WebCoreInset) const { return 0; }
     IntRect frameRectShrunkByInset() const;
 
     // The visible content rect has a location that is the scrolled offset of the document. The width and height are the unobscured viewport
@@ -267,7 +268,7 @@ public:
     ScrollPosition documentScrollPositionRelativeToScrollableAreaOrigin() const;
 
     // scrollPostion() anchors its (0,0) point at the ScrollableArea's origin. The top of the scrolling
-    // layer does not represent the top of the view when there is a topContentInset. Additionally, as
+    // layer does not represent the top/left of the view when there are content insets. Additionally, as
     // detailed above, the origin of the scrolling layer also does not necessarily correspond with the
     // top of the document anyway, since there could also be header. documentScrollPositionRelativeToViewOrigin()
     // will return a version of the current scroll offset which tracks the top of the Document
@@ -431,8 +432,8 @@ protected:
     virtual bool isVerticalDocument() const = 0;
     virtual bool isFlippedDocument() const = 0;
 
-    float platformTopContentInset() const;
-    void platformSetTopContentInset(float);
+    FloatBoxExtent platformContentInsets() const;
+    void platformSetContentInsets(const FloatBoxExtent&);
 
     void handleDeferredScrollUpdateAfterContentSizeChange();
 

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BoxExtents.h"
 #include "IntPoint.h"
 #include "PlatformLayerIdentifier.h"
 #include "TileGridIdentifier.h"
@@ -122,7 +123,7 @@ public:
     virtual bool tilesWouldChangeForCoverageRect(const FloatRect&) const = 0;
 
     virtual void setTiledScrollingIndicatorPosition(const FloatPoint&) = 0;
-    virtual void setTopContentInset(float) = 0;
+    virtual void setObscuredContentInsets(const FloatBoxExtent&) = 0;
 
     virtual void setVelocity(const VelocityData&) = 0;
 

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -314,10 +314,10 @@ void TileController::setScrollability(OptionSet<Scrollability> scrollability)
     notePendingTileSizeChange();
 }
 
-void TileController::setTopContentInset(float topContentInset)
+void TileController::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInsets)
 {
-    m_topContentInset = topContentInset;
-    setTiledScrollingIndicatorPosition(FloatPoint(0, m_topContentInset));
+    m_obscuredContentInsets = obscuredContentInsets;
+    setTiledScrollingIndicatorPosition({ obscuredContentInsets.left(), obscuredContentInsets.top() });
 }
 
 void TileController::setTiledScrollingIndicatorPosition(const FloatPoint& position)

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BoxExtents.h"
 #include "FloatRect.h"
 #include "IntRect.h"
 #include "LengthBox.h"
@@ -156,7 +157,7 @@ private:
 
     void scheduleTileRevalidation(Seconds interval);
 
-    float topContentInset() const { return m_topContentInset; }
+    FloatBoxExtent obscuredContentInsets() const { return m_obscuredContentInsets; }
 
     // TiledBacking member functions.
     PlatformLayerIdentifier layerIdentifier() const final;
@@ -170,7 +171,7 @@ private:
     void setCoverageRect(const FloatRect&) final;
     bool tilesWouldChangeForCoverageRect(const FloatRect&) const final;
     void setTiledScrollingIndicatorPosition(const FloatPoint&) final;
-    void setTopContentInset(float) final;
+    void setObscuredContentInsets(const FloatBoxExtent&) final;
     void setVelocity(const VelocityData&) final;
     void setScrollability(OptionSet<Scrollability>) final;
     void prepopulateRect(const FloatRect&) final;
@@ -269,7 +270,7 @@ private:
     Color m_tileDebugBorderColor;
     float m_tileDebugBorderWidth { 0 };
     ScrollingModeIndication m_indicatorMode { SynchronousScrollingBecauseOfLackOfScrollingCoordinatorIndication };
-    float m_topContentInset { 0 };
+    FloatBoxExtent m_obscuredContentInsets;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp
@@ -42,8 +42,10 @@ TileCoverageMap::TileCoverageMap(const TileController& controller)
     , m_visibleViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
     , m_layoutViewportIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
     , m_coverageRectIndicatorLayer(controller.rootLayer().createCompatibleLayer(PlatformCALayer::LayerType::LayerTypeLayer, nullptr))
-    , m_position(FloatPoint(0, controller.topContentInset()))
 {
+    auto obscuredContentInsets = controller.obscuredContentInsets();
+    m_position = { obscuredContentInsets.left(), obscuredContentInsets.top() };
+
     m_layer.get().setOpacity(0.75);
     m_layer.get().setAnchorPoint(FloatPoint3D());
     m_layer.get().setBorderColor(Color::black);
@@ -101,7 +103,7 @@ void TileCoverageMap::update()
     float scale = 1;
     if (!containerBounds.isEmpty()) {
         widthScale = std::min<float>(visibleRect.width() / containerBounds.width(), 0.1);
-        float visibleHeight = visibleRect.height() - std::min(m_controller.topContentInset(), visibleRect.y());
+        float visibleHeight = visibleRect.height() - std::min(m_controller.obscuredContentInsets().top(), visibleRect.y());
         scale = std::min(widthScale, visibleHeight / containerBounds.height());
     }
 

--- a/Source/WebCore/platform/ios/ScrollViewIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollViewIOS.mm
@@ -138,12 +138,12 @@ void ScrollView::setActualScrollPosition(const IntPoint& position)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-float ScrollView::platformTopContentInset() const
+FloatBoxExtent ScrollView::platformContentInsets() const
 {
-    return 0;
+    return { };
 }
 
-void ScrollView::platformSetTopContentInset(float)
+void ScrollView::platformSetContentInsets(const FloatBoxExtent&)
 {
 }
 

--- a/Source/WebCore/platform/mac/ScrollViewMac.mm
+++ b/Source/WebCore/platform/mac/ScrollViewMac.mm
@@ -114,26 +114,29 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
-float ScrollView::platformTopContentInset() const
+FloatBoxExtent ScrollView::platformContentInsets() const
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    return scrollView().contentInsets.top;
+    auto insets = scrollView().contentInsets;
+    return {
+        static_cast<float>(insets.top),
+        static_cast<float>(insets.right),
+        static_cast<float>(insets.bottom),
+        static_cast<float>(insets.left)
+    };
     END_BLOCK_OBJC_EXCEPTIONS
 
     return 0;
 }
 
-void ScrollView::platformSetTopContentInset(float topContentInset)
+void ScrollView::platformSetContentInsets(const FloatBoxExtent& insets)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    if (topContentInset)
+    if (insets.top() || insets.left() || insets.right() || insets.bottom())
         scrollView().automaticallyAdjustsContentInsets = NO;
     else
         scrollView().automaticallyAdjustsContentInsets = YES;
-
-    NSEdgeInsets contentInsets = scrollView().contentInsets;
-    contentInsets.top = topContentInset;
-    scrollView().contentInsets = contentInsets;
+    scrollView().contentInsets = NSEdgeInsetsMake(insets.top(), insets.left(), insets.bottom(), insets.right());
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2389,7 +2389,7 @@ bool RenderLayerCompositor::updateBacking(RenderLayer& layer, RequiresCompositin
                 updateRootContentLayerClipping();
 
                 if (auto* tiledBacking = layer.backing()->tiledBacking())
-                    tiledBacking->setTopContentInset(frameView.topContentInset());
+                    tiledBacking->setObscuredContentInsets(frameView.obscuredContentInsets());
             }
 
             layer.setNeedsCompositingGeometryUpdate();
@@ -2840,7 +2840,7 @@ FloatPoint RenderLayerCompositor::positionForClipLayer() const
     auto& frameView = m_renderView.frameView();
 
     return FloatPoint(frameView.insetForLeftScrollbarSpace(),
-        LocalFrameView::yPositionForInsetClipLayer(frameView.scrollPosition(), frameView.topContentInset()));
+        LocalFrameView::yPositionForInsetClipLayer(frameView.scrollPosition(), frameView.obscuredContentInsets().top()));
 }
 
 void RenderLayerCompositor::frameViewDidScroll()
@@ -4637,7 +4637,7 @@ GraphicsLayer* RenderLayerCompositor::updateLayerForBottomOverhangArea(bool want
     }
 
     m_layerForBottomOverhangArea->setPosition(FloatPoint(0, m_rootContentsLayer->size().height() + m_renderView.frameView().headerHeight()
-        + m_renderView.frameView().footerHeight() + m_renderView.frameView().topContentInset()));
+        + m_renderView.frameView().footerHeight() + m_renderView.frameView().obscuredContentInsets().top()));
     return m_layerForBottomOverhangArea.get();
 }
 
@@ -4665,7 +4665,7 @@ GraphicsLayer* RenderLayerCompositor::updateLayerForHeader(bool wantsLayer)
     }
 
     m_layerForHeader->setPosition(FloatPoint(0,
-        LocalFrameView::yPositionForHeaderLayer(m_renderView.frameView().scrollPosition(), m_renderView.frameView().topContentInset())));
+        LocalFrameView::yPositionForHeaderLayer(m_renderView.frameView().scrollPosition(), m_renderView.frameView().obscuredContentInsets().top())));
     m_layerForHeader->setAnchorPoint(FloatPoint3D());
     m_layerForHeader->setSize(FloatSize(m_renderView.frameView().visibleWidth(), m_renderView.frameView().headerHeight()));
 
@@ -4702,7 +4702,7 @@ GraphicsLayer* RenderLayerCompositor::updateLayerForFooter(bool wantsLayer)
 
     float totalContentHeight = m_rootContentsLayer->size().height() + m_renderView.frameView().headerHeight() + m_renderView.frameView().footerHeight();
     m_layerForFooter->setPosition(FloatPoint(0, LocalFrameView::yPositionForFooterLayer(m_renderView.frameView().scrollPosition(),
-        m_renderView.frameView().topContentInset(), totalContentHeight, m_renderView.frameView().footerHeight())));
+        m_renderView.frameView().obscuredContentInsets().top(), totalContentHeight, m_renderView.frameView().footerHeight())));
     m_layerForFooter->setAnchorPoint(FloatPoint3D());
     m_layerForFooter->setSize(FloatSize(m_renderView.frameView().visibleWidth(), m_renderView.frameView().footerHeight()));
 
@@ -4845,12 +4845,12 @@ void RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer()
     if (!m_layerForOverhangAreas)
         return;
 
-    float topContentInset = m_renderView.frameView().topContentInset();
+    auto obscuredContentInsets = m_renderView.frameView().obscuredContentInsets();
     IntSize overhangAreaSize = m_renderView.frameView().frameRect().size();
-    overhangAreaSize.contract(0, topContentInset);
+    overhangAreaSize.contract(obscuredContentInsets.left(), obscuredContentInsets.top());
     overhangAreaSize.clampNegativeToZero();
     m_layerForOverhangAreas->setSize(overhangAreaSize);
-    m_layerForOverhangAreas->setPosition({ 0, topContentInset });
+    m_layerForOverhangAreas->setPosition({ obscuredContentInsets.left(), obscuredContentInsets.top() });
 }
 #endif
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BoxExtents.h"
 #include "PseudoElementIdentifier.h"
 #include "WritingMode.h"
 #include <unicode/utypes.h>
@@ -282,10 +283,8 @@ struct TransformOperationData;
 template<typename> class FontTaggedSettings;
 template<typename> class RectEdges;
 
-using FloatBoxExtent = RectEdges<float>;
 using FontVariationSettings = FontTaggedSettings<float>;
 using IntOutsets = RectEdges<int>;
-using LayoutBoxExtent = RectEdges<LayoutUnit>;
 
 namespace Style {
 class CustomPropertyRegistry;

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "BoxExtents.h"
 #include "CSSPrimitiveNumericUnits.h"
 #include "Length.h"
 #include "StyleValueTypes.h"
@@ -34,7 +35,6 @@ class CSSValue;
 class LayoutRect;
 class LayoutUnit;
 class RenderStyle;
-using LayoutBoxExtent = RectEdges<LayoutUnit>;
 
 namespace Style {
 

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "BoxExtents.h"
 #include "CSSPrimitiveNumericUnits.h"
 #include "Length.h"
 #include "StyleValueTypes.h"
@@ -34,7 +35,6 @@ class CSSValue;
 class LayoutRect;
 class LayoutUnit;
 class RenderStyle;
-using LayoutBoxExtent = RectEdges<LayoutUnit>;
 
 namespace Style {
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -580,7 +580,7 @@ void Internals::resetToConsistentState(Page& page)
     if (mainFrameView) {
         page.setHeaderHeight(0);
         page.setFooterHeight(0);
-        page.setTopContentInset(0);
+        page.setObscuredContentInsets({ });
         mainFrameView->setUseFixedLayout(false);
         mainFrameView->setFixedLayoutSize(IntSize());
         mainFrameView->enableFixedWidthAutoSizeMode(false, { });

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -180,8 +180,8 @@ static void dump(TextStream& ts, const ScrollingStateFrameScrollingNode& node, b
     if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::FooterHeight))
         ts.dumpProperty("footer-height", node.footerHeight());
 
-    if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::TopContentInset))
-        ts.dumpProperty("top-content-inset", node.topContentInset());
+    if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::ObscuredContentInsets))
+        ts.dumpProperty("content-insets", node.obscuredContentInsets());
 
     if (!changedPropertiesOnly || node.hasChangedProperty(ScrollingStateNode::Property::FrameScaleFactor))
         ts.dumpProperty("frame-scale-factor", node.frameScaleFactor());

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -105,7 +105,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::HeaderHeight] int headerHeight()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::FooterHeight] int footerHeight()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::BehaviorForFixedElements] WebCore::ScrollBehaviorForFixedElements scrollBehaviorForFixedElements()
-    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::TopContentInset] float topContentInset()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ObscuredContentInsets] WebCore::FloatBoxExtent obscuredContentInsets()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::VisualViewportIsSmallerThanLayoutViewport] bool visualViewportIsSmallerThanLayoutViewport()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::AsyncFrameOrOverflowScrollingEnabled] bool asyncFrameOrOverflowScrollingEnabled()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::WheelEventGesturesBecomeNonBlocking] bool wheelEventGesturesBecomeNonBlocking();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4402,7 +4402,7 @@ header: <WebCore/ScrollingStateNode.h>
     HeaderLayer
     FooterLayer
     BehaviorForFixedElements
-    TopContentInset
+    ObscuredContentInsets
     VisualViewportIsSmallerThanLayoutViewport
     AsyncFrameOrOverflowScrollingEnabled
     WheelEventGesturesBecomeNonBlocking

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -154,7 +154,7 @@ struct WebPageCreationParameters {
     double textZoomFactor { 1 };
     double pageZoomFactor { 1 };
 
-    float topContentInset { 0 };
+    WebCore::FloatBoxExtent obscuredContentInsets { };
     
     float mediaVolume { 0 };
     WebCore::MediaProducerMutedStateFlags muted { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -76,7 +76,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     double textZoomFactor;
     double pageZoomFactor;
 
-    float topContentInset;
+    WebCore::FloatBoxExtent obscuredContentInsets;
 
     float mediaVolume;
     WebCore::MediaProducerMutedStateFlags muted;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1868,12 +1868,12 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     auto frame = WebCore::FloatSize(self.frame.size);
 
 #if PLATFORM(MAC)
-    CGFloat additionalTopInset = self._topContentInset;
+    auto additionalInsets = _impl->obscuredContentInsets();
 #else
-    CGFloat additionalTopInset = 0;
+    WebCore::FloatBoxExtent additionalInsets;
 #endif
 
-    auto maximumViewportInsetSize = WebCore::FloatSize(maximumViewportInset.left + maximumViewportInset.right, maximumViewportInset.top + additionalTopInset + maximumViewportInset.bottom);
+    auto maximumViewportInsetSize = WebCore::FloatSize(maximumViewportInset.left + additionalInsets.left() + maximumViewportInset.right, maximumViewportInset.top + additionalInsets.top() + maximumViewportInset.bottom);
     auto minimumUnobscuredSize = frame - maximumViewportInsetSize;
     if (minimumUnobscuredSize.isEmpty()) {
         if (!maximumViewportInsetSize.isEmpty()) {
@@ -1888,7 +1888,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
         minimumUnobscuredSize = frame;
     }
 
-    auto minimumViewportInsetSize = WebCore::FloatSize(minimumViewportInset.left + minimumViewportInset.right, minimumViewportInset.top + additionalTopInset + minimumViewportInset.bottom);
+    auto minimumViewportInsetSize = WebCore::FloatSize(minimumViewportInset.left + additionalInsets.left() + minimumViewportInset.right, minimumViewportInset.top + additionalInsets.top() + minimumViewportInset.bottom);
     auto maximumUnobscuredSize = frame - minimumViewportInsetSize;
     if (maximumUnobscuredSize.isEmpty()) {
         if (!minimumViewportInsetSize.isEmpty()) {

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1471,21 +1471,25 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _impl->setDrawsBackground(drawsBackground);
 }
 
-- (void)_setTopContentInset:(CGFloat)contentInset
+- (void)_setTopContentInset:(CGFloat)inset
 {
-    _impl->setTopContentInset(contentInset);
+    auto insets = _impl->obscuredContentInsets();
+    insets.setTop(static_cast<float>(inset));
+    _impl->setObscuredContentInsets(insets);
 }
 
 - (CGFloat)_topContentInset
 {
-    return _impl->topContentInset();
+    return _impl->obscuredContentInsets().top();
 }
 
-- (void)_setTopContentInset:(CGFloat)contentInset immediate:(BOOL)immediate
+- (void)_setTopContentInset:(CGFloat)inset immediate:(BOOL)immediate
 {
-    _impl->setTopContentInset(contentInset);
+    auto insets = _impl->obscuredContentInsets();
+    insets.setTop(static_cast<float>(inset));
+    _impl->setObscuredContentInsets(insets);
     if (immediate)
-        _impl->flushPendingTopContentInset();
+        _impl->flushPendingObscuredContentInsetChanges();
 }
 
 - (void)_setAutomaticallyAdjustsContentInsets:(BOOL)automaticallyAdjustsContentInsets

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -2069,9 +2069,10 @@ void WebAutomationSession::performMouseInteraction(const Inspector::Protocol::Au
             if (error)
                 callback->sendFailure(error.value().toProtocolString());
             else {
+                auto obscuredContentInsets = page->obscuredContentInsets();
                 callback->sendSuccess(Inspector::Protocol::Automation::Point::create()
-                    .setX(floatX)
-                    .setY(floatY - page->topContentInset())
+                    .setX(floatX - obscuredContentInsets.left())
+                    .setY(floatY - obscuredContentInsets.top())
                     .release());
             }
         };

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -160,7 +160,8 @@ static WebCore::IntPoint viewportLocationToWindowLocation(WebCore::IntPoint loca
 {
     IntRect windowRect;
 
-    IntPoint locationInView = locationInViewport + IntPoint(0, page.topContentInset());
+    auto obscuredContentInsets = page.obscuredContentInsets();
+    IntPoint locationInView = locationInViewport + IntPoint(obscuredContentInsets.left(), obscuredContentInsets.top());
     page.rootViewToWindow(IntRect(locationInView, IntSize()), windowRect);
     return windowRect.location();
 }

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -56,7 +56,7 @@ public:
 
     void pageClosed() override;
 
-    void topContentInsetDidChange() final;
+    void obscuredContentInsetsDidChange() final;
 
 #if ENABLE(GPU_PROCESS)
     void gpuProcessDidFinishLaunching() override;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -54,7 +54,7 @@ PageClientImplCocoa::PageClientImplCocoa(WKWebView *webView)
 
 PageClientImplCocoa::~PageClientImplCocoa() = default;
 
-void PageClientImplCocoa::topContentInsetDidChange()
+void PageClientImplCocoa::obscuredContentInsetsDidChange()
 {
     [m_webView _recalculateViewportSizesWithMinimumViewportInset:[m_webView minimumViewportInset] maximumViewportInset:[m_webView maximumViewportInset] throwOnInvalidInput:NO];
 }

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -134,7 +134,6 @@ struct TextIndicatorData;
 struct ShareDataWithParsedURL;
 
 template <typename> class RectEdges;
-using FloatBoxExtent = RectEdges<float>;
 
 #if ENABLE(DRAG_SUPPORT)
 struct DragItem;
@@ -313,7 +312,7 @@ public:
 
     virtual void didChangeContentSize(const WebCore::IntSize&) = 0;
 
-    virtual void topContentInsetDidChange() { }
+    virtual void obscuredContentInsetsDidChange() { }
 
     virtual void showBrowsingWarning(const BrowsingWarning&, CompletionHandler<void(std::variant<ContinueUnsafeLoad, URL>&&)>&& completionHandler) { completionHandler(ContinueUnsafeLoad::Yes); }
     virtual void clearBrowsingWarning() { }
@@ -684,7 +683,7 @@ public:
 
     virtual bool windowIsFrontWindowUnderMouse(const NativeWebMouseEvent&) { return false; }
 
-    virtual std::optional<float> computeAutomaticTopContentInset() { return std::nullopt; }
+    virtual std::optional<float> computeAutomaticTopObscuredInset() { return std::nullopt; }
 
     virtual WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() = 0;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -132,7 +132,7 @@ private:
     virtual void scheduleDisplayRefreshCallbacks() { }
     virtual void pauseDisplayRefreshCallbacks() { }
 
-    virtual void dispatchSetTopContentInset() { }
+    virtual void dispatchSetObscuredContentInsets() { }
 
     float indicatorScale(WebCore::IntSize contentsSize) const;
     void updateDebugIndicator() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -171,7 +171,7 @@ void RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry()
     m_lastSentSizeToContentAutoSizeMaximumSize = webPageProxy->sizeToContentAutoSizeMaximumSize();
     m_lastSentSize = m_size;
 
-    dispatchSetTopContentInset();
+    dispatchSetObscuredContentInsets();
 
     m_isWaitingForDidUpdateGeometry = true;
     sendWithAsyncReply(Messages::DrawingArea::UpdateGeometry(m_size, false /* flushSynchronously */, MachSendRight()), [weakThis = WeakPtr { this }] {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -287,9 +287,9 @@ WebCore::FloatRect RemoteScrollingCoordinatorProxy::computeVisibleContentRect()
     return visibleContentRect;
 }
 
-float RemoteScrollingCoordinatorProxy::topContentInset() const
+WebCore::FloatBoxExtent RemoteScrollingCoordinatorProxy::obscuredContentInsets() const
 {
-    return m_scrollingTree->mainFrameTopContentInset();
+    return m_scrollingTree->mainFrameObscuredContentInsets();
 }
 
 WebCore::FloatPoint RemoteScrollingCoordinatorProxy::currentMainFrameScrollPosition() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -158,7 +158,7 @@ public:
     virtual void windowScreenWillChange() { }
     virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) { }
 
-    float topContentInset() const;
+    WebCore::FloatBoxExtent obscuredContentInsets() const;
     WebCore::FloatPoint currentMainFrameScrollPosition() const;
     WebCore::FloatRect computeVisibleContentRect();
     WebCore::IntPoint scrollOrigin() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -84,7 +84,7 @@ private:
     void windowScreenDidChange(WebCore::PlatformDisplayID) override;
     std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() override;
 
-    void dispatchSetTopContentInset() override;
+    void dispatchSetObscuredContentInsets() override;
 
     void colorSpaceDidChange() override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -173,20 +173,20 @@ void RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers(const RemoteLayerTre
         [CATransaction commit];
     };
 
-    float topContentInset = webPageProxy->scrollingCoordinatorProxy()->topContentInset();
+    float topInset = webPageProxy->scrollingCoordinatorProxy()->obscuredContentInsets().top();
     auto scrollPosition = webPageProxy->scrollingCoordinatorProxy()->currentMainFrameScrollPosition();
     
     if (headerBannerLayer) {
         auto headerHeight = headerBannerLayer.frame.size.height;
         totalContentsHeight += headerHeight;
-        auto y = LocalFrameView::yPositionForHeaderLayer(scrollPosition, topContentInset);
+        auto y = LocalFrameView::yPositionForHeaderLayer(scrollPosition, topInset);
         layoutBannerLayer(headerBannerLayer, y, size().width());
     }
 
     if (footerBannerLayer) {
         auto footerHeight = footerBannerLayer.frame.size.height;
         totalContentsHeight += footerBannerLayer.frame.size.height;
-        auto y = LocalFrameView::yPositionForFooterLayer(scrollPosition, topContentInset, totalContentsHeight, footerHeight);
+        auto y = LocalFrameView::yPositionForFooterLayer(scrollPosition, topInset, totalContentsHeight, footerHeight);
         layoutBannerLayer(footerBannerLayer, y, size().width());
     }
 }
@@ -534,10 +534,10 @@ void RemoteLayerTreeDrawingAreaProxyMac::didChangeViewExposedRect()
     updateDebugIndicatorPosition();
 }
 
-void RemoteLayerTreeDrawingAreaProxyMac::dispatchSetTopContentInset()
+void RemoteLayerTreeDrawingAreaProxyMac::dispatchSetObscuredContentInsets()
 {
     if (RefPtr page = m_webPageProxy.get())
-        page->dispatchSetTopContentInset();
+        page->dispatchSetObscuredContentInsets();
 }
 
 void RemoteLayerTreeDrawingAreaProxyMac::colorSpaceDidChange()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -484,7 +484,7 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
 
     RetainPtr scrolledContentsLayer { static_cast<CALayer*>(rootScrollingNode->scrolledContentsLayer()) };
 
-    auto rootContentsLayerPosition = LocalFrameView::positionForRootContentLayer(rootScrollingNode->currentScrollPosition(), FloatPoint { 0, 0 }, rootScrollingNode->topContentInset(), rootScrollingNode->headerHeight());
+    auto rootContentsLayerPosition = LocalFrameView::positionForRootContentLayer(rootScrollingNode->currentScrollPosition(), FloatPoint { 0, 0 }, rootScrollingNode->obscuredContentInsets().top(), rootScrollingNode->headerHeight());
     auto pointInContentsLayer = point;
     pointInContentsLayer.moveBy(rootContentsLayerPosition);
 

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -594,7 +594,7 @@ bool ViewGestureController::isPhysicallySwipingLeft(SwipeDirection direction) co
     return isLTR != isSwipingForward;
 }
 
-bool ViewGestureController::shouldUseSnapshotForSize(ViewSnapshot& snapshot, FloatSize swipeLayerSize, float topContentInset)
+bool ViewGestureController::shouldUseSnapshotForSize(ViewSnapshot& snapshot, FloatSize swipeLayerSize, FloatBoxExtent obscuredContentInsets)
 {
     RefPtr page = m_webPageProxy.get();
     if (!page)
@@ -604,7 +604,7 @@ bool ViewGestureController::shouldUseSnapshotForSize(ViewSnapshot& snapshot, Flo
     if (snapshot.deviceScaleFactor() != deviceScaleFactor)
         return false;
 
-    FloatSize unobscuredSwipeLayerSizeInDeviceCoordinates = swipeLayerSize - FloatSize(0, topContentInset);
+    FloatSize unobscuredSwipeLayerSizeInDeviceCoordinates = swipeLayerSize - FloatSize(obscuredContentInsets.left(), obscuredContentInsets.top());
     unobscuredSwipeLayerSizeInDeviceCoordinates.scale(deviceScaleFactor);
     if (snapshot.size() != unobscuredSwipeLayerSizeInDeviceCoordinates)
         return false;

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -303,7 +303,7 @@ private:
 
     void willEndSwipeGesture(WebBackForwardListItem& targetItem, bool cancelled);
     void endSwipeGesture(WebBackForwardListItem* targetItem, bool cancelled);
-    bool shouldUseSnapshotForSize(ViewSnapshot&, WebCore::FloatSize swipeLayerSize, float topContentInset);
+    bool shouldUseSnapshotForSize(ViewSnapshot&, WebCore::FloatSize swipeLayerSize, WebCore::FloatBoxExtent obscuredContentInsets);
 
 #if PLATFORM(MAC)
     static double resistanceForDelta(double deltaScale, double currentScale, double minMagnification, double maxMagnification);

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -29,6 +29,7 @@
 
 #include "FullScreenMediaDetails.h"
 #include "MessageReceiver.h"
+#include <WebCore/BoxExtents.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/ProcessIdentifier.h>
@@ -45,9 +46,6 @@ class FloatSize;
 class IntRect;
 
 enum class ScreenOrientationType : uint8_t;
-
-template <typename> class RectEdges;
-using FloatBoxExtent = RectEdges<float>;
 }
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2720,22 +2720,23 @@ void WebPageProxy::setBackgroundColor(const std::optional<Color>& color)
         send(Messages::WebPage::SetBackgroundColor(color));
 }
 
-void WebPageProxy::setTopContentInset(float contentInset)
+void WebPageProxy::setObscuredContentInsets(const WebCore::FloatBoxExtent& obscuredContentInsets)
 {
-    if (m_topContentInset == contentInset)
+    if (m_obscuredContentInsets == obscuredContentInsets)
         return;
 
-    m_topContentInset = contentInset;
+    m_obscuredContentInsets = obscuredContentInsets;
 
     if (RefPtr pageClient = this->pageClient())
-        pageClient->topContentInsetDidChange();
+        pageClient->obscuredContentInsetsDidChange();
 
     if (!hasRunningProcess())
         return;
+
 #if PLATFORM(COCOA)
-    send(Messages::WebPage::SetTopContentInsetFenced(contentInset, m_drawingArea->createFence()));
+    send(Messages::WebPage::SetObscuredContentInsetsFenced(m_obscuredContentInsets, m_drawingArea->createFence()));
 #else
-    send(Messages::WebPage::SetTopContentInset(contentInset));
+    send(Messages::WebPage::SetObscuredContentInsets(m_obscuredContentInsets));
 #endif
 }
 
@@ -11381,7 +11382,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.viewScaleFactor = m_viewScaleFactor;
     parameters.textZoomFactor = m_textZoomFactor;
     parameters.pageZoomFactor = m_pageZoomFactor;
-    parameters.topContentInset = m_topContentInset;
+    parameters.obscuredContentInsets = m_obscuredContentInsets;
     parameters.mediaVolume = m_mediaVolume;
     parameters.muted = internals().mutedState;
     parameters.openedByDOM = m_openedByDOM;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "MessageReceiver.h"
+#include <WebCore/BoxExtents.h>
 #include <WebCore/CryptoKeyData.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/LayerTreeAsTextOptions.h>
@@ -346,7 +347,6 @@ template<typename> class RectEdges;
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 using BackForwardFrameItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardFrameItemIdentifierType>>;
 using DictationContext = ObjectIdentifier<DictationContextType>;
-using FloatBoxExtent = RectEdges<float>;
 using FramesPerSecond = unsigned;
 using IntDegrees = int32_t;
 using HTMLMediaElementIdentifier = ObjectIdentifier<MediaPlayerClientIdentifierType>;
@@ -905,15 +905,15 @@ public:
 
     String currentURL() const;
 
-    float topContentInset() const { return m_topContentInset; }
-    void setTopContentInset(float);
+    const WebCore::FloatBoxExtent& obscuredContentInsets() const { return m_obscuredContentInsets; }
+    void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
 
 #if PLATFORM(MAC)
-    void setTopContentInsetAsync(float);
-    float pendingOrActualTopContentInset() const;
+    void setObscuredContentInsetsAsync(const WebCore::FloatBoxExtent&);
+    WebCore::FloatBoxExtent pendingOrActualObscuredContentInsets() const;
 
-    void scheduleSetTopContentInsetDispatch();
-    void dispatchSetTopContentInset();
+    void scheduleSetObscuredContentInsetsDispatch();
+    void dispatchSetObscuredContentInsets();
 
     void setAutomaticallyAdjustsContentInsets(bool);
     bool automaticallyAdjustsContentInsets() const { return m_automaticallyAdjustsContentInsets; }
@@ -3488,10 +3488,10 @@ private:
     float m_intrinsicDeviceScaleFactor { 1 };
     std::optional<float> m_customDeviceScaleFactor;
 
-    float m_topContentInset { 0 };
+    WebCore::FloatBoxExtent m_obscuredContentInsets;
 #if PLATFORM(MAC)
-    std::optional<CGFloat> m_pendingTopContentInset;
-    bool m_didScheduleSetTopContentInsetDispatch { false };
+    std::optional<WebCore::FloatBoxExtent> m_pendingObscuredContentInsets;
+    bool m_didScheduleSetObscuredContentInsetsDispatch { false };
     bool m_automaticallyAdjustsContentInsets { false };
 #endif
     bool m_hasPendingUnderPageBackgroundColorOverrideToDispatch { false };

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -153,7 +153,7 @@ static constexpr auto baseMinimumEffectiveDeviceWidth = 0;
 #endif
 
 struct WKWebViewState {
-    float _savedTopContentInset = 0.0;
+    WebCore::FloatBoxExtent _savedWebPageObscuredContentInsets;
     CGFloat _savedPageScale = baseScale;
     CGFloat _savedViewScale = 1.0;
     CGFloat _savedZoomScale = baseScale;
@@ -215,7 +215,7 @@ struct WKWebViewState {
             [webView _clearOverrideLayoutParameters];
 
         if (auto page = webView._page) {
-            page->setTopContentInset(_savedTopContentInset);
+            page->setObscuredContentInsets(_savedWebPageObscuredContentInsets);
             page->setForceAlwaysUserScalable(_savedForceAlwaysUserScalable);
         }
         [webView _setViewScale:_savedViewScale];
@@ -241,7 +241,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _savedContentInsetAdjustmentBehaviorWasExternallyOverridden = scrollView._contentInsetAdjustmentBehaviorWasExternallyOverridden;
 #endif
         if (auto page = webView._page) {
-            _savedTopContentInset = page->topContentInset();
+            _savedWebPageObscuredContentInsets = page->obscuredContentInsets();
             _savedForceAlwaysUserScalable = page->forceAlwaysUserScalable();
         }
         _savedViewScale = webView._viewScale;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -288,7 +288,7 @@ private:
     void didRestoreScrollPosition() override;
     bool windowIsFrontWindowUnderMouse(const NativeWebMouseEvent&) override;
 
-    std::optional<float> computeAutomaticTopContentInset() override;
+    std::optional<float> computeAutomaticTopObscuredInset() override;
 
     void takeFocus(WebCore::FocusDirection) override;
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1017,7 +1017,7 @@ bool PageClientImpl::windowIsFrontWindowUnderMouse(const NativeWebMouseEvent& ev
     return m_impl->windowIsFrontWindowUnderMouse(event.nativeEvent());
 }
 
-std::optional<float> PageClientImpl::computeAutomaticTopContentInset()
+std::optional<float> PageClientImpl::computeAutomaticTopObscuredInset()
 {
     RetainPtr window = [m_view window];
     if (([window styleMask] & NSWindowStyleMaskFullSizeContentView) && ![window titlebarAppearsTransparent] && ![m_view enclosingScrollView]) {

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -63,7 +63,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
     FullScreenState _fullScreenState;
 
     double _savedScale;
-    float _savedTopContentInset;
+    WebCore::FloatBoxExtent _savedObscuredContentInsets;
 }
 
 @property (readonly) NSRect initialFrame;

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -251,8 +251,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _page->startDeferringResizeEvents();
     _page->startDeferringScrollEvents();
     [self _manager]->saveScrollPosition();
-    _savedTopContentInset = _page->topContentInset();
-    _page->setTopContentInset(0);
+    _savedObscuredContentInsets = _page->obscuredContentInsets();
+    _page->setObscuredContentInsets({ });
     [[self window] setFrame:screenFrame display:NO];
 
     // Painting is normally suspended when the WKView is removed from the window, but this is
@@ -272,7 +272,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // Then insert the WebView into the full screen window
     NSView *contentView = [[self window] contentView];
     [_clipView addSubview:_webView.get().get() positioned:NSWindowBelow relativeTo:nil];
-    [_webView setFrame:NSInsetRect(contentView.bounds, 0, -_page->topContentInset())];
+    auto obscuredContentInsets = _page->obscuredContentInsets();
+    [_webView setFrame:NSInsetRect(contentView.bounds, -obscuredContentInsets.left(), -obscuredContentInsets.top())];
 
     _savedScale = _page->pageScaleFactor();
     _page->scalePageRelativeToScrollPosition(1, { });
@@ -368,7 +369,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         _page->scalePageRelativeToScrollPosition(_savedScale, { });
         [self _manager]->restoreScrollPosition();
-        _page->setTopContentInset(_savedTopContentInset);
+        _page->setObscuredContentInsets(_savedObscuredContentInsets);
         [self _manager]->setAnimatingFullScreen(false);
         [self _manager]->didExitFullScreen();
 
@@ -544,7 +545,7 @@ static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captu
     [self _manager]->didExitFullScreen();
     _page->scalePageRelativeToScrollPosition(_savedScale, { });
     [self _manager]->restoreScrollPosition();
-    _page->setTopContentInset(_savedTopContentInset);
+    _page->setObscuredContentInsets(_savedObscuredContentInsets);
     _page->flushDeferredResizeEvents();
     _page->flushDeferredScrollEvents();
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -270,9 +270,9 @@ public:
     void setAutomaticallyAdjustsContentInsets(bool);
     bool automaticallyAdjustsContentInsets() const;
     void updateContentInsetsIfAutomatic();
-    void setTopContentInset(CGFloat);
-    CGFloat topContentInset() const;
-    void flushPendingTopContentInset();
+    void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
+    WebCore::FloatBoxExtent obscuredContentInsets() const;
+    void flushPendingObscuredContentInsetChanges();
 
     void prepareContentInRect(CGRect);
     void updateViewExposedRect();

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -100,7 +100,6 @@ protected:
     WebCore::IntRect m_initialFrame;
     WebCore::IntRect m_finalFrame;
     WebCore::IntPoint m_scrollPosition;
-    float m_topContentInset { 0 };
     Ref<WebPage> m_page;
     RefPtr<WebCore::Element> m_element;
     WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_elementToRestore;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1182,11 +1182,12 @@ void UnifiedPDFPlugin::setPageScaleFactor(double scale, std::optional<WebCore::I
         return;
 
     if (origin) {
-        // Compensate for the subtraction of topContentInset that happens in ViewGestureController::handleMagnificationGestureEvent();
+        // Compensate for the subtraction of content insets that happens in ViewGestureController::handleMagnificationGestureEvent();
         // origin is not in root view coordinates.
-        RefPtr frameView = m_frame->coreLocalFrame()->view();
-        if (frameView)
-            origin->move(0, std::round(frameView->topContentInset()));
+        if (RefPtr frameView = m_frame->coreLocalFrame()->view()) {
+            auto obscuredContentInsets = frameView->obscuredContentInsets();
+            origin->move(std::round(obscuredContentInsets.left()), std::round(obscuredContentInsets.top()));
+        }
     }
 
     if (scale != 1.0)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -323,7 +323,7 @@ void PluginView::manualLoadDidFail()
     protectedPlugin()->streamDidFail();
 }
 
-void PluginView::topContentInsetDidChange()
+void PluginView::obscuredContentInsetsDidChange()
 {
     viewGeometryDidChange();
 }

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -113,7 +113,7 @@ public:
 
     bool populateEditorStateIfNeeded(EditorState&) const;
 
-    void topContentInsetDidChange();
+    void obscuredContentInsetsDidChange();
 
     void webPageDestroyed();
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -228,7 +228,8 @@ void DrawingArea::scaleViewToFitDocumentIfNeeded()
                 viewScale = minimumViewScale;
                 documentWidth = std::ceil(viewWidth / viewScale);
             }
-            IntSize fixedLayoutSize(documentWidth, std::ceil((webPage->size().height() - webPage->corePage()->topContentInset()) / viewScale));
+            // FIXME: Account for left content insets.
+            IntSize fixedLayoutSize(documentWidth, std::ceil((webPage->size().height() - webPage->corePage()->obscuredContentInsets().top()) / viewScale));
             webPage->setFixedLayoutSize(fixedLayoutSize);
             webPage->scaleView(viewScale);
 
@@ -273,7 +274,8 @@ void DrawingArea::scaleViewToFitDocumentIfNeeded()
             viewScale = minimumViewScale;
             documentWidth = std::ceil(viewWidth / viewScale);
         }
-        IntSize fixedLayoutSize(documentWidth, std::ceil((webPage->size().height() - webPage->corePage()->topContentInset()) / viewScale));
+        // FIXME: Account for left content insets.
+        IntSize fixedLayoutSize(documentWidth, std::ceil((webPage->size().height() - webPage->corePage()->obscuredContentInsets().top()) / viewScale));
         webPage->setFixedLayoutSize(fixedLayoutSize);
 
         LOG(Resize, "  using fixed layout at %dx%d. document width %d, scaled to %.4f to fit view width %d", fixedLayoutSize.width(), fixedLayoutSize.height(), documentWidth, viewScale, viewWidth);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1026,7 +1026,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     else
         m_scrollbarOverlayStyle = std::optional<ScrollbarOverlayStyle>();
 
-    setTopContentInset(parameters.topContentInset);
+    setObscuredContentInsets(parameters.obscuredContentInsets);
 
     m_userAgent = parameters.userAgent;
 
@@ -4051,23 +4051,28 @@ void WebPage::setBackgroundColor(const std::optional<WebCore::Color>& background
 }
 
 #if PLATFORM(COCOA)
-void WebPage::setTopContentInsetFenced(float contentInset, const WTF::MachSendRight& machSendRight)
+void WebPage::setObscuredContentInsetsFenced(const FloatBoxExtent& obscuredContentInsets, const WTF::MachSendRight& machSendRight)
 {
     protectedDrawingArea()->addFence(machSendRight);
-    setTopContentInset(contentInset);
+    setObscuredContentInsets(obscuredContentInsets);
 }
 #endif
 
-void WebPage::setTopContentInset(float contentInset)
+FloatBoxExtent WebPage::obscuredContentInsets() const
 {
-    if (contentInset == m_page->topContentInset())
+    return m_page->obscuredContentInsets();
+}
+
+void WebPage::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInsets)
+{
+    if (obscuredContentInsets == m_page->obscuredContentInsets())
         return;
 
-    m_page->setTopContentInset(contentInset);
+    m_page->setObscuredContentInsets(obscuredContentInsets);
 
 #if ENABLE(PDF_PLUGIN)
     for (auto& pluginView : m_pluginViews)
-        pluginView.topContentInsetDidChange();
+        pluginView.obscuredContentInsetsDidChange();
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -29,6 +29,7 @@
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <WebCore/BoxExtents.h>
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/DisabledAdaptations.h>
 #include <WebCore/DragActions.h>
@@ -1923,7 +1924,8 @@ public:
 #endif
     void loadRequest(LoadParameters&&);
 
-    void setTopContentInset(float);
+    WebCore::FloatBoxExtent obscuredContentInsets() const;
+    void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
 
     void updateOpener(WebCore::FrameIdentifier, WebCore::FrameIdentifier);
 
@@ -2137,7 +2139,7 @@ private:
     void setBackgroundColor(const std::optional<WebCore::Color>&);
 
 #if PLATFORM(COCOA)
-    void setTopContentInsetFenced(float, const WTF::MachSendRight&);
+    void setObscuredContentInsetsFenced(const WebCore::FloatBoxExtent&, const WTF::MachSendRight&);
 #endif
 
     void viewWillStartLiveResize();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -40,10 +40,10 @@ messages -> WebPage WantsAsyncDispatchMessage {
     TestProcessIncomingSyncMessagesWhenWaitingForSyncReply() -> (bool handled) Synchronous AllowedWhenWaitingForSyncReplyDuringUnboundedIPC
 
 #if PLATFORM(COCOA)
-    SetTopContentInsetFenced(float contentInset, MachSendRight machSendRight)
+    SetObscuredContentInsetsFenced(WebCore::FloatBoxExtent obscuredContentInsets, MachSendRight machSendRight)
 #endif
 #if !PLATFORM(COCOA)
-    SetTopContentInset(float contentInset)
+    SetObscuredContentInsets(WebCore::FloatBoxExtent obscuredContentInsets)
 #endif
 
     SetUnderlayColor(WebCore::Color color)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -119,10 +119,13 @@ void WebPageTesting::clearWheelEventTestMonitor()
     page->clearWheelEventTestMonitor();
 }
 
-void WebPageTesting::setTopContentInset(float contentInset, CompletionHandler<void()>&& completionHandler)
+void WebPageTesting::setTopContentInset(float topInset, CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr page = m_page.get())
-        page->setTopContentInset(contentInset);
+    if (RefPtr page = m_page.get()) {
+        auto obscuredContentInsets = page->obscuredContentInsets();
+        obscuredContentInsets.setTop(topInset);
+        page->setObscuredContentInsets(obscuredContentInsets);
+    }
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -347,8 +347,10 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             if (CheckedPtr frameView = focusedLocalFrame->view())
                 convertedPoint.moveBy(frameView->scrollPosition());
         }
-        if (auto* page = protectedSelf->m_page->corePage())
-            convertedPoint.move(0, -page->topContentInset());
+        if (RefPtr page = protectedSelf->m_page->corePage()) {
+            auto obscuredContentInsets = page->obscuredContentInsets();
+            convertedPoint.move(-obscuredContentInsets.left(), -obscuredContentInsets.top());
+        }
         return convertedPoint;
     });
     

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -106,7 +106,7 @@ public:
     FloatRect coverageRect() const final { return { }; };
     bool tilesWouldChangeForCoverageRect(const FloatRect&) const final { return false; }
     void setTiledScrollingIndicatorPosition(const FloatPoint&) final { }
-    void setTopContentInset(float) final { }
+    void setObscuredContentInsets(const FloatBoxExtent&) final { }
     void setVelocity(const VelocityData&) final { }
     void setTileSizeUpdateDelayDisabledForTesting(bool) final { };
     void setScrollability(OptionSet<Scrollability>) final { }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -4167,10 +4167,13 @@ IGNORE_WARNINGS_END
     return nil;
 }
 
-- (void)_setTopContentInsetForTesting:(float)contentInset
+- (void)_setTopContentInsetForTesting:(float)inset
 {
-    if (_private && _private->page)
-        _private->page->setTopContentInset(contentInset);
+    if (_private && _private->page) {
+        auto obscuredContentInsets = _private->page->obscuredContentInsets();
+        obscuredContentInsets.setTop(inset);
+        _private->page->setObscuredContentInsets(obscuredContentInsets);
+    }
 }
 
 - (BOOL)_isSoftwareRenderable


### PR DESCRIPTION
#### fc41c7f03db40c81cb26976470ef16abbe61fff2
<pre>
[macOS] Refactor top content inset logic to account for content insets on all rect edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=287128">https://bugs.webkit.org/show_bug.cgi?id=287128</a>

Reviewed by Simon Fraser and Tim Horton.

Currently, the `-_topContentInset` SPI on macOS is propagated through WebKit into WebCore as a
single `float` value through `Page`, `FrameView`, various scrolling/compositing-related classes,
and many other codepaths. In preparation for exposing API to control content insets on all sides of
a webpage on macOS, this PR refactors support for top content inset in WebKit and WebCore to plumb
a full `RectEdges&lt;float&gt;` (i.e. `FloatBoxExtent`) through the engine, instead of just a single
`float` for the top content inset.

Note that there should be no change in behavior yet, since the ability for clients to set non-zero
left/right/bottom content insets does not exist yet. In a subsequent patch, I&apos;ll add this capability
along with tests to exercise it.

See below for more details.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Drive-by fix: add `FrameView.cpp` to the Xcode project. This source file is currently compiled as
part of unified sources, but is absent from Xcode (making text searches skip this file).

* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawBounds):
(WebCore::InspectorOverlay::drawRulers):
(WebCore::InspectorOverlay::drawElementTitle):
(WebCore::InspectorOverlay::buildGridOverlay):

Swap `topContentInset` for `obscuredContentInsets`.

* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::obscuredContentInsets const):
(WebCore::FrameView::topContentInset const): Deleted.

Replace `topContentInset` with `obscuredContentInsets`; rename `TopContentInsetType` to `InsetType`.

* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::obscuredContentInsetsDidChange):

Rename `topContentInsetDidChange` → `obscuredContentInsetsDidChange`.

(WebCore::LocalFrameView::yPositionForInsetClipLayer):
(WebCore::LocalFrameView::yPositionForHeaderLayer):
(WebCore::LocalFrameView::yPositionForFooterLayer):
(WebCore::LocalFrameView::positionForRootContentLayer):
(WebCore::LocalFrameView::positionForRootContentLayer const):

Pass in `obscuredContentInsets().top()` in place of `topContentInset()`. Note that we might need
more refactoring in this area in a subsequent patch to make it properly handle left/right insets.

(WebCore::LocalFrameView::topContentInsetDidChange): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setObscuredContentInsets):
(WebCore::Page::setTopContentInset): Deleted.

Rename `setTopContentInset` → `setObscuredContentInsets`, and make it take a `FloatBoxExtent`. Note
that the `m_obscuredInsets` member already exists on `Page`, but is currently iOS-only, and reflects
the value of `_obscuredInset` on `WKWebView`. This is actually slightly distinct from this
refactored notion of `obscuredContentInsets` on macOS, which represents extra margins that surround
the `Page`, are intended to be obscured by the WebKit client&apos;s UI at scroll extents, and also
requires WebCore to move its layers to accomodate the inset content.

* Source/WebCore/page/Page.h:
(WebCore::Page::obscuredInsets const):
(WebCore::Page::setObscuredInsets):
(WebCore::Page::obscuredContentInsets const):
(WebCore::Page::topContentInset const): Deleted.
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::mouseEvent):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::buildPhoneNumberHighlights):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):

Plumb content insets through `ScrollingStateFrameScrollingNode` and related classes.

* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
(WebCore::ScrollingStateFrameScrollingNode::applicableProperties const):
(WebCore::ScrollingStateFrameScrollingNode::setObscuredContentInsets):
(WebCore::ScrollingStateFrameScrollingNode::dumpProperties const):
(WebCore::ScrollingStateFrameScrollingNode::setTopContentInset): Deleted.
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:

Rename the `TopContentInset` property flag → `ObscuredContentInsets`.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::mainFrameObscuredContentInsets const):
(WebCore::ScrollingTree::mainFrameTopContentInset const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp:
(WebCore::ScrollingTreeFrameScrollingNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNode::viewToContentsOffset const):
(WebCore::ScrollingTreeFrameScrollingNode::dumpProperties const):

Augment this debugging description to show non-zero top/bottom/left/right insets separately.

* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp:
(WebCore::ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers):
* Source/WebCore/platform/BoxExtents.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailViewInternal.h.

Add a new `WebCore/platform` header that defines several box extent types used throughout WebCore
and WebKit:

- FloatBoxExtent
- IntBoxExtent
- LayoutBoxExtent

* Source/WebCore/platform/LengthBox.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::sizeForUnobscuredContent const):

Account for the left inset.

(WebCore::ScrollView::frameRectShrunkByInset const):

Account for insets on all sides.

(WebCore::ScrollView::documentScrollPositionRelativeToViewOrigin const):
(WebCore::ScrollView::updateScrollbars):
(WebCore::ScrollView::rootViewToTotalContents const):
(WebCore::ScrollView::scrollCornerRect const):
(WebCore::ScrollView::platformContentInsets const):
(WebCore::ScrollView::platformSetContentInsets):
(WebCore::ScrollView::platformTopContentInset const): Deleted.
(WebCore::ScrollView::platformSetTopContentInset): Deleted.
* Source/WebCore/platform/ScrollView.h:
(WebCore::ScrollView::obscuredContentInsets const):
(WebCore::ScrollView::topContentInset const): Deleted.
* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::setObscuredContentInsets):
(WebCore::TileController::setTopContentInset): Deleted.

Replace more `topContentInset` with `obscuredContentInsets`.

* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp:
(WebCore::TileCoverageMap::TileCoverageMap):
(WebCore::TileCoverageMap::update):
* Source/WebCore/platform/ios/ScrollViewIOS.mm:
(WebCore::ScrollView::platformContentInsets const):
(WebCore::ScrollView::platformSetContentInsets):
(WebCore::ScrollView::platformTopContentInset const): Deleted.
(WebCore::ScrollView::platformSetTopContentInset): Deleted.
* Source/WebCore/platform/mac/ScrollViewMac.mm:
(WebCore::ScrollView::platformContentInsets const):
(WebCore::ScrollView::platformSetContentInsets):
(WebCore::ScrollView::platformTopContentInset const): Deleted.
(WebCore::ScrollView::platformSetTopContentInset): Deleted.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::calculateBackgroundImageGeometry):

Account for the left inset.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBacking):
(WebCore::RenderLayerCompositor::positionForClipLayer const):
(WebCore::RenderLayerCompositor::updateLayerForBottomOverhangArea):
(WebCore::RenderLayerCompositor::updateLayerForHeader):
(WebCore::RenderLayerCompositor::updateLayerForFooter):
(WebCore::RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::dump):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _recalculateViewportSizesWithMinimumViewportInset:maximumViewportInset:throwOnInvalidInput:]):

Account for the left content inset.

* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailView.mm:
(-[_WKThumbnailView requestSnapshot]):
(-[_WKThumbnailView _viewWasUnparented]):
(-[_WKThumbnailView _viewWasParented]):
(-[_WKThumbnailView setScale:]):
(-[_WKThumbnailView _setSublayerTranslation:]):
(-[_WKThumbnailView _setSublayerVerticalTranslationAmount:]): Deleted.

Rename `sublayerVerticalTranslationAmount` to just `sublayerTranslation`, which is now a `CGPoint`
that represents both `x` and `y` offsets.

* Source/WebKit/UIProcess/API/Cocoa/_WKThumbnailViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setTopContentInset:]):
(-[WKWebView _topContentInset]):
(-[WKWebView _setTopContentInset:immediate:]):

Keep these APIs as-is, but implement them in terms of `FloatBoxExtent`-backed content insets on the
`WebViewImpl`.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::performMouseInteraction):

Account for the left inset.

* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::viewportLocationToWindowLocation):
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::obscuredContentInsetsDidChange):
(WebKit::PageClientImplCocoa::topContentInsetDidChange): Deleted.

Rename `topContentInsetDidChange` to `obscuredContentInsetsDidChange`.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::obscuredContentInsetsDidChange):
(WebKit::PageClient::computeAutomaticTopObscuredInset):
(WebKit::PageClient::topContentInsetDidChange): Deleted.
(WebKit::PageClient::computeAutomaticTopContentInset): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::dispatchSetObscuredContentInsets):
(WebKit::RemoteLayerTreeDrawingAreaProxy::dispatchSetTopContentInset): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::obscuredContentInsets const):
(WebKit::RemoteScrollingCoordinatorProxy::topContentInset const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::dispatchSetObscuredContentInsets):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::dispatchSetTopContentInset): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingNodeForPoint):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::shouldUseSnapshotForSize):

Make this account for non-zero inset as well.

* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setObscuredContentInsets):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::setTopContentInset): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
(WebKit::WKWebViewState::store):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::computeAutomaticTopObscuredInset):
(WebKit::PageClientImpl::computeAutomaticTopContentInset): Deleted.
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleMagnificationGestureEvent):
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:completionHandler:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::updateContentInsetsIfAutomatic):
(WebKit::WebPageProxy::setObscuredContentInsetsAsync):
(WebKit::WebPageProxy::pendingOrActualObscuredContentInsets const):
(WebKit::WebPageProxy::scheduleSetObscuredContentInsetsDispatch):
(WebKit::WebPageProxy::dispatchSetObscuredContentInsets):
(WebKit::WebPageProxy::setTopContentInsetAsync): Deleted.
(WebKit::WebPageProxy::pendingOrActualTopContentInset const): Deleted.
(WebKit::WebPageProxy::scheduleSetTopContentInsetDispatch): Deleted.
(WebKit::WebPageProxy::dispatchSetTopContentInset): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::obscuredContentInsets const):
(WebKit::WebViewImpl::setObscuredContentInsets):
(WebKit::WebViewImpl::flushPendingObscuredContentInsetChanges):
(WebKit::WebViewImpl::endDeferringViewInWindowChanges):
(WebKit::WebViewImpl::endDeferringViewInWindowChangesSync):
(WebKit::WebViewImpl::prepareForMoveToWindow):
(WebKit::WebViewImpl::takeViewSnapshot):

Make this account for insets on all sides.

(WebKit::WebViewImpl::topContentInset const): Deleted.
(WebKit::WebViewImpl::setTopContentInset): Deleted.
(WebKit::WebViewImpl::flushPendingTopContentInset): Deleted.

Rename `flushPendingTopContentInset` to `flushPendingObscuredContentInsetChanges`.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:

Remove an unused member, `m_topContentInset`.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::obscuredContentInsetsDidChange):
(WebKit::PluginView::topContentInsetDidChange): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::scaleViewToFitDocumentIfNeeded):

Add a couple of FIXMEs to (possibly) account for left content inset in fixed layout mode, in a
future patch.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::setObscuredContentInsetsFenced):
(WebKit::WebPage::obscuredContentInsets const):
(WebKit::WebPage::setObscuredContentInsets):
(WebKit::WebPage::setTopContentInsetFenced): Deleted.
(WebKit::WebPage::setTopContentInset): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::setTopContentInset):

Make this testing-only helper set only the top obscured content inset on the page.

* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _setTopContentInsetForTesting:]):

Canonical link: <a href="https://commits.webkit.org/290068@main">https://commits.webkit.org/290068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c745b22fe7865421ca00e55b357616d8cbaa5314

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88651 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68355 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6314 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34592 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38513 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95451 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15826 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11588 "Found 1 new test failure: imported/w3c/web-platform-tests/WebCryptoAPI/import_export/symmetric_importKey.https.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77223 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76506 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20886 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19308 "Found 5 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8865 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21150 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->