### PR TITLE
Display warning message when unloading is throttled.

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--3.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--3.html
@@ -1,0 +1,10 @@
+Using significant resources and eligible for resource monitoring.
+It will post message to the parent when finished.
+
+<script>
+    const size = 20 * 1024;
+    fetch(`./generate-byte.py?size=${size}`).then(async (response) => {
+        const body = await response.blob();
+        parent.postMessage(true, "*");
+    });
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
+++ b/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
@@ -10,7 +10,7 @@ async function setup() {
         internals.setResourceMonitorNetworkUsageThreshold(10 * 1024, 0.001);
 
         // Skip throttling of unloading.
-        internals.shouldSkipResourceMonitorThrottling = true;
+        internals.shouldSkipResourceMonitorThrottling = false;
 
         return true;
     } else {

--- a/LayoutTests/http/tests/iframe-monitor/throttler-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/throttler-expected.txt
@@ -1,0 +1,22 @@
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame's network usage exceeded the limit.
+Test throttler prevents unloaded.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.querySelector('iframe[name=frame1]').srcdoc is not ""
+PASS document.querySelector('iframe[name=frame2]').srcdoc is not ""
+PASS document.querySelector('iframe[name=frame3]').srcdoc is not ""
+PASS document.querySelector('iframe[name=frame4]').srcdoc is not ""
+PASS document.querySelector('iframe[name=frame5]').srcdoc is not ""
+PASS result is true
+PASS document.querySelector('iframe[name=frame6]').srcdoc is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/throttler.html
+++ b/LayoutTests/http/tests/iframe-monitor/throttler.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="./resources/monitor-setup.js"></script>
+</head>
+<body>
+<script>
+
+description("Test throttler prevents unloaded.");
+window.jsTestIsAsync = true;
+
+onload = async () => {
+    if (!await setup()) {
+        finishJSTest();
+        return;
+    }
+
+    // Make sure iframe load is done after rule is set correctly.
+    const stage = document.querySelector('#stage');
+    const base = 'http://localhost:8080/iframe-monitor/resources';
+
+    for (let no = 1; no <= 5; no++) {
+        stage.innerHTML = `
+            <iframe name="frame${no}" src="http://localhost:8080/iframe-monitor/resources/iframe--eligible--.html"></iframe>
+        `;
+
+        await waitUntilUnload(`frame${no}`);
+        shouldNotBe(`document.querySelector('iframe[name=frame${no}]').srcdoc`, '""');
+    }
+
+    // Then load another one which will send a message after the fetch.
+    // Throttler should prevent this iframe unloaded.
+    stage.innerHTML = `
+        <iframe name="frame6" src="http://localhost:8080/iframe-monitor/resources/iframe--eligible--3.html"></iframe>
+    `;
+
+    window.addEventListener('message', async (event) => {
+        await pause(100);
+        result = event.data;
+
+        shouldBeTrue('result');
+        shouldBe(`document.querySelector('iframe[name=frame6]').srcdoc`, '""');
+        finishJSTest();
+    });
+}
+</script>
+
+<div id="stage"></div>
+</body>
+</html>

--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -33,11 +33,11 @@
 
 namespace WebCore {
 
-class ResourceMonitorThrottler final {
+class ResourceMonitorThrottler final : public RefCounted<ResourceMonitorThrottler> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT ResourceMonitorThrottler();
-    WEBCORE_EXPORT ResourceMonitorThrottler(size_t count, Seconds duration, size_t maxHosts);
+    WEBCORE_EXPORT static Ref<ResourceMonitorThrottler> create();
+    WEBCORE_EXPORT static Ref<ResourceMonitorThrottler> create(size_t count, Seconds duration, size_t maxHosts);
 
     WEBCORE_EXPORT bool tryAccess(const String& host, ApproximateTime = ApproximateTime::now());
 
@@ -65,6 +65,8 @@ private:
         PriorityQueue<ApproximateTime> m_accessTimes;
         ApproximateTime m_newestAccessTime { -ApproximateTime::infinity() };
     };
+
+    ResourceMonitorThrottler(size_t count, Seconds duration, size_t maxHosts);
 
     AccessThrottler& throttlerForHost(const String& host);
     void removeExpiredThrottler();

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1474,6 +1474,12 @@ void LocalFrame::showResourceMonitoringError()
     document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Error, "Frame was unloaded because its network usage exceeded the limit."_s);
 }
 
+void LocalFrame::reportResourceMonitoringWarning()
+{
+    if (RefPtr document = this->document())
+        document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Warning, "Frame's network usage exceeded the limit."_s);
+}
+
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -334,6 +334,7 @@ public:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WEBCORE_EXPORT void showResourceMonitoringError();
+    WEBCORE_EXPORT void reportResourceMonitoringWarning();
 #endif
 
 protected:

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -782,3 +782,12 @@ void WKWebsiteDataStoreGetAllStorageAccessEntries(WKWebsiteDataStoreRef dataStor
         callback(context, domainArrayRef);
     });
 }
+
+void WKWebsiteDataStoreResetResourceMonitorThrottler(WKWebsiteDataStoreRef dataStoreRef)
+{
+#if ENABLE(CONTENT_EXTENSIONS)
+    WebKit::toImpl(dataStoreRef)->resetResourceMonitorThrottlerForTesting();
+#else
+    UNUSED_PARAM(dataStoreRef);
+#endif
+}

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h
@@ -228,6 +228,8 @@ WK_EXPORT void WKWebsiteDataStoreClearBundleIdentifierInNetworkProcess(WKWebsite
 typedef void (*KWebsiteDataStoreSetOriginQuotaRatioEnabledCallback)(void* functionContext);
 WK_EXPORT void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, KWebsiteDataStoreSetOriginQuotaRatioEnabledCallback callback);
 
+WK_EXPORT void WKWebsiteDataStoreResetResourceMonitorThrottler(WKWebsiteDataStoreRef dataStoreRef);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2751,4 +2751,19 @@ bool WebsiteDataStore::builtInNotificationsEnabled() const
 }
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+WebCore::ResourceMonitorThrottler& WebsiteDataStore::resourceMonitorThrottler()
+{
+    if (!m_resourceMonitorThrottler)
+        m_resourceMonitorThrottler = WebCore::ResourceMonitorThrottler::create();
+
+    return *m_resourceMonitorThrottler;
+}
+
+void WebsiteDataStore::resetResourceMonitorThrottlerForTesting()
+{
+    m_resourceMonitorThrottler = nullptr;
+}
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -495,7 +495,8 @@ public:
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    WebCore::ResourceMonitorThrottler& resourceMonitorThrottler() { return m_resourceMonitorThrottler; }
+    WebCore::ResourceMonitorThrottler& resourceMonitorThrottler();
+    void resetResourceMonitorThrottlerForTesting();
 #endif
 
 private:
@@ -640,7 +641,7 @@ private:
     HashSet<URL> m_persistedSiteURLs;
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    WebCore::ResourceMonitorThrottler m_resourceMonitorThrottler;
+    RefPtr<WebCore::ResourceMonitorThrottler> m_resourceMonitorThrottler;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -2007,6 +2007,8 @@ void WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold()
             return;
         if (wasGranted)
             frame->showResourceMonitoringError();
+        else
+            frame->reportResourceMonitoringWarning();
     };
 
     if (document->shouldSkipResourceMonitorThrottling())

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1283,6 +1283,8 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     resetMockMediaDevices();
     WKPageSetMediaCaptureReportingDelayForTesting(m_mainWebView->page(), 0);
 
+    WKWebsiteDataStoreResetResourceMonitorThrottler(websiteDataStore());
+
     // FIXME: This function should also ensure that there is only one page open.
 
     // Reset the EventSender for each test.


### PR DESCRIPTION
#### ba40879e6a926ad6dc5199e7ba737de922663836
<pre>
Display warning message when unloading is throttled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287180">https://bugs.webkit.org/show_bug.cgi?id=287180</a>
<a href="https://rdar.apple.com/144335494">rdar://144335494</a>

Reviewed by Chris Dumez.

If throttler decides not to grant the unloading, currently it is simply ignored.
Add console message to report the network usage exceed warning.

* LayoutTests/http/tests/iframe-monitor/resources/iframe--eligible--3.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js:
(async setup):
* LayoutTests/http/tests/iframe-monitor/throttler-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/throttler.html: Added.
* Source/WebCore/loader/ResourceMonitorThrottler.cpp:
(WebCore::ResourceMonitorThrottler::create):
* Source/WebCore/loader/ResourceMonitorThrottler.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::reportResourceMonitoringWarning):
* Source/WebCore/page/LocalFrame.h:
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreResetResouceMonitorThrottler):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resourceMonitorThrottler):
(WebKit::WebsiteDataStore::resetResourceMonitorThrottlerForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::resourceMonitorThrottler): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold):
* Tools/TestWebKitAPI/Tests/WebCore/ResourceMonitor.cpp:
(TestWebKitAPI::ResourceMonitorTest::prepareThrottler):
(TestWebKitAPI::ResourceMonitorTest::disposeThrottler):
(TestWebKitAPI::ResourceMonitorTest::throttler):
(TestWebKitAPI::ResourceMonitorTest::tryAccess):
(TestWebKitAPI::TEST_F(ResourceMonitorTest, ThrottlerBasic)):
(TestWebKitAPI::TEST_F(ResourceMonitorTest, ThrottlerMaxHosts)):
(TestWebKitAPI::TEST_F(ResourceMonitorTest, ThrottlerLeastRecentAccessedHostWillBeRemoved)):
(TestWebKitAPI::TEST_F(ResourceMonitorTest, ThrottlerEmptyHostname)):
(TestWebKitAPI::ResouceMonitorTest::now): Deleted.
(TestWebKitAPI::ResouceMonitorTest::later): Deleted.
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerBasic)): Deleted.
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerMaxHosts)): Deleted.
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerLeastRecentAccessedHostWillBeRemoved)): Deleted.
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerEmptyHostname)): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/290028@main">https://commits.webkit.org/290028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7e491c201ab96337ae72dc7a605347b0f8d0d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16465 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80276 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38624 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15937 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76575 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20965 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15951 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->