### PR TITLE
Use twisted http server for PGO profile collection script.

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -87,7 +87,7 @@ jsargs=(
     --plan jetstream2
     --diagnose-directory="$BASE/jetstream"
     --generate-pgo-profiles
-    --http-server-type builtin
+    --http-server-type twisted
     --count 1
 )
 
@@ -95,7 +95,7 @@ sp3args=(
     --plan speedometer3
     --diagnose-directory="$BASE/speedometer3"
     --generate-pgo-profiles
-    --http-server-type builtin
+    --http-server-type twisted
     --count 1
 )
 
@@ -103,7 +103,7 @@ mmargs=(
     --plan motionmark
     --diagnose-directory="$BASE/motionmark"
     --generate-pgo-profiles
-    --http-server-type builtin
+    --http-server-type twisted
     --count 1
 )
 


### PR DESCRIPTION
#### 0d803a8e2bbf1e95aceb13ed975e24232d01584b
<pre>
Use twisted http server for PGO profile collection script.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287213">https://bugs.webkit.org/show_bug.cgi?id=287213</a>
<a href="https://rdar.apple.com/144356986">rdar://144356986</a>

Reviewed by NOBODY (OOPS!).

Python builtin http server sometimes can be flaky. use twisted http server instead which is more robust.

* Tools/Scripts/build-and-collect-pgo-profiles:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d803a8e2bbf1e95aceb13ed975e24232d01584b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68333 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26035 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38491 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15804 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11567 "Found 1 new test failure: fast/dom/crash-with-bad-url.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77198 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76474 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20862 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19286 "Found 5 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8843 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15820 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->