### PR TITLE
[JSC] Use DestructionMode instead of bool for JSCell::needsDestruction

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.h
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.h
@@ -37,7 +37,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {

--- a/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
+++ b/Source/JavaScriptCore/API/JSAPIWrapperObject.mm
@@ -76,7 +76,7 @@ static JSC_DECLARE_CUSTOM_GETTER(staticFunctionGetterJSAPIWrapperObjectCallbackO
 DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<>, JSCallbackObject<JSAPIWrapperObject>);
 
 template <> const ClassInfo JSCallbackObject<JSAPIWrapperObject>::s_info = { "JSAPIWrapperObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCallbackObject) };
-template <> const bool JSCallbackObject<JSAPIWrapperObject>::needsDestruction = true;
+template <> const JSC::DestructionMode JSCallbackObject<JSAPIWrapperObject>::needsDestruction = JSC::NeedsDestruction;
 
 template <>
 NativeFunction::Ptr JSCallbackObject<JSAPIWrapperObject>::getCallFunction()

--- a/Source/JavaScriptCore/API/JSCallbackConstructor.h
+++ b/Source/JavaScriptCore/API/JSCallbackConstructor.h
@@ -38,7 +38,7 @@ class JSCallbackConstructor final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | ImplementsHasInstance | ImplementsDefaultHasInstance;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/API/JSCallbackObject.cpp
+++ b/Source/JavaScriptCore/API/JSCallbackObject.cpp
@@ -47,8 +47,8 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<>, JSCallbackObject<JSGlobalObject>
 // Define the two types of JSCallbackObjects we support.
 template <> const ClassInfo JSCallbackObject<JSNonFinalObject>::s_info = { "CallbackObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCallbackObject) };
 template <> const ClassInfo JSCallbackObject<JSGlobalObject>::s_info = { "CallbackGlobalObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCallbackObject) };
-template<> const bool JSCallbackObject<JSNonFinalObject>::needsDestruction = true;
-template<> const bool JSCallbackObject<JSGlobalObject>::needsDestruction = true;
+template<> const DestructionMode JSCallbackObject<JSNonFinalObject>::needsDestruction = NeedsDestruction;
+template<> const DestructionMode JSCallbackObject<JSGlobalObject>::needsDestruction = NeedsDestruction;
 
 template<>
 NativeFunction::Ptr JSCallbackObject<JSNonFinalObject>::getCallFunction()

--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -145,7 +145,7 @@ public:
     }
     static JSCallbackObject<Parent>* create(VM&, JSClassRef, Structure*);
 
-    static const bool needsDestruction;
+    static const DestructionMode needsDestruction;
     static void destroy(JSCell* cell)
     {
         static_cast<JSCallbackObject*>(cell)->JSCallbackObject::~JSCallbackObject();

--- a/Source/JavaScriptCore/API/ObjCCallbackFunction.h
+++ b/Source/JavaScriptCore/API/ObjCCallbackFunction.h
@@ -60,7 +60,7 @@ public:
     }
 
     static ObjCCallbackFunction* create(VM&, JSGlobalObject*, const String& name, std::unique_ptr<ObjCCallbackFunctionImpl>);
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/JavaScriptCore/API/glib/JSAPIWrapperGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/glib/JSAPIWrapperGlobalObject.cpp
@@ -63,7 +63,7 @@ static JSC_DECLARE_CUSTOM_GETTER(staticFunctionGetterJSAPIWrapperGlobalObjectCal
 DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<>, JSCallbackObject<JSAPIWrapperGlobalObject>);
 
 template <> const ClassInfo JSCallbackObject<JSAPIWrapperGlobalObject>::s_info = { "JSAPIWrapperGlobalObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCallbackObject) };
-template<> const bool JSCallbackObject<JSAPIWrapperGlobalObject>::needsDestruction = true;
+template<> const DestructionMode JSCallbackObject<JSAPIWrapperGlobalObject>::needsDestruction = NeedsDestruction;
 
 template <>
 NativeFunction::Ptr JSCallbackObject<JSAPIWrapperGlobalObject>::getCallFunction()

--- a/Source/JavaScriptCore/API/glib/JSAPIWrapperObjectGLib.cpp
+++ b/Source/JavaScriptCore/API/glib/JSAPIWrapperObjectGLib.cpp
@@ -76,7 +76,7 @@ static JSC_DECLARE_CUSTOM_GETTER(staticFunctionGetterJSAPIWrapperObjectCallbackO
 DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<>, JSCallbackObject<JSAPIWrapperObject>);
 
 template <> const ClassInfo JSCallbackObject<JSAPIWrapperObject>::s_info = { "JSAPIWrapperObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCallbackObject) };
-template<> const bool JSCallbackObject<JSAPIWrapperObject>::needsDestruction = true;
+template<> const DestructionMode JSCallbackObject<JSAPIWrapperObject>::needsDestruction = NeedsDestruction;
 
 template <>
 NativeFunction::Ptr JSCallbackObject<JSAPIWrapperObject>::getCallFunction()

--- a/Source/JavaScriptCore/API/glib/JSCCallbackFunction.h
+++ b/Source/JavaScriptCore/API/glib/JSCCallbackFunction.h
@@ -53,7 +53,7 @@ public:
     };
 
     static JSCCallbackFunction* create(VM&, JSGlobalObject*, const String& name, Type, JSCClass*, GRefPtr<GClosure>&&, GType, std::optional<Vector<GType>>&&);
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -118,7 +118,7 @@ public:
     enum CopyParsedBlockTag { CopyParsedBlock };
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename, SubspaceAccess>
     static void subspaceFor(VM&)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -140,7 +140,7 @@ public:
     typedef JSCell Base;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename, SubspaceAccess>
     static void subspaceFor(VM&)

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -149,7 +149,7 @@ public:
 
     PrivateBrandRequirement privateBrandRequirement() const { return static_cast<PrivateBrandRequirement>(m_privateBrandRequirement); }
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     ImplementationVisibility implementationVisibility() const { return static_cast<ImplementationVisibility>(m_implementationVisibility); }

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
@@ -35,7 +35,7 @@ class JSInjectedScriptHost final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr bool needsDestruction = true;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
 
     template<typename CellType, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/Source/JavaScriptCore/inspector/JSJavaScriptCallFrame.h
+++ b/Source/JavaScriptCore/inspector/JSJavaScriptCallFrame.h
@@ -34,7 +34,7 @@ class JSJavaScriptCallFrame final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr bool needsDestruction = true;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
 
     template<typename CellType, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -44,7 +44,7 @@ class AbstractModuleRecord : public JSInternalFieldObjectImpl<2> {
 public:
     using Base = JSInternalFieldObjectImpl<2>;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess>
     static void subspaceFor(VM&)

--- a/Source/JavaScriptCore/runtime/DateInstance.h
+++ b/Source/JavaScriptCore/runtime/DateInstance.h
@@ -28,7 +28,7 @@ class DateInstance final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell* cell)
     {
         static_cast<DateInstance*>(cell)->DateInstance::~DateInstance();

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -34,7 +34,7 @@ public:
     using Base = JSNonFinalObject;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnSpecialPropertyNames | OverridesPut | GetOwnPropertySlotIsImpureForPropertyAbsence;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/Exception.h
+++ b/Source/JavaScriptCore/runtime/Exception.h
@@ -35,7 +35,7 @@ class Exception final : public JSCell {
 public:
     using Base = JSCell;
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/ExecutableBase.h
+++ b/Source/JavaScriptCore/runtime/ExecutableBase.h
@@ -71,7 +71,7 @@ protected:
 public:
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
     
     // Force subclasses to override this.

--- a/Source/JavaScriptCore/runtime/FunctionRareData.h
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.h
@@ -53,7 +53,7 @@ public:
 
     static FunctionRareData* create(VM&, ExecutableBase*);
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/IntlCollator.h
+++ b/Source/JavaScriptCore/runtime/IntlCollator.h
@@ -40,7 +40,7 @@ class IntlCollator final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -46,7 +46,7 @@ class IntlDateTimeFormat final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.h
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.h
@@ -37,7 +37,7 @@ class IntlDisplayNames final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.h
@@ -39,7 +39,7 @@ class IntlDurationFormat final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlListFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.h
@@ -42,7 +42,7 @@ class IntlListFormat final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlLocale.h
+++ b/Source/JavaScriptCore/runtime/IntlLocale.h
@@ -34,7 +34,7 @@ class IntlLocale final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -137,7 +137,7 @@ class IntlNumberFormat final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.h
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.h
@@ -44,7 +44,7 @@ class IntlPluralRules final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
@@ -38,7 +38,7 @@ class IntlRelativeTimeFormat final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlSegmentIterator.h
+++ b/Source/JavaScriptCore/runtime/IntlSegmentIterator.h
@@ -34,7 +34,7 @@ class IntlSegmentIterator final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlSegmenter.h
+++ b/Source/JavaScriptCore/runtime/IntlSegmenter.h
@@ -37,7 +37,7 @@ class IntlSegmenter final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/IntlSegments.h
+++ b/Source/JavaScriptCore/runtime/IntlSegments.h
@@ -33,7 +33,7 @@ class IntlSegments final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell* cell)
     {

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -25,6 +25,7 @@
 #include "CallData.h"
 #include "CellState.h"
 #include "ConstructData.h"
+#include "DestructionMode.h"
 #include "EnumerationMode.h"
 #include "Heap.h"
 #include "HeapCell.h"
@@ -99,7 +100,7 @@ class JSCell : public HeapCell {
 public:
     static constexpr unsigned StructureFlags = 0;
 
-    static constexpr bool needsDestruction = false;
+    static constexpr DestructionMode needsDestruction = DoesNotNeedDestruction;
 
     static constexpr bool usePreciseAllocationsOnly = false;
     static constexpr uint8_t numberOfLowerTierPreciseCells = 8;

--- a/Source/JavaScriptCore/runtime/JSCustomGetterFunction.h
+++ b/Source/JavaScriptCore/runtime/JSCustomGetterFunction.h
@@ -36,7 +36,7 @@ public:
 
     using CustomFunctionPointer = GetValueFunc;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/runtime/JSCustomSetterFunction.h
+++ b/Source/JavaScriptCore/runtime/JSCustomSetterFunction.h
@@ -36,7 +36,7 @@ public:
 
     using CustomFunctionPointer = PutValueFunc;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/runtime/JSDestructibleObject.h
+++ b/Source/JavaScriptCore/runtime/JSDestructibleObject.h
@@ -35,7 +35,7 @@ class JSDestructibleObject : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     
     const ClassInfo* classInfo() const { return m_classInfo; }
 

--- a/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -72,7 +72,7 @@ public:
     void finalizeUnconditionally(VM&, CollectionScope);
     DECLARE_VISIT_CHILDREN;
     static void destroy(JSCell*);
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     JSValue takeDeadHoldingsValue();
 

--- a/Source/JavaScriptCore/runtime/JSGlobalLexicalEnvironment.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalLexicalEnvironment.h
@@ -54,7 +54,7 @@ public:
     static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
 
     static void destroy(JSCell*);
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     bool isEmpty() const { return !symbolTable()->size(); }
     bool isConstVariable(UniquedStringImpl*);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -630,7 +630,7 @@ public:
     using Base = JSSegmentedVariableObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable | OverridesGetOwnPropertySlot | OverridesPut | IsImmutablePrototypeExoticObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
@@ -36,7 +36,7 @@ public:
     using Base = JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesPut | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | GetOwnPropertySlotIsImpureForPropertyAbsence | IsImmutablePrototypeExoticObject;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.h
@@ -42,7 +42,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
+++ b/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
@@ -38,7 +38,7 @@ public:
     using Base = JSFunction;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell* cell)
     {
         static_cast<JSNativeStdFunction*>(cell)->JSNativeStdFunction::~JSNativeStdFunction();

--- a/Source/JavaScriptCore/runtime/JSScriptFetchParameters.h
+++ b/Source/JavaScriptCore/runtime/JSScriptFetchParameters.h
@@ -37,7 +37,7 @@ public:
     using Base = JSCell;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     DECLARE_EXPORT_INFO;
 

--- a/Source/JavaScriptCore/runtime/JSScriptFetcher.h
+++ b/Source/JavaScriptCore/runtime/JSScriptFetcher.h
@@ -37,7 +37,7 @@ public:
     using Base = JSCell;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     DECLARE_EXPORT_INFO;
 

--- a/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h
+++ b/Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h
@@ -54,7 +54,7 @@ public:
 
     DECLARE_INFO;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     template<typename CellType, SubspaceAccess>
     static void subspaceFor(VM&) { RELEASE_ASSERT_NOT_REACHED(); }
 

--- a/Source/JavaScriptCore/runtime/JSSourceCode.h
+++ b/Source/JavaScriptCore/runtime/JSSourceCode.h
@@ -36,7 +36,7 @@ public:
     using Base = JSCell;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     DECLARE_EXPORT_INFO;
 

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -110,8 +110,9 @@ public:
     // Do we really need InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero?
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=212958
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | StructureIsImmortal | OverridesPut;
+    static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     // We specialize the string subspace to get the fastest possible sweep. This wouldn't be
@@ -322,6 +323,7 @@ class JSRopeString final : public JSString {
     friend class RegExpObject;
     friend class RegExpSubstringGlobalAtomCache;
 public:
+    static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
     static void destroy(JSCell*);
 
     template<typename, SubspaceAccess>

--- a/Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.h
+++ b/Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.h
@@ -36,7 +36,7 @@ public:
     using Base = JSCell;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -115,7 +115,7 @@ public:
         return &vm.propertyTableSpace();
     }
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
     DECLARE_VISIT_CHILDREN;
 

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -44,7 +44,7 @@ class RegExp final : public JSCell {
 public:
     using Base = JSCell;
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
@@ -49,7 +49,7 @@ class ScopedArgumentsTable final : public JSCell {
 public:
     using Base = JSCell;
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.h
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.h
@@ -66,7 +66,7 @@ public:
 
     static SparseArrayValueMap* create(VM&);
     
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess>

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -330,7 +330,7 @@ public:
 
     JS_EXPORT_PRIVATE Structure* flattenDictionaryStructure(VM&, JSObject*);
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     // Versions that take a func will call it after making the change but while still holding

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -74,7 +74,7 @@ public:
 
     static StructureRareData* create(VM&, Structure*);
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     DECLARE_VISIT_CHILDREN;

--- a/Source/JavaScriptCore/runtime/Symbol.h
+++ b/Source/JavaScriptCore/runtime/Symbol.h
@@ -40,7 +40,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -436,7 +436,7 @@ private:
 };
 
 struct SymbolTableIndexHashTraits : HashTraits<SymbolTableEntry> {
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 };
 
 class SymbolTable final : public JSCell {
@@ -466,7 +466,7 @@ public:
         return symbolTable;
     }
     
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
@@ -41,7 +41,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -196,7 +196,7 @@ class WeakMapImpl : public JSNonFinalObject {
 public:
     using BucketType = WeakMapBucketType;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     DECLARE_VISIT_CHILDREN;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -605,7 +605,7 @@ public:
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
 
 IGNORE_WARNINGS_BEGIN("unused-const-variable")
-    static constexpr bool needsDestruction = false;
+    static constexpr DestructionMode needsDestruction = DoesNotNeedDestruction;
 IGNORE_WARNINGS_END
 
     template<typename CellType, SubspaceAccess>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -42,7 +42,7 @@ class JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
 
 public:
     using Base = WebAssemblyGCObjectBase;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell*);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
@@ -36,7 +36,7 @@ namespace JSC {
 class JSWebAssemblyException final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     using Payload = FixedVector<uint64_t>;
 
     static void destroy(JSCell*);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
@@ -39,7 +39,7 @@ namespace JSC {
 class JSWebAssemblyGlobal final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -61,7 +61,7 @@ class JSWebAssemblyInstance final : public JSNonFinalObject {
 
 public:
     using Base = JSNonFinalObject;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     static constexpr bool usePreciseAllocationsOnly = true;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
@@ -41,7 +41,7 @@ class JSArrayBuffer;
 class JSWebAssemblyMemory final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
@@ -52,7 +52,7 @@ class SymbolTable;
 class JSWebAssemblyModule final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -39,7 +39,7 @@ class JSWebAssemblyInstance;
 class JSWebAssemblyStruct final : public WebAssemblyGCObjectBase {
 public:
     using Base = WebAssemblyGCObjectBase;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell*);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -39,7 +39,7 @@ namespace JSC {
 class JSWebAssemblyTable final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTag.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTag.h
@@ -35,7 +35,7 @@ namespace JSC {
 class JSWebAssemblyTag final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell*);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -45,7 +45,7 @@ public:
 
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
@@ -44,7 +44,7 @@ class WebAssemblyModuleRecord final : public AbstractModuleRecord {
 public:
     using Base = AbstractModuleRecord;
 
-    static constexpr bool needsDestruction = true;
+    static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>

--- a/Source/WebCore/bindings/js/JSDOMConstructorBase.h
+++ b/Source/WebCore/bindings/js/JSDOMConstructorBase.h
@@ -33,7 +33,7 @@ public:
     using Base = InternalFunction;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr bool needsDestruction = false;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::DoesNotNeedDestruction;
 
     template<typename CellType, JSC::SubspaceAccess>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/Source/WebCore/bindings/js/JSDOMConstructorNotCallable.h
+++ b/Source/WebCore/bindings/js/JSDOMConstructorNotCallable.h
@@ -36,7 +36,7 @@ public:
     using Base = JSDOMObject;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags;
-    static constexpr bool needsDestruction = false;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::DoesNotNeedDestruction;
     static JSDOMConstructorNotCallable* create(JSC::VM&, JSC::Structure*, JSDOMGlobalObject&);
     static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject&, JSC::JSValue prototype);
 

--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.h
@@ -34,7 +34,7 @@ public:
     using Base = JSDOMObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::GetOwnPropertySlotIsImpureForPropertyAbsence | JSC::InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | JSC::OverridesGetOwnPropertySlot | JSC::OverridesIsExtensible | JSC::IsImmutablePrototypeExoticObject;
 
-    static constexpr bool needsDestruction = false;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::DoesNotNeedDestruction;
     template<typename CellType, JSC::SubspaceAccess>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/js/JSObservableArray.h
+++ b/Source/WebCore/bindings/js/JSObservableArray.h
@@ -45,7 +45,7 @@ class JSObservableArray final : public JSArray {
 public:
     using Base = JSArray;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesPut | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
-    static constexpr bool needsDestruction = true;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
 
     template<typename CellType, JSC::SubspaceAccess>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -44,7 +44,7 @@ class Frame;
 class WEBCORE_EXPORT JSWindowProxy final : public JSC::JSGlobalProxy {
 public:
     using Base = JSC::JSGlobalProxy;
-    static constexpr bool needsDestruction = true;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
     static void destroy(JSCell*);
 
     template<typename CellType, JSC::SubspaceAccess> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm) { return subspaceForImpl(vm); }

--- a/Source/WebCore/bridge/objc/objc_runtime.h
+++ b/Source/WebCore/bridge/objc/objc_runtime.h
@@ -92,7 +92,7 @@ class ObjcFallbackObjectImp final : public JSDestructibleObject {
 public:
     using Base = JSDestructibleObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetCallData | OverridesPut;
-    static constexpr bool needsDestruction = true;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
 
     template<typename CellType, JSC::SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/Source/WebCore/bridge/runtime_array.h
+++ b/Source/WebCore/bridge/runtime_array.h
@@ -36,7 +36,7 @@ class RuntimeArray final : public JSArray {
 public:
     using Base = JSArray;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesPut | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
-    static constexpr bool needsDestruction = true;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
 
     template<typename CellType, JSC::SubspaceAccess>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/Source/WebCore/bridge/runtime_object.h
+++ b/Source/WebCore/bridge/runtime_object.h
@@ -38,7 +38,7 @@ class WEBCORE_EXPORT RuntimeObject : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetCallData | OverridesPut | GetOwnPropertySlotMayBeWrongAboutDontEnum;
-    static constexpr bool needsDestruction = true;
+    static constexpr JSC::DestructionMode needsDestruction = JSC::NeedsDestruction;
 
     template<typename CellType, JSC::SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)


### PR DESCRIPTION
#### e92b51edbf680b35ff5b4a97597f7cc48091ebb4
<pre>
[JSC] Use DestructionMode instead of bool for JSCell::needsDestruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=287207">https://bugs.webkit.org/show_bug.cgi?id=287207</a>
<a href="https://rdar.apple.com/problem/144349726">rdar://problem/144349726</a>

Reviewed by Yijia Huang and Keith Miller.

This patch changes needsDestruction from bool to DestructionMode.
We would like to add a third variant later, like, &quot;MayNeedDestruction&quot;
for optimization, so this is a preparation for that.

* Source/JavaScriptCore/API/JSAPIGlobalObject.h:
* Source/JavaScriptCore/API/JSAPIWrapperObject.mm:
* Source/JavaScriptCore/API/JSCallbackConstructor.h:
* Source/JavaScriptCore/API/JSCallbackObject.cpp:
* Source/JavaScriptCore/API/JSCallbackObject.h:
* Source/JavaScriptCore/API/ObjCCallbackFunction.h:
* Source/JavaScriptCore/API/glib/JSAPIWrapperGlobalObject.cpp:
* Source/JavaScriptCore/API/glib/JSAPIWrapperObjectGLib.cpp:
* Source/JavaScriptCore/API/glib/JSCCallbackFunction.h:
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/heap/BlockDirectory.h:
(JSC::BlockDirectory::needsDestruction const):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::sweep):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.h:
* Source/JavaScriptCore/inspector/JSJavaScriptCallFrame.h:
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/DateInstance.h:
* Source/JavaScriptCore/runtime/ErrorInstance.h:
* Source/JavaScriptCore/runtime/Exception.h:
* Source/JavaScriptCore/runtime/ExecutableBase.h:
* Source/JavaScriptCore/runtime/FunctionRareData.h:
* Source/JavaScriptCore/runtime/IntlCollator.h:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
* Source/JavaScriptCore/runtime/IntlDisplayNames.h:
* Source/JavaScriptCore/runtime/IntlDurationFormat.h:
* Source/JavaScriptCore/runtime/IntlListFormat.h:
* Source/JavaScriptCore/runtime/IntlLocale.h:
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/IntlPluralRules.h:
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h:
* Source/JavaScriptCore/runtime/IntlSegmentIterator.h:
* Source/JavaScriptCore/runtime/IntlSegmenter.h:
* Source/JavaScriptCore/runtime/IntlSegments.h:
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/JSCustomGetterFunction.h:
* Source/JavaScriptCore/runtime/JSCustomSetterFunction.h:
* Source/JavaScriptCore/runtime/JSDestructibleObject.h:
* Source/JavaScriptCore/runtime/JSFinalizationRegistry.h:
* Source/JavaScriptCore/runtime/JSGlobalLexicalEnvironment.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h:
* Source/JavaScriptCore/runtime/JSModuleRecord.h:
* Source/JavaScriptCore/runtime/JSNativeStdFunction.h:
* Source/JavaScriptCore/runtime/JSScriptFetchParameters.h:
* Source/JavaScriptCore/runtime/JSScriptFetcher.h:
* Source/JavaScriptCore/runtime/JSSegmentedVariableObject.h:
* Source/JavaScriptCore/runtime/JSSourceCode.h:
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.h:
* Source/JavaScriptCore/runtime/PropertyTable.h:
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.h:
* Source/JavaScriptCore/runtime/SparseArrayValueMap.h:
* Source/JavaScriptCore/runtime/Structure.h:
* Source/JavaScriptCore/runtime/StructureRareData.h:
* Source/JavaScriptCore/runtime/Symbol.h:
* Source/JavaScriptCore/runtime/SymbolTable.h:
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTag.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h:
* Source/WebCore/bindings/js/JSDOMConstructorBase.h:
* Source/WebCore/bindings/js/JSDOMConstructorNotCallable.h:
* Source/WebCore/bindings/js/JSDOMWindowProperties.h:
* Source/WebCore/bindings/js/JSObservableArray.h:
* Source/WebCore/bindings/js/JSWindowProxy.h:
* Source/WebCore/bridge/objc/objc_runtime.h:
* Source/WebCore/bridge/runtime_array.h:
* Source/WebCore/bridge/runtime_object.h:

Canonical link: <a href="https://commits.webkit.org/289983@main">https://commits.webkit.org/289983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70895e24b0f7d6c4381bff3e59d4ad79060e9a64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93592 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16333 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91632 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/38492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/81429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95430 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87406 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15805 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16061 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/20863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13860 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/15821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/109899 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/26411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/17344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->