### PR TITLE
Address safer C++ static analysis warnings in WebResourceLoadStatisticsStore.cpp

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -252,7 +252,7 @@ private:
     StorageAccessWasGranted storageAccessWasGrantedValueForFrame(WebCore::FrameIdentifier, const WebCore::RegistrableDomain&);
 
     WeakPtr<NetworkSession> m_networkSession;
-    Ref<SuspendableWorkQueue> m_statisticsQueue;
+    const Ref<SuspendableWorkQueue> m_statisticsQueue;
     RefPtr<ResourceLoadStatisticsStore> m_statisticsStore;
 
     RunLoop::Timer m_dailyTasksTimer;

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -3,7 +3,6 @@ AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
 NetworkProcess/BackgroundFetchLoad.cpp
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
-NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 NetworkProcess/Downloads/Download.cpp
 NetworkProcess/Downloads/DownloadManager.cpp
 NetworkProcess/Downloads/PendingDownload.cpp


### PR DESCRIPTION
#### 1f677841d3ebd3a86127dfaa9199a79a24d4b643
<pre>
Address safer C++ static analysis warnings in WebResourceLoadStatisticsStore.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287214">https://bugs.webkit.org/show_bug.cgi?id=287214</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::setIsRunningTest):
(WebKit::WebResourceLoadStatisticsStore::setShouldClassifyResourcesBeforeDataRecordsRemoval):
(WebKit::WebResourceLoadStatisticsStore::WebResourceLoadStatisticsStore):
(WebKit::WebResourceLoadStatisticsStore::postTaskReply):
(WebKit::WebResourceLoadStatisticsStore::populateMemoryStoreFromDisk):
(WebKit::WebResourceLoadStatisticsStore::setResourceLoadStatisticsDebugMode):
(WebKit::WebResourceLoadStatisticsStore::setPrevalentResourceForDebugMode):
(WebKit::WebResourceLoadStatisticsStore::scheduleStatisticsAndDataRecordsProcessing):
(WebKit::WebResourceLoadStatisticsStore::statisticsDatabaseHasAllTables):
(WebKit::WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated):
(WebKit::WebResourceLoadStatisticsStore::hasStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccessEphemeral):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener):
(WebKit::WebResourceLoadStatisticsStore::grantStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::setThirdPartyCookieBlockingMode):
(WebKit::WebResourceLoadStatisticsStore::setSameSiteStrictEnforcementEnabled):
(WebKit::WebResourceLoadStatisticsStore::setFirstPartyWebsiteDataRemovalMode):
(WebKit::WebResourceLoadStatisticsStore::setPersistedDomains):
(WebKit::WebResourceLoadStatisticsStore::setStandaloneApplicationDomain):
(WebKit::WebResourceLoadStatisticsStore::setAppBoundDomains):
(WebKit::WebResourceLoadStatisticsStore::setManagedDomains):
(WebKit::WebResourceLoadStatisticsStore::didCreateNetworkProcess):
(WebKit::WebResourceLoadStatisticsStore::performDailyTasks):
(WebKit::WebResourceLoadStatisticsStore::logFrameNavigation):
(WebKit::WebResourceLoadStatisticsStore::logUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::logCrossSiteLoadWithLinkDecoration):
(WebKit::WebResourceLoadStatisticsStore::clearUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::setTimeAdvanceForTesting):
(WebKit::WebResourceLoadStatisticsStore::hasHadUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::setLastSeen):
(WebKit::WebResourceLoadStatisticsStore::mergeStatisticForTesting):
(WebKit::WebResourceLoadStatisticsStore::isRelationshipOnlyInDatabaseOnce):
(WebKit::WebResourceLoadStatisticsStore::setPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::setVeryPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::setMostRecentWebPushInteractionTime):
(WebKit::WebResourceLoadStatisticsStore::dumpResourceLoadStatistics):
(WebKit::WebResourceLoadStatisticsStore::isPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::isVeryPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::isRegisteredAsSubresourceUnder):
(WebKit::WebResourceLoadStatisticsStore::isRegisteredAsSubFrameUnder):
(WebKit::WebResourceLoadStatisticsStore::isRegisteredAsRedirectingTo):
(WebKit::WebResourceLoadStatisticsStore::clearPrevalentResource):
(WebKit::WebResourceLoadStatisticsStore::setGrandfathered):
(WebKit::WebResourceLoadStatisticsStore::isGrandfathered):
(WebKit::WebResourceLoadStatisticsStore::setSubframeUnderTopFrameDomain):
(WebKit::WebResourceLoadStatisticsStore::setSubresourceUnderTopFrameDomain):
(WebKit::WebResourceLoadStatisticsStore::setSubresourceUniqueRedirectTo):
(WebKit::WebResourceLoadStatisticsStore::setSubresourceUniqueRedirectFrom):
(WebKit::WebResourceLoadStatisticsStore::setTopFrameUniqueRedirectTo):
(WebKit::WebResourceLoadStatisticsStore::setTopFrameUniqueRedirectFrom):
(WebKit::WebResourceLoadStatisticsStore::scheduleCookieBlockingUpdate):
(WebKit::WebResourceLoadStatisticsStore::scheduleClearInMemoryAndPersistent):
(WebKit::WebResourceLoadStatisticsStore::domainIDExistsInDatabase):
(WebKit::WebResourceLoadStatisticsStore::setTimeToLiveUserInteraction):
(WebKit::WebResourceLoadStatisticsStore::setMinimumTimeBetweenDataRecordsRemoval):
(WebKit::WebResourceLoadStatisticsStore::setGrandfatheringTime):
(WebKit::WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesForHandler):
(WebKit::WebResourceLoadStatisticsStore::setMaxStatisticsEntries):
(WebKit::WebResourceLoadStatisticsStore::setPruneEntriesDownTo):
(WebKit::WebResourceLoadStatisticsStore::resetParametersToDefaultValues):
(WebKit::WebResourceLoadStatisticsStore::logTestingEvent):
(WebKit::WebResourceLoadStatisticsStore::removeDataForDomain):
(WebKit::WebResourceLoadStatisticsStore::registrableDomains):
(WebKit::WebResourceLoadStatisticsStore::registrableDomainsWithLastAccessedTime):
(WebKit::WebResourceLoadStatisticsStore::registrableDomainsExemptFromWebsiteDataDeletion):
(WebKit::WebResourceLoadStatisticsStore::aggregatedThirdPartyData):
(WebKit::WebResourceLoadStatisticsStore::insertExpiredStatisticForTesting):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:

Canonical link: <a href="https://commits.webkit.org/290004@main">https://commits.webkit.org/290004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/816838266e19b02d68b1f979d7cc37e67a3d7470

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39473 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16424 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68402 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 22 flakes 239 failures; Uploaded test results") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26094 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6363 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38581 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95520 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15894 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76549 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19354 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15910 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19100 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->