### PR TITLE
Address safer C++ static analysis warnings in SVGFilter and SVGFilterGraph

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1529,7 +1529,6 @@ svg/SVGViewSpec.cpp
 svg/animation/SVGSMILElement.cpp
 svg/graphics/SVGImage.cpp
 svg/graphics/SVGImageForContainer.h
-svg/graphics/filters/SVGFilterGraph.h
 svg/properties/SVGAnimatedDecoratedProperty.h
 svg/properties/SVGAnimatedPrimitiveProperty.h
 svg/properties/SVGAnimatedPropertyAnimator.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -259,8 +259,6 @@ style/Styleable.cpp
 svg/SVGAnimationElement.cpp
 svg/SVGDocumentExtensions.cpp
 svg/SVGViewSpec.cpp
-svg/graphics/filters/SVGFilter.cpp
-svg/graphics/filters/SVGFilterGraph.h
 svg/properties/SVGPropertyOwnerRegistry.h
 testing/MockMediaSessionCoordinator.cpp
 workers/Worker.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -841,8 +841,6 @@ svg/SVGToOTFFontConversion.cpp
 svg/SVGUseElement.cpp
 svg/graphics/SVGImage.cpp
 svg/graphics/SVGImageCache.cpp
-svg/graphics/filters/SVGFilter.cpp
-svg/graphics/filters/SVGFilterGraph.h
 svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGPropertyOwnerRegistry.h
 testing/InternalSettings.cpp

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -103,24 +103,24 @@ static std::optional<std::tuple<SVGFilterEffectsGraph, FilterEffectGeometryMap>>
     SVGFilterEffectsGraph graph(SourceGraphic::create(colorSpace), SourceAlpha::create(colorSpace));
     FilterEffectGeometryMap effectGeometryMap;
 
-    for (auto& effectElement : childrenOfType<SVGFilterPrimitiveStandardAttributes>(filterElement)) {
-        auto inputs = graph.getNamedNodes(effectElement.filterEffectInputsNames());
+    for (Ref effectElement : childrenOfType<SVGFilterPrimitiveStandardAttributes>(filterElement)) {
+        auto inputs = graph.getNamedNodes(effectElement->filterEffectInputsNames());
         if (!inputs)
             return std::nullopt;
 
-        auto effect = effectElement.filterEffect(*inputs, destinationContext);
+        auto effect = effectElement->filterEffect(*inputs, destinationContext);
         if (!effect)
             return std::nullopt;
 
-        if (auto flags = effectElement.effectGeometryFlags()) {
-            auto effectBoundaries = SVGLengthContext::resolveRectangle<SVGFilterPrimitiveStandardAttributes>(&effectElement, filter.primitiveUnits(), filter.targetBoundingBox());
+        if (auto flags = effectElement->effectGeometryFlags()) {
+            auto effectBoundaries = SVGLengthContext::resolveRectangle<SVGFilterPrimitiveStandardAttributes>(effectElement.ptr(), filter.primitiveUnits(), filter.targetBoundingBox());
             effectGeometryMap.add(*effect, FilterEffectGeometry(effectBoundaries, flags));
         }
 
-        if (effectElement.colorInterpolation() == ColorInterpolation::LinearRGB)
+        if (effectElement->colorInterpolation() == ColorInterpolation::LinearRGB)
             effect->setOperatingColorSpace(DestinationColorSpace::LinearSRGB());
 
-        graph.addNamedNode(AtomString { effectElement.result() }, { *effect });
+        graph.addNamedNode(AtomString { effectElement->result() }, { *effect });
         graph.setNodeInputs(*effect, WTFMove(*inputs));
     }
 
@@ -170,10 +170,10 @@ static std::optional<SVGFilterPrimitivesGraph> buildFilterPrimitivesGraph(SVGFil
 
     SVGFilterPrimitivesGraph graph;
 
-    for (auto& effectElement : childrenOfType<SVGFilterPrimitiveStandardAttributes>(filterElement)) {
+    for (Ref effectElement : childrenOfType<SVGFilterPrimitiveStandardAttributes>(filterElement)) {
         // We should not be strict about not finding the input primitives here because SourceGraphic and SourceAlpha do not have primitives.
-        auto inputs = graph.getNamedNodes(effectElement.filterEffectInputsNames()).value_or(SVGFilterPrimitivesGraph::NodeVector());
-        graph.addNamedNode(AtomString { effectElement.result() }, { effectElement });
+        auto inputs = graph.getNamedNodes(effectElement->filterEffectInputsNames()).value_or(SVGFilterPrimitivesGraph::NodeVector());
+        graph.addNamedNode(AtomString { effectElement->result() }, effectElement.copyRef());
         graph.setNodeInputs(effectElement, WTFMove(inputs));
     }
 
@@ -300,8 +300,8 @@ RefPtr<FilterImage> SVGFilter::apply(FilterImage* sourceImage, FilterResults& re
         auto& geometry = term.geometry;
 
         if (effect->filterType() == FilterEffect::Type::SourceGraphic) {
-            if (auto result = results.effectResult(effect)) {
-                stack.append({ *result });
+            if (RefPtr result = results.effectResult(effect)) {
+                stack.append(result.releaseNonNull());
                 continue;
             }
 

--- a/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
@@ -79,10 +79,10 @@ public:
     RefPtr<NodeType> getNamedNode(const AtomString& id) const
     {
         if (!id.isEmpty()) {
-            if (auto sourceNode = m_sourceNodes.get(id))
+            if (RefPtr sourceNode = m_sourceNodes.get(id))
                 return sourceNode;
 
-            if (auto namedNode = m_namedNodes.get(id))
+            if (RefPtr namedNode = m_namedNodes.get(id))
                 return namedNode;
         }
 
@@ -129,13 +129,14 @@ public:
     NodeType* lastNode() const { return m_lastNode.get(); }
 
     template<typename Callback>
-    bool visit(Callback callback)
+    bool visit(NOESCAPE const Callback& callback)
     {
-        if (!lastNode())
+        RefPtr lastNode = m_lastNode;
+        if (!lastNode)
             return false;
 
         Vector<Ref<NodeType>> stack;
-        return visit(*lastNode(), stack, 0, callback);
+        return visit(*lastNode, stack, 0, callback);
     }
 
 private:
@@ -145,7 +146,7 @@ private:
     }
 
     template<typename Callback>
-    bool visit(NodeType& node, Vector<Ref<NodeType>>& stack, unsigned level, Callback callback)
+    bool visit(NodeType& node, Vector<Ref<NodeType>>& stack, unsigned level, NOESCAPE const Callback& callback)
     {
         // A cycle is detected.
         if (stack.containsIf([&](auto& item) { return item.ptr() == &node; }))


### PR DESCRIPTION
#### 305ea49038831820a270c67aadc7e42ba7cf1d2f
<pre>
Address safer C++ static analysis warnings in SVGFilter and SVGFilterGraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=287212">https://bugs.webkit.org/show_bug.cgi?id=287212</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::buildFilterEffectsGraph):
(WebCore::buildFilterPrimitivesGraph):
(WebCore::SVGFilter::apply):
* Source/WebCore/svg/graphics/filters/SVGFilterGraph.h:
(WebCore::SVGFilterGraph::getNamedNode const):
(WebCore::SVGFilterGraph::visit):

Canonical link: <a href="https://commits.webkit.org/290003@main">https://commits.webkit.org/290003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6357318a54000462e008b07a31e2091ee5e3c063

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16423 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91720 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6362 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38580 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15893 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76547 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19352 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15909 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->