### PR TITLE
Address safer C++ static analysis warnings in OriginStorageManager.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -33,7 +33,6 @@ NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
 NetworkProcess/storage/BackgroundFetchStoreManager.cpp
 NetworkProcess/storage/CacheStorageDiskStore.cpp
 NetworkProcess/storage/IDBStorageRegistry.cpp
-NetworkProcess/storage/OriginStorageManager.cpp
 NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
 Platform/IPC/ArgumentCoders.h
 Platform/IPC/SharedBufferReference.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -5,7 +5,6 @@ NetworkProcess/PingLoad.h
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
 NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
-NetworkProcess/storage/OriginStorageManager.cpp
 Platform/IPC/MessageSenderInlines.h
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm
 Shared/API/APIArray.cpp


### PR DESCRIPTION
#### 860428a484bed11b62976f5aebfbb3daeb9fbd9d
<pre>
Address safer C++ static analysis warnings in OriginStorageManager.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287199">https://bugs.webkit.org/show_bug.cgi?id=287199</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::hasDataInMemory const):
(WebKit::OriginStorageManager::StorageBucket::fetchDataTypesInListFromMemory):
(WebKit::OriginStorageManager::createQuotaManager):
(WebKit::OriginStorageManager::estimate):
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/290000@main">https://commits.webkit.org/290000@main</a>
</pre>
