### PR TITLE
Address safer C++ static analysis warnings in MediaPlayerPrivateRemote

### DIFF
--- a/Source/WebCore/platform/graphics/LegacyCDMSession.h
+++ b/Source/WebCore/platform/graphics/LegacyCDMSession.h
@@ -88,6 +88,8 @@ public:
     virtual void releaseKeys() = 0;
     virtual bool update(Uint8Array*, RefPtr<Uint8Array>& nextMessage, unsigned short& errorCode, uint32_t& systemCode) = 0;
     virtual RefPtr<ArrayBuffer> cachedKeyForKeyID(const String&) const = 0;
+
+    virtual bool isRemoteLegacyCDMSession() const { return false; }
 };
 
 }

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -28,7 +28,6 @@ UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/WebAuthentication/Virtual/VirtualService.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
-WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
 WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
 WebProcess/Network/NetworkProcessConnection.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -316,7 +316,6 @@ WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
 WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
 WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
-WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/media/RemoteAudioHardwareListener.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -56,7 +56,6 @@ WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
 WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
 WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
-WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/media/RemoteAudioSession.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -65,7 +65,6 @@ WebProcess/Automation/WebAutomationSessionProxy.cpp
 WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
 WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
-WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
 WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -483,6 +483,7 @@ private:
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);
 #endif
     RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return protectedManager()->protectedGPUProcessConnection()->videoFrameObjectHeapProxy(); }
+    Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const { return videoFrameObjectHeapProxy(); }
 
     Ref<RemoteMediaPlayerManager> protectedManager() const;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
@@ -68,6 +68,7 @@ private:
     void releaseKeys() final;
     bool update(Uint8Array*, RefPtr<Uint8Array>& nextMessage, unsigned short& errorCode, uint32_t& systemCode) final;
     RefPtr<ArrayBuffer> cachedKeyForKeyID(const String&) const final;
+    bool isRemoteLegacyCDMSession() const final { return true; }
 
     // Messages
     void sendMessage(RefPtr<WebCore::SharedBuffer>&& message, const String& destinationURL);
@@ -81,5 +82,9 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::RemoteLegacyCDMSession)
+    static bool isType(const WebCore::LegacyCDMSession& session) { return session.isRemoteLegacyCDMSession(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -50,7 +50,7 @@ PlatformLayerContainer MediaPlayerPrivateRemote::createVideoFullscreenLayer()
 
 void MediaPlayerPrivateRemote::pushVideoFrameMetadata(WebCore::VideoFrameMetadata&& videoFrameMetadata, RemoteVideoFrameProxy::Properties&& properties)
 {
-    auto videoFrame = RemoteVideoFrameProxy::create(protectedConnection(), videoFrameObjectHeapProxy(), WTFMove(properties));
+    auto videoFrame = RemoteVideoFrameProxy::create(protectedConnection(), protectedVideoFrameObjectHeapProxy(), WTFMove(properties));
     if (!m_isGatheringVideoFrameMetadata)
         return;
     m_videoFrameMetadata = WTFMove(videoFrameMetadata);
@@ -66,7 +66,7 @@ RefPtr<NativeImage> MediaPlayerPrivateRemote::nativeImageForCurrentTime()
     if (!videoFrame)
         return nullptr;
 
-    return WebProcess::singleton().ensureGPUProcessConnection().videoFrameObjectHeapProxy().getNativeImage(*videoFrame);
+    return WebProcess::singleton().ensureGPUProcessConnection().protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
 }
 
 WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()
@@ -74,7 +74,7 @@ WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()
     if (readyState() < MediaPlayer::ReadyState::HaveCurrentData)
         return DestinationColorSpace::SRGB();
 
-    auto sendResult = connection().sendSync(Messages::RemoteMediaPlayerProxy::ColorSpace(), m_id);
+    auto sendResult = protectedConnection()->sendSync(Messages::RemoteMediaPlayerProxy::ColorSpace(), m_id);
     auto [colorSpace] = sendResult.takeReplyOr(DestinationColorSpace::SRGB());
     return colorSpace;
 }
@@ -103,7 +103,7 @@ WebCore::FloatSize MediaPlayerPrivateRemote::videoLayerSize() const
 
 void MediaPlayerPrivateRemote::setVideoLayerSizeFenced(const FloatSize& size, WTF::MachSendRight&& machSendRight)
 {
-    connection().send(Messages::RemoteMediaPlayerProxy::SetVideoLayerSizeFenced(size, WTFMove(machSendRight)), m_id);
+    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetVideoLayerSizeFenced(size, WTFMove(machSendRight)), m_id);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### d30e25e93990da68e4b849e806b4d7a58318a760
<pre>
Address safer C++ static analysis warnings in MediaPlayerPrivateRemote
<a href="https://bugs.webkit.org/show_bug.cgi?id=287171">https://bugs.webkit.org/show_bug.cgi?id=287171</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/graphics/LegacyCDMSession.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote):
(WebKit::MediaPlayerPrivateRemote::prepareForPlayback):
(WebKit::MediaPlayerPrivateRemote::load):
(WebKit::MediaPlayerPrivateRemote::cancelLoad):
(WebKit::MediaPlayerPrivateRemote::prepareToPlay):
(WebKit::MediaPlayerPrivateRemote::play):
(WebKit::MediaPlayerPrivateRemote::pause):
(WebKit::MediaPlayerPrivateRemote::setPreservesPitch):
(WebKit::MediaPlayerPrivateRemote::setPitchCorrectionAlgorithm):
(WebKit::MediaPlayerPrivateRemote::setVolumeLocked):
(WebKit::MediaPlayerPrivateRemote::setVolumeDouble):
(WebKit::MediaPlayerPrivateRemote::setMuted):
(WebKit::MediaPlayerPrivateRemote::setPreload):
(WebKit::MediaPlayerPrivateRemote::setPrivateBrowsingMode):
(WebKit::MediaPlayerPrivateRemote::duration const):
(WebKit::MediaPlayerPrivateRemote::currentTimeWithLockHeld const):
(WebKit::MediaPlayerPrivateRemote::seekToTarget):
(WebKit::MediaPlayerPrivateRemote::didLoadingProgressAsync const):
(WebKit::MediaPlayerPrivateRemote::acceleratedRenderingStateChanged):
(WebKit::MediaPlayerPrivateRemote::prepareForRendering):
(WebKit::MediaPlayerPrivateRemote::setPageIsVisible):
(WebKit::MediaPlayerPrivateRemote::setShouldMaintainAspectRatio):
(WebKit::MediaPlayerPrivateRemote::setShouldDisableSleep):
(WebKit::MediaPlayerPrivateRemote::addRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::remoteAudioTrackConfigurationChanged):
(WebKit::MediaPlayerPrivateRemote::addRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::remoteTextTrackConfigurationChanged):
(WebKit::MediaPlayerPrivateRemote::parseWebVTTFileHeader):
(WebKit::MediaPlayerPrivateRemote::parseWebVTTCueData):
(WebKit::MediaPlayerPrivateRemote::parseWebVTTCueDataStruct):
(WebKit::MediaPlayerPrivateRemote::addDataCue):
(WebKit::MediaPlayerPrivateRemote::addDataCueWithType):
(WebKit::MediaPlayerPrivateRemote::updateDataCue):
(WebKit::MediaPlayerPrivateRemote::removeDataCue):
(WebKit::MediaPlayerPrivateRemote::addGenericCue):
(WebKit::MediaPlayerPrivateRemote::updateGenericCue):
(WebKit::MediaPlayerPrivateRemote::removeGenericCue):
(WebKit::MediaPlayerPrivateRemote::addRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::remoteVideoTrackConfigurationChanged):
(WebKit::MediaPlayerPrivateRemote::updateVideoFullscreenInlineImage):
(WebKit::MediaPlayerPrivateRemote::setVideoFullscreenGravity):
(WebKit::MediaPlayerPrivateRemote::setVideoFullscreenMode):
(WebKit::MediaPlayerPrivateRemote::videoFullscreenStandbyChanged):
(WebKit::MediaPlayerPrivateRemote::accessLog const):
(WebKit::MediaPlayerPrivateRemote::errorLog const):
(WebKit::MediaPlayerPrivateRemote::setBufferingPolicy):
(WebKit::MediaPlayerPrivateRemote::setRateDouble):
(WebKit::MediaPlayerPrivateRemote::setPresentationSize):
(WebKit::MediaPlayerPrivateRemote::videoFrameForCurrentTime):
(WebKit::MediaPlayerPrivateRemote::setWirelessVideoPlaybackDisabled):
(WebKit::MediaPlayerPrivateRemote::setWirelessPlaybackTarget):
(WebKit::MediaPlayerPrivateRemote::setShouldPlayToPlaybackTarget):
(WebKit::MediaPlayerPrivateRemote::isCrossOrigin const):
(WebKit::MediaPlayerPrivateRemote::setCDM):
(WebKit::MediaPlayerPrivateRemote::setCDMSession):
(WebKit::MediaPlayerPrivateRemote::keyAdded):
(WebKit::MediaPlayerPrivateRemote::cdmInstanceAttached):
(WebKit::MediaPlayerPrivateRemote::cdmInstanceDetached):
(WebKit::MediaPlayerPrivateRemote::attemptToDecryptWithInstance):
(WebKit::MediaPlayerPrivateRemote::setShouldContinueAfterKeyNeeded):
(WebKit::MediaPlayerPrivateRemote::tracksChanged):
(WebKit::MediaPlayerPrivateRemote::beginSimulatedHDCPError):
(WebKit::MediaPlayerPrivateRemote::endSimulatedHDCPError):
(WebKit::MediaPlayerPrivateRemote::updateVideoPlaybackMetricsUpdateInterval):
(WebKit::MediaPlayerPrivateRemote::notifyTrackModeChanged):
(WebKit::MediaPlayerPrivateRemote::notifyActiveSourceBuffersChanged):
(WebKit::MediaPlayerPrivateRemote::applicationWillResignActive):
(WebKit::MediaPlayerPrivateRemote::applicationDidBecomeActive):
(WebKit::MediaPlayerPrivateRemote::setPreferredDynamicRangeMode):
(WebKit::MediaPlayerPrivateRemote::performTaskAtTime):
(WebKit::MediaPlayerPrivateRemote::playAtHostTime):
(WebKit::MediaPlayerPrivateRemote::pauseAtHostTime):
(WebKit::MediaPlayerPrivateRemote::startVideoFrameMetadataGathering):
(WebKit::MediaPlayerPrivateRemote::stopVideoFrameMetadataGathering):
(WebKit::MediaPlayerPrivateRemote::playerContentBoxRectChanged):
(WebKit::MediaPlayerPrivateRemote::setShouldDisableHDR):
(WebKit::MediaPlayerPrivateRemote::requestResource):
(WebKit::MediaPlayerPrivateRemote::requestHostingContextID):
(WebKit::MediaPlayerPrivateRemote::setShouldCheckHardwareSupport):
(WebKit::MediaPlayerPrivateRemote::setDefaultSpatialTrackingLabel):
(WebKit::MediaPlayerPrivateRemote::setSpatialTrackingLabel):
(WebKit::MediaPlayerPrivateRemote::isInFullscreenOrPictureInPictureChanged):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h:
(isType):
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::pushVideoFrameMetadata):
(WebKit::MediaPlayerPrivateRemote::nativeImageForCurrentTime):
(WebKit::MediaPlayerPrivateRemote::colorSpace):
(WebKit::MediaPlayerPrivateRemote::setVideoLayerSizeFenced):

Canonical link: <a href="https://commits.webkit.org/289987@main">https://commits.webkit.org/289987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b1e2d68dc5513f0989099c82987bb4e79ef6099

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88648 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93610 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6548 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48713 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38510 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95448 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15823 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76488 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20882 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15839 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15580 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->