### PR TITLE
Implement more smart pointers in WebResourceLoader.h/cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -377,7 +377,6 @@ WebProcess/Inspector/WebInspectorUIExtensionController.cpp
 WebProcess/Network/NetworkProcessConnection.cpp
 WebProcess/Network/WebLoaderStrategy.cpp
 WebProcess/Network/WebMockContentFilterManager.cpp
-WebProcess/Network/WebResourceLoader.cpp
 WebProcess/Network/WebSocketChannel.cpp
 WebProcess/Network/WebSocketChannelManager.cpp
 WebProcess/Network/WebTransportSession.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -41,7 +41,6 @@ WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
 WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
 WebProcess/Inspector/WebInspectorInternal.cpp
 WebProcess/Network/WebLoaderStrategy.cpp
-WebProcess/Network/WebResourceLoader.cpp
 WebProcess/Network/WebSocketChannel.cpp
 WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
 WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -87,7 +87,7 @@ IPC::Connection* WebResourceLoader::messageSenderConnection() const
 uint64_t WebResourceLoader::messageSenderDestinationID() const
 {
     RELEASE_ASSERT(RunLoop::isMain());
-    return m_coreLoader->identifier()->toUInt64();
+    return protectedCoreLoader()->identifier()->toUInt64();
 }
 
 void WebResourceLoader::detachFromCoreLoader()
@@ -98,15 +98,16 @@ void WebResourceLoader::detachFromCoreLoader()
 
 MainFrameMainResource WebResourceLoader::mainFrameMainResource() const
 {
-    RefPtr frame = m_coreLoader->frame();
+    RefPtr coreLoader = m_coreLoader;
+    RefPtr frame = coreLoader->frame();
     if (!frame || !frame->isMainFrame())
         return MainFrameMainResource::No;
 
-    RefPtr frameLoader = m_coreLoader->frameLoader();
+    RefPtr frameLoader = coreLoader->frameLoader();
     if (!frameLoader)
         return MainFrameMainResource::No;
 
-    if (!frameLoader->notifier().isInitialRequestIdentifier(*m_coreLoader->identifier()))
+    if (!frameLoader->notifier().isInitialRequestIdentifier(*coreLoader->identifier()))
         return MainFrameMainResource::No;
 
     return MainFrameMainResource::Yes;
@@ -115,6 +116,7 @@ MainFrameMainResource WebResourceLoader::mainFrameMainResource() const
 void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::FormDataReference&& proposedRequestBody, ResourceResponse&& redirectResponse, CompletionHandler<void(ResourceRequest&&, bool)>&& completionHandler)
 {
     Ref<WebResourceLoader> protectedThis(*this);
+    RefPtr coreLoader = m_coreLoader;
 
     // Make the request whole again as we do not normally encode the request's body when sending it over IPC, for performance reasons.
     proposedRequest.setHTTPBody(proposedRequestBody.takeData());
@@ -122,32 +124,34 @@ void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::
     LOG(Network, "(WebProcess) WebResourceLoader::willSendRequest to '%s'", proposedRequest.url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_WILLSENDREQUEST);
     
-    if (RefPtr frame = m_coreLoader->frame()) {
+    if (RefPtr frame = coreLoader->frame()) {
         if (RefPtr page = frame->page()) {
             if (!page->allowsLoadFromURL(proposedRequest.url(), mainFrameMainResource()))
                 proposedRequest = { };
         }
     }
 
-    m_coreLoader->willSendRequest(WTFMove(proposedRequest), redirectResponse, [this, protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] (ResourceRequest&& request) mutable {
-        if (!m_coreLoader || !m_coreLoader->identifier()) {
+    coreLoader->willSendRequest(WTFMove(proposedRequest), redirectResponse, [this, protectedThis = WTFMove(protectedThis), completionHandler = WTFMove(completionHandler)] (ResourceRequest&& request) mutable {
+        RefPtr coreLoader = m_coreLoader;
+        if (!m_coreLoader || !coreLoader->identifier()) {
             WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_WILLSENDREQUEST_NO_CORELOADER);
             return completionHandler({ }, false);
         }
 
         WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_WILLSENDREQUEST_CONTINUE);
-        completionHandler(WTFMove(request), m_coreLoader->isAllowedToAskUserForCredentials());
+        completionHandler(WTFMove(request), coreLoader->isAllowedToAskUserForCredentials());
     });
 }
 
 void WebResourceLoader::didSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent)
 {
-    m_coreLoader->didSendData(bytesSent, totalBytesToBeSent);
+    protectedCoreLoader()->didSendData(bytesSent, totalBytesToBeSent);
 }
 
 void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateRelayed privateRelayed, bool needsContinueDidReceiveResponseMessage, std::optional<NetworkLoadMetrics>&& metrics)
 {
-    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResponse for '%s'. Status %d.", m_coreLoader->url().string().latin1().data(), response.httpStatusCode());
+    RefPtr coreLoader = m_coreLoader;
+    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResponse for '%s'. Status %d.", coreLoader->url().string().latin1().data(), response.httpStatusCode());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESPONSE, response.httpStatusCode());
 
     Ref<WebResourceLoader> protectedThis(*this);
@@ -166,61 +170,64 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
         m_isProcessingNetworkResponse = true;
 #endif
         policyDecisionCompletionHandler = [this, protectedThis = WTFMove(protectedThis)] {
+            RefPtr coreLoader = m_coreLoader;
 #if ASSERT_ENABLED
             m_isProcessingNetworkResponse = false;
 #endif
-            // If m_coreLoader becomes null as a result of the didReceiveResponse callback, we can't use the send function().
-            if (m_coreLoader && m_coreLoader->identifier())
+            // If coreLoader becomes null as a result of the didReceiveResponse callback, we can't use the send function().
+            if (m_coreLoader && coreLoader->identifier())
                 send(Messages::NetworkResourceLoader::ContinueDidReceiveResponse());
             else
                 WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESPONSE_NOT_CONTINUING_LOAD);
         };
     }
 
-    if (InspectorInstrumentationWebKit::shouldInterceptResponse(m_coreLoader->frame(), response)) {
-        auto interceptedRequestIdentifier = *m_coreLoader->identifier();
+    if (InspectorInstrumentationWebKit::shouldInterceptResponse(coreLoader->frame(), response)) {
+        auto interceptedRequestIdentifier = *coreLoader->identifier();
         m_interceptController.beginInterceptingResponse(interceptedRequestIdentifier);
-        InspectorInstrumentationWebKit::interceptResponse(m_coreLoader->frame(), response, interceptedRequestIdentifier, [this, protectedThis = Ref { *this }, interceptedRequestIdentifier, policyDecisionCompletionHandler = WTFMove(policyDecisionCompletionHandler)](const ResourceResponse& inspectorResponse, RefPtr<FragmentedSharedBuffer> overrideData) mutable {
-            if (!m_coreLoader || !m_coreLoader->identifier()) {
+        InspectorInstrumentationWebKit::interceptResponse(coreLoader->frame(), response, interceptedRequestIdentifier, [this, protectedThis = Ref { *this }, interceptedRequestIdentifier, policyDecisionCompletionHandler = WTFMove(policyDecisionCompletionHandler)](const ResourceResponse& inspectorResponse, RefPtr<FragmentedSharedBuffer> overrideData) mutable {
+            RefPtr coreLoader = m_coreLoader;
+            if (!m_coreLoader || !coreLoader->identifier()) {
                 WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESPONSE_NOT_CONTINUING_INTERCEPT_LOAD);
                 m_interceptController.continueResponse(interceptedRequestIdentifier);
                 return;
             }
 
-            m_coreLoader->didReceiveResponse(inspectorResponse, [this, protectedThis = WTFMove(protectedThis), interceptedRequestIdentifier, policyDecisionCompletionHandler = WTFMove(policyDecisionCompletionHandler), overrideData = WTFMove(overrideData)]() mutable {
+            coreLoader->didReceiveResponse(inspectorResponse, [this, protectedThis = WTFMove(protectedThis), interceptedRequestIdentifier, policyDecisionCompletionHandler = WTFMove(policyDecisionCompletionHandler), overrideData = WTFMove(overrideData)]() mutable {
+                RefPtr coreLoader = m_coreLoader;
                 if (policyDecisionCompletionHandler)
                     policyDecisionCompletionHandler();
 
-                if (!m_coreLoader || !m_coreLoader->identifier()) {
+                if (!m_coreLoader || !coreLoader->identifier()) {
                     m_interceptController.continueResponse(interceptedRequestIdentifier);
                     return;
                 }
 
-                RefPtr<WebCore::ResourceLoader> protectedCoreLoader = m_coreLoader;
                 if (!overrideData)
                     m_interceptController.continueResponse(interceptedRequestIdentifier);
                 else {
                     m_interceptController.interceptedResponse(interceptedRequestIdentifier);
                     if (unsigned bufferSize = overrideData->size())
-                        protectedCoreLoader->didReceiveBuffer(overrideData.releaseNonNull(), bufferSize, DataPayloadWholeResource);
+                        coreLoader->didReceiveBuffer(overrideData.releaseNonNull(), bufferSize, DataPayloadWholeResource);
                     WebCore::NetworkLoadMetrics emptyMetrics;
-                    protectedCoreLoader->didFinishLoading(emptyMetrics);
+                    coreLoader->didFinishLoading(emptyMetrics);
                 }
             });
         });
         return;
     }
 
-    m_coreLoader->didReceiveResponse(response, WTFMove(policyDecisionCompletionHandler));
+    coreLoader->didReceiveResponse(response, WTFMove(policyDecisionCompletionHandler));
 }
 
 void WebResourceLoader::didReceiveData(IPC::SharedBufferReference&& data, uint64_t encodedDataLength)
 {
-    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveData of size %lu for '%s'", data.size(), m_coreLoader->url().string().latin1().data());
+    RefPtr coreLoader = m_coreLoader;
+    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveData of size %lu for '%s'", data.size(), coreLoader->url().string().latin1().data());
     ASSERT_WITH_MESSAGE(!m_isProcessingNetworkResponse, "Network process should not send data until we've validated the response");
 
-    if (UNLIKELY(m_interceptController.isIntercepting(*m_coreLoader->identifier()))) {
-        m_interceptController.defer(*m_coreLoader->identifier(), [this, protectedThis = Ref { *this }, buffer = WTFMove(data), encodedDataLength]() mutable {
+    if (UNLIKELY(m_interceptController.isIntercepting(*coreLoader->identifier()))) {
+        m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, buffer = WTFMove(data), encodedDataLength]() mutable {
             if (m_coreLoader)
                 didReceiveData(WTFMove(buffer), encodedDataLength);
         });
@@ -231,16 +238,17 @@ void WebResourceLoader::didReceiveData(IPC::SharedBufferReference&& data, uint64
         WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVEDATA);
     m_numBytesReceived += data.size();
 
-    m_coreLoader->didReceiveData(data.isNull() ? SharedBuffer::create() : data.unsafeBuffer().releaseNonNull(), encodedDataLength, DataPayloadBytes);
+    coreLoader->didReceiveData(data.isNull() ? SharedBuffer::create() : data.unsafeBuffer().releaseNonNull(), encodedDataLength, DataPayloadBytes);
 }
 
 void WebResourceLoader::didFinishResourceLoad(NetworkLoadMetrics&& networkLoadMetrics)
 {
-    LOG(Network, "(WebProcess) WebResourceLoader::didFinishResourceLoad for '%s'", m_coreLoader->url().string().latin1().data());
+    RefPtr coreLoader = m_coreLoader;
+    LOG(Network, "(WebProcess) WebResourceLoader::didFinishResourceLoad for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDFINISHRESOURCELOAD, m_numBytesReceived);
 
-    if (UNLIKELY(m_interceptController.isIntercepting(*m_coreLoader->identifier()))) {
-        m_interceptController.defer(*m_coreLoader->identifier(), [this, protectedThis = Ref { *this }, networkLoadMetrics = WTFMove(networkLoadMetrics)]() mutable {
+    if (UNLIKELY(m_interceptController.isIntercepting(*coreLoader->identifier()))) {
+        m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, networkLoadMetrics = WTFMove(networkLoadMetrics)]() mutable {
             if (m_coreLoader)
                 didFinishResourceLoad(WTFMove(networkLoadMetrics));
         });
@@ -250,15 +258,16 @@ void WebResourceLoader::didFinishResourceLoad(NetworkLoadMetrics&& networkLoadMe
     networkLoadMetrics.workerStart = m_workerStart;
 
     ASSERT_WITH_MESSAGE(!m_isProcessingNetworkResponse, "Load should not be able to finish before we've validated the response");
-    m_coreLoader->didFinishLoading(networkLoadMetrics);
+    coreLoader->didFinishLoading(networkLoadMetrics);
 }
 
 void WebResourceLoader::didFailServiceWorkerLoad(const ResourceError& error)
 {
-    if (RefPtr document = m_coreLoader->frame() ? m_coreLoader->frame()->document() : nullptr) {
-        if (m_coreLoader->options().destination != FetchOptions::Destination::EmptyString || error.isGeneral())
+    RefPtr coreLoader = m_coreLoader;
+    if (RefPtr document = coreLoader->frame() ? coreLoader->frame()->document() : nullptr) {
+        if (coreLoader->options().destination != FetchOptions::Destination::EmptyString || error.isGeneral())
             document->addConsoleMessage(MessageSource::JS, MessageLevel::Error, error.localizedDescription());
-        if (m_coreLoader->options().destination != FetchOptions::Destination::EmptyString)
+        if (coreLoader->options().destination != FetchOptions::Destination::EmptyString)
             document->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("Cannot load "_s, error.failingURL().string(), '.'));
     }
 
@@ -267,21 +276,23 @@ void WebResourceLoader::didFailServiceWorkerLoad(const ResourceError& error)
 
 void WebResourceLoader::serviceWorkerDidNotHandle()
 {
+    RefPtr coreLoader = m_coreLoader;
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_SERVICEWORKERDIDNOTHANDLE);
 
-    ASSERT(m_coreLoader->options().serviceWorkersMode == ServiceWorkersMode::Only);
-    auto error = internalError(m_coreLoader->request().url());
+    ASSERT(coreLoader->options().serviceWorkersMode == ServiceWorkersMode::Only);
+    auto error = internalError(coreLoader->request().url());
     error.setType(ResourceError::Type::Cancellation);
-    m_coreLoader->didFail(error);
+    coreLoader->didFail(error);
 }
 
 void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
 {
-    LOG(Network, "(WebProcess) WebResourceLoader::didFailResourceLoad for '%s'", m_coreLoader->url().string().latin1().data());
+    RefPtr coreLoader = m_coreLoader;
+    LOG(Network, "(WebProcess) WebResourceLoader::didFailResourceLoad for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDFAILRESOURCELOAD);
 
-    if (UNLIKELY(m_interceptController.isIntercepting(*m_coreLoader->identifier()))) {
-        m_interceptController.defer(*m_coreLoader->identifier(), [this, protectedThis = Ref { *this }, error]() mutable {
+    if (UNLIKELY(m_interceptController.isIntercepting(*coreLoader->identifier()))) {
+        m_interceptController.defer(*coreLoader->identifier(), [this, protectedThis = Ref { *this }, error]() mutable {
             if (m_coreLoader)
                 didFailResourceLoad(error);
         });
@@ -290,29 +301,32 @@ void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
 
     ASSERT_WITH_MESSAGE(!m_isProcessingNetworkResponse, "Load should not be able to finish before we've validated the response");
 
-    m_coreLoader->didFail(error);
+    coreLoader->didFail(error);
 }
 
 void WebResourceLoader::didBlockAuthenticationChallenge()
 {
-    LOG(Network, "(WebProcess) WebResourceLoader::didBlockAuthenticationChallenge for '%s'", m_coreLoader->url().string().latin1().data());
+    RefPtr coreLoader = m_coreLoader;
+    LOG(Network, "(WebProcess) WebResourceLoader::didBlockAuthenticationChallenge for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDBLOCKAUTHENTICATIONCHALLENGE);
 
-    m_coreLoader->didBlockAuthenticationChallenge();
+    coreLoader->didBlockAuthenticationChallenge();
 }
 
 void WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(const ResourceResponse& response)
 {
-    LOG(Network, "(WebProcess) WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied for '%s'", m_coreLoader->url().string().latin1().data());
+    RefPtr coreLoader = m_coreLoader;
+    LOG(Network, "(WebProcess) WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_STOPLOADINGAFTERSECURITYPOLICYDENIED);
 
-    m_coreLoader->protectedDocumentLoader()->stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(*m_coreLoader->identifier(), response);
+    coreLoader->protectedDocumentLoader()->stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(*coreLoader->identifier(), response);
 }
 
 #if ENABLE(SHAREABLE_RESOURCE)
 void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
 {
-    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResource for '%s'", m_coreLoader->url().string().latin1().data());
+    RefPtr coreLoader = m_coreLoader;
+    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResource for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESOURCE);
 
     RefPtr<SharedBuffer> buffer = WTFMove(handle).tryWrapInSharedBuffer();
@@ -320,11 +334,11 @@ void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
     if (!buffer) {
         LOG_ERROR("Unable to create buffer from ShareableResource sent from the network process.");
         WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESOURCE_UNABLE_TO_CREATE_FRAGMENTEDSHAREDBUFFER);
-        if (RefPtr frame = m_coreLoader->frame()) {
+        if (RefPtr frame = coreLoader->frame()) {
             if (RefPtr page = frame->page())
                 page->diagnosticLoggingClient().logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::createSharedBufferFailedKey(), WebCore::ShouldSample::No);
         }
-        m_coreLoader->didFail(internalError(m_coreLoader->request().url()));
+        coreLoader->didFail(internalError(coreLoader->request().url()));
         return;
     }
 
@@ -332,28 +346,34 @@ void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
 
     // Only send data to the didReceiveData callback if it exists.
     if (unsigned bufferSize = buffer->size())
-        m_coreLoader->didReceiveData(buffer.releaseNonNull(), bufferSize, DataPayloadWholeResource);
+        coreLoader->didReceiveData(buffer.releaseNonNull(), bufferSize, DataPayloadWholeResource);
 
     if (!m_coreLoader)
         return;
 
     NetworkLoadMetrics emptyMetrics;
-    m_coreLoader->didFinishLoading(emptyMetrics);
+    coreLoader->didFinishLoading(emptyMetrics);
 }
 #endif
 
 #if ENABLE(CONTENT_FILTERING)
 void WebResourceLoader::contentFilterDidBlockLoad(const WebCore::ContentFilterUnblockHandler& unblockHandler, String&& unblockRequestDeniedScript, const ResourceError& error, const URL& blockedPageURL,  WebCore::SubstituteData&& substituteData)
 {
-    if (!m_coreLoader || !m_coreLoader->documentLoader())
+    RefPtr coreLoader = m_coreLoader;
+    if (!m_coreLoader || !coreLoader->documentLoader())
         return;
-    RefPtr documentLoader = m_coreLoader->documentLoader();
+    RefPtr documentLoader = coreLoader->documentLoader();
     documentLoader->setBlockedPageURL(blockedPageURL);
     documentLoader->setSubstituteDataFromContentFilter(WTFMove(substituteData));
     documentLoader->handleContentFilterDidBlock(unblockHandler, WTFMove(unblockRequestDeniedScript));
     documentLoader->cancelMainResourceLoad(error);
 }
 #endif // ENABLE(CONTENT_FILTERING)
+
+RefPtr<WebCore::ResourceLoader> WebResourceLoader::protectedCoreLoader() const
+{
+    return RefPtr { m_coreLoader };
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -74,6 +74,8 @@ public:
 
     WebCore::ResourceLoader* resourceLoader() const { return m_coreLoader.get(); }
 
+    RefPtr<WebCore::ResourceLoader> protectedCoreLoader() const;
+
     void detachFromCoreLoader();
 
 private:


### PR DESCRIPTION
#### cac61b474e4467da3640ab13a411a21d1d7e12f6
<pre>
Implement more smart pointers in WebResourceLoader.h/cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287211">https://bugs.webkit.org/show_bug.cgi?id=287211</a>

Reviewed by Ryosuke Niwa.

Addressed the smart pointer static analyzer warnings.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
(WebKit::WebResourceLoader::messageSenderDestinationID const):
(WebKit::WebResourceLoader::mainFrameMainResource const):
(WebKit::WebResourceLoader::willSendRequest):
(WebKit::WebResourceLoader::didSendData):
(WebKit::WebResourceLoader::didReceiveResponse):
(WebKit::WebResourceLoader::didReceiveData):
(WebKit::WebResourceLoader::didFinishResourceLoad):
(WebKit::WebResourceLoader::didFailServiceWorkerLoad):
(WebKit::WebResourceLoader::serviceWorkerDidNotHandle):
(WebKit::WebResourceLoader::didFailResourceLoad):
(WebKit::WebResourceLoader::didBlockAuthenticationChallenge):
(WebKit::WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
(WebKit::WebResourceLoader::didReceiveResource):
(WebKit::WebResourceLoader::contentFilterDidBlockLoad):

Canonical link: <a href="https://commits.webkit.org/290084@main">https://commits.webkit.org/290084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acfb5960e9be9538ea8dff2cf8238ee0eec1e172

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39677 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68501 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26181 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48866 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6478 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76841 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95729 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77379 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76667 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19479 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9164 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13931 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16112 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15853 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->