### PR TITLE
[UIIntelligenceSupport] [iOS] Text extraction fails for web content in the Notion app

### DIFF
--- a/LayoutTests/fast/text-extraction/text-extraction-display-contents-expected.txt
+++ b/LayoutTests/fast/text-extraction/text-extraction-display-contents-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+(ROOT (TEXT "Heading\n\nSubheading\n\nSome plain text and a link.\n\n" {<https://www.apple.com/> in [37,47]}))

--- a/LayoutTests/fast/text-extraction/text-extraction-display-contents.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-display-contents.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true useFlexibleViewport=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html, body {
+    font-family: system-ui;
+}
+
+div.display-contents {
+    display: contents;
+}
+
+div.display-none {
+    display: none;
+}
+
+div.transparent {
+    opacity: 0;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script>
+addEventListener("load", async () => {
+    jsTestIsAsync = true;
+
+    document.body.textContent = await UIHelper.requestTextExtraction();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <h1>Heading</h1>
+    <div class="display-contents">
+        <h2>Subheading</h2>
+        <p>Some plain text <a href="https://www.apple.com">and a link</a>.</p>
+    </div>
+    <div class="display-none">
+        <h2>1. Fail (this text should not be extracted)</h2>
+    </div>
+    <div class="transparent">
+        <h2>2. Fail (this text should not be extracted)</h2>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -270,6 +270,11 @@ static bool shouldTreatAsPasswordField(const Element* element)
 static inline std::variant<SkipExtraction, ItemData, URL, Editable> extractItemData(Node& node, TraversalContext& context)
 {
     CheckedPtr renderer = node.renderer();
+
+    RefPtr element = dynamicDowncast<Element>(node);
+    if (element && element->hasDisplayContents())
+        return { SkipExtraction::Self };
+
     if (!renderer || renderer->style().opacity() < minOpacityToConsiderVisible)
         return { SkipExtraction::SelfAndSubtree };
 
@@ -287,7 +292,6 @@ static inline std::variant<SkipExtraction, ItemData, URL, Editable> extractItemD
         return { SkipExtraction::Self };
     }
 
-    RefPtr element = dynamicDowncast<Element>(node);
     if (!element)
         return { SkipExtraction::Self };
 


### PR DESCRIPTION
#### 1623bf99b0424e05403acc6124bea75f8b75c22a
<pre>
[UIIntelligenceSupport] [iOS] Text extraction fails for web content in the Notion app
<a href="https://bugs.webkit.org/show_bug.cgi?id=287191">https://bugs.webkit.org/show_bug.cgi?id=287191</a>
<a href="https://rdar.apple.com/144279805">rdar://144279805</a>

Reviewed by Abrar Rahman Protyasha.

Currently, the implementation of `TextExtraction::extractItemData` (which pulls data from DOM nodes
for the purposes of context retrieval and resolution) works by traversing the DOM in depth-first
order, building a tree of text extraction items which preserve only a subset of DOM nodes that
contain rendered text, or are otherwise &quot;interesting&quot; to the system (e.g. images, scrollable areas,
editable elements).

This algorithm currently skips entire DOM subtrees for elements that don&apos;t have a renderer, which
works well for `display: none;` content. However, this also causes us to omit nodes inside of
`display: contents;` subtrees, which are visible to the user.

Fix this by only skipping the current element rather than the whole subtree, if the current element
has `display: contents;`.

* LayoutTests/fast/text-extraction/text-extraction-display-contents-expected.txt: Added.
* LayoutTests/fast/text-extraction/text-extraction-display-contents.html: Added.

Add a layout test to exercise the change.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):

Canonical link: <a href="https://commits.webkit.org/289979@main">https://commits.webkit.org/289979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89e439c697ba4af50786af9d08f15ef3ef9f7dbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68301 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26008 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6252 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34520 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html http/tests/eventsource/eventsource-page-cache-connected.html http/tests/eventsource/eventsource-page-cache-connecting.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/websocket/tests/hybi/client-close-2.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-005.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76623 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35406 "Found 5 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15751 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77165 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8790 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15767 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->