### PR TITLE
command IDL property reflects invalid values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection-expected.txt
@@ -7,13 +7,13 @@ PASS invoker should reflect hide-popover properly
 PASS invoker should reflect show-popover properly
 PASS invoker should reflect close properly
 PASS invoker should reflect --custom properly
-FAIL invoker should reflect odd cased sHoW-MoDaL properly - as show-modal assert_equals: invoker should reflect odd cased sHoW-MoDaL properly - as show-modal expected "show-modal" but got "sHoW-MoDaL"
-FAIL invoker should reflect odd cased tOgGlE-pOpOvEr properly - as toggle-popover assert_equals: invoker should reflect odd cased tOgGlE-pOpOvEr properly - as toggle-popover expected "toggle-popover" but got "tOgGlE-pOpOvEr"
-FAIL invoker should reflect odd cased hIdE-pOpOvEr properly - as hide-popover assert_equals: invoker should reflect odd cased hIdE-pOpOvEr properly - as hide-popover expected "hide-popover" but got "hIdE-pOpOvEr"
-FAIL invoker should reflect odd cased sHoW-pOpOvEr properly - as show-popover assert_equals: invoker should reflect odd cased sHoW-pOpOvEr properly - as show-popover expected "show-popover" but got "sHoW-pOpOvEr"
-FAIL invoker should reflect odd cased ClOsE properly - as close assert_equals: invoker should reflect odd cased ClOsE properly - as close expected "close" but got "ClOsE"
+PASS invoker should reflect odd cased sHoW-MoDaL properly - as show-modal
+PASS invoker should reflect odd cased tOgGlE-pOpOvEr properly - as toggle-popover
+PASS invoker should reflect odd cased hIdE-pOpOvEr properly - as hide-popover
+PASS invoker should reflect odd cased sHoW-pOpOvEr properly - as show-popover
+PASS invoker should reflect odd cased ClOsE properly - as close
 PASS invoker should reflect odd cased --cUsToM properly - as --cUsToM
-FAIL invoker should reflect the invalid value "invalid" as the empty string assert_equals: invoker should reflect the invalid value "invalid" as the empty string expected "" but got "invalid"
-FAIL invoker should reflect the invalid value "show-invalid" as the empty string assert_equals: invoker should reflect the invalid value "show-invalid" as the empty string expected "" but got "show-invalid"
-FAIL invoker should reflect the invalid value "foo-bar" as the empty string assert_equals: invoker should reflect the invalid value "foo-bar" as the empty string expected "" but got "foo-bar"
+PASS invoker should reflect the invalid value "invalid" as the empty string
+PASS invoker should reflect the invalid value "show-invalid" as the empty string
+PASS invoker should reflect the invalid value "foo-bar" as the empty string
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface-expected.txt
@@ -6,9 +6,9 @@ PASS commandForElement reflects set value across shadow root into light dom
 PASS commandForElement does not reflect set value inside shadowroot
 PASS commandForElement throws error on assignment of non Element
 PASS command reflects '' when attribute empty, setAttribute version
-FAIL command reflects correctly for invalid assert_equals: expected "" but got "fooBarBaz"
+PASS command reflects correctly for invalid
 PASS command reflects '' when attribute empty, IDL version
-FAIL command reflects correctly for invalid when array assert_equals: expected "" but got "1,2,3"
+PASS command reflects correctly for invalid when array
 PASS command reflects '' when attribute set to []
-FAIL command reflects correctly for invalid when object assert_equals: expected "" but got "[object Object]"
+PASS command reflects correctly for invalid when object
 

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -149,30 +149,55 @@ RefPtr<Element> HTMLButtonElement::commandForElement() const
     return elementForAttributeInternal(commandforAttr);
 }
 
-constexpr ASCIILiteral togglePopoverLiteral = "toggle-popover"_s;
-constexpr ASCIILiteral showPopoverLiteral = "show-popover"_s;
-constexpr ASCIILiteral hidePopoverLiteral = "hide-popover"_s;
-constexpr ASCIILiteral showModalLiteral = "show-modal"_s;
-constexpr ASCIILiteral closeLiteral = "close"_s;
+static const AtomString& togglePopoverAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("toggle-popover"_s);
+    return identifier;
+}
+
+static const AtomString& showPopoverAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("show-popover"_s);
+    return identifier;
+}
+
+static const AtomString& hidePopoverAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("hide-popover"_s);
+    return identifier;
+}
+
+static const AtomString& closeAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("close"_s);
+    return identifier;
+}
+
+static const AtomString& showModalAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("show-modal"_s);
+    return identifier;
+}
+
 CommandType HTMLButtonElement::commandType() const
 {
     auto action = attributeWithoutSynchronization(HTMLNames::commandAttr);
     if (action.isNull() || action.isEmpty())
         return CommandType::Invalid;
 
-    if (equalLettersIgnoringASCIICase(action, togglePopoverLiteral))
+    if (equalIgnoringASCIICase(action, togglePopoverAtom()))
         return CommandType::TogglePopover;
 
-    if (equalLettersIgnoringASCIICase(action, showPopoverLiteral))
+    if (equalIgnoringASCIICase(action, showPopoverAtom()))
         return CommandType::ShowPopover;
 
-    if (equalLettersIgnoringASCIICase(action, hidePopoverLiteral))
+    if (equalIgnoringASCIICase(action, hidePopoverAtom()))
         return CommandType::HidePopover;
 
-    if (equalLettersIgnoringASCIICase(action, showModalLiteral))
+    if (equalIgnoringASCIICase(action, showModalAtom()))
         return CommandType::ShowModal;
 
-    if (equalLettersIgnoringASCIICase(action, closeLiteral))
+    if (equalIgnoringASCIICase(action, closeAtom()))
         return CommandType::Close;
 
     if (action.startsWith("--"_s))
@@ -209,6 +234,34 @@ void HTMLButtonElement::handleCommand()
 
     if (!event->defaultPrevented() && command != CommandType::Custom)
         invokee->handleCommandInternal(*this, command);
+}
+
+const AtomString& HTMLButtonElement::command() const
+{
+    switch (commandType()) {
+    case CommandType::TogglePopover:
+        return togglePopoverAtom();
+    case CommandType::ShowPopover:
+        return showPopoverAtom();
+    case CommandType::HidePopover:
+        return hidePopoverAtom();
+    case CommandType::Close:
+        return closeAtom();
+    case CommandType::ShowModal:
+        return showModalAtom();
+    case CommandType::Custom:
+        return attributeWithoutSynchronization(HTMLNames::commandAttr);
+    case CommandType::Invalid:
+        return emptyAtom();
+    }
+
+    ASSERT_NOT_REACHED();
+    return nullAtom();
+}
+
+void HTMLButtonElement::setCommand(const AtomString& value)
+{
+    setAttributeWithoutSynchronization(HTMLNames::commandAttr, value);
 }
 
 void HTMLButtonElement::defaultEventHandler(Event& event)

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -40,6 +40,9 @@ public:
     
     const AtomString& value() const;
 
+    const AtomString& command() const;
+    void setCommand(const AtomString&);
+
     RefPtr<Element> commandForElement() const;
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -36,7 +36,7 @@
 
     // Command Invokers
     [CEReactions=NotNeeded, Reflect=commandfor, EnabledBySetting=InvokerAttributesEnabled] attribute Element? commandForElement;
-    [CEReactions=NotNeeded, Reflect=command, EnabledBySetting=InvokerAttributesEnabled] attribute DOMString command;
+    [CEReactions=NotNeeded, EnabledBySetting=InvokerAttributesEnabled] attribute [AtomString] DOMString command;
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;


### PR DESCRIPTION
#### 72347c4a2ac0df01f6d4bdf0c3d1d2e3e0215d1b
<pre>
command IDL property reflects invalid values
<a href="https://bugs.webkit.org/show_bug.cgi?id=287189">https://bugs.webkit.org/show_bug.cgi?id=287189</a>

Reviewed by Darin Adler.

Swaps the command IDL property to use manual reflection rather than
the Reflect IDL extended attribute.

Invalid values are now correctly reflected as an empty string.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.tentative-expected.txt:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::togglePopoverAtom):
(WebCore::showPopoverAtom):
(WebCore::hidePopoverAtom):
(WebCore::closeAtom):
(WebCore::showModalAtom):
(WebCore::HTMLButtonElement::commandType const):
(WebCore::HTMLButtonElement::command const):
(WebCore::HTMLButtonElement::setCommand):
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLButtonElement.idl:

Canonical link: <a href="https://commits.webkit.org/291954@main">https://commits.webkit.org/291954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/433fa5777b3af2ac3e8c11e9019f730100042984

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72116 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3029 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44348 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101572 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20067 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14788 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26677 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->