### PR TITLE
Try to use WidthCache regardless of fallbackFonts usage

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -327,7 +327,7 @@ float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>
     else
         result = widthForSimpleText(run, fallbackFonts, glyphOverflow);
 
-    if (cacheEntry && fallbackFonts->isEmptyIgnoringNullReferences())
+    if (cacheEntry)
         *cacheEntry = result;
     return result;
 }


### PR DESCRIPTION
#### b9773932f17ffc2d031769c258529fc2cbd02f30
<pre>
Try to use WidthCache regardless of fallbackFonts usage
Need the bug URL (OOPS!). Include a Radar link (OOPS!).
Reviewed by NOBODY (OOPS!).
Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::width const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9773932f17ffc2d031769c258529fc2cbd02f30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69012 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26663 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92602 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7305 "Found 4 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7036 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35732 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html fullscreen/exit-full-screen-video-crash.html fullscreen/full-screen-document-background-color.html fullscreen/full-screen-request-removed.html fullscreen/fullscreen-cancel-after-request-crash.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77390 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36752 "Found 4 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96421 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16783 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12330 "Found 4 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77885 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77202 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21639 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20251 "Found 4 new test failures: fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9950 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22112 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->