### PR TITLE
Adopt more smart pointers in WebPageProxy (Part 7)

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -21,7 +21,6 @@ UIProcess/SuspendedPageProxy.cpp
 UIProcess/UserMediaPermissionRequestManagerProxy.cpp
 UIProcess/WebContextMenuProxy.cpp
 UIProcess/WebEditCommandProxy.cpp
-UIProcess/WebPageProxy.cpp
 UIProcess/WebURLSchemeTask.cpp
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -3,7 +3,6 @@ UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKProcessPool.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
-UIProcess/WebPageProxy.cpp
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -237,7 +237,6 @@ UIProcess/WebContextMenuProxy.cpp
 UIProcess/WebEditCommandProxy.cpp
 UIProcess/WebFrameProxy.cpp
 UIProcess/WebOpenPanelResultListenerProxy.cpp
-UIProcess/WebPageProxy.cpp
 UIProcess/WebPreferences.h
 UIProcess/WebProcessActivityState.cpp
 UIProcess/WebURLSchemeHandler.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -20,7 +20,6 @@ UIProcess/WebAuthentication/Cocoa/NfcService.mm
 UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
 UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
 UIProcess/WebBackForwardList.cpp
-UIProcess/WebPageProxy.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -45,7 +45,6 @@ UIProcess/WebAuthentication/Cocoa/NfcService.mm
 UIProcess/WebBackForwardCache.cpp
 UIProcess/WebBackForwardCacheEntry.cpp
 UIProcess/WebBackForwardList.cpp
-UIProcess/WebPageProxy.cpp
 UIProcess/WebPreferences.cpp
 UIProcess/WebProcessCache.cpp
 UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm

--- a/Source/WebKit/UIProcess/API/APIAttachment.h
+++ b/Source/WebKit/UIProcess/API/APIAttachment.h
@@ -69,7 +69,7 @@ public:
 #if PLATFORM(COCOA)
     void cloneFileWrapperTo(Attachment&);
     bool shouldUseFileWrapperIconForDirectory() const;
-    void doWithFileWrapper(Function<void(NSFileWrapper *)>&&) const;
+    void doWithFileWrapper(NOESCAPE Function<void(NSFileWrapper *)>&&) const;
     void setFileWrapper(NSFileWrapper *);
     void setFileWrapperAndUpdateContentType(NSFileWrapper *, NSString *contentType);
     WTF::String utiType() const;

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -61,7 +61,7 @@ void Attachment::setFileWrapper(NSFileWrapper *fileWrapper)
     m_fileWrapper = fileWrapper;
 }
 
-void Attachment::doWithFileWrapper(Function<void(NSFileWrapper *)>&& function) const
+void Attachment::doWithFileWrapper(NOESCAPE Function<void(NSFileWrapper *)>&& function) const
 {
     Locker locker { m_fileWrapperLock };
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -90,6 +90,8 @@ public:
     }
 
     static WebFrameProxy* webFrame(std::optional<WebCore::FrameIdentifier>);
+    static RefPtr<WebFrameProxy> protectedWebFrame(std::optional<WebCore::FrameIdentifier> identifier) { return webFrame(identifier); }
+
     static bool canCreateFrame(WebCore::FrameIdentifier);
 
     virtual ~WebFrameProxy();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2831,6 +2831,7 @@ private:
 
 #if ENABLE(ENCRYPTED_MEDIA)
     MediaKeySystemPermissionRequestManagerProxy& mediaKeySystemPermissionRequestManager();
+    Ref<MediaKeySystemPermissionRequestManagerProxy> protectedMediaKeySystemPermissionRequestManager();
 #endif
     void requestMediaKeySystemPermissionForFrame(IPC::Connection&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, const WebCore::SecurityOriginData& topLevelDocumentOriginIdentifier, const String&);
 
@@ -3313,6 +3314,7 @@ private:
     bool hasValidOpeningAppLinkActivity() const;
 #endif
 
+RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionManager();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&&) const;
@@ -3322,7 +3324,7 @@ private:
     String presentingApplicationBundleIdentifier() const;
 #endif
 
-    UniqueRef<Internals> m_internals;
+    const UniqueRef<Internals> m_internals;
     Identifier m_identifier;
     WebCore::PageIdentifier m_webPageID;
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -206,6 +206,7 @@ struct PrivateClickMeasurementAndMetadata {
     String purchaser;
 };
 
+#if ENABLE(SPEECH_SYNTHESIS)
 struct SpeechSynthesisData {
     Ref<WebCore::PlatformSpeechSynthesizer> synthesizer;
     RefPtr<WebCore::PlatformSpeechSynthesisUtterance> utterance;
@@ -213,7 +214,10 @@ struct SpeechSynthesisData {
     CompletionHandler<void()> speakingFinishedCompletionHandler;
     CompletionHandler<void()> speakingPausedCompletionHandler;
     CompletionHandler<void()> speakingResumedCompletionHandler;
+
+    Ref<WebCore::PlatformSpeechSynthesizer> protectedSynthesizer() { return synthesizer; }
 };
+#endif
 
 #if ENABLE(TOUCH_EVENTS)
 
@@ -459,7 +463,9 @@ public:
 
     Ref<WebPageProxy> protectedPage() const;
 
+#if ENABLE(SPEECH_SYNTHESIS)
     SpeechSynthesisData& speechSynthesisData();
+#endif
 
     // WebPopupMenuProxy::Client
     void valueChangedForPopupMenu(WebPopupMenuProxy*, int32_t newSelectedIndex) final;


### PR DESCRIPTION
#### fbdca47e7a7aee5274bd100cf2add90f269328c3
<pre>
Adopt more smart pointers in WebPageProxy (Part 7)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287202">https://bugs.webkit.org/show_bug.cgi?id=287202</a>
<a href="https://rdar.apple.com/144348285">rdar://144348285</a>

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.
7th time&apos;s the charm. (Hopefully).

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::protectedWebFrame):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::backForwardGoToItemShared):
(WebKit::WebPageProxy::willStartCapture):
(WebKit::WebPageProxy::requestUserMediaPermissionForFrame):
(WebKit::WebPageProxy::enumerateMediaDevicesForFrame):
(WebKit::WebPageProxy::beginMonitoringCaptureDevices):
(WebKit::WebPageProxy::validateCaptureStateUpdate):
(WebKit::WebPageProxy::setShouldListenToVoiceActivity):
(WebKit::WebPageProxy::syncIfMockDevicesEnabledChanged):
(WebKit::WebPageProxy::clearUserMediaState):
(WebKit::WebPageProxy::requestMediaKeySystemPermissionForFrame):
(WebKit::WebPageProxy::protectedMediaKeySystemPermissionRequestManager):
(WebKit::WebPageProxy::clearNotificationPermissionState):
(WebKit::WebPageProxy::pageWillLikelyUseNotifications):
(WebKit::WebPageProxy::showNotification):
(WebKit::WebPageProxy::cancelNotification):
(WebKit::WebPageProxy::clearNotifications):
(WebKit::WebPageProxy::didDestroyNotification):
(WebKit::WebPageProxy::endPrinting):
(WebKit::WebPageProxy::updateBackingStoreDiscardableState):
(WebKit::WebPageProxy::setOverlayScrollbarStyle):
(WebKit::WebPageProxy::setScrollPerformanceDataCollectionEnabled):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
(WebKit::WebPageProxy::hasActiveVideoForControlsManager const):
(WebKit::WebPageProxy::isPlayingVideoInEnhancedFullscreen const):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
(WebKit::WebPageProxy::requestStorageAccessConfirm):
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromData):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromFilePath):
(WebKit::WebPageProxy::registerAttachmentIdentifier):
(WebKit::WebPageProxy::registerAttachmentsFromSerializedData):
(WebKit::WebPageProxy::cloneAttachmentData):
(WebKit::WebPageProxy::serializedAttachmentDataForIdentifiers):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
(WebKit::WebPageProxy::didRemoveAttachmentWithIdentifier):
(WebKit::WebPageProxy::resetPaymentCoordinator):
(WebKit::WebPageProxy::resetSpeechSynthesizer):
(WebKit::WebPageProxy::speechSynthesisVoiceList):
(WebKit::WebPageProxy::speechSynthesisSpeak):
(WebKit::WebPageProxy::speechSynthesisCancel):
(WebKit::WebPageProxy::speechSynthesisResetState):
(WebKit::WebPageProxy::speechSynthesisPause):
(WebKit::WebPageProxy::speechSynthesisResume):
(WebKit::WebPageProxy::setOrientationForMediaCapture):
(WebKit::WebPageProxy::gpuProcessExited):
(WebKit::WebPageProxy::protectedSpeechRecognitionPermissionManager):
(WebKit::WebPageProxy::requestSpeechRecognitionPermission):
(WebKit::WebPageProxy::requestUserMediaPermissionForSpeechRecognition):
(WebKit::WebPageProxy::createRealtimeMediaSourceForSpeechRecognition):
(WebKit::WebPageProxy::processForSite):
(WebKit::WebPageProxy::webPageIDInProcess const):
(WebKit::WebPageProxy::sendToWebPage):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
(WebKit::SpeechSynthesisData::protectedSynthesizer):

Canonical link: <a href="https://commits.webkit.org/290246@main">https://commits.webkit.org/290246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/266846ba21d31354c34f783f594edc8dc9b3c33a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40116 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68850 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26513 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49201 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6858 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39223 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96170 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77712 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76888 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77013 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9686 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14019 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16549 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21860 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->