### PR TITLE
[HDR] Ensure HDR layers and IOSurfaces are created only when they contain HDR contents

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2491,6 +2491,9 @@ fast/images/jpegxl-as-image.html [ Skip ]
 fast/images/jpegxl-with-color-profile.html [ Skip ]
 fast/images/animated-jpegxl-loop-count.html [ Skip ]
 
+# Only applicable on platforms with HDR support
+compositing/hdr/hdr-basic-canvas.html [ Skip ]
+
 # Experimental H265 support.
 webrtc/h265.html [ Pass Failure ]
 

--- a/LayoutTests/compositing/hdr/hdr-basic-canvas.html
+++ b/LayoutTests/compositing/hdr/hdr-basic-canvas.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ CanvasPixelFormatEnabled=true ] -->
+<style>
+    canvas {
+        border: 1px solid black;
+    }
+</style>
+<body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
+    <canvas id="canvas1"></canvas>
+    <canvas id="canvas2"></canvas>
+    <div style="position: fixed; top: 192px;">
+        <canvas id="canvas3"></canvas>
+    </div>
+    <div style="position: fixed; top: 192px; left: 315px">
+        <canvas id="canvas4"></canvas>
+    </div>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        if (window.internals)
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+
+        let canvas1 = document.getElementById("canvas1");
+        let context1 = canvas1.getContext("2d", { pixelFormat: "float16" });
+        context1.fillStyle = "green";
+        context1.fillRect(0, 0, 100, 100);
+
+        let canvas2 = document.getElementById("canvas2");
+        let context2 = canvas2.getContext("2d");
+        context2.fillStyle = "green";
+        context2.fillRect(0, 0, 100, 100);
+
+        let canvas3 = document.getElementById("canvas3");
+        let context3 = canvas3.getContext("2d", { pixelFormat: "float16" });
+        context3.fillStyle = "green";
+        context3.fillRect(0, 0, 100, 100);
+
+        let canvas4 = document.getElementById("canvas4");
+        let context4 = canvas4.getContext("2d");
+        context4.fillStyle = "green";
+        context4.fillRect(0, 0, 100, 100);
+
+        document.getElementById("layers").textContent = internals.layerTreeAsText(document);
+    </script>
+</body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4497,6 +4497,9 @@ fast/images/page-wide-animation-toggle.html [ Pass ]
 fast/images/pagewide-play-pause-animateTransform-svg-animation.html [ Pass ]
 fast/images/pagewide-play-pause-offscreen-animations.html [ Pass ]
 
+# Only applicable on platforms with HDR support
+compositing/hdr/hdr-basic-canvas.html [ Pass ]
+
 # Re-enabling tests fixed by DocumentManager in iOS16+ rdar://102159271
 fast/forms/ios/file-upload-panel-capture.html [ Pass Crash ] # remove crash after this is resolved: webkit.org/b/268568
 fast/forms/ios/show-file-upload-context-menu-above-keyboard.html [ Pass ]

--- a/LayoutTests/platform/ios/compositing/hdr/hdr-basic-canvas-expected.txt
+++ b/LayoutTests/platform/ios/compositing/hdr/hdr-basic-canvas-expected.txt
@@ -1,0 +1,55 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 35.00)
+          (bounds 302.00 152.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+        (GraphicsLayer
+          (position 314.00 35.00)
+          (bounds 302.00 152.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 8.00 192.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 302.00 152.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 302.00 152.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 315.00 192.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 302.00 152.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 302.00 152.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1518,6 +1518,9 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 [ Sonoma+ ] fast/images/mac/animation-context-menu-items-presence.html [ Pass ]
 # This test was added in https://bugs.webkit.org/show_bug.cgi?id=250475 — re-enable it here for Sonoma.
 
+# Only applicable on platforms with HDR support
+[ Sequoia+ ] compositing/hdr/hdr-basic-canvas.html [ Pass ]
+
 # The direct image codepath is not used with the remote layer tree.
 [ Sonoma+ ] compositing/images/direct-image-object-fit.html [ Skip ]
 [ Sonoma+ ] compositing/reflections/direct-image-object-fit-reflected.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-canvas-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-canvas-expected.txt
@@ -1,0 +1,55 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 36.00)
+          (bounds 302.00 152.00)
+          (drawsContent 1)
+          (drawsHDRContent 1)
+        )
+        (GraphicsLayer
+          (position 314.00 36.00)
+          (bounds 302.00 152.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 8.00 192.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 302.00 152.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 302.00 152.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 315.00 192.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 302.00 152.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 302.00 152.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -119,7 +119,7 @@ public:
     virtual std::optional<RenderingMode> renderingModeForTesting() const { return std::nullopt; }
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    bool drawsHDRContent() const { return pixelFormat() == ImageBufferPixelFormat::RGBA16F; }
+    bool isHDR() const { return pixelFormat() == ImageBufferPixelFormat::RGBA16F; }
 #endif
 
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -99,7 +99,7 @@ public:
 
     Headroom headroom() const;
 #if ENABLE(HDR_FOR_IMAGES)
-    bool drawsHDRContent() const { return headroom() > Headroom::None; }
+    bool isHDR() const { return headroom() > Headroom::None; }
 #endif
 
     bool isManuallyCached() const { return m_isManuallyCached; }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4230,6 +4230,16 @@ void Page::setFullscreenAutoHideDuration(Seconds duration)
     });
 }
 
+#if HAVE(HDR_SUPPORT)
+bool Page::canDrawHDRContents() const
+{
+    if (!(m_settings->hdrForImagesEnabled() || m_settings->canvasPixelFormatEnabled()))
+        return false;
+
+    return screenSupportsHighDynamicRange();
+}
+#endif
+
 Document* Page::outermostFullscreenDocument() const
 {
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -663,6 +663,10 @@ public:
 
     Document* outermostFullscreenDocument() const;
 
+#if HAVE(HDR_SUPPORT)
+    bool canDrawHDRContents() const;
+#endif
+
     bool shouldSuppressScrollbarAnimations() const { return m_suppressScrollbarAnimations; }
     WEBCORE_EXPORT void setShouldSuppressScrollbarAnimations(bool suppressAnimations);
     void lockAllOverlayScrollbarsToHidden(bool lockOverlayScrollbars);

--- a/Source/WebCore/page/PageOverlayController.cpp
+++ b/Source/WebCore/page/PageOverlayController.cpp
@@ -353,9 +353,6 @@ void PageOverlayController::updateSettingsForLayer(GraphicsLayer& layer)
     layer.setAcceleratesDrawing(settings->acceleratedDrawingEnabled());
     layer.setShowDebugBorder(settings->showDebugBorders());
     layer.setShowRepaintCounter(settings->showRepaintCounter());
-#if ENABLE(HDR_FOR_IMAGES)
-    layer.setHDRForImagesEnabled(settings->hdrForImagesEnabled());
-#endif
 }
 
 bool PageOverlayController::handleMouseEvent(const PlatformMouseEvent& mouseEvent)

--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -70,6 +70,18 @@ const ScreenData* screenData(PlatformDisplayID screenDisplayID)
     return &screenProperties().screenDataMap.begin()->value;
 }
 
+#if HAVE(HDR_SUPPORT)
+void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat> contentsFormats)
+{
+    screenProperties().screenContentsFormatsForTesting = contentsFormats;
+}
+
+OptionSet<ContentsFormat> screenContentsFormatsForTesting()
+{
+    return screenProperties().screenContentsFormatsForTesting;
+}
+#endif
+
 } // namespace WebCore
 
 #endif // PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -111,7 +111,12 @@ WEBCORE_EXPORT void setScreenProperties(const ScreenProperties&);
 const ScreenProperties& getScreenProperties();
 WEBCORE_EXPORT const ScreenData* screenData(PlatformDisplayID screendisplayID);
 WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID();
-    
+
+#if HAVE(HDR_SUPPORT)
+WEBCORE_EXPORT void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat>);
+OptionSet<ContentsFormat> screenContentsFormatsForTesting();
+#endif
+
 #if PLATFORM(MAC)
 
 WEBCORE_EXPORT PlatformDisplayID displayID(NSScreen *);

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -66,6 +66,9 @@ using ScreenDataMap = HashMap<PlatformDisplayID, ScreenData>;
 struct ScreenProperties {
     PlatformDisplayID primaryDisplayID { 0 };
     ScreenDataMap screenDataMap;
+#if HAVE(HDR_SUPPORT)
+    OptionSet<ContentsFormat> screenContentsFormatsForTesting;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -444,6 +444,14 @@ void GraphicsLayer::setDrawsContent(bool b)
     m_drawsContent = b;
 }
 
+#if HAVE(HDR_SUPPORT)
+void GraphicsLayer::setDrawsHDRContent(bool b)
+{
+    ASSERT(m_type != Type::Structural);
+    m_drawsHDRContent = b;
+}
+#endif
+
 const TransformationMatrix& GraphicsLayer::transform() const
 {
     return m_transform ? *m_transform : TransformationMatrix::identity;
@@ -975,6 +983,11 @@ void GraphicsLayer::dumpProperties(TextStream& ts, OptionSet<LayerTreeAsTextOpti
 
     if (m_drawsContent && client().shouldDumpPropertyForLayer(this, "drawsContent"_s, options))
         ts << indent << "(drawsContent "_s << m_drawsContent << ")\n"_s;
+
+#if HAVE(HDR_SUPPORT)
+    if (m_drawsHDRContent)
+        ts << indent << "(drawsHDRContent "_s << m_drawsHDRContent << ")\n"_s;
+#endif
 
     if (!m_contentsVisible)
         ts << indent << "(contentsVisible "_s << m_contentsVisible << ")\n"_s;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -424,6 +424,11 @@ public:
     bool drawsContent() const { return m_drawsContent; }
     WEBCORE_EXPORT virtual void setDrawsContent(bool);
 
+#if HAVE(HDR_SUPPORT)
+    bool drawsHDRContent() const { return m_drawsHDRContent; }
+    WEBCORE_EXPORT virtual void setDrawsHDRContent(bool);
+#endif
+
     bool contentsAreVisible() const { return m_contentsVisible; }
     virtual void setContentsVisible(bool b) { m_contentsVisible = b; }
 
@@ -612,11 +617,6 @@ public:
 
     virtual void setShowRepaintCounter(bool show) { m_showRepaintCounter = show; }
     bool isShowingRepaintCounter() const { return m_showRepaintCounter; }
-
-#if ENABLE(HDR_FOR_IMAGES)
-    virtual void setHDRForImagesEnabled(bool b) { m_hdrForImagesEnabled = b; }
-    bool hdrForImagesEnabled() const { return m_hdrForImagesEnabled; }
-#endif
 
     // FIXME: this is really a paint count.
     int repaintCount() const { return m_repaintCount; }
@@ -822,6 +822,9 @@ protected:
     bool m_backfaceVisibility : 1;
     bool m_masksToBounds : 1;
     bool m_drawsContent : 1;
+#if HAVE(HDR_SUPPORT)
+    bool m_drawsHDRContent : 1 { false };
+#endif
     bool m_contentsVisible : 1;
     bool m_contentsRectClipsDescendants : 1;
     bool m_acceleratesDrawing : 1;
@@ -845,9 +848,6 @@ protected:
     bool m_isSeparatedPortal : 1;
     bool m_isDescendentOfSeparatedPortal : 1;
 #endif
-#endif
-#if ENABLE(HDR_FOR_IMAGES)
-    bool m_hdrForImagesEnabled : 1;
 #endif
 
     int m_repaintCount { 0 };

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -116,10 +116,6 @@ public:
     virtual bool isFlushingLayers() const { return false; }
     virtual bool isTrackingRepaints() const { return false; }
 
-#if ENABLE(HDR_FOR_IMAGES)
-    virtual bool hdrForImagesEnabled() const { return false; }
-#endif
-
     virtual bool shouldSkipLayerInDump(const GraphicsLayer*, OptionSet<LayerTreeAsTextOptions>) const { return false; }
     virtual bool shouldDumpPropertyForLayer(const GraphicsLayer*, ASCIILiteral, OptionSet<LayerTreeAsTextOptions>) const { return true; }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -730,6 +730,17 @@ void GraphicsLayerCA::setDrawsContent(bool drawsContent)
     noteLayerPropertyChanged(DrawsContentChanged | DebugIndicatorsChanged);
 }
 
+#if HAVE(HDR_SUPPORT)
+void GraphicsLayerCA::setDrawsHDRContent(bool drawsHDRContent)
+{
+    if (drawsHDRContent == m_drawsHDRContent)
+        return;
+
+    GraphicsLayer::setDrawsHDRContent(drawsHDRContent);
+    noteLayerPropertyChanged(DrawsHDRContentChanged | DebugIndicatorsChanged);
+}
+#endif
+
 void GraphicsLayerCA::setContentsVisible(bool contentsVisible)
 {
     if (contentsVisible == m_contentsVisible)
@@ -2132,6 +2143,11 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
     if (m_uncommittedChanges & DrawsContentChanged)
         updateDrawsContent();
 
+#if HAVE(HDR_SUPPORT)
+    if (m_uncommittedChanges & DrawsHDRContentChanged)
+        updateDrawsHDRContent();
+#endif
+
     if (m_uncommittedChanges & NameChanged)
         updateNames();
 
@@ -3290,6 +3306,14 @@ void GraphicsLayerCA::updateReplicatedLayers()
     else
         m_layer->insertSublayer(*replicaRoot, 0);
 }
+
+#if HAVE(HDR_SUPPORT)
+void GraphicsLayerCA::updateDrawsHDRContent()
+{
+    auto contentsFormat = PlatformCALayer::contentsFormatForLayer(nullptr, this);
+    m_layer->setContentsFormat(contentsFormat);
+}
+#endif
 
 // For now, this assumes that layers only ever have one replica, so replicaIndices contains only 0 and 1.
 GraphicsLayerCA::CloneID GraphicsLayerCA::ReplicaState::cloneID() const
@@ -4600,6 +4624,9 @@ ASCIILiteral GraphicsLayerCA::layerChangeAsString(LayerChange layerChange)
     case LayerChange::BackdropRootChanged: return "BackdropRootChanged"_s;
 #if HAVE(CORE_MATERIAL)
     case LayerChange::AppleVisualEffectChanged: return "AppleVisualEffectChanged"_s;
+#endif
+#if HAVE(HDR_SUPPORT)
+    case LayerChange::DrawsHDRContentChanged: return "DrawsHDRContentChanged"_s;
 #endif
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -99,6 +99,9 @@ public:
     WEBCORE_EXPORT void setPreserves3D(bool) override;
     WEBCORE_EXPORT void setMasksToBounds(bool) override;
     WEBCORE_EXPORT void setDrawsContent(bool) override;
+#if HAVE(HDR_SUPPORT)
+    WEBCORE_EXPORT void setDrawsHDRContent(bool) override;
+#endif
     WEBCORE_EXPORT void setContentsVisible(bool) override;
     WEBCORE_EXPORT void setAcceleratesDrawing(bool) override;
     WEBCORE_EXPORT void setUsesDisplayListDrawing(bool) override;
@@ -272,8 +275,9 @@ private:
 
     bool isCommittingChanges() const override { return m_isCommittingChanges; }
     bool isUsingDisplayListDrawing(PlatformCALayer*) const override { return m_usesDisplayListDrawing; }
-#if ENABLE(HDR_FOR_IMAGES)
-    bool hdrForImagesEnabled() const override { return client().hdrForImagesEnabled(); }
+#if HAVE(HDR_SUPPORT)
+    bool drawsHDRContent() const override { return m_drawsHDRContent; }
+    void updateDrawsHDRContent();
 #endif
 
     WEBCORE_EXPORT void setAllowsBackingStoreDetaching(bool) override;
@@ -654,6 +658,9 @@ private:
         BackdropRootChanged                     = 1LLU << 45,
 #if HAVE(CORE_MATERIAL)
         AppleVisualEffectChanged                = 1LLU << 46,
+#endif
+#if HAVE(HDR_SUPPORT)
+        DrawsHDRContentChanged                  = 1LLU << 47,
 #endif
     };
     typedef uint64_t LayerChangeFlags;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -77,7 +77,7 @@ void PlatformCALayer::drawRepaintIndicator(GraphicsContext& graphicsContext, Pla
     constexpr auto unacceleratedContextLabelColor = Color::white;
     constexpr auto displayListBorderColor = Color::black.colorWithAlphaByte(166);
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    constexpr auto rgba16FBackgroundColor = SRGBA<uint8_t> { 116, 214, 255 };
+    constexpr auto rgba16FBackgroundColor = SRGBA<uint8_t> { 255, 215, 0 };
 #endif
 
     TextRun textRun(String::number(repaintCount));
@@ -182,7 +182,7 @@ ContentsFormat PlatformCALayer::contentsFormatForLayer(Widget* widget, PlatformC
 {
     auto contentsFormats = screenContentsFormats(widget);
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (client && client->hdrForImagesEnabled() && contentsFormats.contains(ContentsFormat::RGBA16F))
+    if (client && client->drawsHDRContent() && contentsFormats.contains(ContentsFormat::RGBA16F))
         return ContentsFormat::RGBA16F;
 #endif
 #if ENABLE(PIXEL_FORMAT_RGB10)

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -73,8 +73,8 @@ public:
 
     virtual bool isUsingDisplayListDrawing(PlatformCALayer*) const { return false; }
 
-#if ENABLE(HDR_FOR_IMAGES)
-    virtual bool hdrForImagesEnabled() const { return false; }
+#if HAVE(HDR_SUPPORT)
+    virtual bool drawsHDRContent() const { return false; }
 #endif
 
     virtual void platformCALayerLogFilledVisibleFreshTile(unsigned /* blankPixelCount */) { }

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -92,6 +92,11 @@ OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 
 bool screenSupportsExtendedColor(Widget*)
 {
+#if HAVE(HDR_SUPPORT) && ENABLE(PIXEL_FORMAT_RGB10)
+    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
+        return true;
+#endif
+
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->screenSupportsExtendedColor;
 
@@ -100,6 +105,11 @@ bool screenSupportsExtendedColor(Widget*)
 
 bool screenSupportsHighDynamicRange(Widget*)
 {
+#if HAVE(HDR_SUPPORT) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
+        return true;
+#endif
+
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->screenSupportsHighDynamicRange;
 

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -384,6 +384,11 @@ OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 
 bool screenSupportsExtendedColor(Widget* widget)
 {
+#if HAVE(HDR_SUPPORT) && ENABLE(PIXEL_FORMAT_RGB10)
+    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
+        return true;
+#endif
+
     if (auto data = screenProperties(widget))
         return data->screenSupportsExtendedColor;
 
@@ -393,6 +398,11 @@ bool screenSupportsExtendedColor(Widget* widget)
 
 bool screenSupportsHighDynamicRange(Widget* widget)
 {
+#if HAVE(HDR_SUPPORT) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
+        return true;
+#endif
+
     if (auto data = screenProperties(widget))
         return data->screenSupportsHighDynamicRange;
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -569,7 +569,6 @@ public:
 #if HAVE(HDR_SUPPORT)
         void setHasPaintedHDRContent() { hasPaintedHDRContent = RequestState::True; }
         void makePaintedHDRContentUnknown() { hasPaintedHDRContent = RequestState::Unknown; }
-        bool probablyHasPaintedHDRContent() const { return hasPaintedHDRContent == RequestState::True || hasPaintedHDRContent == RequestState::Undetermined; }
         bool isPaintedHDRContentSatisfied() const { return hasPaintedHDRContent != RequestState::Unknown; }
 #endif
 
@@ -594,6 +593,10 @@ public:
     bool isVisuallyNonEmpty(PaintedContentRequest* = nullptr) const;
     // True if this layer container renderers that paint.
     void determineNonLayerDescendantsPaintedContent(PaintedContentRequest&) const;
+#if HAVE(HDR_SUPPORT)
+    // True of if renderer itself draws HDR content, no traversal is done.
+    bool isReplacedElementWithHDR() const;
+#endif
 
     // FIXME: We should ASSERT(!m_hasSelfPaintingLayerDescendantDirty); here but we hit the same bugs as visible content above.
     // Part of the issue is with subtree relayout: we don't check if our ancestors have some descendant flags dirty, missing some updates.

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -249,9 +249,6 @@ public:
     bool isTrackingRepaints() const override;
     bool shouldSkipLayerInDump(const GraphicsLayer*, OptionSet<LayerTreeAsTextOptions>) const override;
     bool shouldDumpPropertyForLayer(const GraphicsLayer*, ASCIILiteral propertyName, OptionSet<LayerTreeAsTextOptions>) const override;
-#if ENABLE(HDR_FOR_IMAGES)
-    bool hdrForImagesEnabled() const override;
-#endif
 
     bool shouldAggressivelyRetainTiles(const GraphicsLayer*) const override;
     bool shouldTemporarilyRetainTileCohorts(const GraphicsLayer*) const override;
@@ -395,6 +392,9 @@ private:
     void updateImageContents(PaintedContentsInfo&);
     bool isUnscaledBitmapOnly() const;
     bool isBitmapOnly() const;
+#if HAVE(HDR_SUPPORT)
+    bool isReplacedElementWithHDR() const;
+#endif
 
     void updateDirectlyCompositedBoxDecorations(PaintedContentsInfo&, bool& didUpdateContentsRect);
     void updateDirectlyCompositedBackgroundColor(PaintedContentsInfo&, bool& didUpdateContentsRect);

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -774,13 +774,6 @@ bool RenderLayerCompositor::backdropRootIsOpaque(const GraphicsLayer* layer) con
     return !viewHasTransparentBackground();
 }
 
-#if ENABLE(HDR_FOR_IMAGES)
-bool RenderLayerCompositor::hdrForImagesEnabled() const
-{
-    return m_renderView.settings().hdrForImagesEnabled();
-}
-#endif
-
 void RenderLayerCompositor::notifyFlushRequired(const GraphicsLayer*)
 {
     scheduleRenderingUpdate();

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -431,9 +431,6 @@ private:
     bool backdropRootIsOpaque(const GraphicsLayer*) const override;
     bool isFlushingLayers() const override { return m_flushingLayers; }
     bool isTrackingRepaints() const override { return m_isTrackingRepaints; }
-#if ENABLE(HDR_FOR_IMAGES)
-    bool hdrForImagesEnabled() const override;
-#endif
 
     // Copy the accelerated compositing related flags from Settings
     void cacheAcceleratedCompositingFlags();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3927,6 +3927,35 @@ ExceptionOr<void> Internals::setFullscreenAutoHideDuration(double duration)
     return { };
 }
 
+void Internals::setScreenContentsFormatsForTesting(const Vector<Internals::ContentsFormat>& formats)
+{
+    OptionSet<WebCore::ContentsFormat> contentsFormats;
+
+    for (auto format : formats) {
+        switch (format) {
+        case Internals::ContentsFormat::RGBA8:
+            contentsFormats.add(WebCore::ContentsFormat::RGBA8);
+            break;
+#if ENABLE(PIXEL_FORMAT_RGB10)
+        case Internals::ContentsFormat::RGBA10:
+            contentsFormats.add(WebCore::ContentsFormat::RGBA10);
+            break;
+#endif
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        case Internals::ContentsFormat::RGBA16F:
+            contentsFormats.add(WebCore::ContentsFormat::RGBA16F);
+            break;
+#endif
+        }
+    }
+
+#if HAVE(HDR_SUPPORT)
+    WebCore::setScreenContentsFormatsForTesting(contentsFormats);
+#else
+    UNUSED_PARAM(contentsFormats);
+#endif
+}
+
 #if ENABLE(VIDEO)
 bool Internals::isChangingPresentationMode(HTMLVideoElement& element) const
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -651,6 +651,17 @@ public:
     void setFullscreenInsets(FullscreenInsets);
     ExceptionOr<void> setFullscreenAutoHideDuration(double);
 
+    enum ContentsFormat {
+        RGBA8,
+#if ENABLE(PIXEL_FORMAT_RGB10)
+        RGBA10,
+#endif
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        RGBA16F,
+#endif
+    };
+    void setScreenContentsFormatsForTesting(const Vector<Internals::ContentsFormat>&);
+
 #if ENABLE(VIDEO)
     bool isChangingPresentationMode(HTMLVideoElement&) const;
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -469,6 +469,16 @@ enum RenderingMode {
     "Accelerated"
 };
 
+enum ContentsFormat {
+    "RGBA8",
+#if defined(ENABLE_PIXEL_FORMAT_RGB10)
+    "RGBA10",
+#endif
+#if defined(ENABLE_PIXEL_FORMAT_RGBA16F)
+    "RGBA16F",
+#endif
+};
+
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     LegacyNoInterfaceObject,
@@ -849,6 +859,8 @@ enum RenderingMode {
 
     undefined setFullscreenInsets(FullscreenInsets insets);
     undefined setFullscreenAutoHideDuration(double duration);
+
+    undefined setScreenContentsFormatsForTesting(sequence<ContentsFormat> contentsFormats);
 
     [Conditional=VIDEO] boolean isChangingPresentationMode(HTMLVideoElement element);
     [Conditional=VIDEO_PRESENTATION_MODE] undefined setMockVideoPresentationModeEnabled(boolean enabled);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2488,10 +2488,25 @@ header: <WebCore/ScreenProperties.h>
 #endif
 };
 
+#if HAVE(HDR_SUPPORT)
+[OptionSet] enum class WebCore::ContentsFormat : uint8_t {
+    RGBA8,
+#if ENABLE(PIXEL_FORMAT_RGB10)
+    RGBA10,
+#endif
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    RGBA16F,
+#endif
+};
+#endif
+
 using WebCore::PlatformDisplayID = uint32_t;
 struct WebCore::ScreenProperties {
     WebCore::PlatformDisplayID primaryDisplayID;
     HashMap<WebCore::PlatformDisplayID, WebCore::ScreenData> screenDataMap;
+#if HAVE(HDR_SUPPORT)
+    OptionSet<WebCore::ContentsFormat> screenContentsFormatsForTesting;
+#endif
 };
 
 class WebCore::PlatformTimeRanges {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -172,11 +172,6 @@ private:
     };
     RootLayerInfo* rootLayerInfoWithFrameIdentifier(WebCore::FrameIdentifier);
 
-    // GraphicsLayerClient
-#if ENABLE(HDR_FOR_IMAGES)
-    bool hdrForImagesEnabled() const override;
-#endif
-
     Vector<RootLayerInfo, 1> m_rootLayers;
 
     std::optional<WebCore::FloatRect> m_viewExposedRect;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -472,15 +472,6 @@ auto RemoteLayerTreeDrawingArea::rootLayerInfoWithFrameIdentifier(WebCore::Frame
     return &m_rootLayers[index];
 }
 
-#if ENABLE(HDR_FOR_IMAGES)
-bool RemoteLayerTreeDrawingArea::hdrForImagesEnabled() const
-{
-    if (auto corePage = m_webPage->corePage())
-        return corePage->settings().hdrForImagesEnabled();
-    return false;
-}
-#endif
-
 void RemoteLayerTreeDrawingArea::mainFrameContentSizeChanged(WebCore::FrameIdentifier frameID, const IntSize& contentsSize)
 {
     if (auto* layerInfo = rootLayerInfoWithFrameIdentifier(frameID))


### PR DESCRIPTION
#### 1ffb2f06c35a2fa0af0654a8c9de49197b19fa07
<pre>
[HDR] Ensure HDR layers and IOSurfaces are created only when they contain HDR contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=282298">https://bugs.webkit.org/show_bug.cgi?id=282298</a>
<a href="https://rdar.apple.com/138877325">rdar://138877325</a>

Reviewed by Simon Fraser.

Each layer will decide whether it needs to draw HDR content or not. The renderer
of the RenderLayer and its sub-tree will be inspected for any HDR image or canvas.

RenderLayer::isReplacedElementWithHDR() will return true if the renderer of the
layer itself needs to draw HDR content. The image of the ImageDocument will be
handled as a special case.

PaintedContentsInfo::isReplacedElementWithHDR() will return whether the renderer
of the layer itself will need to draw HDR content or not.

All the virtual methods hdrForImagesEnabled() will be deleted and replaced by
drawsHDRContent(). drawsHDRContent() will be set to true only if the layer will
need to draw HDR contents and settings.hdrForImagesEnabled() is true.

Since determineNonLayerDescendantsPaintedContent() traverses the render tree of
layer to set hasPaintedContent, it will be used also to set hasPaintedHDRContent
of PaintedContentRequest.

Since RenderLayerBacking::updateDrawsContent() sets GraphicsLayer::setDrawsContent
from the renderer of the layer itself, this function will be used also to set
GraphicsLayer::setDrawsHDRContent() by calling
PaintedContentsInfo::isReplacedElementWithHDR().

PlatformCALayer::contentsFormatForLayer() will call GraphicsLayerCA::drawsHDRContent()
instead of calling hdrForImagesEnabled() to know whether to return RGBA16F for
this layer or not.

For testing support the internal API setScreenContentsFormatsForTesting() is added
to force the screen supported ContentsFormats to certain values.

* LayoutTests/TestExpectations:
* LayoutTests/compositing/hdr/hdr-basic-canvas.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/compositing/hdr/hdr-basic-canvas-expected.txt: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-canvas-expected.txt: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::isHDR const):
(WebCore::CanvasRenderingContext::drawsHDRContent const): Deleted.
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::canDrawHDRContents const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::updateSettingsForLayer):
* Source/WebCore/platform/PlatformScreen.cpp:
(WebCore::setScreenContentsFormatsForTesting):
(WebCore::screenContentsFormatsForTesting):
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::setDrawsHDRContent):
(WebCore::GraphicsLayer::dumpProperties const):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::drawsHDRContent const):
(WebCore::GraphicsLayer::setHDRForImagesEnabled): Deleted.
(WebCore::GraphicsLayer::hdrForImagesEnabled const): Deleted.
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::hdrForImagesEnabled const): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setDrawsHDRContent):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::drawRepaintIndicator):
(WebCore::PlatformCALayer::contentsFormatForLayer):
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::drawsHDRContent const):
(WebCore::PlatformCALayerClient::hdrForImagesEnabled const): Deleted.
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::screenSupportsExtendedColor):
(WebCore::screenSupportsHighDynamicRange):
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::screenSupportsExtendedColor):
(WebCore::screenSupportsHighDynamicRange):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::PaintedContentRequest::PaintedContentRequest):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::PaintedContentsInfo):
(WebCore::PaintedContentsInfo::isPaintsContentSatisfied const):
(WebCore::PaintedContentsInfo::paintsHDRContent):
(WebCore::PaintedContentsInfo::isContentsTypeSatisfied const):
(WebCore::PaintedContentsInfo::isSimpleContainer):
(WebCore::PaintedContentsInfo::isDirectlyCompositedImage):
(WebCore::PaintedContentsInfo::isUnscaledBitmapOnly):
(WebCore::PaintedContentsInfo::isReplacedElementWithHDR):
(WebCore::PaintedContentsInfo::determinePaintsContent):
(WebCore::PaintedContentsInfo::determineContentsType):
(WebCore::RenderLayerBacking::updateDrawsContent):
(WebCore::RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent const):
(WebCore::RenderLayerBacking::isReplacedElementWithHDR const):
(WebCore::PaintedContentsInfo::contentsTypeDetermination): Deleted.
(WebCore::RenderLayerBacking::hdrForImagesEnabled const): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::hdrForImagesEnabled const): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setScreenContentsFormatsForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::hdrForImagesEnabled const): Deleted.

Canonical link: <a href="https://commits.webkit.org/290503@main">https://commits.webkit.org/290503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cde3dbea1f239991d2d9812d1c74a663367302cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90237 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95239 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41013 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69472 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27069 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7511 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40144 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97072 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17425 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77675 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19183 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10684 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17435 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17176 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->