### PR TITLE
[WebGPU] Perform buffer allocations via MTLHeap

### DIFF
--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -181,8 +181,8 @@ public:
     id<MTLRenderPipelineState> icbCommandClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
     id<MTLFunction> icbCommandClampFunction(MTLIndexType);
     id<MTLRenderPipelineState> copyIndexIndirectArgsPipeline(NSUInteger rasterSampleCount);
-    id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeDefault) const;
     id<MTLBuffer> safeCreateBuffer(NSUInteger) const;
+    id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeTracked) const;
     void loseTheDevice(WGPUDeviceLostReason);
     int bufferIndexForICBContainer() const;
     void setOwnerWithIdentity(id<MTLResource>) const;
@@ -280,6 +280,7 @@ private:
 #endif
     NSMapTable<id<MTLCommandBuffer>, id<MTLCounterSampleBuffer>>* m_sampleCounterBuffers;
     NSMapTable<id<MTLCommandBuffer>, NSMutableArray<id<MTLBuffer>>*>* m_resolvedSampleCounterBuffers;
+    NSMutableArray<id<MTLHeap>>* m_heaps;
     id<MTLSharedEvent> m_resolveTimestampsSharedEvent { nil };
     uint64_t m_commandEncoderId { 0 };
     bool m_supressAllErrors { false };

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -331,6 +331,7 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     m_placeholderDepthStencilTexture = [m_device newTextureWithDescriptor:desc];
     m_sampleCounterBuffers = [NSMapTable weakToStrongObjectsMapTable];
     m_resolvedSampleCounterBuffers = [NSMapTable weakToStrongObjectsMapTable];
+    m_heaps = [NSMutableArray array];
 }
 
 Device::Device(Adapter& adapter)
@@ -626,7 +627,7 @@ id<MTLBuffer> Device::dispatchCallBuffer()
         return nil;
 
     if (!m_dispatchCallBuffer) {
-        m_dispatchCallBuffer = [m_device newBufferWithLength:sizeof(MTLDispatchThreadgroupsIndirectArguments) options:MTLResourceStorageModePrivate];
+        m_dispatchCallBuffer = safeCreateBuffer(sizeof(MTLDispatchThreadgroupsIndirectArguments));
         setOwnerWithIdentity(m_dispatchCallBuffer);
     }
     return m_dispatchCallBuffer;

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -63,7 +63,7 @@ Ref<QuerySet> Device::createQuerySet(const WGPUQuerySetDescriptor& descriptor)
         return QuerySet::createInvalid(*this);
 #endif
     } case WGPUQueryType_Occlusion: {
-        auto buffer = safeCreateBuffer(sizeof(uint64_t) * count, MTLStorageModePrivate);
+        auto buffer = safeCreateBuffer(sizeof(uint64_t) * count);
         buffer.label = fromAPI(label);
         return QuerySet::create(buffer, count, type, *this);
     }


### PR DESCRIPTION
#### c5c8fba7a67eaf335594846084e15a40acd81edf
<pre>
[WebGPU] Perform buffer allocations via MTLHeap
<a href="https://bugs.webkit.org/show_bug.cgi?id=287187">https://bugs.webkit.org/show_bug.cgi?id=287187</a>
<a href="https://rdar.apple.com/144337603">rdar://144337603</a>

Reviewed by NOBODY (OOPS!).

Perform allocations via MTLHeap to ensure MTLBuffers don&apos;t
get sub-allocated into a single memory page from different
web content processes.

Regression test: all existing tests pass.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Device::safeCreateBuffer const):
(WebGPU::Device::createBuffer):
(WebGPU::Buffer::Buffer):
(WebGPU::storageMode): Deleted.
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::dispatchCallBuffer):
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::Device::createQuerySet):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5c8fba7a67eaf335594846084e15a40acd81edf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39404 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26047 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6307 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76673 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35485 "Found 3 new test failures: http/tests/webgpu/webgpu/api/operation/buffers/map.html http/tests/webgpu/webgpu/api/operation/command_buffer/queries/occlusionQuery.html http/tests/webgpu/webgpu/shader/execution/flow_control/switch.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95450 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15825 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11610 "Found 3 new test failures: http/tests/webgpu/webgpu/api/operation/command_buffer/queries/occlusionQuery.html http/tests/webgpu/webgpu/shader/execution/flow_control/switch.html media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77214 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76491 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20881 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19302 "Found 18 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html http/tests/webgpu/webgpu/api/operation/buffers/map.html http/tests/webgpu/webgpu/api/operation/buffers/map_ArrayBuffer.html http/tests/webgpu/webgpu/api/operation/buffers/map_detach.html http/tests/webgpu/webgpu/api/operation/buffers/map_oom.html http/tests/webgpu/webgpu/api/validation/buffer/create.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8864 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15841 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21149 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15582 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19031 "Hash c5c8fba7 for PR 40155 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17364 "Hash c5c8fba7 for PR 40155 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->