### PR TITLE
Migrate usage of http.server.HTTPServer to ThreadingHTTPServer

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from http.server import SimpleHTTPRequestHandler, HTTPServer
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 import argparse
 import logging
 import sys
@@ -80,6 +80,6 @@ if __name__ == '__main__':
     logging.basicConfig(datefmt='%Y-%m-%d %H:%M:%S',
                         format='%(asctime)s [%(levelname)s]: %(message)s', filename=args.log_path, level=logging.INFO)
     Handler.web_root = args.web_root
-    HTTPServer.address_family = family_type
-    httpd = HTTPServer(addr_pair, Handler)
+    ThreadingHTTPServer.address_family = family_type
+    httpd = ThreadingHTTPServer(addr_pair, Handler)
     httpd.serve_forever()

--- a/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
+++ b/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
@@ -34,7 +34,7 @@ from webkitpy.common.system.executive import ScriptError
 from webkitpy.port.base import Port
 from webkitpy.tool.servers.reflectionhandler import ReflectionHandler
 
-from http.server import HTTPServer
+from http.server import ThreadingHTTPServer
 
 
 STATE_NEEDS_REBASELINE = 'needs_rebaseline'
@@ -196,10 +196,10 @@ def get_test_baselines(test_file, test_config):
     return all_test_baselines
 
 
-class RebaselineHTTPServer(HTTPServer):
+class RebaselineHTTPServer(ThreadingHTTPServer):
     def __init__(self, httpd_port, config):
         server_name = ""
-        HTTPServer.__init__(self, (server_name, httpd_port), RebaselineHTTPRequestHandler)
+        super.__init__((server_name, httpd_port), RebaselineHTTPRequestHandler)
         self.test_config = config['test_config']
         self.results_json = config['results_json']
         self.platforms_json = config['platforms_json']


### PR DESCRIPTION
#### f3615e97b23eeffb42559c059d0311ad724aa691
<pre>
Migrate usage of http.server.HTTPServer to ThreadingHTTPServer
<a href="https://bugs.webkit.org/show_bug.cgi?id=287215">https://bugs.webkit.org/show_bug.cgi?id=287215</a>
<a href="https://rdar.apple.com/problem/144358027">rdar://problem/144358027</a>

Reviewed by Dewei Zhu.

As the Python docs say:

&gt; This is useful to handle web browsers pre-opening sockets, on which
&gt; HTTPServer would wait indefinitely.

This should thus make all of our usage more resilient.

* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py:
* Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py:
(RebaselineHTTPServer):
(RebaselineHTTPServer.__init__):

Canonical link: <a href="https://commits.webkit.org/289986@main">https://commits.webkit.org/289986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/551d41ac1c1ca4c4988fbe511d3f1a17ea0db5d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39387 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16336 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48703 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/88133 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6296 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38495 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95433 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15808 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76477 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20868 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13862 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15824 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->