### PR TITLE
Add support for test.runWithUserGesture and isProcessingUserGesture.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -37,11 +37,13 @@
 #import "WebExtensionControllerMessages.h"
 #import "WebExtensionControllerProxy.h"
 #import "WebExtensionEventListenerType.h"
+#import "WebFrame.h"
 #import "WebPage.h"
 #import "WebProcess.h"
 #import <JavaScriptCore/APICast.h>
 #import <JavaScriptCore/ScriptCallStack.h>
 #import <JavaScriptCore/ScriptCallStackFactory.h>
+#import <WebCore/LocalFrame.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -111,6 +113,19 @@ WebExtensionAPIEvent& WebExtensionAPITest::onMessage()
         m_onMessage = WebExtensionAPIEvent::create(*this, WebExtensionEventListenerType::TestOnMessage);
 
     return *m_onMessage;
+}
+
+JSValue *WebExtensionAPITest::runWithUserGesture(WebFrame& frame, JSValue *function)
+{
+    RefPtr coreFrame = frame.protectedCoreLocalFrame();
+    WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, coreFrame ? coreFrame->document() : nullptr);
+
+    return [function callWithArguments:@[ ]];
+}
+
+bool WebExtensionAPITest::isProcessingUserGesture()
+{
+    return WebCore::UserGestureIndicator::processingUserGesture();
 }
 
 inline NSString *debugString(JSValue *value)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -47,6 +47,9 @@ public:
     void sendMessage(JSContextRef, NSString *message, JSValue *argument);
     WebExtensionAPIEvent& onMessage();
 
+    JSValue *runWithUserGesture(WebFrame&, JSValue *function);
+    bool isProcessingUserGesture();
+
     void log(JSContextRef, JSValue *);
 
     void fail(JSContextRef, NSString *message);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -40,6 +40,12 @@
     // Event for receiving messages from the test harness.
     readonly attribute WebExtensionAPIEvent onMessage;
 
+    // Runs the provided function in the context of a user gesture.
+    [NeedsFrame] any runWithUserGesture([ValuesAllowed] any function);
+
+    // Returns if a user gesture is active.
+    boolean isProcessingUserGesture();
+
     // Logs a message during testing.
     [NeedsScriptContext] void log([ValuesAllowed] any message);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -1527,17 +1527,22 @@ TEST(WKWebExtensionAPIAction, WindowOpenOpensInNewWindow)
         @"browser.test.sendMessage('Open Popup')"
     ]);
 
+    auto *popupScript = Util::constructScript(@[
+        @"browser.test.runWithUserGesture(() => {",
+        @"  window.open('https://example.com/', '_blank', 'popup, width=100, height=50')",
+        @"})"
+    ]);
+
     auto *resources = @{
         @"background.js": backgroundScript,
-        @"popup.html": @"",
+        @"popup.html": @"<script type='module' src='popup.js'></script>",
+        @"popup.js": popupScript
     };
 
     auto manager = Util::loadExtension(actionPopupManifest, resources);
 
     manager.get().internalDelegate.presentPopupForAction = ^(WKWebExtensionAction *action) {
         EXPECT_NOT_NULL(action);
-
-        Util::runScriptWithUserGesture("window.open('https://example.com/', '_blank', 'popup, width=100, height=50')"_s, action.popupWebView);
     };
 
 #if PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -143,11 +143,9 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
-        @"}",
-
-        @"browser.test.sendMessage('Ready')",
+        @"browser.test.runWithUserGesture(async () => {",
+        @"  browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -179,10 +177,6 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
 
     manager.get().controllerDelegate = requestDelegate.get();
 
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
-
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
@@ -196,11 +190,9 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
-        @"}",
-
-        @"browser.test.sendMessage('Ready')",
+        @"browser.test.runWithUserGesture(async () => {",
+        @"  browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -223,10 +215,6 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)
 
     manager.get().controllerDelegate = requestDelegate.get();
 
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
-
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
@@ -240,11 +228,9 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  await browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
-        @"}",
-
-        @"browser.test.sendMessage('Ready')",
+        @"browser.test.runWithUserGesture(async () => {",
+        @"  browser.test.assertFalse(await browser.permissions.request({'permissions': ['declarativeNetRequest'], 'origins': ['*://*.apple.com/*']}))",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -268,10 +254,6 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)
 
     manager.get().controllerDelegate = requestDelegate.get();
 
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
-
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
@@ -285,11 +267,9 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  await browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest']}))",
-        @"}",
-
-        @"browser.test.sendMessage('Ready')",
+        @"browser.test.runWithUserGesture(async () => {",
+        @"  browser.test.assertTrue(await browser.permissions.request({'permissions': ['declarativeNetRequest']}))",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -315,10 +295,6 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
 
     manager.get().controllerDelegate = requestDelegate.get();
 
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
-
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
@@ -332,11 +308,9 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  await browser.test.assertTrue(await browser.permissions.request({'origins': ['*://*.apple.com/*']}))",
-        @"}",
-
-        @"browser.test.sendMessage('Ready')",
+        @"browser.test.runWithUserGesture(async () => {",
+        @"  browser.test.assertTrue(await browser.permissions.request({'origins': ['*://*.apple.com/*']}))",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -362,10 +336,6 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
 
     manager.get().controllerDelegate = requestDelegate.get();
 
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
-
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
@@ -384,11 +354,9 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  await browser.test.assertFalse(await browser.permissions.request({'permissions': ['alarms', 'declarativeNetRequest']}))",
-        @"}",
-
-        @"browser.test.sendMessage('Ready')",
+        @"browser.test.runWithUserGesture(async () => {",
+        @"  browser.test.assertFalse(await browser.permissions.request({'permissions': ['alarms', 'declarativeNetRequest']}))",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -414,10 +382,6 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
 
     manager.get().controllerDelegate = requestDelegate.get();
 
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
-
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
@@ -431,11 +395,9 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  await browser.test.assertFalse(await browser.permissions.request({'origins': ['*://*.apple.com/*', '*://*.example.com/*']}))",
-        @"}",
-
-        @"browser.test.sendMessage('Ready')",
+        @"browser.test.runWithUserGesture(async () => {",
+        @"  browser.test.assertFalse(await browser.permissions.request({'origins': ['*://*.apple.com/*', '*://*.example.com/*']}))",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -458,10 +420,6 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
-
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("runTest()"_s, manager.get().context._backgroundWebView);
 
     TestWebKitAPI::Util::run(&requestComplete);
 }
@@ -613,25 +571,23 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"window.runTest = async () => {",
-        @"  try {",
-        @"    await navigator.clipboard.writeText('Initial Attempt Without Permission')",
-        @"  } catch (error) {",
-        @"    browser.test.assertTrue(error instanceof DOMException, 'Expect a DOMException for insufficient permissions')",
-        @"  }",
-
-        @"  const permissionGranted = await browser.permissions.request({ permissions: [ 'clipboardWrite' ] })",
-
-        @"  if (permissionGranted) {",
-        @"    await navigator.clipboard.writeText('Test Clipboard Write After Permission')",
-
-        @"    browser.test.sendMessage('Clipboard Written')",
-        @"  } else {",
-        @"    browser.test.notifyFail('Permission was not granted')",
-        @"  }",
+        @"try {",
+        @"  await navigator.clipboard.writeText('Initial Attempt Without Permission')",
+        @"} catch (error) {",
+        @"  browser.test.assertTrue(error instanceof DOMException, 'Expect a DOMException for insufficient permissions')",
         @"}",
 
-        @"browser.test.sendMessage('Ready')",
+        @"const permissionGranted = await browser.test.runWithUserGesture(() => {",
+        @"  return browser.permissions.request({ permissions: [ 'clipboardWrite' ] })",
+        @"})",
+
+        @"if (permissionGranted) {",
+        @"  await navigator.clipboard.writeText('Test Clipboard Write After Permission')",
+
+        @"  browser.test.sendMessage('Clipboard Written')",
+        @"} else {",
+        @"  browser.test.notifyFail('Permission was not granted')",
+        @"}"
     ]);
 
     auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
@@ -646,10 +602,6 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
-
-    [manager runUntilTestMessage:@"Ready"];
-
-    Util::runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
 
     [manager runUntilTestMessage:@"Clipboard Written"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
@@ -823,13 +823,11 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionToggleFailsWithoutUserGesture)
 TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenSucceedsWithUserGesture)
 {
     auto *script = @[
-        @"window.runTest = async () => {",
-        @"    await browser.test.assertSafeResolve(() => browser.sidebarAction.open())",
+        @"await browser.test.runWithUserGesture(() => {",
+        @"  return browser.test.assertSafeResolve(() => browser.sidebarAction.open())",
+        @"})",
 
-        @"    browser.test.notifyPass()",
-        @"}",
-
-        @"browser.test.sendMessage('Apply user gesture')",
+        @"browser.test.notifyPass()",
     ];
 
     auto *resources = @{
@@ -854,12 +852,7 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenSucceedsWithUserGesture)
         EXPECT_NS_EQUAL(webViewURL.path, @"/sidebar.html");
     };
 
-    [manager load];
-    [manager runUntilTestMessage:@"Apply user gesture"];
-
-    Util::runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
-
-    [manager run];
+    [manager loadAndRun];
 
     EXPECT_EQ(presentSidebarCallCount, 1);
 }
@@ -867,13 +860,11 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenSucceedsWithUserGesture)
 TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseSucceedsWithUserGesture)
 {
     auto *script = @[
-        @"window.runTest = async () => {",
-        @"    await browser.test.assertSafeResolve(() => browser.sidebarAction.close())",
+        @"await browser.test.runWithUserGesture(() => {",
+        @"  return browser.test.assertSafeResolve(() => browser.sidebarAction.close())",
+        @"})",
 
-        @"    browser.test.notifyPass()",
-        @"}",
-
-        @"browser.test.sendMessage('Apply user gesture')",
+        @"browser.test.notifyPass()",
     ];
 
     auto *resources = @{
@@ -900,12 +891,7 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseSucceedsWithUserGesture)
         EXPECT_NS_EQUAL(webViewURL.path, @"/sidebar.html");
     };
 
-    [manager load];
-    [manager runUntilTestMessage:@"Apply user gesture"];
-
-    Util::runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
-
-    [manager run];
+    [manager loadAndRun];
 
     EXPECT_EQ(closeSidebarCallCount, 1);
 }
@@ -913,13 +899,11 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseSucceedsWithUserGesture)
 TEST_F(WKWebExtensionAPISidebar, SidebarActionToggleSucceedsWithUserGesture)
 {
     auto *script = @[
-        @"window.runTest = async () => {",
-        @"    await browser.test.assertSafeResolve(() => browser.sidebarAction.toggle())",
+        @"await browser.test.runWithUserGesture(() => {",
+        @"  return browser.test.assertSafeResolve(() => browser.sidebarAction.toggle())",
+        @"})",
 
-        @"    browser.test.notifyPass()",
-        @"}",
-
-        @"browser.test.sendMessage('Apply user gesture')",
+        @"browser.test.notifyPass()",
     ];
 
     auto *resources = @{
@@ -935,12 +919,7 @@ TEST_F(WKWebExtensionAPISidebar, SidebarActionToggleSucceedsWithUserGesture)
         (*openSidebarCallCountPtr)++;
     };
 
-    [manager load];
-    [manager runUntilTestMessage:@"Apply user gesture"];
-
-    Util::runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
-
-    [manager run];
+    [manager loadAndRun];
 
     EXPECT_EQ(openSidebarCallCount, 1);
 }
@@ -1241,15 +1220,13 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowFailsWithoutUserGesture)
 TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForTabSucceedsWithUserGesture)
 {
     auto *script = @[
-        @"window.runTest = async () => {",
-        @"    await browser.test.assertSafeResolve(() => browser.sidePanel.open({ tabId: tabs[0].id }))",
-
-        @"    browser.test.notifyPass()",
-        @"}",
-
         @"var tabs = await browser.tabs.query({})",
 
-        @"browser.test.sendMessage('Apply user gesture')",
+        @"await browser.test.runWithUserGesture(() => {",
+        @"  return browser.test.assertSafeResolve(() => browser.sidePanel.open({ tabId: tabs[0].id }))",
+        @"})",
+
+        @"browser.test.notifyPass()",
     ];
 
     auto *resources = @{
@@ -1274,12 +1251,7 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForTabSucceedsWithUserGesture)
         EXPECT_NS_EQUAL(webViewURL.path, @"/sidebar.html");
     };
 
-    [manager load];
-    [manager runUntilTestMessage:@"Apply user gesture"];
-
-    Util::runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
-
-    [manager run];
+    [manager loadAndRun];
 
     EXPECT_EQ(presentSidebarCallCount, 1);
 }
@@ -1287,15 +1259,13 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForTabSucceedsWithUserGesture)
 TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowSucceedsWithUserGesture)
 {
     auto *script = @[
-        @"window.runTest = async () => {",
-        @"    await browser.test.assertSafeResolve(() => browser.sidePanel.open({ windowId: currentWindow.id }))",
-
-        @"    browser.test.notifyPass()",
-        @"}",
-
         @"var currentWindow = await browser.windows.getCurrent()",
 
-        @"browser.test.sendMessage('Apply user gesture')",
+        @"await browser.test.runWithUserGesture(() => {",
+        @"  return browser.test.assertSafeResolve(() => browser.sidePanel.open({ windowId: currentWindow.id }))",
+        @"})",
+
+        @"browser.test.notifyPass()",
     ];
 
     auto *resources = @{
@@ -1327,12 +1297,7 @@ TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowSucceedsWithUserGesture)
         EXPECT_TRUE([defaultWindow.tabs containsObject:sidebar.associatedTab]);
     };
 
-    [manager load];
-    [manager runUntilTestMessage:@"Apply user gesture"];
-
-    Util::runScriptWithUserGesture("window.runTest()"_s, manager.get().context._backgroundWebView);
-
-    [manager run];
+    [manager loadAndRun];
 
     EXPECT_EQ(presentSidebarCallCount, 1);
 }

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -162,8 +162,6 @@ inline NSString *constructJSArrayOfStrings(NSArray *elements) { return [NSString
 
 NSData *makePNGData(CGSize, SEL colorSelector);
 
-void runScriptWithUserGesture(const String&, WKWebView *);
-
 enum class Appearance { Light, Dark };
 
 void performWithAppearance(Appearance, void (^block)(void));

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -991,26 +991,6 @@ NSData *makePNGData(CGSize size, SEL colorSelector)
 #endif
 }
 
-void runScriptWithUserGesture(const String& script, WKWebView *webView)
-{
-    ASSERT(webView);
-
-    bool callbackComplete = false;
-    id evalResult;
-
-    [webView callAsyncJavaScript:script arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:[&](id result, NSError *error) {
-        evalResult = result;
-        callbackComplete = true;
-
-        EXPECT_NULL(error);
-
-        if (error)
-            NSLog(@"Encountered error: %@ while evaluating script: %@", error, static_cast<NSString *>(script));
-    }];
-
-    TestWebKitAPI::Util::run(&callbackComplete);
-}
-
 void performWithAppearance(Appearance appearance, void (^block)(void))
 {
 #if USE(APPKIT)


### PR DESCRIPTION
#### ac7bdb81b1c961a62dc49687f3fffd6cad166e94
<pre>
Add support for test.runWithUserGesture and isProcessingUserGesture.
<a href="https://webkit.org/b/287176">https://webkit.org/b/287176</a>
<a href="https://rdar.apple.com/problem/144332522">rdar://problem/144332522</a>

Reviewed by Brian Weinstein.

Add the standard way for web extension tests to invoke a function with a user gesture.
Remove our previous `Util::runScriptWithUserGesture` method and move existing tests over.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::runWithUserGesture): Added.
(WebKit::WebExtensionAPITest::isProcessingUserGesture): Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIAction, WindowOpenOpensInNewWindow)): Updated.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)): Updated.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)): Updated.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)): Updated.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)): Updated.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)): Updated.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)): Updated.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)): Updated.
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)): Updated.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionOpenSucceedsWithUserGesture)): Updated.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionCloseSucceedsWithUserGesture)): Updated.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidebarActionToggleSucceedsWithUserGesture)): Updated.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForTabSucceedsWithUserGesture)): Updated.
(TestWebKitAPI::TEST_F(WKWebExtensionAPISidebar, SidePanelOpenForWindowSucceedsWithUserGesture)): Updated.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(TestWebKitAPI::Util::runScriptWithUserGesture): Deleted.

Canonical link: <a href="https://commits.webkit.org/289970@main">https://commits.webkit.org/289970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4457fb0998eff9599732ce7ab58d1d4968a1f2e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43028 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90635 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8490 "Failed to checkout and rebase branch from PR 40152") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/93544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91586 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/8490 "Failed to checkout and rebase branch from PR 40152") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/8490 "Failed to checkout and rebase branch from PR 40152") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/38446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/8490 "Failed to checkout and rebase branch from PR 40152") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/95384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/15759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/95384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/16015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/75973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/95384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13852 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/15775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/18965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/17298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->