### PR TITLE
[Cocoa] InbandTextTrackPrivateAVF::AVFInbandTrackParent should be a WeakPtr

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,7 +57,7 @@ AVFInbandTrackParent::~AVFInbandTrackParent() = default;
 
 InbandTextTrackPrivateAVF::InbandTextTrackPrivateAVF(AVFInbandTrackParent* owner, TrackID trackID, CueFormat format)
     : InbandTextTrackPrivate(format)
-    , m_owner(owner)
+    , m_owner(*owner)
     , m_pendingCueStatus(None)
     , m_index(0)
     , m_hasBeenReported(false)
@@ -445,7 +445,7 @@ void InbandTextTrackPrivateAVF::beginSeeking()
 
 void InbandTextTrackPrivateAVF::disconnect()
 {
-    m_owner = 0;
+    m_owner = { };
     m_index = 0;
 }
 
@@ -489,7 +489,8 @@ void InbandTextTrackPrivateAVF::resetCueValues()
 
 void InbandTextTrackPrivateAVF::setMode(InbandTextTrackPrivate::Mode newMode)
 {
-    if (!m_owner)
+    RefPtr owner = m_owner.get();
+    if (!owner)
         return;
 
     InbandTextTrackPrivate::Mode oldMode = mode();
@@ -498,7 +499,7 @@ void InbandTextTrackPrivateAVF::setMode(InbandTextTrackPrivate::Mode newMode)
     if (oldMode == newMode)
         return;
 
-    m_owner->trackModeChanged();
+    owner->trackModeChanged();
 }
 
 void InbandTextTrackPrivateAVF::processNativeSamples(CFArrayRef nativeSamples, const MediaTime& presentationTime)

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 
 #include "InbandTextTrackPrivate.h"
 #include "InbandTextTrackPrivateClient.h"
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 typedef const struct opaqueCMFormatDescription* CMFormatDescriptionRef;
@@ -40,7 +41,7 @@ class ArrayBuffer;
 
 namespace WebCore {
 
-class AVFInbandTrackParent {
+class AVFInbandTrackParent : public AbstractRefCountedAndCanMakeWeakPtr<AVFInbandTrackParent> {
 public:
     virtual ~AVFInbandTrackParent();
     
@@ -104,7 +105,7 @@ private:
     MediaTime m_currentCueEndTime;
 
     Vector<Ref<InbandGenericCue>> m_cues;
-    AVFInbandTrackParent* m_owner;
+    WeakPtr<AVFInbandTrackParent> m_owner;
 
     enum PendingCueStatus {
         None,


### PR DESCRIPTION
#### 43d7d7dcb3243e0fd7e9f1d7efa827c3002800f2
<pre>
[Cocoa] InbandTextTrackPrivateAVF::AVFInbandTrackParent should be a WeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=287201">https://bugs.webkit.org/show_bug.cgi?id=287201</a>
<a href="https://rdar.apple.com/144347940">rdar://144347940</a>

Reviewed by Jean-Yves Avenard.

* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::InbandTextTrackPrivateAVF):
(WebCore::InbandTextTrackPrivateAVF::disconnect):
(WebCore::InbandTextTrackPrivateAVF::setMode): Ref `m_owner` before calling `trackModeChanged`.

* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.h: Make
AVFInbandTrackParent AbstractRefCountedAndCanMakeWeakPtr.

Canonical link: <a href="https://commits.webkit.org/290009@main">https://commits.webkit.org/290009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dec93b009787abf625716b5bce8f0bb4e87ec651

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68314 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26022 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91605 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6509 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48678 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34543 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77182 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76453 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/18845 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8817 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15794 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21102 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->