### PR TITLE
Address safer C++ static analysis warnings in AVTrackPrivateAVFObjCImpl.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1123,7 +1123,6 @@ platform/graphics/SourceBufferPrivate.cpp
 platform/graphics/TrackBuffer.cpp
 platform/graphics/TransparencyLayerContextSwitcher.cpp
 platform/graphics/WidthIterator.cpp
-platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -67,8 +67,8 @@ static AVAssetTrack* assetTrackFor(const AVTrackPrivateAVFObjCImpl& impl)
         return impl.playerItemTrack().assetTrack;
     if (impl.assetTrack())
         return impl.assetTrack();
-    if (impl.mediaSelectionOption() && impl.mediaSelectionOption()->assetTrack())
-        return impl.mediaSelectionOption()->assetTrack();
+    if (RefPtr mediaSelectionOption = impl.mediaSelectionOption(); mediaSelectionOption && mediaSelectionOption->assetTrack())
+        return mediaSelectionOption->assetTrack();
     return nil;
 }
 
@@ -115,8 +115,8 @@ bool AVTrackPrivateAVFObjCImpl::enabled() const
 {
     if (m_playerItemTrack)
         return [m_playerItemTrack isEnabled];
-    if (m_mediaSelectionOption)
-        return m_mediaSelectionOption->selected();
+    if (RefPtr mediaSelectionOption = m_mediaSelectionOption)
+        return mediaSelectionOption->selected();
     ASSERT_NOT_REACHED();
     return false;
 }
@@ -125,8 +125,8 @@ void AVTrackPrivateAVFObjCImpl::setEnabled(bool enabled)
 {
     if (m_playerItemTrack)
         [m_playerItemTrack setEnabled:enabled];
-    else if (m_mediaSelectionOption)
-        m_mediaSelectionOption->setSelected(enabled);
+    else if (RefPtr mediaSelectionOption = m_mediaSelectionOption)
+        mediaSelectionOption->setSelected(enabled);
     else
         ASSERT_NOT_REACHED();
 }
@@ -193,8 +193,8 @@ int AVTrackPrivateAVFObjCImpl::index() const
 {
     if (m_assetTrack)
         return [[[m_assetTrack asset] tracks] indexOfObject:m_assetTrack.get()];
-    if (m_mediaSelectionOption)
-        return [[[m_playerItem asset] tracks] count] + m_mediaSelectionOption->index();
+    if (RefPtr mediaSelectionOption = m_mediaSelectionOption)
+        return [[[m_playerItem asset] tracks] count] + mediaSelectionOption->index();
     ASSERT_NOT_REACHED();
     return 0;
 }


### PR DESCRIPTION
#### 92f85b4a971230601e96fd16710794701f877d8a
<pre>
Address safer C++ static analysis warnings in AVTrackPrivateAVFObjCImpl.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=287190">https://bugs.webkit.org/show_bug.cgi?id=287190</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::assetTrackFor):
(WebCore::AVTrackPrivateAVFObjCImpl::enabled const):
(WebCore::AVTrackPrivateAVFObjCImpl::setEnabled):
(WebCore::AVTrackPrivateAVFObjCImpl::index const):

Canonical link: <a href="https://commits.webkit.org/289999@main">https://commits.webkit.org/289999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8407c387dabbe8d550b70838fdbf419c84f51792

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39337 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68303 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26019 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95383 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75971 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76440 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/color-chooser-request, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/audio-usermedia-permission-request, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /TestWebKit:WebKit.EvaluateJavaScriptThatThrowsAnException, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/insert/link ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8797 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13866 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15774 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21082 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15515 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->