### PR TITLE
Pipe a context through the CSS serialization code

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -978,6 +978,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/typedom/numeric/CSSNumericType.h
 
     css/values/CSSNoConversionDataRequiredToken.h
+    css/values/CSSSerializationContext.h
     css/values/CSSValueAggregates.h
     css/values/CSSValueConcepts.h
     css/values/CSSValueTypes.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -489,7 +489,6 @@ css/ComputedStyleExtractor.cpp
 css/DeprecatedCSSOMPrimitiveValue.h
 css/DeprecatedCSSOMRGBColor.h
 css/DeprecatedCSSOMRect.h
-css/DeprecatedCSSOMValue.h
 css/FontFace.cpp
 css/FontFaceSet.cpp
 css/ImmutableStyleProperties.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1150,6 +1150,7 @@ css/typedom/transform/CSSSkewY.cpp
 css/typedom/transform/CSSTransformComponent.cpp
 css/typedom/transform/CSSTransformValue.cpp
 css/typedom/transform/CSSTranslate.cpp
+css/values/CSSSerializationContext.cpp
 css/values/CSSValueAggregates.cpp
 css/values/CSSValueTypes.cpp
 css/values/backgrounds/CSSBorderRadius.cpp

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -37,6 +37,7 @@
 #include "CSSPropertyParserConsumer+Animations.h"
 #include "CSSPropertyParserConsumer+Easing.h"
 #include "CSSSelector.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleDeclaration.h"
 #include "CSSTransition.h"
 #include "CSSUnitValue.h"
@@ -920,7 +921,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
                 if (cssPropertyId == CSSPropertyCustom)
                     continue;
                 if (auto cssValue = parsedKeyframe.style->getPropertyCSSValue(cssPropertyId))
-                    stringValue = cssValue->cssText();
+                    stringValue = cssValue->cssText(CSS::defaultSerializationContext());
             }
             computedKeyframe.easing = timingFunctionForKeyframeAtIndex(i)->cssText();
             computedKeyframes.append(WTFMove(computedKeyframe));
@@ -1051,7 +1052,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
             }
             if (styleString.isEmpty()) {
                 if (auto cssValue = computedStyleExtractor.valueForPropertyInStyle(style, cssPropertyId, nullptr, ComputedStyleExtractor::PropertyValueType::Computed))
-                    styleString = cssValue->cssText();
+                    styleString = cssValue->cssText(CSS::defaultSerializationContext());
             }
             computedKeyframe.styleStrings.set(cssPropertyId, styleString);
         };
@@ -1072,7 +1073,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
             }
             if (styleString.isEmpty()) {
                 if (auto* cssValue = style.customPropertyValue(customProperty))
-                    styleString = cssValue->cssText();
+                    styleString = cssValue->cssText(CSS::defaultSerializationContext());
             }
             computedKeyframe.customStyleStrings.set(customProperty, styleString);
         };

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -30,6 +30,7 @@
 #include "AnimationPlaybackEvent.h"
 #include "AnimationTimeline.h"
 #include "CSSPropertyAnimation.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleDeclaration.h"
 #include "CSSUnitValue.h"
 #include "CSSUnits.h"
@@ -1775,12 +1776,12 @@ ExceptionOr<void> WebAnimation::commitStyles()
         return WTF::switchOn(property,
             [&] (CSSPropertyID propertyId) {
                 if (auto cssValue = computedStyleExtractor.valueForPropertyInStyle(*animatedStyle, propertyId, nullptr, ComputedStyleExtractor::PropertyValueType::Computed))
-                    return inlineStyle->setProperty(propertyId, cssValue->cssText(), { styledElement->document() });
+                    return inlineStyle->setProperty(propertyId, cssValue->cssText(CSS::defaultSerializationContext()), { styledElement->document() });
                 return false;
             },
             [&] (const AtomString& customProperty) {
                 if (auto cssValue = computedStyleExtractor.customPropertyValue(customProperty))
-                    return inlineStyle->setCustomProperty(customProperty, cssValue->cssText(), { styledElement->document() });
+                    return inlineStyle->setCustomProperty(customProperty, cssValue->cssText(CSS::defaultSerializationContext()), { styledElement->document() });
                 return false;
             }
         );
@@ -1802,7 +1803,7 @@ ExceptionOr<void> WebAnimation::commitStyles()
         didMutate = commitProperty(property) || didMutate;
 
     if (didMutate)
-        styledElement->setAttribute(HTMLNames::styleAttr, inlineStyle->asTextAtom());
+        styledElement->setAttribute(HTMLNames::styleAttr, inlineStyle->asTextAtom(CSS::defaultSerializationContext()));
 
     return { };
 }

--- a/Source/WebCore/css/CSSAppleColorFilterPropertyValue.cpp
+++ b/Source/WebCore/css/CSSAppleColorFilterPropertyValue.cpp
@@ -45,9 +45,9 @@ CSSAppleColorFilterPropertyValue::CSSAppleColorFilterPropertyValue(CSS::AppleCol
 {
 }
 
-String CSSAppleColorFilterPropertyValue::customCSSText() const
+String CSSAppleColorFilterPropertyValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_filter);
+    return CSS::serializationForCSS(context, m_filter);
 }
 
 bool CSSAppleColorFilterPropertyValue::equals(const CSSAppleColorFilterPropertyValue& other) const

--- a/Source/WebCore/css/CSSAppleColorFilterPropertyValue.h
+++ b/Source/WebCore/css/CSSAppleColorFilterPropertyValue.h
@@ -35,7 +35,7 @@ public:
 
     const CSS::AppleColorFilterProperty& filter() const { return m_filter; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSAppleColorFilterPropertyValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSAspectRatioValue.cpp
+++ b/Source/WebCore/css/CSSAspectRatioValue.cpp
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-String CSSAspectRatioValue::customCSSText() const
+String CSSAspectRatioValue::customCSSText(const CSS::SerializationContext&) const
 {
     return makeString(m_numeratorValue, " / "_s, m_denominatorValue);
 }

--- a/Source/WebCore/css/CSSAspectRatioValue.h
+++ b/Source/WebCore/css/CSSAspectRatioValue.h
@@ -39,7 +39,7 @@ public:
         return adoptRef(*new CSSAspectRatioValue(numeratorValue, denominatorValue));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     float numeratorValue() const { return m_numeratorValue; }
     float denominatorValue() const { return m_denominatorValue; }

--- a/Source/WebCore/css/CSSAttrValue.cpp
+++ b/Source/WebCore/css/CSSAttrValue.cpp
@@ -48,14 +48,14 @@ bool CSSAttrValue::equals(const CSSAttrValue& other) const
     return m_attributeName == other.m_attributeName;
 }
 
-String CSSAttrValue::customCSSText() const
+String CSSAttrValue::customCSSText(const CSS::SerializationContext& context) const
 {
     RefPtr fallback = dynamicDowncast<CSSPrimitiveValue>(m_fallback);
     return makeString(
         "attr("_s,
         m_attributeName.impl(),
         fallback && !fallback->stringValue().isEmpty() ? ", "_s : ""_s,
-        fallback && !fallback->stringValue().isEmpty() ? fallback->cssText() : ""_s,
+        fallback && !fallback->stringValue().isEmpty() ? fallback->cssText(context) : ""_s,
         ')'
     );
 }

--- a/Source/WebCore/css/CSSAttrValue.h
+++ b/Source/WebCore/css/CSSAttrValue.h
@@ -39,7 +39,7 @@ public:
     const String attributeName() const { return m_attributeName; }
     const CSSValue* fallback() const { return m_fallback.get(); }
     bool equals(const CSSAttrValue& other) const;
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
 private:
     explicit CSSAttrValue(String&& attributeName, RefPtr<CSSValue>&& fallback)

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.cpp
@@ -44,7 +44,7 @@ Ref<CSSBackgroundRepeatValue> CSSBackgroundRepeatValue::create(CSSValueID repeat
     return adoptRef(*new CSSBackgroundRepeatValue(repeatXValue, repeatYValue));
 }
 
-String CSSBackgroundRepeatValue::customCSSText() const
+String CSSBackgroundRepeatValue::customCSSText(const CSS::SerializationContext&) const
 {
     // background-repeat/mask-repeat behave a little like a shorthand, but `repeat no-repeat` is transformed to `repeat-x`.
     if (m_xValue != m_yValue) {

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.h
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.h
@@ -35,7 +35,7 @@ class CSSBackgroundRepeatValue final : public CSSValue {
 public:
     static Ref<CSSBackgroundRepeatValue> create(CSSValueID repeatXValue, CSSValueID repeatYValue);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSBackgroundRepeatValue&) const;
 
     CSSValueID xValue() const { return m_xValue; }

--- a/Source/WebCore/css/CSSBasicShapeValue.cpp
+++ b/Source/WebCore/css/CSSBasicShapeValue.cpp
@@ -38,9 +38,9 @@
 
 namespace WebCore {
 
-String CSSBasicShapeValue::customCSSText() const
+String CSSBasicShapeValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_shape);
+    return CSS::serializationForCSS(context, m_shape);
 }
 
 bool CSSBasicShapeValue::equals(const CSSBasicShapeValue& other) const

--- a/Source/WebCore/css/CSSBasicShapeValue.h
+++ b/Source/WebCore/css/CSSBasicShapeValue.h
@@ -44,7 +44,7 @@ public:
 
     const CSS::BasicShape& shape() const { return m_shape; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSBasicShapeValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;

--- a/Source/WebCore/css/CSSBorderImageSliceValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.cpp
@@ -45,11 +45,11 @@ Ref<CSSBorderImageSliceValue> CSSBorderImageSliceValue::create(Quad slices, bool
     return adoptRef(*new CSSBorderImageSliceValue(WTFMove(slices), fill));
 }
 
-String CSSBorderImageSliceValue::customCSSText() const
+String CSSBorderImageSliceValue::customCSSText(const CSS::SerializationContext& context) const
 {
     if (m_fill)
-        return makeString(m_slices.cssText(), " fill"_s);
-    return m_slices.cssText();
+        return makeString(m_slices.cssText(context), " fill"_s);
+    return m_slices.cssText(context);
 }
 
 bool CSSBorderImageSliceValue::equals(const CSSBorderImageSliceValue& other) const

--- a/Source/WebCore/css/CSSBorderImageSliceValue.h
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.h
@@ -40,7 +40,7 @@ public:
     const Quad& slices() const { return m_slices; }
     bool fill() const { return m_fill; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSBorderImageSliceValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSBorderImageWidthValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.cpp
@@ -44,14 +44,14 @@ Ref<CSSBorderImageWidthValue> CSSBorderImageWidthValue::create(Quad widths, bool
     return adoptRef(*new CSSBorderImageWidthValue(WTFMove(widths), overridesBorderWidths));
 }
 
-String CSSBorderImageWidthValue::customCSSText() const
+String CSSBorderImageWidthValue::customCSSText(const CSS::SerializationContext& context) const
 {
     // The border-image-width longhand can't set m_overridesBorderWidths to true, so serialize as empty string.
     // This can only be created by the -webkit-border-image shorthand, which will not serialize as empty string in this case.
     // This is an unconventional relationship between a longhand and a shorthand, which we may want to revise.
     if (m_overridesBorderWidths)
         return String();
-    return m_widths.cssText();
+    return m_widths.cssText(context);
 }
 
 bool CSSBorderImageWidthValue::equals(const CSSBorderImageWidthValue& other) const

--- a/Source/WebCore/css/CSSBorderImageWidthValue.h
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.h
@@ -40,7 +40,7 @@ public:
     const Quad& widths() const { return m_widths; }
     bool overridesBorderWidths() const { return m_overridesBorderWidths; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSBorderImageWidthValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSBoxShadowPropertyValue.cpp
+++ b/Source/WebCore/css/CSSBoxShadowPropertyValue.cpp
@@ -46,9 +46,9 @@ CSSBoxShadowPropertyValue::CSSBoxShadowPropertyValue(CSS::BoxShadowProperty&& sh
 {
 }
 
-String CSSBoxShadowPropertyValue::customCSSText() const
+String CSSBoxShadowPropertyValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_shadow);
+    return CSS::serializationForCSS(context, m_shadow);
 }
 
 bool CSSBoxShadowPropertyValue::equals(const CSSBoxShadowPropertyValue& other) const

--- a/Source/WebCore/css/CSSBoxShadowPropertyValue.h
+++ b/Source/WebCore/css/CSSBoxShadowPropertyValue.h
@@ -35,7 +35,7 @@ public:
 
     const CSS::BoxShadowProperty& shadow() const { return m_shadow; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSBoxShadowPropertyValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;

--- a/Source/WebCore/css/CSSCanvasValue.cpp
+++ b/Source/WebCore/css/CSSCanvasValue.cpp
@@ -39,7 +39,7 @@ CSSCanvasValue::CSSCanvasValue(String&& name)
 
 CSSCanvasValue::~CSSCanvasValue() = default;
 
-String CSSCanvasValue::customCSSText() const
+String CSSCanvasValue::customCSSText(const CSS::SerializationContext&) const
 {
     return makeString("-webkit-canvas("_s, m_name, ')');
 }

--- a/Source/WebCore/css/CSSCanvasValue.h
+++ b/Source/WebCore/css/CSSCanvasValue.h
@@ -41,7 +41,7 @@ public:
     static Ref<CSSCanvasValue> create(String name) { return adoptRef(*new CSSCanvasValue(WTFMove(name))); }
     ~CSSCanvasValue();
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCanvasValue&) const;
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSColorSchemeValue.cpp
+++ b/Source/WebCore/css/CSSColorSchemeValue.cpp
@@ -40,9 +40,9 @@ CSSColorSchemeValue::CSSColorSchemeValue(CSS::ColorScheme colorScheme)
 {
 }
 
-String CSSColorSchemeValue::customCSSText() const
+String CSSColorSchemeValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_colorScheme);
+    return CSS::serializationForCSS(context, m_colorScheme);
 }
 
 bool CSSColorSchemeValue::equals(const CSSColorSchemeValue& other) const

--- a/Source/WebCore/css/CSSColorSchemeValue.h
+++ b/Source/WebCore/css/CSSColorSchemeValue.h
@@ -35,7 +35,7 @@ class CSSColorSchemeValue final : public CSSValue {
 public:
     static Ref<CSSColorSchemeValue> create(CSS::ColorScheme);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSColorSchemeValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSColorValue.cpp
+++ b/Source/WebCore/css/CSSColorValue.cpp
@@ -66,9 +66,9 @@ WebCore::Color CSSColorValue::absoluteColor(const CSSValue& value)
     return { };
 }
 
-String CSSColorValue::customCSSText() const
+String CSSColorValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_color);
+    return CSS::serializationForCSS(context, m_color);
 }
 
 bool CSSColorValue::equals(const CSSColorValue& other) const

--- a/Source/WebCore/css/CSSColorValue.h
+++ b/Source/WebCore/css/CSSColorValue.h
@@ -39,7 +39,7 @@ public:
 
     const CSS::Color& color() const { return m_color; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSColorValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -30,6 +30,7 @@
 #include "CSSPropertyParser.h"
 #include "CSSSelector.h"
 #include "CSSSelectorParser.h"
+#include "CSSSerializationContext.h"
 #include "CSSValuePool.h"
 #include "ComposedTreeAncestorIterator.h"
 #include "ComputedStyleExtractor.h"
@@ -141,12 +142,12 @@ String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) c
         }
     };
     if (isShorthand(propertyID) && canUseShorthandSerializerForPropertyValue())
-        return serializeShorthandValue({ m_element.ptr(), m_allowVisitedStyle, m_pseudoElementIdentifier }, propertyID);
+        return serializeShorthandValue(CSS::defaultSerializationContext(), { m_element.ptr(), m_allowVisitedStyle, m_pseudoElementIdentifier }, propertyID);
 
     auto value = getPropertyCSSValue(propertyID);
     if (!value)
         return emptyString(); // FIXME: Should this be null instead, as it is in StyleProperties::getPropertyValue?
-    return value->cssText();
+    return value->cssText(CSS::defaultSerializationContext());
 }
 
 unsigned CSSComputedStyleDeclaration::length() const

--- a/Source/WebCore/css/CSSContentDistributionValue.cpp
+++ b/Source/WebCore/css/CSSContentDistributionValue.cpp
@@ -45,7 +45,7 @@ Ref<CSSContentDistributionValue> CSSContentDistributionValue::create(CSSValueID 
     return adoptRef(*new CSSContentDistributionValue(distribution, position, overflow));
 }
 
-String CSSContentDistributionValue::customCSSText() const
+String CSSContentDistributionValue::customCSSText(const CSS::SerializationContext&) const
 {
     auto word1 = m_distribution;
     CSSValueID word2;

--- a/Source/WebCore/css/CSSContentDistributionValue.h
+++ b/Source/WebCore/css/CSSContentDistributionValue.h
@@ -39,7 +39,7 @@ public:
     CSSValueID position() const { return m_position; }
     CSSValueID overflow() const { return m_overflow; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSContentDistributionValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSCounterValue.cpp
+++ b/Source/WebCore/css/CSSCounterValue.cpp
@@ -52,7 +52,7 @@ bool CSSCounterValue::equals(const CSSCounterValue& other) const
     return m_identifier == other.m_identifier && m_separator == other.m_separator && arePointingToEqualData(m_counterStyle, other.m_counterStyle);
 }
 
-String CSSCounterValue::customCSSText() const
+String CSSCounterValue::customCSSText(const CSS::SerializationContext&) const
 {
     bool isDecimal = m_counterStyle->valueID() == CSSValueDecimal || (m_counterStyle->isCustomIdent() && m_counterStyle->customIdent() == "decimal"_s);
     auto listStyleSeparator = isDecimal ? ""_s : ", "_s;

--- a/Source/WebCore/css/CSSCounterValue.h
+++ b/Source/WebCore/css/CSSCounterValue.h
@@ -39,7 +39,7 @@ public:
     RefPtr<CSSValue> counterStyle() const { return m_counterStyle; }
     String counterStyleCSSText() const;
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCounterValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSCrossfadeValue.cpp
+++ b/Source/WebCore/css/CSSCrossfadeValue.cpp
@@ -59,9 +59,9 @@ bool CSSCrossfadeValue::equalInputImages(const CSSCrossfadeValue& other) const
     return compareCSSValue(m_fromValueOrNone, other.m_fromValueOrNone) && compareCSSValue(m_toValueOrNone, other.m_toValueOrNone);
 }
 
-String CSSCrossfadeValue::customCSSText() const
+String CSSCrossfadeValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return makeString(m_isPrefixed ? "-webkit-"_s : ""_s, "cross-fade("_s, m_fromValueOrNone->cssText(), ", "_s, m_toValueOrNone->cssText(), ", "_s, m_percentageValue->cssText(), ')');
+    return makeString(m_isPrefixed ? "-webkit-"_s : ""_s, "cross-fade("_s, m_fromValueOrNone->cssText(context), ", "_s, m_toValueOrNone->cssText(context), ", "_s, m_percentageValue->cssText(context), ')');
 }
 
 RefPtr<StyleImage> CSSCrossfadeValue::createStyleImage(const Style::BuilderState& state) const

--- a/Source/WebCore/css/CSSCrossfadeValue.h
+++ b/Source/WebCore/css/CSSCrossfadeValue.h
@@ -46,7 +46,7 @@ public:
     bool equals(const CSSCrossfadeValue&) const;
     bool equalInputImages(const CSSCrossfadeValue&) const;
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool isPrefixed() const { return m_isPrefixed; }
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -60,12 +60,12 @@ CSSCursorImageValue::CSSCursorImageValue(Ref<CSSValue>&& imageValue, RefPtr<CSSV
 
 CSSCursorImageValue::~CSSCursorImageValue() = default;
 
-String CSSCursorImageValue::customCSSText() const
+String CSSCursorImageValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    auto text = m_imageValue->cssText();
+    auto text = m_imageValue->cssText(context);
     if (!m_hotSpot)
         return text;
-    return makeString(text, ' ', m_hotSpot->first().cssText(), ' ', m_hotSpot->second().cssText());
+    return makeString(text, ' ', m_hotSpot->first().cssText(context), ' ', m_hotSpot->second().cssText(context));
 }
 
 bool CSSCursorImageValue::equals(const CSSCursorImageValue& other) const

--- a/Source/WebCore/css/CSSCursorImageValue.h
+++ b/Source/WebCore/css/CSSCursorImageValue.h
@@ -42,7 +42,7 @@ public:
     ~CSSCursorImageValue();
 
     const URL& imageURL() const { return m_originalURL; }
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCursorImageValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -30,8 +30,8 @@
 #include "CSSFunctionValue.h"
 #include "CSSMarkup.h"
 #include "CSSParserIdioms.h"
+#include "CSSSerializationContext.h"
 #include "CSSTokenizer.h"
-#include "ColorSerialization.h"
 #include "ComputedStyleExtractor.h"
 #include "RenderStyle.h"
 #include <wtf/NeverDestroyed.h>
@@ -69,23 +69,23 @@ bool CSSCustomPropertyValue::equals(const CSSCustomPropertyValue& other) const
     });
 }
 
-String CSSCustomPropertyValue::customCSSText() const
+String CSSCustomPropertyValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    auto serializeSyntaxValue = [](const SyntaxValue& syntaxValue) -> String {
+    auto serializeSyntaxValue = [&](const SyntaxValue& syntaxValue) -> String {
         return WTF::switchOn(syntaxValue, [&](const Length& value) {
             if (value.type() == LengthType::Calculated) {
                 // FIXME: Implement serialization for CalculationValue directly.
                 auto calcValue = CSSCalcValue::create(value.calculationValue(), RenderStyle::defaultStyle());
-                return calcValue->cssText();
+                return calcValue->cssText(context);
             }
-            return CSSPrimitiveValue::create(value, RenderStyle::defaultStyle())->cssText();
+            return CSSPrimitiveValue::create(value, RenderStyle::defaultStyle())->cssText(context);
         }, [&](const NumericSyntaxValue& value) {
-            return CSSPrimitiveValue::create(value.value, value.unitType)->cssText();
+            return CSSPrimitiveValue::create(value.value, value.unitType)->cssText(context);
         }, [&](const Style::Color& value) {
-            return serializationForCSS(value);
+            return serializationForCSS(context, value);
         }, [&](const RefPtr<StyleImage>& value) {
             // FIXME: This is not right for gradients that use `currentcolor`. There should be a way preserve it.
-            return value->computedStyleValue(RenderStyle::defaultStyle())->cssText();
+            return value->computedStyleValue(RenderStyle::defaultStyle())->cssText(context);
         }, [&](const URL& value) {
             return serializeURL(value.string());
         }, [&](const String& value) {
@@ -94,13 +94,13 @@ String CSSCustomPropertyValue::customCSSText() const
             auto cssValue = transformOperationAsCSSValue(value.transform, RenderStyle::defaultStyle());
             if (!cssValue)
                 return emptyString();
-            return cssValue->cssText();
+            return cssValue->cssText(context);
         });
     };
 
     auto serialize = [&] {
         return WTF::switchOn(m_value, [&](const Ref<CSSVariableReferenceValue>& value) {
-            return value->cssText();
+            return value->cssText(context);
         }, [&](const CSSValueID& value) {
             return nameString(value).string();
         }, [&](const Ref<CSSVariableData>& value) {
@@ -139,7 +139,7 @@ const Vector<CSSParserToken>& CSSCustomPropertyValue::tokens() const
         return value->tokens();
     }, [&](auto&) -> const Vector<CSSParserToken>& {
         if (!m_cachedTokens) {
-            CSSTokenizer tokenizer { customCSSText() };
+            CSSTokenizer tokenizer { customCSSText(CSS::defaultSerializationContext()) };
             m_cachedTokens = CSSVariableData::create(tokenizer.tokenRange());
         }
         return m_cachedTokens->tokens();

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -88,7 +88,7 @@ public:
         return adoptRef(*new CSSCustomPropertyValue(name, VariantValue { WTFMove(syntaxValueList) }));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     const AtomString& name() const { return m_name; }
     bool isResolved() const { return !std::holds_alternative<Ref<CSSVariableReferenceValue>>(m_value); }

--- a/Source/WebCore/css/CSSDynamicRangeLimitValue.cpp
+++ b/Source/WebCore/css/CSSDynamicRangeLimitValue.cpp
@@ -43,9 +43,9 @@ CSSDynamicRangeLimitValue::CSSDynamicRangeLimitValue(CSS::DynamicRangeLimit&& dy
 {
 }
 
-String CSSDynamicRangeLimitValue::customCSSText() const
+String CSSDynamicRangeLimitValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_dynamicRangeLimit);
+    return CSS::serializationForCSS(context, m_dynamicRangeLimit);
 }
 
 bool CSSDynamicRangeLimitValue::equals(const CSSDynamicRangeLimitValue& other) const

--- a/Source/WebCore/css/CSSDynamicRangeLimitValue.h
+++ b/Source/WebCore/css/CSSDynamicRangeLimitValue.h
@@ -35,7 +35,7 @@ public:
 
     const CSS::DynamicRangeLimit& dynamicRangeLimit() const { return m_dynamicRangeLimit; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSDynamicRangeLimitValue&) const;
 
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;

--- a/Source/WebCore/css/CSSEasingFunctionValue.cpp
+++ b/Source/WebCore/css/CSSEasingFunctionValue.cpp
@@ -41,9 +41,9 @@ CSSEasingFunctionValue::CSSEasingFunctionValue(CSS::EasingFunction easingFunctio
 {
 }
 
-String CSSEasingFunctionValue::customCSSText() const
+String CSSEasingFunctionValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_easingFunction);
+    return CSS::serializationForCSS(context, m_easingFunction);
 }
 
 bool CSSEasingFunctionValue::equals(const CSSEasingFunctionValue& other) const

--- a/Source/WebCore/css/CSSEasingFunctionValue.h
+++ b/Source/WebCore/css/CSSEasingFunctionValue.h
@@ -36,7 +36,7 @@ public:
 
     const CSS::EasingFunction& easingFunction() const { return m_easingFunction; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSEasingFunctionValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -55,9 +55,9 @@ bool CSSFilterImageValue::equalInputImages(const CSSFilterImageValue& other) con
     return compareCSSValue(m_imageValueOrNone, other.m_imageValueOrNone);
 }
 
-String CSSFilterImageValue::customCSSText() const
+String CSSFilterImageValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return makeString("filter("_s, m_imageValueOrNone->cssText(), ", "_s, CSS::serializationForCSS(m_filter), ')');
+    return makeString("filter("_s, m_imageValueOrNone->cssText(context), ", "_s, CSS::serializationForCSS(context, m_filter), ')');
 }
 
 IterationStatus CSSFilterImageValue::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSFilterImageValue.h
+++ b/Source/WebCore/css/CSSFilterImageValue.h
@@ -50,7 +50,7 @@ public:
     bool equals(const CSSFilterImageValue&) const;
     bool equalInputImages(const CSSFilterImageValue&) const;
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSFilterPropertyValue.cpp
+++ b/Source/WebCore/css/CSSFilterPropertyValue.cpp
@@ -45,9 +45,9 @@ CSSFilterPropertyValue::CSSFilterPropertyValue(CSS::FilterProperty filter)
 {
 }
 
-String CSSFilterPropertyValue::customCSSText() const
+String CSSFilterPropertyValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_filter);
+    return CSS::serializationForCSS(context, m_filter);
 }
 
 bool CSSFilterPropertyValue::equals(const CSSFilterPropertyValue& other) const

--- a/Source/WebCore/css/CSSFilterPropertyValue.h
+++ b/Source/WebCore/css/CSSFilterPropertyValue.h
@@ -35,7 +35,7 @@ public:
 
     const CSS::FilterProperty& filter() const { return m_filter; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSFilterPropertyValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSFontFaceRule.cpp
+++ b/Source/WebCore/css/CSSFontFaceRule.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "CSSFontFaceRule.h"
 
+#include "CSSSerializationContext.h"
 #include "MutableStyleProperties.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "StyleProperties.h"
@@ -52,17 +53,12 @@ CSSStyleDeclaration& CSSFontFaceRule::style()
 
 String CSSFontFaceRule::cssText() const
 {
-    return cssTextInternal(m_fontFaceRule->properties().asText());
+    return cssTextInternal(m_fontFaceRule->properties().asText(CSS::defaultSerializationContext()));
 }
 
-String CSSFontFaceRule::cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const
+String CSSFontFaceRule::cssText(const CSS::SerializationContext& context) const
 {
-    auto mutableStyleProperties = m_fontFaceRule->properties().mutableCopy();
-    mutableStyleProperties->setReplacementURLForSubresources(replacementURLStrings);
-    auto declarations = mutableStyleProperties->asText();
-    mutableStyleProperties->clearReplacementURLForSubresources();
-
-    return cssTextInternal(declarations);
+    return cssTextInternal(m_fontFaceRule->properties().asText(context));
 }
 
 String CSSFontFaceRule::cssTextInternal(const String& declarations) const

--- a/Source/WebCore/css/CSSFontFaceRule.h
+++ b/Source/WebCore/css/CSSFontFaceRule.h
@@ -42,7 +42,7 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFace; }
     String cssText() const final;
-    String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    String cssText(const CSS::SerializationContext&) const final;
     String cssTextInternal(const String& declarations) const;
     void reattach(StyleRuleBase&) final;
 

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -27,6 +27,7 @@
 #include "CSSFontFaceSrcValue.h"
 
 #include "CSSMarkup.h"
+#include "CSSSerializationContext.h"
 #include "CachedFont.h"
 #include "CachedFontLoadRequest.h"
 #include "CachedResourceLoader.h"
@@ -63,7 +64,7 @@ void CSSFontFaceSrcLocalValue::setSVGFontFaceElement(SVGFontFaceElement& element
     m_element = &element;
 }
 
-String CSSFontFaceSrcLocalValue::customCSSText() const
+String CSSFontFaceSrcLocalValue::customCSSText(const CSS::SerializationContext&) const
 {
     return makeString("local("_s, serializeString(m_fontFaceName), ')');
 }
@@ -124,36 +125,21 @@ bool CSSFontFaceSrcResourceValue::customTraverseSubresources(NOESCAPE const Func
     return m_cachedFont && handler(*m_cachedFont);
 }
 
-void CSSFontFaceSrcResourceValue::customSetReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>& replacementURLStrings)
-{
-    auto replacementURLString = replacementURLStrings.get(m_location.resolvedURL.string());
-    if (!replacementURLString.isNull())
-        m_replacementURLString = replacementURLString;
-    m_shouldUseResolvedURLInCSSText = true;
-}
-
-void CSSFontFaceSrcResourceValue::customClearReplacementURLForSubresources()
-{
-    m_replacementURLString = { };
-    m_shouldUseResolvedURLInCSSText = false;
-}
-
 bool CSSFontFaceSrcResourceValue::customMayDependOnBaseURL() const
 {
     return WebCore::mayDependOnBaseURL(m_location);
 }
 
-String CSSFontFaceSrcResourceValue::customCSSText() const
+String CSSFontFaceSrcResourceValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder builder;
-    if (!m_replacementURLString.isEmpty())
-        builder.append(serializeURL(m_replacementURLString));
-    else {
-        if (m_shouldUseResolvedURLInCSSText)
-            builder.append(serializeURL(m_location.resolvedURL.string()));
-        else
-            builder.append(serializeURL(m_location.specifiedURLString));
-    }
+    if (auto replacementURLString = context.replacementURLStrings.get(m_location.resolvedURL.string()); !replacementURLString.isEmpty())
+        builder.append(serializeURL(replacementURLString));
+    else if (context.shouldUseResolvedURLInCSSText)
+        builder.append(serializeURL(m_location.resolvedURL.string()));
+    else
+        builder.append(serializeURL(m_location.specifiedURLString));
+
     if (!m_format.isEmpty())
         builder.append(" format("_s, serializeString(m_format), ')');
     if (!m_technologies.isEmpty()) {

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -50,7 +50,7 @@ public:
     SVGFontFaceElement* svgFontFaceElement() const;
     void setSVGFontFaceElement(SVGFontFaceElement&);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSFontFaceSrcLocalValue&) const;
 
 private:
@@ -108,16 +108,13 @@ inline ASCIILiteral cssTextFromFontTech(FontTechnology tech)
 
 class CSSFontFaceSrcResourceValue final : public CSSValue {
 public:
-
     static Ref<CSSFontFaceSrcResourceValue> create(ResolvedURL, String format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource = LoadedFromOpaqueSource::No);
 
     bool isEmpty() const { return m_location.specifiedURLString.isEmpty(); }
     std::unique_ptr<FontLoadRequest> fontLoadRequest(ScriptExecutionContext&, bool isInitiatingElementInUserAgentShadowTree);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&) const;
-    void customSetReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>&);
-    void customClearReplacementURLForSubresources();
     bool customMayDependOnBaseURL() const;
     bool equals(const CSSFontFaceSrcResourceValue&) const;
 
@@ -129,8 +126,6 @@ private:
     Vector<FontTechnology> m_technologies;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     CachedResourceHandle<CachedFont> m_cachedFont;
-    String m_replacementURLString;
-    bool m_shouldUseResolvedURLInCSSText { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSFontFeatureValue.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValue.cpp
@@ -39,13 +39,13 @@ CSSFontFeatureValue::CSSFontFeatureValue(FontTag&& tag, Ref<CSSPrimitiveValue>&&
 {
 }
 
-String CSSFontFeatureValue::customCSSText() const
+String CSSFontFeatureValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder builder;
     builder.append('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], '"');
     // Omit the value if it's `1` as `1` is implied by default.
     if (m_value->resolveAsIntegerIfNotCalculated() != 1)
-        builder.append(' ', m_value->customCSSText());
+        builder.append(' ', m_value->customCSSText(context));
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSFontFeatureValue.h
+++ b/Source/WebCore/css/CSSFontFeatureValue.h
@@ -41,7 +41,7 @@ public:
     const FontTag& tag() const { return m_tag; }
     const CSSPrimitiveValue& value() const { return m_value; }
     Ref<CSSPrimitiveValue> protectedValue() const { return m_value; }
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSFontFeatureValue&) const;
 

--- a/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.cpp
+++ b/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.cpp
@@ -30,9 +30,9 @@
 
 namespace WebCore {
 
-String CSSFontPaletteValuesOverrideColorsValue::customCSSText() const
+String CSSFontPaletteValuesOverrideColorsValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return makeString(m_key->cssText(), ' ', m_color->cssText());
+    return makeString(m_key->cssText(context), ' ', m_color->cssText(context));
 }
 
 bool CSSFontPaletteValuesOverrideColorsValue::equals(const CSSFontPaletteValuesOverrideColorsValue& other) const

--- a/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h
@@ -49,7 +49,7 @@ public:
     const CSSPrimitiveValue& key() const { return m_key; }
     const CSSValue& color() const { return m_color; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSFontPaletteValuesOverrideColorsValue&) const;
 

--- a/Source/WebCore/css/CSSFontStyleRangeValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.cpp
@@ -30,15 +30,15 @@
 
 namespace WebCore {
 
-String CSSFontStyleRangeValue::customCSSText() const
+String CSSFontStyleRangeValue::customCSSText(const CSS::SerializationContext& context) const
 {
     if (!obliqueValues)
-        return fontStyleValue->cssText();
+        return fontStyleValue->cssText(context);
 
     StringBuilder builder;
-    builder.append(fontStyleValue->cssText());
+    builder.append(fontStyleValue->cssText(context));
     builder.append(' ');
-    builder.append(obliqueValues->cssText());
+    builder.append(obliqueValues->cssText(context));
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSFontStyleRangeValue.h
+++ b/Source/WebCore/css/CSSFontStyleRangeValue.h
@@ -42,7 +42,7 @@ public:
         return adoptRef(*new CSSFontStyleRangeValue(WTFMove(fontStyleValue), WTFMove(obliqueValues)));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSFontStyleRangeValue&) const;
 

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.cpp
@@ -43,11 +43,11 @@ Ref<CSSFontStyleWithAngleValue> CSSFontStyleWithAngleValue::create(ObliqueAngle&
     return adoptRef(*new CSSFontStyleWithAngleValue(WTFMove(obliqueAngle)));
 }
 
-String CSSFontStyleWithAngleValue::customCSSText() const
+String CSSFontStyleWithAngleValue::customCSSText(const CSS::SerializationContext& context) const
 {
     if (m_obliqueAngle.isKnownZero())
         return nameLiteralForSerialization(CSSValueNormal);
-    return makeString(nameLiteralForSerialization(CSSValueOblique), ' ', CSS::serializationForCSS(m_obliqueAngle));
+    return makeString(nameLiteralForSerialization(CSSValueOblique), ' ', CSS::serializationForCSS(context, m_obliqueAngle));
 }
 
 bool CSSFontStyleWithAngleValue::equals(const CSSFontStyleWithAngleValue& other) const

--- a/Source/WebCore/css/CSSFontStyleWithAngleValue.h
+++ b/Source/WebCore/css/CSSFontStyleWithAngleValue.h
@@ -39,7 +39,7 @@ public:
 
     const ObliqueAngle& obliqueAngle() const { return m_obliqueAngle; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSFontStyleWithAngleValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSFontValue.cpp
+++ b/Source/WebCore/css/CSSFontValue.cpp
@@ -28,24 +28,24 @@
 
 namespace WebCore {
 
-String CSSFontValue::customCSSText() const
+String CSSFontValue::customCSSText(const CSS::SerializationContext& context) const
 {
     // font variant weight size / line-height family
     StringBuilder result;
     if (style)
-        result.append(style->cssText());
+        result.append(style->cssText(context));
     if (variant)
-        result.append(result.isEmpty() ? ""_s : " "_s, variant->cssText());
+        result.append(result.isEmpty() ? ""_s : " "_s, variant->cssText(context));
     if (weight)
-        result.append(result.isEmpty() ? ""_s : " "_s, weight->cssText());
+        result.append(result.isEmpty() ? ""_s : " "_s, weight->cssText(context));
     if (width)
-        result.append(result.isEmpty() ? ""_s : " "_s, width->cssText());
+        result.append(result.isEmpty() ? ""_s : " "_s, width->cssText(context));
     if (size)
-        result.append(result.isEmpty() ? ""_s : " "_s, size->cssText());
+        result.append(result.isEmpty() ? ""_s : " "_s, size->cssText(context));
     if (lineHeight)
-        result.append(size ? " / "_s : result.isEmpty() ? ""_s : " "_s, lineHeight->cssText());
+        result.append(size ? " / "_s : result.isEmpty() ? ""_s : " "_s, lineHeight->cssText(context));
     if (family)
-        result.append(result.isEmpty() ? ""_s : " "_s, family->cssText());
+        result.append(result.isEmpty() ? ""_s : " "_s, family->cssText(context));
     return result.toString();
 }
 

--- a/Source/WebCore/css/CSSFontValue.h
+++ b/Source/WebCore/css/CSSFontValue.h
@@ -35,7 +35,7 @@ public:
         return adoptRef(*new CSSFontValue);
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSFontValue&) const;
 

--- a/Source/WebCore/css/CSSFontVariantAlternatesValue.cpp
+++ b/Source/WebCore/css/CSSFontVariantAlternatesValue.cpp
@@ -36,7 +36,7 @@ CSSFontVariantAlternatesValue::CSSFontVariantAlternatesValue(FontVariantAlternat
 {
 }
 
-String CSSFontVariantAlternatesValue::customCSSText() const
+String CSSFontVariantAlternatesValue::customCSSText(const CSS::SerializationContext&) const
 {
     TextStream ts;
     // For the moment, the stream operator implements the CSS serialization exactly.

--- a/Source/WebCore/css/CSSFontVariantAlternatesValue.h
+++ b/Source/WebCore/css/CSSFontVariantAlternatesValue.h
@@ -39,7 +39,7 @@ public:
     }
 
     const FontVariantAlternates& value() const { return m_value; }
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSFontVariantAlternatesValue&) const;
 

--- a/Source/WebCore/css/CSSFontVariationValue.cpp
+++ b/Source/WebCore/css/CSSFontVariationValue.cpp
@@ -39,9 +39,9 @@ CSSFontVariationValue::CSSFontVariationValue(FontTag tag, Ref<CSSPrimitiveValue>
 {
 }
 
-String CSSFontVariationValue::customCSSText() const
+String CSSFontVariationValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return makeString('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, m_value->customCSSText());
+    return makeString('"', m_tag[0], m_tag[1], m_tag[2], m_tag[3], "\" "_s, m_value->customCSSText(context));
 }
 
 bool CSSFontVariationValue::equals(const CSSFontVariationValue& other) const

--- a/Source/WebCore/css/CSSFontVariationValue.h
+++ b/Source/WebCore/css/CSSFontVariationValue.h
@@ -40,7 +40,7 @@ public:
 
     const FontTag& tag() const { return m_tag; }
     const CSSPrimitiveValue& value() const { return m_value; }
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSFontVariationValue&) const;
 

--- a/Source/WebCore/css/CSSFunctionValue.cpp
+++ b/Source/WebCore/css/CSSFunctionValue.cpp
@@ -99,11 +99,11 @@ Ref<CSSFunctionValue> CSSFunctionValue::create(CSSValueID name, Ref<CSSValue> ar
     return adoptRef(*new CSSFunctionValue(name, WTFMove(argument1), WTFMove(argument2), WTFMove(argument3), WTFMove(argument4)));
 }
 
-String CSSFunctionValue::customCSSText() const
+String CSSFunctionValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder result;
     result.append(nameLiteral(m_name), '(');
-    serializeItems(result);
+    serializeItems(result, context);
     result.append(')');
     return result.toString();
 }

--- a/Source/WebCore/css/CSSFunctionValue.h
+++ b/Source/WebCore/css/CSSFunctionValue.h
@@ -42,7 +42,7 @@ public:
 
     CSSValueID name() const { return m_name; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSFunctionValue& other) const { return m_name == other.m_name && itemsEqual(other); }
 
 private:

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -104,9 +104,9 @@ RefPtr<StyleImage> CSSGradientValue::createStyleImage(const Style::BuilderState&
     return styleImage;
 }
 
-String CSSGradientValue::customCSSText() const
+String CSSGradientValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_gradient);
+    return CSS::serializationForCSS(context, m_gradient);
 }
 
 bool CSSGradientValue::equals(const CSSGradientValue& other) const

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -41,7 +41,7 @@ public:
         return adoptRef(*new CSSGradientValue(WTFMove(gradient)));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGradientValue&) const;
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.cpp
@@ -53,11 +53,11 @@ CSSValueID CSSGridAutoRepeatValue::autoRepeatID() const
     return m_isAutoFit ? CSSValueAutoFit : CSSValueAutoFill;
 }
 
-String CSSGridAutoRepeatValue::customCSSText() const
+String CSSGridAutoRepeatValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder result;
     result.append("repeat("_s, nameLiteral(autoRepeatID()), ", "_s);
-    serializeItems(result);
+    serializeItems(result, context);
     result.append(')');
     return result.toString();
 }

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.h
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.h
@@ -51,7 +51,7 @@ public:
 
     CSSValueID autoRepeatID() const;
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridAutoRepeatValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.cpp
@@ -46,11 +46,11 @@ Ref<CSSGridIntegerRepeatValue> CSSGridIntegerRepeatValue::create(Ref<CSSPrimitiv
     return adoptRef(*new CSSGridIntegerRepeatValue(WTFMove(repetitions), WTFMove(builder)));
 }
 
-String CSSGridIntegerRepeatValue::customCSSText() const
+String CSSGridIntegerRepeatValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder result;
-    result.append("repeat("_s, m_repetitions->cssText(), ", "_s);
-    serializeItems(result);
+    result.append("repeat("_s, m_repetitions->cssText(context), ", "_s);
+    serializeItems(result, context);
     result.append(')');
     return result.toString();
 }

--- a/Source/WebCore/css/CSSGridIntegerRepeatValue.h
+++ b/Source/WebCore/css/CSSGridIntegerRepeatValue.h
@@ -49,7 +49,7 @@ public:
 
     const CSSPrimitiveValue& repetitions() const { return m_repetitions; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridIntegerRepeatValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSGridLineNamesValue.cpp
+++ b/Source/WebCore/css/CSSGridLineNamesValue.cpp
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-String CSSGridLineNamesValue::customCSSText() const
+String CSSGridLineNamesValue::customCSSText(const CSS::SerializationContext&) const
 {
     StringBuilder result;
     result.append('[');

--- a/Source/WebCore/css/CSSGridLineNamesValue.h
+++ b/Source/WebCore/css/CSSGridLineNamesValue.h
@@ -42,7 +42,7 @@ public:
 
     std::span<const String> names() const { return m_names; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridLineNamesValue& other) const { return m_names == other.m_names; }
 
 private:

--- a/Source/WebCore/css/CSSGridLineValue.cpp
+++ b/Source/WebCore/css/CSSGridLineValue.cpp
@@ -32,19 +32,19 @@
 
 namespace WebCore {
 
-String CSSGridLineValue::customCSSText() const
+String CSSGridLineValue::customCSSText(const CSS::SerializationContext& context) const
 {
     Vector<String> parts;
     if (m_spanValue)
-        parts.append(m_spanValue->cssText());
+        parts.append(m_spanValue->cssText(context));
     // Only return the numeric value if not 1, or if it provided without a span value.
     // https://drafts.csswg.org/css-grid-2/#grid-placement-span-int
     if (m_numericValue) {
         if (m_numericValue->isOne() != true || !m_spanValue || !m_gridLineName)
-            parts.append(m_numericValue->cssText());
+            parts.append(m_numericValue->cssText(context));
     }
     if (m_gridLineName)
-        parts.append(m_gridLineName->cssText());
+        parts.append(m_gridLineName->cssText(context));
     return makeStringByJoining(parts, " "_s);
 }
 

--- a/Source/WebCore/css/CSSGridLineValue.h
+++ b/Source/WebCore/css/CSSGridLineValue.h
@@ -34,7 +34,7 @@ class CSSGridLineValue final : public CSSValue {
 public:
     static Ref<CSSGridLineValue> create(RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridLineValue& other) const;
 
     CSSPrimitiveValue* spanValue() const { return m_spanValue.get(); }

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
@@ -95,7 +95,7 @@ String CSSGridTemplateAreasValue::stringForRow(size_t row) const
     return builder.toString();
 }
 
-String CSSGridTemplateAreasValue::customCSSText() const
+String CSSGridTemplateAreasValue::customCSSText(const CSS::SerializationContext&) const
 {
     StringBuilder builder;
     for (size_t row = 0; row < m_rowCount; ++row) {

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.h
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.h
@@ -40,7 +40,7 @@ class CSSGridTemplateAreasValue final : public CSSValue {
 public:
     static Ref<CSSGridTemplateAreasValue> create(NamedGridAreaMap, size_t rowCount, size_t columnCount);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     const NamedGridAreaMap& gridAreaMap() const { return m_map; }
     size_t rowCount() const { return m_rowCount; }

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -147,19 +147,19 @@ void CSSGroupingRule::cssTextForRules(StringBuilder& rules) const
     }
 }
 
-void CSSGroupingRule::appendCSSTextWithReplacementURLsForItems(StringBuilder& builder, const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+void CSSGroupingRule::appendCSSTextWithReplacementURLsForItems(StringBuilder& builder, const CSS::SerializationContext& context) const
 {
     StringBuilder rules;
-    cssTextForRulesWithReplacementURLs(rules, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+    cssTextForRulesWithReplacementURLs(rules, context);
     appendCSSTextForItemsInternal(builder, rules);
 }
 
-void CSSGroupingRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+void CSSGroupingRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const CSS::SerializationContext& context) const
 {
     auto& childRules = m_groupRule->childRules();
     for (unsigned index = 0; index < childRules.size(); index++) {
         auto wrappedRule = item(index);
-        rules.append("\n  "_s, wrappedRule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
+        rules.append("\n  "_s, wrappedRule->cssText(context));
     }
 }
 

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -47,14 +47,14 @@ protected:
     StyleRuleGroup& groupRule() { return m_groupRule; }
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
-    void appendCSSTextWithReplacementURLsForItems(StringBuilder&, const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const;
+    void appendCSSTextWithReplacementURLsForItems(StringBuilder&, const CSS::SerializationContext&) const;
     RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&) override;
 
 private:
     bool isGroupingRule() const final { return true; }
     void appendCSSTextForItemsInternal(StringBuilder&, StringBuilder&) const;
     void cssTextForRules(StringBuilder&) const;
-    void cssTextForRulesWithReplacementURLs(StringBuilder&, const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const;
+    void cssTextForRulesWithReplacementURLs(StringBuilder&, const CSS::SerializationContext&) const;
 
     Ref<StyleRuleGroup> m_groupRule;
     mutable Vector<RefPtr<CSSRule>> m_childRuleCSSOMWrappers;

--- a/Source/WebCore/css/CSSImageSetOptionValue.cpp
+++ b/Source/WebCore/css/CSSImageSetOptionValue.cpp
@@ -77,11 +77,11 @@ bool CSSImageSetOptionValue::equals(const CSSImageSetOptionValue& other) const
     return true;
 }
 
-String CSSImageSetOptionValue::customCSSText() const
+String CSSImageSetOptionValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder result;
-    result.append(m_image->cssText());
-    result.append(' ', m_resolution->cssText());
+    result.append(m_image->cssText(context));
+    result.append(' ', m_resolution->cssText(context));
     if (!m_mimeType.isNull())
         result.append(" type(\""_s, m_mimeType, "\")"_s);
 
@@ -101,18 +101,6 @@ void CSSImageSetOptionValue::setType(String type)
 bool CSSImageSetOptionValue::customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const
 {
     return m_resolution->traverseSubresources(handler) || m_image->traverseSubresources(handler);
-}
-
-void CSSImageSetOptionValue::customSetReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>& replacementURLStrings)
-{
-    m_image->setReplacementURLForSubresources(replacementURLStrings);
-    m_resolution->setReplacementURLForSubresources(replacementURLStrings);
-}
-
-void CSSImageSetOptionValue::customClearReplacementURLForSubresources()
-{
-    m_image->clearReplacementURLForSubresources();
-    m_resolution->clearReplacementURLForSubresources();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -39,7 +39,7 @@ public:
     static Ref<CSSImageSetOptionValue> create(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&, String);
 
     bool equals(const CSSImageSetOptionValue&) const;
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     Ref<CSSValue> image() const { return m_image; }
 
@@ -58,8 +58,6 @@ public:
         return IterationStatus::Continue;
     }
     bool customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&) const;
-    void customSetReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>&);
-    void customClearReplacementURLForSubresources();
 
 private:
     CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -46,7 +46,7 @@ CSSImageSetValue::CSSImageSetValue(CSSValueListBuilder builder)
 {
 }
 
-String CSSImageSetValue::customCSSText() const
+String CSSImageSetValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder result;
     result.append("image-set("_s);
@@ -54,7 +54,7 @@ String CSSImageSetValue::customCSSText() const
         if (i > 0)
             result.append(", "_s);
         ASSERT(is<CSSImageSetOptionValue>(item(i)));
-        result.append(item(i)->cssText());
+        result.append(item(i)->cssText(context));
     }
     result.append(')');
     return result.toString();

--- a/Source/WebCore/css/CSSImageSetValue.h
+++ b/Source/WebCore/css/CSSImageSetValue.h
@@ -39,7 +39,7 @@ class CSSImageSetValue final : public CSSValueContainingVector {
 public:
     static Ref<CSSImageSetValue> create(CSSValueListBuilder);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSImageSetValue& other) const { return itemsEqual(other); }
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -56,7 +56,7 @@ public:
 
     URL reresolvedURL(const Document&) const;
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     Ref<DeprecatedCSSOMValue> createDeprecatedCSSOMWrapper(CSSStyleDeclaration&) const;
 
@@ -92,8 +92,6 @@ private:
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     RefPtr<CSSImageValue> m_unresolvedValue;
     bool m_isInvalid { false };
-    String m_replacementURLString;
-    bool m_shouldUseResolvedURLInCSSText { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -103,16 +103,16 @@ String CSSImportRule::cssText() const
     return cssTextInternal(m_importRule->href());
 }
 
-String CSSImportRule::cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+String CSSImportRule::cssText(const CSS::SerializationContext& context) const
 {
     if (RefPtr sheet = styleSheet()) {
-        auto urlString = replacementURLStringsForCSSStyleSheet.get(sheet);
+        auto urlString = context.replacementURLStringsForCSSStyleSheet.get(*sheet);
         if (!urlString.isEmpty())
             return cssTextInternal(urlString);
     }
 
     auto urlString = m_importRule->href();
-    auto replacementURLString = replacementURLStrings.get(urlString);
+    auto replacementURLString = context.replacementURLStrings.get(urlString);
     return replacementURLString.isEmpty() ? cssTextInternal(urlString) : cssTextInternal(replacementURLString);
 }
 

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -53,7 +53,7 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Import; }
     String cssText() const final;
-    String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    String cssText(const CSS::SerializationContext&) const final;
     void reattach(StyleRuleBase&) final;
     void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) final;
 

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSKeyframesRule.h"
 #include "CSSParser.h"
+#include "CSSSerializationContext.h"
 #include "MutableStyleProperties.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "StyleProperties.h"
@@ -117,7 +118,7 @@ bool StyleRuleKeyframe::setKeyText(const String& keyText)
 
 String StyleRuleKeyframe::cssText() const
 {
-    if (auto declarations = m_properties->asText(); !declarations.isEmpty())
+    if (auto declarations = m_properties->asText(CSS::defaultSerializationContext()); !declarations.isEmpty())
         return makeString(keyText(), " { "_s, declarations, " }"_s);
     return makeString(keyText(), " { }"_s);
 }

--- a/Source/WebCore/css/CSSLineBoxContainValue.cpp
+++ b/Source/WebCore/css/CSSLineBoxContainValue.cpp
@@ -36,7 +36,7 @@ CSSLineBoxContainValue::CSSLineBoxContainValue(OptionSet<LineBoxContain> value)
 {
 }
 
-String CSSLineBoxContainValue::customCSSText() const
+String CSSLineBoxContainValue::customCSSText(const CSS::SerializationContext&) const
 {
     StringBuilder text;
     if (m_value.contains(LineBoxContain::Block))

--- a/Source/WebCore/css/CSSLineBoxContainValue.h
+++ b/Source/WebCore/css/CSSLineBoxContainValue.h
@@ -51,7 +51,7 @@ public:
         return adoptRef(*new CSSLineBoxContainValue(value));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSLineBoxContainValue& other) const { return m_value == other.m_value; }
     OptionSet<LineBoxContain> value() const { return m_value; }
 

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -60,11 +60,11 @@ String CSSMediaRule::cssText() const
     return builder.toString();
 }
 
-String CSSMediaRule::cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+String CSSMediaRule::cssText(const CSS::SerializationContext& context) const
 {
     StringBuilder builder;
     builder.append("@media "_s, conditionText());
-    appendCSSTextWithReplacementURLsForItems(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+    appendCSSTextWithReplacementURLsForItems(builder, context);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -48,7 +48,7 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Media; }
     String cssText() const final;
-    String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    String cssText(const CSS::SerializationContext&) const final;
     String conditionText() const final;
 
     const MQ::MediaQueryList& mediaQueries() const;

--- a/Source/WebCore/css/CSSNamedImageValue.cpp
+++ b/Source/WebCore/css/CSSNamedImageValue.cpp
@@ -39,7 +39,7 @@ CSSNamedImageValue::CSSNamedImageValue(String&& name)
 
 CSSNamedImageValue::~CSSNamedImageValue() = default;
 
-String CSSNamedImageValue::customCSSText() const
+String CSSNamedImageValue::customCSSText(const CSS::SerializationContext&) const
 {
     return makeString("-webkit-named-image("_s, m_name, ')');
 }

--- a/Source/WebCore/css/CSSNamedImageValue.h
+++ b/Source/WebCore/css/CSSNamedImageValue.h
@@ -44,7 +44,7 @@ public:
     }
     ~CSSNamedImageValue();
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSNamedImageValue&) const;
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;

--- a/Source/WebCore/css/CSSNestedDeclarations.cpp
+++ b/Source/WebCore/css/CSSNestedDeclarations.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "CSSNestedDeclarations.h"
 
+#include "CSSSerializationContext.h"
 #include "DeclaredStylePropertyMap.h"
 #include "MutableStyleProperties.h"
 #include "PropertySetCSSStyleDeclaration.h"
@@ -47,7 +48,7 @@ CSSStyleDeclaration& CSSNestedDeclarations::style()
 
 String CSSNestedDeclarations::cssText() const
 {
-    return m_styleRule->properties().asText();
+    return m_styleRule->properties().asText(CSS::defaultSerializationContext());
 }
 
 void CSSNestedDeclarations::reattach(StyleRuleBase& rule)

--- a/Source/WebCore/css/CSSOffsetRotateValue.cpp
+++ b/Source/WebCore/css/CSSOffsetRotateValue.cpp
@@ -30,18 +30,18 @@
 
 namespace WebCore {
 
-String CSSOffsetRotateValue::customCSSText() const
+String CSSOffsetRotateValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder builder;
 
     if (m_modifier)
-        builder.append(m_modifier->cssText());
+        builder.append(m_modifier->cssText(context));
 
     if (m_angle) {
         if (!builder.isEmpty())
             builder.append(' ');
 
-        builder.append(m_angle->cssText());
+        builder.append(m_angle->cssText(context));
     }
 
     return builder.toString();

--- a/Source/WebCore/css/CSSOffsetRotateValue.h
+++ b/Source/WebCore/css/CSSOffsetRotateValue.h
@@ -37,7 +37,7 @@ public:
         return adoptRef(*new CSSOffsetRotateValue(WTFMove(modifier), WTFMove(angle)));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     CSSPrimitiveValue* modifier() const { return m_modifier.get(); }
     CSSPrimitiveValue* angle() const { return m_angle.get(); }

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -24,6 +24,7 @@
 
 #include "CSSParser.h"
 #include "CSSSelector.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
 #include "CommonAtomStrings.h"
 #include "Document.h"
@@ -79,7 +80,7 @@ String CSSPageRule::cssText() const
 {
     auto selector = selectorText();
     auto optionalSpace = selector.isEmpty() ? ""_s : " "_s;
-    if (auto declarations = m_pageRule->properties().asText(); !declarations.isEmpty())
+    if (auto declarations = m_pageRule->properties().asText(CSS::defaultSerializationContext()); !declarations.isEmpty())
         return makeString("@page"_s, optionalSpace, selector, " { "_s, declarations, " }"_s);
     return makeString("@page"_s, optionalSpace, selector, " { }"_s);
 }

--- a/Source/WebCore/css/CSSPaintImageValue.cpp
+++ b/Source/WebCore/css/CSSPaintImageValue.cpp
@@ -43,7 +43,7 @@ CSSPaintImageValue::CSSPaintImageValue(String&& name, Ref<CSSVariableData>&& arg
 
 CSSPaintImageValue::~CSSPaintImageValue() = default;
 
-String CSSPaintImageValue::customCSSText() const
+String CSSPaintImageValue::customCSSText(const CSS::SerializationContext&) const
 {
     // FIXME: This should include the arguments too.
     return makeString("paint("_s, m_name, ')');

--- a/Source/WebCore/css/CSSPaintImageValue.h
+++ b/Source/WebCore/css/CSSPaintImageValue.h
@@ -49,7 +49,7 @@ public:
     const String& name() const { return m_name; }
 
     bool equals(const CSSPaintImageValue& other) const { return m_name == other.m_name; }
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     RefPtr<StyleImage> createStyleImage(const Style::BuilderState&) const;
 

--- a/Source/WebCore/css/CSSPathValue.cpp
+++ b/Source/WebCore/css/CSSPathValue.cpp
@@ -38,9 +38,9 @@
 
 namespace WebCore {
 
-String CSSPathValue::customCSSText() const
+String CSSPathValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_path);
+    return CSS::serializationForCSS(context, m_path);
 }
 
 bool CSSPathValue::equals(const CSSPathValue& other) const

--- a/Source/WebCore/css/CSSPathValue.h
+++ b/Source/WebCore/css/CSSPathValue.h
@@ -46,7 +46,7 @@ public:
 
     const CSS::PathFunction& path() const { return m_path; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSPathValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -47,7 +47,7 @@ public:
     CSSPropertyID shorthandPropertyId() const { return m_shorthandPropertyId; }
 
     bool equals(const CSSPendingSubstitutionValue& other) const { return m_shorthandValue.ptr() == other.m_shorthandValue.ptr(); }
-    static String customCSSText() { return emptyString(); }
+    static String customCSSText(const CSS::SerializationContext&) { return emptyString(); }
 
     RefPtr<CSSValue> resolveValue(Style::BuilderState&, CSSPropertyID) const;
 

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSPositionTryRule.h"
 
+#include "CSSSerializationContext.h"
 #include "PropertySetCSSStyleDeclaration.h"
 
 namespace WebCore {
@@ -73,7 +74,7 @@ String CSSPositionTryRule::cssText() const
 
     auto propertiesRef = m_positionTryRule->protectedProperties();
 
-    if (auto declarations = propertiesRef->asText(); !declarations.isEmpty())
+    if (auto declarations = propertiesRef->asText(CSS::defaultSerializationContext()); !declarations.isEmpty())
         builder.append(' ', declarations, ' ');
     else
         builder.append(' ');

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -29,6 +29,7 @@
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPrimitiveValueMappings.h"
 #include "CSSPropertyNames.h"
+#include "CSSSerializationContext.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSValueKeywords.h"
 #include "CSSValuePool.h"
@@ -901,7 +902,7 @@ String CSSPrimitiveValue::stringValue() const
     case CSSUnitType::CSS_PROPERTY_ID:
         return nameString(m_value.propertyID);
     case CSSUnitType::CSS_ATTR:
-        return m_value.attr->cssText();
+        return m_value.attr->cssText(CSS::defaultSerializationContext());
     default:
         return String();
     }
@@ -1008,7 +1009,7 @@ ASCIILiteral CSSPrimitiveValue::unitTypeString(CSSUnitType unitType)
     return ""_s;
 }
 
-ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
+ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal(const CSS::SerializationContext& context) const
 {
     auto type = primitiveUnitType();
     switch (type) {
@@ -1078,9 +1079,9 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
     case CSSUnitType::CSS_X:
         return formatNumberValue(unitTypeString(type));
     case CSSUnitType::CSS_ATTR:
-        return m_value.attr->cssText();
+        return m_value.attr->cssText(context);
     case CSSUnitType::CSS_CALC:
-        return m_value.calc->cssText();
+        return m_value.calc->cssText(context);
     case CSSUnitType::CSS_DIMENSION:
         // FIXME: This isn't correct.
         return formatNumberValue(""_s);
@@ -1112,7 +1113,7 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal() const
     return String();
 }
 
-String CSSPrimitiveValue::customCSSText() const
+String CSSPrimitiveValue::customCSSText(const CSS::SerializationContext& context) const
 {
     switch (primitiveUnitType()) {
     case CSSUnitType::CSS_UNKNOWN:
@@ -1126,7 +1127,7 @@ String CSSPrimitiveValue::customCSSText() const
         ASSERT(map.contains(this) == m_hasCachedCSSText);
         if (m_hasCachedCSSText)
             return map.get(this);
-        String serializedValue = serializeInternal();
+        String serializedValue = serializeInternal(context);
         m_hasCachedCSSText = true;
         map.add(this, serializedValue);
         return serializedValue;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -204,7 +204,7 @@ public:
     const CSSCalcValue* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
     const CSSAttrValue* cssAttrValue() const { return isAttr() ? m_value.attr : nullptr; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSPrimitiveValue&) const;
 
@@ -265,7 +265,7 @@ private:
 
     bool addDerivedHash(Hasher&) const;
 
-    ALWAYS_INLINE String serializeInternal() const;
+    ALWAYS_INLINE String serializeInternal(const CSS::SerializationContext&) const;
     NEVER_INLINE String formatNumberValue(ASCIILiteral suffix) const;
     NEVER_INLINE String formatIntegerValue(ASCIILiteral suffix) const;
     static constexpr bool isFontIndependentLength(CSSUnitType);

--- a/Source/WebCore/css/CSSQuadValue.cpp
+++ b/Source/WebCore/css/CSSQuadValue.cpp
@@ -41,9 +41,9 @@ Ref<CSSQuadValue> CSSQuadValue::create(Quad quad)
     return adoptRef(*new CSSQuadValue(WTFMove(quad)));
 }
 
-String CSSQuadValue::customCSSText() const
+String CSSQuadValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return m_quad.cssText();
+    return m_quad.cssText(context);
 }
 
 bool CSSQuadValue::equals(const CSSQuadValue& other) const

--- a/Source/WebCore/css/CSSQuadValue.h
+++ b/Source/WebCore/css/CSSQuadValue.h
@@ -35,7 +35,7 @@ public:
 
     const Quad& quad() const { return m_quad; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSQuadValue&) const;
     bool canBeCoalesced() const;
 

--- a/Source/WebCore/css/CSSRayValue.cpp
+++ b/Source/WebCore/css/CSSRayValue.cpp
@@ -37,10 +37,10 @@
 
 namespace WebCore {
 
-String CSSRayValue::customCSSText() const
+String CSSRayValue::customCSSText(const CSS::SerializationContext& context) const
 {
     StringBuilder builder;
-    CSS::serializationForCSS(builder, m_ray);
+    CSS::serializationForCSS(builder, context, m_ray);
 
     if (m_coordinateBox != CSSBoxType::BoxMissing)
         builder.append(' ', nameLiteralForSerialization(toCSSValueID(m_coordinateBox)));

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -47,7 +47,7 @@ public:
     const CSS::RayFunction& ray() const { return m_ray; }
     CSSBoxType coordinateBox() const { return m_coordinateBox; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSRayValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSRectValue.cpp
+++ b/Source/WebCore/css/CSSRectValue.cpp
@@ -39,9 +39,9 @@ Ref<CSSRectValue> CSSRectValue::create(Rect rect)
     return adoptRef(*new CSSRectValue(WTFMove(rect)));
 }
 
-String CSSRectValue::customCSSText() const
+String CSSRectValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return m_rect.cssText();
+    return m_rect.cssText(context);
 }
 
 bool CSSRectValue::equals(const CSSRectValue& other) const

--- a/Source/WebCore/css/CSSRectValue.h
+++ b/Source/WebCore/css/CSSRectValue.h
@@ -35,7 +35,7 @@ public:
 
     const Rect& rect() const { return m_rect; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSRectValue&) const;
 
 private:

--- a/Source/WebCore/css/CSSReflectValue.cpp
+++ b/Source/WebCore/css/CSSReflectValue.cpp
@@ -43,11 +43,11 @@ Ref<CSSReflectValue> CSSReflectValue::create(CSSValueID direction, Ref<CSSPrimit
     return adoptRef(*new CSSReflectValue(direction, WTFMove(offset), WTFMove(mask)));
 }
 
-String CSSReflectValue::customCSSText() const
+String CSSReflectValue::customCSSText(const CSS::SerializationContext& context) const
 {
     if (m_mask)
-        return makeString(nameLiteral(m_direction), ' ', m_offset->cssText(), ' ', m_mask->cssText());
-    return makeString(nameLiteral(m_direction), ' ', m_offset->cssText());
+        return makeString(nameLiteral(m_direction), ' ', m_offset->cssText(context), ' ', m_mask->cssText(context));
+    return makeString(nameLiteral(m_direction), ' ', m_offset->cssText(context));
 }
 
 bool CSSReflectValue::equals(const CSSReflectValue& other) const

--- a/Source/WebCore/css/CSSReflectValue.h
+++ b/Source/WebCore/css/CSSReflectValue.h
@@ -39,7 +39,7 @@ public:
     const CSSPrimitiveValue& offset() const { return m_offset.get(); }
     const CSSValue* mask() const { return m_mask.get(); }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSReflectValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -36,6 +36,10 @@ class StyleRuleWithNesting;
 
 struct CSSParserContext;
 
+namespace CSS {
+struct SerializationContext;
+}
+
 class CSSRule : public RefCounted<CSSRule> {
 public:
     virtual ~CSSRule() = default;
@@ -45,7 +49,7 @@ public:
     virtual StyleRuleType styleRuleType() const = 0;
     virtual bool isGroupingRule() const { return false; }
     virtual String cssText() const = 0;
-    virtual String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const { return cssText(); }
+    virtual String cssText(const CSS::SerializationContext&) const { return cssText(); }
     virtual void reattach(StyleRuleBase&) = 0;
 
     void setParentStyleSheet(CSSStyleSheet*);

--- a/Source/WebCore/css/CSSScrollValue.cpp
+++ b/Source/WebCore/css/CSSScrollValue.cpp
@@ -34,16 +34,16 @@
 
 namespace WebCore {
 
-String CSSScrollValue::customCSSText() const
+String CSSScrollValue::customCSSText(const CSS::SerializationContext& context) const
 {
     auto hasScroller = m_scroller && m_scroller->valueID() != CSSValueNearest;
     auto hasAxis = m_axis && m_axis->valueID() != CSSValueBlock;
 
     return makeString(
         "scroll("_s,
-        hasScroller ? m_scroller->cssText() : ""_s,
+        hasScroller ? m_scroller->cssText(context) : ""_s,
         hasScroller && hasAxis ? " "_s : ""_s,
-        hasAxis ? m_axis->cssText() : ""_s,
+        hasAxis ? m_axis->cssText(context) : ""_s,
         ")"_s
     );
 }

--- a/Source/WebCore/css/CSSScrollValue.h
+++ b/Source/WebCore/css/CSSScrollValue.h
@@ -47,7 +47,7 @@ public:
         return adoptRef(*new CSSScrollValue(WTFMove(scroller), WTFMove(axis)));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     const RefPtr<CSSValue>& scroller() const { return m_scroller; }
     const RefPtr<CSSValue>& axis() const { return m_axis; }

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -27,6 +27,7 @@
 #include "CSSParserEnum.h"
 #include "CSSParserImpl.h"
 #include "CSSRuleList.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
 #include "DeclaredStylePropertyMap.h"
 #include "MutableStyleProperties.h"
@@ -148,7 +149,7 @@ Vector<Ref<StyleRuleBase>> CSSStyleRule::nestedRules() const
 // https://w3c.github.io/csswg-drafts/cssom-1/#serialize-a-css-rule
 String CSSStyleRule::cssText() const
 {
-    auto declarationsString = m_styleRule->properties().asText();
+    auto declarationsString = m_styleRule->properties().asText(CSS::defaultSerializationContext());
     StringBuilder declarations;
     StringBuilder rules;
     declarations.append(declarationsString);
@@ -166,26 +167,23 @@ void CSSStyleRule::cssTextForRules(StringBuilder& rules) const
     }
 }
 
-String CSSStyleRule::cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+String CSSStyleRule::cssText(const CSS::SerializationContext& context) const
 {
     StringBuilder declarations;
     StringBuilder rules;
 
-    auto mutableStyleProperties = m_styleRule->properties().mutableCopy();
-    mutableStyleProperties->setReplacementURLForSubresources(replacementURLStrings);
-    auto declarationsString = mutableStyleProperties->asText();
-    mutableStyleProperties->clearReplacementURLForSubresources();
-
+    auto declarationsString = m_styleRule->properties().asText(context);
     declarations.append(declarationsString);
-    cssTextForRulesWithReplacementURLs(rules, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+
+    cssTextForRulesWithReplacementURLs(rules, context);
 
     return cssTextInternal(declarations, rules);
 }
 
-void CSSStyleRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+void CSSStyleRule::cssTextForRulesWithReplacementURLs(StringBuilder& rules, const CSS::SerializationContext& context) const
 {
     for (unsigned index = 0; index < length(); index++)
-        rules.append("\n  "_s, item(index)->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet));
+        rules.append("\n  "_s, item(index)->cssText(context));
 }
 
 String CSSStyleRule::cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -64,7 +64,7 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Style; }
     String cssText() const final;
-    String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    String cssText(const CSS::SerializationContext&) const final;
     String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
     void reattach(StyleRuleBase&) final;
     void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) final;
@@ -72,7 +72,7 @@ private:
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;
     void cssTextForRules(StringBuilder& rules) const;
-    void cssTextForRulesWithReplacementURLs(StringBuilder& rules, const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const;
+    void cssTextForRulesWithReplacementURLs(StringBuilder& rules, const CSS::SerializationContext&) const;
 
     Ref<StyleRule> m_styleRule;
     Ref<DeclaredStylePropertyMap> m_styleMap;

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -489,7 +489,7 @@ String CSSStyleSheet::debugDescription() const
     return makeString("CSSStyleSheet "_s, "0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase), ' ', href());
 }
 
-String CSSStyleSheet::cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet)
+String CSSStyleSheet::cssText(const CSS::SerializationContext& context)
 {
     auto ruleList = cssRulesSkippingAccessCheck();
     if (!ruleList)
@@ -501,7 +501,7 @@ String CSSStyleSheet::cssTextWithReplacementURLs(const UncheckedKeyHashMap<Strin
         if (!rule)
             continue;
 
-        auto ruleText = rule->cssTextWithReplacementURLs(replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+        auto ruleText = rule->cssText(context);
         if (!result.isEmpty() && !ruleText.isEmpty())
             result.append(' ');
 

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -159,7 +159,7 @@ public:
     bool canAccessRules() const;
 
     String debugDescription() const final;
-    String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&);
+    String cssText(const CSS::SerializationContext&);
     void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&);
 
     bool isDetached() const;

--- a/Source/WebCore/css/CSSSubgridValue.cpp
+++ b/Source/WebCore/css/CSSSubgridValue.cpp
@@ -35,13 +35,13 @@
 
 namespace WebCore {
 
-String CSSSubgridValue::customCSSText() const
+String CSSSubgridValue::customCSSText(const CSS::SerializationContext& context) const
 {
     if (!length())
         return "subgrid"_s;
     StringBuilder result;
     result.append("subgrid "_s);
-    serializeItems(result);
+    serializeItems(result, context);
     return result.toString();
 }
 

--- a/Source/WebCore/css/CSSSubgridValue.h
+++ b/Source/WebCore/css/CSSSubgridValue.h
@@ -38,7 +38,7 @@ class CSSSubgridValue final : public CSSValueContainingVector {
 public:
     static Ref<CSSSubgridValue> create(CSSValueListBuilder);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSSubgridValue& other) const { return itemsEqual(other); }
 
 private:

--- a/Source/WebCore/css/CSSSupportsRule.cpp
+++ b/Source/WebCore/css/CSSSupportsRule.cpp
@@ -56,11 +56,11 @@ String CSSSupportsRule::cssText() const
     return builder.toString();
 }
 
-String CSSSupportsRule::cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>& replacementURLStrings, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>& replacementURLStringsForCSSStyleSheet) const
+String CSSSupportsRule::cssText(const CSS::SerializationContext& context) const
 {
     StringBuilder builder;
     builder.append("@supports "_s, conditionText());
-    appendCSSTextWithReplacementURLsForItems(builder, replacementURLStrings, replacementURLStringsForCSSStyleSheet);
+    appendCSSTextWithReplacementURLsForItems(builder, context);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -41,7 +41,7 @@ public:
     static Ref<CSSSupportsRule> create(StyleRuleSupports&, CSSStyleSheet* parent);
 
     String cssText() const final;
-    String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const final;
+    String cssText(const CSS::SerializationContext&) const final;
     String conditionText() const final;
 
 private:

--- a/Source/WebCore/css/CSSTextShadowPropertyValue.cpp
+++ b/Source/WebCore/css/CSSTextShadowPropertyValue.cpp
@@ -46,9 +46,9 @@ CSSTextShadowPropertyValue::CSSTextShadowPropertyValue(CSS::TextShadowProperty&&
 {
 }
 
-String CSSTextShadowPropertyValue::customCSSText() const
+String CSSTextShadowPropertyValue::customCSSText(const CSS::SerializationContext& context) const
 {
-    return CSS::serializationForCSS(m_shadow);
+    return CSS::serializationForCSS(context, m_shadow);
 }
 
 bool CSSTextShadowPropertyValue::equals(const CSSTextShadowPropertyValue& other) const

--- a/Source/WebCore/css/CSSTextShadowPropertyValue.h
+++ b/Source/WebCore/css/CSSTextShadowPropertyValue.h
@@ -35,7 +35,7 @@ public:
 
     const CSS::TextShadowProperty& shadow() const { return m_shadow; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSTextShadowPropertyValue&) const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;

--- a/Source/WebCore/css/CSSTransformListValue.h
+++ b/Source/WebCore/css/CSSTransformListValue.h
@@ -40,7 +40,7 @@ public:
     static Ref<CSSTransformListValue> create(CSSValueListBuilder);
     static Ref<CSSTransformListValue> create(Ref<CSSValue>);
 
-    String customCSSText() const { return serializeItems(); }
+    String customCSSText(const CSS::SerializationContext& context) const { return serializeItems(context); }
     bool equals(const CSSTransformListValue& other) const { return itemsEqual(other); }
 
 private:

--- a/Source/WebCore/css/CSSUnicodeRangeValue.cpp
+++ b/Source/WebCore/css/CSSUnicodeRangeValue.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-String CSSUnicodeRangeValue::customCSSText() const
+String CSSUnicodeRangeValue::customCSSText(const CSS::SerializationContext&) const
 {
     if (m_from == m_to)
         return makeString("U+"_s, hex(m_from, Lowercase));

--- a/Source/WebCore/css/CSSUnicodeRangeValue.h
+++ b/Source/WebCore/css/CSSUnicodeRangeValue.h
@@ -40,7 +40,7 @@ public:
     char32_t from() const { return m_from; }
     char32_t to() const { return m_to; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     bool equals(const CSSUnicodeRangeValue&) const;
 

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -81,6 +81,7 @@
 #include "CSSRectValue.h"
 #include "CSSReflectValue.h"
 #include "CSSScrollValue.h"
+#include "CSSSerializationContext.h"
 #include "CSSSubgridValue.h"
 #include "CSSTextShadowPropertyValue.h"
 #include "CSSToLengthConversionData.h"
@@ -257,20 +258,6 @@ bool CSSValue::traverseSubresources(NOESCAPE const Function<bool(const CachedRes
     });
 }
 
-void CSSValue::setReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>& replacementURLStrings)
-{
-    return visitDerived([&](auto& value) {
-        return value.customSetReplacementURLForSubresources(replacementURLStrings);
-    });
-}
-
-void CSSValue::clearReplacementURLForSubresources()
-{
-    return visitDerived([&](auto& value) {
-        return value.customClearReplacementURLForSubresources();
-    });
-}
-
 IterationStatus CSSValue::visitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
 {
     return visitDerived([&](auto& value) {
@@ -349,10 +336,10 @@ bool CSSValue::isCSSLocalURL(StringView relativeURL)
     return relativeURL.isEmpty() || relativeURL.startsWith('#');
 }
 
-String CSSValue::cssText() const
+String CSSValue::cssText(const CSS::SerializationContext& context) const
 {
-    return visitDerived([](auto& value) {
-        return value.customCSSText();
+    return visitDerived([&](auto& value) {
+        return value.customCSSText(context);
     });
 }
 

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -47,6 +47,10 @@ struct Counter;
 enum CSSPropertyID : uint16_t;
 enum CSSValueID : uint16_t;
 
+namespace CSS {
+struct SerializationContext;
+}
+
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValue);
 class CSSValue {
     WTF_MAKE_NONCOPYABLE(CSSValue);
@@ -60,7 +64,7 @@ public:
     unsigned refCount() const { return m_refCount / refCountIncrement; }
     bool hasAtLeastOneRef() const { return m_refCount; }
 
-    WEBCORE_EXPORT String cssText() const;
+    WEBCORE_EXPORT String cssText(const CSS::SerializationContext&) const;
 
     bool isAppleColorFilterPropertyValue() const { return m_classType == ClassType::AppleColorFilterProperty; }
     bool isAttrValue() const { return m_classType == ClassType::Attr; }
@@ -138,8 +142,6 @@ public:
     // FIXME: These three traversing functions are buggy. It should be rewritten with visitChildren.
     // https://bugs.webkit.org/show_bug.cgi?id=270600
     bool traverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&) const;
-    void setReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>&);
-    void clearReplacementURLForSubresources();
 
     IterationStatus visitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -216,21 +216,21 @@ CSSValueListBuilder CSSValueContainingVector::copyValues() const
     });
 }
 
-void CSSValueContainingVector::serializeItems(StringBuilder& builder) const
+void CSSValueContainingVector::serializeItems(StringBuilder& builder, const CSS::SerializationContext& context) const
 {
-    builder.append(interleave(*this, [](auto& value) { return value.cssText(); }, separatorCSSText()));
+    builder.append(interleave(*this, [&](auto& value) { return value.cssText(context); }, separatorCSSText()));
 }
 
-String CSSValueContainingVector::serializeItems() const
+String CSSValueContainingVector::serializeItems(const CSS::SerializationContext& context) const
 {
     StringBuilder result;
-    serializeItems(result);
+    serializeItems(result, context);
     return result.toString();
 }
 
-String CSSValueList::customCSSText() const
+String CSSValueList::customCSSText(const CSS::SerializationContext& context) const
 {
-    return serializeItems();
+    return serializeItems(context);
 }
 
 bool CSSValueContainingVector::itemsEqual(const CSSValueContainingVector& other) const
@@ -273,18 +273,6 @@ bool CSSValueContainingVector::customTraverseSubresources(NOESCAPE const Functio
             return true;
     }
     return false;
-}
-
-void CSSValueContainingVector::customSetReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>& replacementURLStrings)
-{
-    for (auto& value : *this)
-        const_cast<CSSValue&>(value).setReplacementURLForSubresources(replacementURLStrings);
-}
-
-void CSSValueContainingVector::customClearReplacementURLForSubresources()
-{
-    for (auto& value : *this)
-        const_cast<CSSValue&>(value).clearReplacementURLForSubresources();
 }
 
 IterationStatus CSSValueContainingVector::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -57,8 +57,8 @@ public:
     bool hasValue(CSSValue&) const;
     bool hasValue(CSSValueID) const;
 
-    void serializeItems(StringBuilder&) const;
-    String serializeItems() const;
+    void serializeItems(StringBuilder&, const CSS::SerializationContext&) const;
+    String serializeItems(const CSS::SerializationContext&) const;
 
     bool itemsEqual(const CSSValueContainingVector&) const;
     bool containsSingleEqualItem(const CSSValue&) const;
@@ -67,8 +67,6 @@ public:
     using CSSValue::separatorCSSText;
 
     bool customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&) const;
-    void customSetReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>&);
-    void customClearReplacementURLForSubresources();
 
     CSSValueListBuilder copyValues() const;
 
@@ -117,7 +115,7 @@ public:
     static Ref<CSSValueList> createSlashSeparated(Ref<CSSValue>); // FIXME: Upgrade callers to not use a list at all.
     static Ref<CSSValueList> createSlashSeparated(Ref<CSSValue>, Ref<CSSValue>);
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSValueList&) const;
 
 private:

--- a/Source/WebCore/css/CSSValuePair.cpp
+++ b/Source/WebCore/css/CSSValuePair.cpp
@@ -61,10 +61,10 @@ bool CSSValuePair::canBeCoalesced() const
     return m_coalesceIdenticalValues && m_first->equals(m_second);
 }
 
-String CSSValuePair::customCSSText() const
+String CSSValuePair::customCSSText(const CSS::SerializationContext& context) const
 {
-    String first = m_first->cssText();
-    String second = m_second->cssText();
+    auto first = m_first->cssText(context);
+    auto second = m_second->cssText(context);
     if (m_coalesceIdenticalValues && first == second)
         return first;
     return makeString(first, separatorCSSText(), second);

--- a/Source/WebCore/css/CSSValuePair.h
+++ b/Source/WebCore/css/CSSValuePair.h
@@ -41,7 +41,7 @@ public:
     Ref<CSSValue> protectedFirst() const { return m_first; }
     Ref<CSSValue> protectedSecond() const { return m_second; }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSValuePair&) const;
     bool canBeCoalesced() const;
 

--- a/Source/WebCore/css/CSSVariableReferenceValue.cpp
+++ b/Source/WebCore/css/CSSVariableReferenceValue.cpp
@@ -66,7 +66,7 @@ bool CSSVariableReferenceValue::equals(const CSSVariableReferenceValue& other) c
     return m_data.get() == other.m_data.get();
 }
 
-String CSSVariableReferenceValue::customCSSText() const
+String CSSVariableReferenceValue::customCSSText(const CSS::SerializationContext&) const
 {
     if (m_stringValue.isNull())
         m_stringValue = m_data->serialize();

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -53,7 +53,7 @@ public:
     static Ref<CSSVariableReferenceValue> create(Ref<CSSVariableData>&&);
 
     bool equals(const CSSVariableReferenceValue&) const;
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     RefPtr<CSSVariableData> resolveVariableReferences(Style::BuilderState&) const;
     const CSSParserContext& context() const;

--- a/Source/WebCore/css/CSSViewValue.cpp
+++ b/Source/WebCore/css/CSSViewValue.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-String CSSViewValue::customCSSText() const
+String CSSViewValue::customCSSText(const CSS::SerializationContext& context) const
 {
     auto hasAxis = m_axis && m_axis->valueID() != CSSValueBlock;
     auto hasEndInset = m_endInset && m_endInset != m_startInset;
@@ -42,11 +42,11 @@ String CSSViewValue::customCSSText() const
 
     return makeString(
         "view("_s,
-        hasAxis ? m_axis->cssText() : ""_s,
+        hasAxis ? m_axis->cssText(context) : ""_s,
         hasAxis && hasStartInset ? " "_s : ""_s,
-        hasStartInset ? m_startInset->cssText() : ""_s,
+        hasStartInset ? m_startInset->cssText(context) : ""_s,
         hasStartInset && hasEndInset ? " "_s : ""_s,
-        hasEndInset ? m_endInset->cssText() : ""_s,
+        hasEndInset ? m_endInset->cssText(context) : ""_s,
         ")"_s
     );
 }

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -47,7 +47,7 @@ public:
         return adoptRef(*new CSSViewValue(WTFMove(axis), WTFMove(startInset), WTFMove(endInset)));
     }
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
 
     const RefPtr<CSSValue>& axis() const { return m_axis; }
     const RefPtr<CSSValue>& startInset() const { return m_startInset; }

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -56,6 +56,7 @@
 #include "CSSReflectValue.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSScrollValue.h"
+#include "CSSSerializationContext.h"
 #include "CSSTextShadowPropertyValue.h"
 #include "CSSTransformListValue.h"
 #include "CSSValueList.h"
@@ -3415,7 +3416,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::customPropertyValue(const AtomString& p
 String ComputedStyleExtractor::customPropertyText(const AtomString& propertyName) const
 {
     RefPtr<CSSValue> propertyValue = customPropertyValue(propertyName);
-    return propertyValue ? propertyValue->cssText() : emptyString();
+    return propertyValue ? propertyValue->cssText(CSS::defaultSerializationContext()) : emptyString();
 }
 
 static Ref<CSSFontValue> fontShorthandValue(const RenderStyle& style, ComputedStyleExtractor::PropertyValueType valueType)

--- a/Source/WebCore/css/DeprecatedCSSOMBoxShadowValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMBoxShadowValue.cpp
@@ -26,6 +26,7 @@
 #include "DeprecatedCSSOMBoxShadowValue.h"
 
 #include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSSerializationContext.h"
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ DeprecatedCSSOMBoxShadowValue::DeprecatedCSSOMBoxShadowValue(CSS::BoxShadow&& sh
 
 String DeprecatedCSSOMBoxShadowValue::cssText() const
 {
-    return CSS::serializationForCSS(m_shadow);
+    return CSS::serializationForCSS(CSS::defaultSerializationContext(), m_shadow);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/DeprecatedCSSOMFilterFunctionValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMFilterFunctionValue.cpp
@@ -26,6 +26,7 @@
 #include "DeprecatedCSSOMFilterFunctionValue.h"
 
 #include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSSerializationContext.h"
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ DeprecatedCSSOMFilterFunctionValue::DeprecatedCSSOMFilterFunctionValue(CSS::Filt
 
 String DeprecatedCSSOMFilterFunctionValue::cssText() const
 {
-    return CSS::serializationForCSS(m_filter);
+    return CSS::serializationForCSS(CSS::defaultSerializationContext(), m_filter);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -29,12 +29,18 @@
 #include "CSSColorValue.h"
 #include "CSSCounterValue.h"
 #include "CSSRectValue.h"
+#include "CSSSerializationContext.h"
 #include "DeprecatedCSSOMCounter.h"
 #include "DeprecatedCSSOMRGBColor.h"
 #include "DeprecatedCSSOMRect.h"
 
 namespace WebCore {
-    
+
+String DeprecatedCSSOMPrimitiveValue::cssText() const
+{
+    return protectedValue()->cssText(CSS::defaultSerializationContext());
+}
+
 unsigned short DeprecatedCSSOMPrimitiveValue::primitiveType() const
 {
     if (m_value->isCounter())

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h
@@ -74,8 +74,8 @@ public:
     }
 
     bool equals(const DeprecatedCSSOMPrimitiveValue& other) const { return m_value->equals(other.m_value); }
-    String cssText() const { return m_value->cssText(); }
-    
+    String cssText() const;
+
     WEBCORE_EXPORT unsigned short primitiveType() const;
     WEBCORE_EXPORT ExceptionOr<float> getFloatValue(unsigned short unitType) const;
     WEBCORE_EXPORT ExceptionOr<String> getStringValue() const;
@@ -95,6 +95,8 @@ private:
         , m_value(value)
     {
     }
+
+    Ref<const CSSValue> protectedValue() const { return m_value; }
 
     Ref<const CSSValue> m_value;
 };

--- a/Source/WebCore/css/DeprecatedCSSOMTextShadowValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMTextShadowValue.cpp
@@ -26,6 +26,7 @@
 #include "DeprecatedCSSOMTextShadowValue.h"
 
 #include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSSerializationContext.h"
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ DeprecatedCSSOMTextShadowValue::DeprecatedCSSOMTextShadowValue(CSS::TextShadow&&
 
 String DeprecatedCSSOMTextShadowValue::cssText() const
 {
-    return CSS::serializationForCSS(m_shadow);
+    return CSS::serializationForCSS(CSS::defaultSerializationContext(), m_shadow);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/DeprecatedCSSOMValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DeprecatedCSSOMValue.h"
 
+#include "CSSSerializationContext.h"
 #include "DeprecatedCSSOMBoxShadowValue.h"
 #include "DeprecatedCSSOMFilterFunctionValue.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
@@ -101,6 +102,11 @@ String DeprecatedCSSOMValue::cssText() const
     }
     ASSERT_NOT_REACHED();
     return emptyString();
+}
+
+String DeprecatedCSSOMComplexValue::cssText() const
+{
+    return protectedValue()->cssText(CSS::defaultSerializationContext());
 }
 
 unsigned short DeprecatedCSSOMComplexValue::cssValueType() const

--- a/Source/WebCore/css/DeprecatedCSSOMValue.h
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.h
@@ -95,8 +95,7 @@ public:
         return adoptRef(*new DeprecatedCSSOMComplexValue(WTFMove(value), owner));
     }
 
-    String cssText() const { return m_value->cssText(); }
-
+    String cssText() const;
     unsigned short cssValueType() const;
 
 protected:
@@ -105,6 +104,8 @@ protected:
         , m_value(WTFMove(value))
     {
     }
+
+    Ref<const CSSValue> protectedValue() const { return m_value; }
 
 private:
     Ref<const CSSValue> m_value;

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSCustomPropertyValue.h"
 #include "CSSParser.h"
+#include "CSSSerializationContext.h"
 #include "CSSValuePool.h"
 #include "ImmutableStyleProperties.h"
 #include "PropertySetCSSStyleDeclaration.h"
@@ -111,7 +112,7 @@ bool MutableStyleProperties::removePropertyAtIndex(int index, String* returnText
 
     if (returnText) {
         auto property = propertyAt(index);
-        *returnText = WebCore::serializeLonghandValue(property.id(), *property.value());
+        *returnText = WebCore::serializeLonghandValue(CSS::defaultSerializationContext(), property.id(), *property.value());
     }
 
     // A more efficient removal strategy would involve marking entries as empty

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -24,6 +24,7 @@
 
 #include "CSSPropertyParser.h"
 #include "CSSRule.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
 #include "Document.h"
 #include "DocumentInlines.h"
@@ -81,7 +82,7 @@ String PropertySetCSSStyleDeclaration::item(unsigned i) const
 
 String PropertySetCSSStyleDeclaration::cssText() const
 {
-    return m_propertySet->asText();
+    return m_propertySet->asText(CSS::defaultSerializationContext());
 }
 
 ExceptionOr<void> PropertySetCSSStyleDeclaration::setCssText(const String& text)

--- a/Source/WebCore/css/Quad.h
+++ b/Source/WebCore/css/Quad.h
@@ -34,9 +34,9 @@ public:
         : RectBase(WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left))
     { }
 
-    String cssText() const
+    String cssText(const CSS::SerializationContext& context) const
     {
-        return serialize(top().cssText(), right().cssText(), bottom().cssText(), left().cssText());
+        return serialize(top().cssText(context), right().cssText(context), bottom().cssText(context), left().cssText(context));
     }
 
     static String serialize(const String& top, const String& right, const String& bottom, const String& left)

--- a/Source/WebCore/css/Rect.h
+++ b/Source/WebCore/css/Rect.h
@@ -31,9 +31,9 @@ public:
         : RectBase(WTFMove(top), WTFMove(right), WTFMove(bottom), WTFMove(left))
     { }
 
-    String cssText() const
+    String cssText(const CSS::SerializationContext& context) const
     {
-        return generateCSSString(top().cssText(), right().cssText(), bottom().cssText(), left().cssText());
+        return generateCSSString(top().cssText(context), right().cssText(context), bottom().cssText(context), left().cssText(context));
     }
 
 private:

--- a/Source/WebCore/css/ShorthandSerializer.h
+++ b/Source/WebCore/css/ShorthandSerializer.h
@@ -33,7 +33,11 @@ class StyleProperties;
 
 enum CSSPropertyID : uint16_t;
 
-String serializeShorthandValue(const ComputedStyleExtractor&, CSSPropertyID);
-String serializeShorthandValue(const StyleProperties&, CSSPropertyID);
-
+namespace CSS {
+struct SerializationContext;
 }
+
+String serializeShorthandValue(const CSS::SerializationContext&, const ComputedStyleExtractor&, CSSPropertyID);
+String serializeShorthandValue(const CSS::SerializationContext&, const StyleProperties&, CSSPropertyID);
+
+} // namespace WebCore

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -30,6 +30,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserConsumer+Font.h"
+#include "CSSSerializationContext.h"
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
 #include "Color.h"
@@ -59,7 +60,7 @@ Ref<ImmutableStyleProperties> StyleProperties::immutableCopyIfNeeded() const
     return const_cast<ImmutableStyleProperties&>(uncheckedDowncast<ImmutableStyleProperties>(*this));
 }
 
-String serializeLonghandValue(CSSPropertyID property, const CSSValue& value)
+String serializeLonghandValue(const CSS::SerializationContext& context, CSSPropertyID property, const CSSValue& value)
 {
     switch (property) {
     case CSSPropertyFillOpacity:
@@ -83,25 +84,26 @@ String serializeLonghandValue(CSSPropertyID property, const CSSValue& value)
         StringBuilder result;
         auto separator = ""_s;
         for (auto& individualValue : *list)
-            result.append(std::exchange(separator, ", "_s), serializeLonghandValue(property, individualValue));
+            result.append(std::exchange(separator, ", "_s), serializeLonghandValue(context, property, individualValue));
         return result.toString();
     }
-    return value.isImplicitInitialValue() ? initialValueTextForLonghand(property) : value.cssText();
+
+    return value.isImplicitInitialValue() ? initialValueTextForLonghand(property) : value.cssText(context);
 }
 
-inline String StyleProperties::serializeLonghandValue(CSSPropertyID propertyID) const
+inline String StyleProperties::serializeLonghandValue(const CSS::SerializationContext& context, CSSPropertyID propertyID) const
 {
-    return WebCore::serializeLonghandValue(propertyID, getPropertyCSSValue(propertyID).get());
+    return WebCore::serializeLonghandValue(context, propertyID, getPropertyCSSValue(propertyID).get());
 }
 
-inline String StyleProperties::serializeShorthandValue(CSSPropertyID propertyID) const
+inline String StyleProperties::serializeShorthandValue(const CSS::SerializationContext& context, CSSPropertyID propertyID) const
 {
-    return WebCore::serializeShorthandValue(*this, propertyID);
+    return WebCore::serializeShorthandValue(context, *this, propertyID);
 }
 
 String StyleProperties::getPropertyValue(CSSPropertyID propertyID) const
 {
-    return isLonghand(propertyID) ? serializeLonghandValue(propertyID) : serializeShorthandValue(propertyID);
+    return isLonghand(propertyID) ? serializeLonghandValue(CSS::defaultSerializationContext(), propertyID) : serializeShorthandValue(CSS::defaultSerializationContext(), propertyID);
 }
 
 std::optional<Color> StyleProperties::propertyAsColor(CSSPropertyID property) const
@@ -111,7 +113,7 @@ std::optional<Color> StyleProperties::propertyAsColor(CSSPropertyID property) co
         return std::nullopt;
     return value->isColor()
         ? CSSColorValue::absoluteColor(*value)
-        : CSSParser::parseColorWithoutContext(WebCore::serializeLonghandValue(property, *value));
+        : CSSParser::parseColorWithoutContext(WebCore::serializeLonghandValue(CSS::defaultSerializationContext(), property, *value));
 }
 
 std::optional<CSSValueID> StyleProperties::propertyAsValueID(CSSPropertyID property) const
@@ -123,7 +125,7 @@ String StyleProperties::getCustomPropertyValue(const String& propertyName) const
 {
     RefPtr<CSSValue> value = getCustomPropertyCSSValue(propertyName);
     if (value)
-        return value->cssText();
+        return value->cssText(CSS::defaultSerializationContext());
     return String();
 }
 
@@ -190,14 +192,14 @@ bool StyleProperties::isPropertyImplicit(CSSPropertyID propertyID) const
     return propertyAt(foundPropertyIndex).isImplicit();
 }
 
-String StyleProperties::asText() const
+String StyleProperties::asText(const CSS::SerializationContext& context) const
 {
-    return asTextInternal().toString();
+    return asTextInternal(context).toString();
 }
 
-AtomString StyleProperties::asTextAtom() const
+AtomString StyleProperties::asTextAtom(const CSS::SerializationContext& context) const
 {
-    return asTextInternal().toAtomString();
+    return asTextInternal(context).toAtomString();
 }
 
 static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSPropertyID longhandID)
@@ -267,7 +269,7 @@ static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSP
     }
 }
 
-StringBuilder StyleProperties::asTextInternal() const
+StringBuilder StyleProperties::asTextInternal(const CSS::SerializationContext& context) const
 {
     StringBuilder result;
 
@@ -305,7 +307,7 @@ StringBuilder StyleProperties::asTextInternal() const
                 continue;
             shorthandPropertyAppeared.set(shorthandPropertyIndex);
 
-            value = serializeShorthandValue(shorthandPropertyID);
+            value = serializeShorthandValue(context, shorthandPropertyID);
             if (!value.isNull()) {
                 propertyID = shorthandPropertyID;
                 shorthandPropertyUsed.set(shorthandPropertyIndex);
@@ -316,7 +318,7 @@ StringBuilder StyleProperties::asTextInternal() const
             continue;
 
         if (value.isNull())
-            value = WebCore::serializeLonghandValue(propertyID, *property.value());
+            value = WebCore::serializeLonghandValue(context, propertyID, *property.value());
 
         if (numDecls++)
             result.append(' ');
@@ -364,18 +366,6 @@ bool StyleProperties::mayDependOnBaseURL() const
             return result;
     }
     return false;
-}
-
-void StyleProperties::setReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>& replacementURLStrings)
-{
-    for (auto property : *this)
-        property.value()->setReplacementURLForSubresources(replacementURLStrings);
-}
-
-void StyleProperties::clearReplacementURLForSubresources()
-{
-    for (auto property : *this)
-        property.value()->clearReplacementURLForSubresources();
 }
 
 bool StyleProperties::propertyMatches(CSSPropertyID propertyID, const CSSValue* propertyValue) const
@@ -432,7 +422,7 @@ static_assert(sizeof(StyleProperties) == sizeof(SameSizeAsStyleProperties), "sty
 #ifndef NDEBUG
 void StyleProperties::showStyle()
 {
-    SAFE_FPRINTF(stderr, "%s\n", asText().ascii());
+    SAFE_FPRINTF(stderr, "%s\n", asText(CSS::defaultSerializationContext()).ascii());
 }
 #endif
 
@@ -443,9 +433,9 @@ String StyleProperties::PropertyReference::cssName() const
     return nameString(id());
 }
 
-String StyleProperties::PropertyReference::cssText() const
+String StyleProperties::PropertyReference::cssText(const CSS::SerializationContext& context) const
 {
-    return makeString(cssName(), ": "_s, WebCore::serializeLonghandValue(id(), *m_value), isImportant() ? " !important;"_s : ";"_s);
+    return makeString(cssName(), ": "_s, WebCore::serializeLonghandValue(context, id(), *m_value), isImportant() ? " !important;"_s : ";"_s);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -33,6 +33,10 @@ class MutableStyleProperties;
 enum CSSValueID : uint16_t;
 enum CSSParserMode : uint8_t;
 
+namespace CSS {
+struct SerializationContext;
+}
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleProperties);
 class StyleProperties : public RefCounted<StyleProperties> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleProperties);
@@ -55,7 +59,7 @@ public:
         bool isImplicit() const { return m_metadata.m_implicit; }
 
         String cssName() const;
-        String cssText() const;
+        String cssText(const CSS::SerializationContext&) const;
 
         const CSSValue* value() const { return m_value; }
         // FIXME: We should try to remove this mutable overload.
@@ -123,15 +127,13 @@ public:
 
     Ref<MutableStyleProperties> copyProperties(std::span<const CSSPropertyID>) const;
     
-    String asText() const;
-    AtomString asTextAtom() const;
+    String asText(const CSS::SerializationContext&) const;
+    AtomString asTextAtom(const CSS::SerializationContext&) const;
 
     bool hasCSSOMWrapper() const;
     bool isMutable() const { return m_isMutable; }
 
     bool traverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const;
-    void setReplacementURLForSubresources(const UncheckedKeyHashMap<String, String>&);
-    void clearReplacementURLForSubresources();
     bool mayDependOnBaseURL() const;
 
     static unsigned averageSizeInBytes();
@@ -154,13 +156,14 @@ protected:
     unsigned m_arraySize : 28 { 0 };
 
 private:
-    StringBuilder asTextInternal() const;
-    String serializeLonghandValue(CSSPropertyID) const;
-    String serializeShorthandValue(CSSPropertyID) const;
+    StringBuilder asTextInternal(const CSS::SerializationContext&) const;
+    String serializeLonghandValue(const CSS::SerializationContext&, CSSPropertyID) const;
+    String serializeShorthandValue(const CSS::SerializationContext&, CSSPropertyID) const;
 };
 
-String serializeLonghandValue(CSSPropertyID, const CSSValue&);
-inline String serializeLonghandValue(CSSPropertyID, const CSSValue*);
+String serializeLonghandValue(const CSS::SerializationContext&, CSSPropertyID, const CSSValue&);
+inline String serializeLonghandValue(const CSS::SerializationContext&, CSSPropertyID, const CSSValue*);
+
 inline CSSValueID longhandValueID(CSSPropertyID, const CSSValue&);
 inline std::optional<CSSValueID> longhandValueID(CSSPropertyID, const CSSValue*);
 

--- a/Source/WebCore/css/StylePropertiesInlines.h
+++ b/Source/WebCore/css/StylePropertiesInlines.h
@@ -94,9 +94,9 @@ inline unsigned StyleProperties::size() const
     return propertyCount();
 }
 
-inline String serializeLonghandValue(CSSPropertyID property, const CSSValue* value)
+inline String serializeLonghandValue(const CSS::SerializationContext& context, CSSPropertyID property, const CSSValue* value)
 {
-    return value ? serializeLonghandValue(property, *value) : String();
+    return value ? serializeLonghandValue(context, property, *value) : String();
 }
 
 inline CSSValueID longhandValueID(CSSPropertyID property, const CSSValue& value)

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -40,6 +40,7 @@
 #include "CSSPositionTryRule.h"
 #include "CSSPropertyRule.h"
 #include "CSSScopeRule.h"
+#include "CSSSerializationContext.h"
 #include "CSSStartingStyleRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
@@ -341,9 +342,7 @@ Vector<Ref<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorCompo
 
 String StyleRule::debugDescription() const
 {
-    StringBuilder builder;
-    builder.append("StyleRule ["_s, m_properties->asText(), ']');
-    return builder.toString();
+    return makeString("StyleRule ["_s, m_properties->asText(CSS::defaultSerializationContext()), ']');
 }
 
 StyleRuleWithNesting::~StyleRuleWithNesting() = default;
@@ -356,7 +355,7 @@ Ref<StyleRuleWithNesting> StyleRuleWithNesting::copy() const
 String StyleRuleWithNesting::debugDescription() const
 {
     StringBuilder builder;
-    builder.append("StyleRuleWithNesting ["_s, properties().asText(), " "_s);
+    builder.append("StyleRuleWithNesting ["_s, properties().asText(CSS::defaultSerializationContext()), " "_s);
     for (const auto& rule : m_nestedRules)
         builder.append(rule->debugDescription());
     builder.append(']');
@@ -404,9 +403,7 @@ StyleRuleNestedDeclarations::StyleRuleNestedDeclarations(Ref<StyleProperties>&& 
 
 String StyleRuleNestedDeclarations::debugDescription() const
 {
-    StringBuilder builder;
-    builder.append("StyleRuleNestedDeclarations ["_s, properties().asText(), ']');
-    return builder.toString();
+    return makeString("StyleRuleNestedDeclarations ["_s, properties().asText(CSS::defaultSerializationContext()), ']');
 }
 
 StyleRuleFontFace::StyleRuleFontFace(Ref<StyleProperties>&& properties)

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -37,6 +37,7 @@
 #include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSPropertyParsing.h"
+#include "CSSSerializationContext.h"
 #include "CSSUnits.h"
 #include "CalculationCategory.h"
 #include "CalculationOperator.h"
@@ -154,7 +155,7 @@ std::optional<Tree> parseAndSimplify(CSSParserTokenRange& range, const CSSParser
         .unique = state.unique,
     };
 
-    LOG_WITH_STREAM(Calc, stream << "Completed top level parse/simplification for function '" << nameLiteralForSerialization(function) << "': " << serializationForCSS(result, { parserOptions.range }) << ", type: " << getType(result.root) << ", category=" << parserOptions.category << ", requires-conversion-data: " << result.requiresConversionData << ", unique: " << result.unique);
+    LOG_WITH_STREAM(Calc, stream << "Completed top level parse/simplification for function '" << nameLiteralForSerialization(function) << "': " << serializationForCSS(result, { parserOptions.range, CSS::defaultSerializationContext() }) << ", type: " << getType(result.root) << ", category=" << parserOptions.category << ", requires-conversion-data: " << result.requiresConversionData << ", unique: " << result.unique);
 
     return result;
 }

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.h
@@ -28,6 +28,11 @@
 #include <wtf/Forward.h>
 
 namespace WebCore {
+
+namespace CSS {
+struct SerializationContext;
+}
+
 namespace CSSCalc {
 
 struct Child;
@@ -36,6 +41,9 @@ struct Tree;
 struct SerializationOptions {
     // `range` represents the allowed numeric range for the calculated result.
     CSS::Range range;
+
+    // `serializationContext` is the context used for CSS serialization state.
+    const CSS::SerializationContext& serializationContext;
 };
 
 // https://drafts.csswg.org/css-values-4/#serialize-a-math-function

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -27,6 +27,7 @@
 #include "CSSCalcTree.h"
 
 #include "CSSCalcTree+Serialization.h"
+#include "CSSSerializationContext.h"
 #include "CSSUnits.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
@@ -448,7 +449,7 @@ std::optional<Type> toType(const ContainerProgress&)
 
 TextStream& operator<<(TextStream& ts, Tree tree)
 {
-    return ts << "CSSCalc::Tree [ " << serializationForCSS(tree, { .range = CSS::All }) << " ]";
+    return ts << "CSSCalc::Tree [ " << serializationForCSS(tree, { .range = CSS::All, .serializationContext = CSS::defaultSerializationContext() }) << " ]";
 }
 
 } // namespace CSSCalc

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -196,10 +196,11 @@ void CSSCalcValue::collectComputedStyleDependencies(ComputedStyleDependencies& d
     CSSCalc::collectComputedStyleDependencies(m_tree, dependencies);
 }
 
-String CSSCalcValue::customCSSText() const
+String CSSCalcValue::customCSSText(const CSS::SerializationContext& context) const
 {
     auto options = CSSCalc::SerializationOptions {
         .range = m_range,
+        .serializationContext = context,
     };
     return CSSCalc::serializationForCSS(m_tree, options);
 }
@@ -325,7 +326,7 @@ void CSSCalcValue::dump(TextStream& ts) const
 
     multilineStream.dumpProperty("minimum value", m_range.min);
     multilineStream.dumpProperty("maximum value", m_range.max);
-    multilineStream.dumpProperty("expression", customCSSText());
+    multilineStream.dumpProperty("expression", customCSSText(CSS::defaultSerializationContext()));
 
     ts << multilineStream.release();
     ts << ")\n";

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -101,7 +101,7 @@ public:
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
 
-    String customCSSText() const;
+    String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCalcValue&) const;
 
     void dump(TextStream&) const;

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -26,6 +26,7 @@
 #include "GenericMediaQuerySerialization.h"
 
 #include "CSSMarkup.h"
+#include "CSSSerializationContext.h"
 #include "CSSValue.h"
 
 namespace WebCore {
@@ -108,12 +109,12 @@ void serialize(StringBuilder& builder, const Feature& feature)
         }
         serializeIdentifier(feature.name, builder);
 
-        builder.append(": "_s, feature.rightComparison->value->cssText());
+        builder.append(": "_s, feature.rightComparison->value->cssText(CSS::defaultSerializationContext()));
         break;
 
     case Syntax::Range:
         if (feature.leftComparison) {
-            builder.append(feature.leftComparison->value->cssText());
+            builder.append(feature.leftComparison->value->cssText(CSS::defaultSerializationContext()));
             serializeRangeComparisonOperator(feature.leftComparison->op);
         }
 
@@ -121,7 +122,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
 
         if (feature.rightComparison) {
             serializeRangeComparisonOperator(feature.rightComparison->op);
-            builder.append(feature.rightComparison->value->cssText());
+            builder.append(feature.rightComparison->value->cssText(CSS::defaultSerializationContext()));
         }
         break;
     }

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSStyleImageValue.h"
 
+#include "CSSSerializationContext.h"
 #include "Document.h"
 
 #include <wtf/TZoneMallocInlines.h>
@@ -46,7 +47,7 @@ CSSStyleImageValue::CSSStyleImageValue(Ref<CSSImageValue>&& cssValue, Document* 
 
 void CSSStyleImageValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
-    builder.append(m_cssValue->cssText());
+    builder.append(m_cssValue->cssText(CSS::defaultSerializationContext()));
 }
 
 Document* CSSStyleImageValue::document() const

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -32,6 +32,7 @@
 
 #include "CSSParser.h"
 #include "CSSPropertyParser.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleValueFactory.h"
 #include "CSSUnitValue.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -90,7 +91,7 @@ String CSSStyleValue::toString() const
 void CSSStyleValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     if (m_propertyValue)
-        builder.append(m_propertyValue->cssText());
+        builder.append(m_propertyValue->cssText(CSS::defaultSerializationContext()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -41,6 +41,7 @@
 #include "CSSParser.h"
 #include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyParser.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleImageValue.h"
 #include "CSSStyleValue.h"
 #include "CSSTextShadowPropertyValue.h"
@@ -282,7 +283,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
             // Per the specification, the CSSKeywordValue's value slot should be set to the serialization
             // of the identifier. As a result, the identifier will be lowercase:
             // https://drafts.css-houdini.org/css-typed-om-1/#reify-ident
-            return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(primitiveValue->cssText()));
+            return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(primitiveValue->cssText(CSS::defaultSerializationContext())));
         default:
             break;
         }
@@ -305,15 +306,15 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
         }, [&](const CSSCustomPropertyValue::SyntaxValue& syntaxValue) -> ExceptionOr<Ref<CSSStyleValue>> {
             if (auto styleValue = constructStyleValueForCustomPropertySyntaxValue(syntaxValue))
                 return { *styleValue };
-            CSSTokenizer tokenizer(customPropertyValue->customCSSText());
+            CSSTokenizer tokenizer(customPropertyValue->customCSSText(CSS::defaultSerializationContext()));
             return { CSSUnparsedValue::create(tokenizer.tokenRange()) };
         }, [&](const CSSCustomPropertyValue::SyntaxValueList& syntaxValueList) -> ExceptionOr<Ref<CSSStyleValue>> {
             if (auto styleValue = constructStyleValueForCustomPropertySyntaxValue(syntaxValueList.values[0]))
                 return { *styleValue };
-            CSSTokenizer tokenizer(customPropertyValue->customCSSText());
+            CSSTokenizer tokenizer(customPropertyValue->customCSSText(CSS::defaultSerializationContext()));
             return { CSSUnparsedValue::create(tokenizer.tokenRange()) };
         }, [&](auto&) {
-            CSSTokenizer tokenizer(customPropertyValue->customCSSText());
+            CSSTokenizer tokenizer(customPropertyValue->customCSSText(CSS::defaultSerializationContext()));
             return ExceptionOr<Ref<CSSStyleValue>> { CSSUnparsedValue::create(tokenizer.tokenRange()) };
         });
     } else if (RefPtr transformList = dynamicDowncast<CSSTransformListValue>(cssValue)) {

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSComputedStyleDeclaration.h"
 #include "CSSPropertyParser.h"
+#include "CSSSerializationContext.h"
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "Element.h"
@@ -56,7 +57,7 @@ RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::propertyValue(CSSPropertyID p
 String ComputedStylePropertyMapReadOnly::shorthandPropertySerialization(CSSPropertyID propertyID) const
 {
     auto value = propertyValue(propertyID);
-    return value ? value->cssText() : String();
+    return value ? value->cssText(CSS::defaultSerializationContext()) : String();
 }
 
 RefPtr<CSSValue> ComputedStylePropertyMapReadOnly::customPropertyValue(const AtomString& property) const

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -27,6 +27,7 @@
 #include "DeclaredStylePropertyMap.h"
 
 #include "CSSCustomPropertyValue.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleRule.h"
 #include "CSSStyleSheet.h"
 #include "CSSUnparsedValue.h"
@@ -114,7 +115,7 @@ bool DeclaredStylePropertyMap::setProperty(CSSPropertyID propertyID, Ref<CSSValu
 
     CSSStyleSheet::RuleMutationScope mutationScope(m_ownerRule.get());
     bool didFailParsing = false;
-    styleRule->mutableProperties().setProperty(propertyID, value->cssText(), IsImportant::No, &didFailParsing);
+    styleRule->mutableProperties().setProperty(propertyID, value->cssText(CSS::defaultSerializationContext()), IsImportant::No, &didFailParsing);
     return !didFailParsing;
 }
 

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -27,6 +27,7 @@
 #include "InlineStylePropertyMap.h"
 
 #include "CSSCustomPropertyValue.h"
+#include "CSSSerializationContext.h"
 #include "Document.h"
 #include "StyleAttributeMutationScope.h"
 #include "StylePropertiesInlines.h"
@@ -115,7 +116,7 @@ bool InlineStylePropertyMap::setProperty(CSSPropertyID propertyID, Ref<CSSValue>
     bool didFailParsing = false;
     // FIXME: We should be able to validate CSSValues without having to serialize to text and go through the
     // parser. This is inefficient.
-    m_element->setInlineStyleProperty(propertyID, value->cssText(), IsImportant::No, &didFailParsing);
+    m_element->setInlineStyleProperty(propertyID, value->cssText(CSS::defaultSerializationContext()), IsImportant::No, &didFailParsing);
     if (!didFailParsing) {
         m_element->setInlineStyleProperty(propertyID, WTFMove(value));
         mutationScope.enqueueMutationRecord();

--- a/Source/WebCore/css/values/CSSSerializationContext.cpp
+++ b/Source/WebCore/css/values/CSSSerializationContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -16,50 +16,35 @@
  * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
  * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CSSSerializationContext.h"
 
-#include "CSSValueTypes.h"
-#include "Color.h"
-#include <wtf/Forward.h>
+#include "CSSStyleSheet.h"
 
 namespace WebCore {
 namespace CSS {
 
-struct PlatformColorResolutionState;
+SerializationContext::SerializationContext() = default;
+SerializationContext::~SerializationContext() = default;
 
-struct ResolvedColor {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
-    WebCore::Color value;
-
-    bool operator==(const ResolvedColor&) const = default;
-};
-
-inline WebCore::Color createColor(const ResolvedColor& unresolved, PlatformColorResolutionState&)
+SerializationContext::SerializationContext(UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, bool shouldUseResolvedURLInCSSText)
+    : replacementURLStrings { WTFMove(replacementURLStrings) }
+    , replacementURLStringsForCSSStyleSheet { WTFMove(replacementURLStringsForCSSStyleSheet) }
+    , shouldUseResolvedURLInCSSText { shouldUseResolvedURLInCSSText }
 {
-    return unresolved.value;
 }
 
-constexpr bool containsColorSchemeDependentColor(const ResolvedColor&)
+const SerializationContext& defaultSerializationContext()
 {
-    return false;
+    static NeverDestroyed<SerializationContext> context;
+    return context;
 }
-
-constexpr bool containsCurrentColor(const ResolvedColor&)
-{
-    return false;
-}
-
-template<> struct Serialize<ResolvedColor> { void operator()(StringBuilder&, const SerializationContext&, const ResolvedColor&); };
-template<> struct ComputedStyleDependenciesCollector<ResolvedColor> { constexpr void operator()(ComputedStyleDependencies&, const ResolvedColor&) { } };
-template<> struct CSSValueChildrenVisitor<ResolvedColor> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const ResolvedColor&) { return IterationStatus::Continue; } };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/CSSSerializationContext.h
+++ b/Source/WebCore/css/values/CSSSerializationContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -16,7 +16,6 @@
  * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
  * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
@@ -25,41 +24,26 @@
 
 #pragma once
 
-#include "CSSValueTypes.h"
-#include "Color.h"
-#include <wtf/Forward.h>
+#include <wtf/HashMap.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+class CSSStyleSheet;
+
 namespace CSS {
 
-struct PlatformColorResolutionState;
+struct SerializationContext {
+    SerializationContext();
+    SerializationContext(UncheckedKeyHashMap<String, String>&&, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&&, bool);
+    ~SerializationContext();
 
-struct ResolvedColor {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
-    WebCore::Color value;
-
-    bool operator==(const ResolvedColor&) const = default;
+    UncheckedKeyHashMap<String, String> replacementURLStrings;
+    UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> replacementURLStringsForCSSStyleSheet;
+    bool shouldUseResolvedURLInCSSText = false;
 };
 
-inline WebCore::Color createColor(const ResolvedColor& unresolved, PlatformColorResolutionState&)
-{
-    return unresolved.value;
-}
-
-constexpr bool containsColorSchemeDependentColor(const ResolvedColor&)
-{
-    return false;
-}
-
-constexpr bool containsCurrentColor(const ResolvedColor&)
-{
-    return false;
-}
-
-template<> struct Serialize<ResolvedColor> { void operator()(StringBuilder&, const SerializationContext&, const ResolvedColor&); };
-template<> struct ComputedStyleDependenciesCollector<ResolvedColor> { constexpr void operator()(ComputedStyleDependencies&, const ResolvedColor&) { } };
-template<> struct CSSValueChildrenVisitor<ResolvedColor> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const ResolvedColor&) { return IterationStatus::Continue; } };
+WEBCORE_EXPORT const SerializationContext& defaultSerializationContext();
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/CSSValueTypes.cpp
+++ b/Source/WebCore/css/values/CSSValueTypes.cpp
@@ -28,7 +28,7 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<CustomIdentifier>::operator()(StringBuilder& builder, const CustomIdentifier& value)
+void Serialize<CustomIdentifier>::operator()(StringBuilder& builder, const SerializationContext&, const CustomIdentifier& value)
 {
     builder.append(value.value);
 }

--- a/Source/WebCore/css/values/backgrounds/CSSBorderRadius.cpp
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderRadius.cpp
@@ -67,7 +67,7 @@ static std::pair<SpaceSeparatedVector<LengthPercentage<Nonnegative>, 4>, bool> g
     return { { WTFMove(result) }, isDefaultValue };
 }
 
-void Serialize<BorderRadius>::operator()(StringBuilder& builder, const BorderRadius& borderRadius)
+void Serialize<BorderRadius>::operator()(StringBuilder& builder, const SerializationContext& context, const BorderRadius& borderRadius)
 {
     // <'border-radius'> = <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
 
@@ -75,11 +75,11 @@ void Serialize<BorderRadius>::operator()(StringBuilder& builder, const BorderRad
     auto [vertical, verticalIsDefault] = gatherSerializableRadiiForAxis(borderRadius.vertical);
 
     if (!horizontalIsDefault || !verticalIsDefault) {
-        serializationForCSS(builder, horizontal);
+        serializationForCSS(builder, context, horizontal);
 
         if (horizontal != vertical) {
             builder.append(" / "_s);
-            serializationForCSS(builder, vertical);
+            serializationForCSS(builder, context, vertical);
         }
     }
 }

--- a/Source/WebCore/css/values/backgrounds/CSSBorderRadius.h
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderRadius.h
@@ -68,7 +68,7 @@ inline BorderRadius BorderRadius::defaultValue()
     };
 }
 
-template<> struct Serialize<BorderRadius> { void operator()(StringBuilder&, const BorderRadius&); };
+template<> struct Serialize<BorderRadius> { void operator()(StringBuilder&, const SerializationContext&, const BorderRadius&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/color-adjust/CSSColorScheme.cpp
+++ b/Source/WebCore/css/values/color-adjust/CSSColorScheme.cpp
@@ -34,17 +34,17 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<ColorScheme>::operator()(StringBuilder& builder, const ColorScheme& value)
+void Serialize<ColorScheme>::operator()(StringBuilder& builder, const SerializationContext& context, const ColorScheme& value)
 {
     if (value.isNormal()) {
-        serializationForCSS(builder, Keyword::Normal { });
+        serializationForCSS(builder, context, Keyword::Normal { });
         return;
     }
 
-    serializationForCSS(builder, value.schemes);
+    serializationForCSS(builder, context, value.schemes);
     if (value.only) {
         builder.append(' ');
-        serializationForCSS(builder, *value.only);
+        serializationForCSS(builder, context, *value.only);
     }
 }
 

--- a/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
+++ b/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
@@ -48,7 +48,7 @@ struct ColorScheme {
     bool operator==(const ColorScheme&) const = default;
 };
 
-template<> struct Serialize<ColorScheme> { void operator()(StringBuilder&, const ColorScheme&); };
+template<> struct Serialize<ColorScheme> { void operator()(StringBuilder&, const SerializationContext&, const ColorScheme&); };
 
 template<size_t I> const auto& get(const ColorScheme& colorScheme)
 {

--- a/Source/WebCore/css/values/color/CSSAbsoluteColor.h
+++ b/Source/WebCore/css/values/color/CSSAbsoluteColor.h
@@ -79,9 +79,9 @@ template<typename D> constexpr bool containsCurrentColor(const AbsoluteColor<D>&
 }
 
 template<typename D> struct Serialize<AbsoluteColor<D>> {
-    void operator()(StringBuilder& builder, const AbsoluteColor<D>& value)
+    void operator()(StringBuilder& builder, const SerializationContext& context, const AbsoluteColor<D>& value)
     {
-        serializationForCSSAbsoluteColor(builder, value);
+        serializationForCSSAbsoluteColor(builder, context, value);
     }
 };
 

--- a/Source/WebCore/css/values/color/CSSAbsoluteColorSerialization.h
+++ b/Source/WebCore/css/values/color/CSSAbsoluteColorSerialization.h
@@ -35,7 +35,7 @@ namespace WebCore {
 namespace CSS {
 
 template<typename AbsoluteColorType>
-void serializationForCSSAbsoluteColor(StringBuilder& builder, const AbsoluteColorType& absoluteColor)
+void serializationForCSSAbsoluteColor(StringBuilder& builder, const SerializationContext& context, const AbsoluteColorType& absoluteColor)
 {
     using Descriptor = typename AbsoluteColorType::Descriptor;
     using ColorType = typename Descriptor::ColorType;
@@ -47,15 +47,15 @@ void serializationForCSSAbsoluteColor(StringBuilder& builder, const AbsoluteColo
 
     auto [c1, c2, c3, alpha] = absoluteColor.components;
 
-    serializationForCSS(builder, c1);
+    serializationForCSS(builder, context, c1);
     builder.append(' ');
-    serializationForCSS(builder, c2);
+    serializationForCSS(builder, context, c2);
     builder.append(' ');
-    serializationForCSS(builder, c3);
+    serializationForCSS(builder, context, c3);
 
     if (alpha) {
         builder.append(" / "_s);
-        serializationForCSS(builder, *alpha);
+        serializationForCSS(builder, context, *alpha);
     }
 
     builder.append(')');

--- a/Source/WebCore/css/values/color/CSSColor.cpp
+++ b/Source/WebCore/css/values/color/CSSColor.cpp
@@ -384,9 +384,9 @@ bool containsColorSchemeDependentColor(const Color& value)
     return WTF::switchOn(value, [&](const auto& color) { return WebCore::CSS::containsColorSchemeDependentColor(color); });
 }
 
-void Serialize<Color>::operator()(StringBuilder& builder, const Color& value)
+void Serialize<Color>::operator()(StringBuilder& builder, const SerializationContext& context, const Color& value)
 {
-    WTF::switchOn(value, [&](const auto& color) { serializationForCSS(builder, color); });
+    WTF::switchOn(value, [&](const auto& color) { serializationForCSS(builder, context, color); });
 }
 
 void ComputedStyleDependenciesCollector<Color>::operator()(ComputedStyleDependencies&dependencies, const Color& value)

--- a/Source/WebCore/css/values/color/CSSColor.h
+++ b/Source/WebCore/css/values/color/CSSColor.h
@@ -181,7 +181,7 @@ WebCore::Color createColor(const Color&, PlatformColorResolutionState&);
 bool containsCurrentColor(const Color&);
 bool containsColorSchemeDependentColor(const Color&);
 
-template<> struct Serialize<Color> { void operator()(StringBuilder&, const Color&); };
+template<> struct Serialize<Color> { void operator()(StringBuilder&, const SerializationContext&, const Color&); };
 template<> struct ComputedStyleDependenciesCollector<Color> { void operator()(ComputedStyleDependencies&, const Color&); };
 template<> struct CSSValueChildrenVisitor<Color> { IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const Color&); };
 

--- a/Source/WebCore/css/values/color/CSSColorLayers.cpp
+++ b/Source/WebCore/css/values/color/CSSColorLayers.cpp
@@ -63,9 +63,9 @@ bool containsColorSchemeDependentColor(const ColorLayers& value)
     });
 }
 
-void Serialize<ColorLayers>::operator()(StringBuilder& builder, const ColorLayers& value)
+void Serialize<ColorLayers>::operator()(StringBuilder& builder, const SerializationContext& context, const ColorLayers& value)
 {
-    serializationForCSSColorLayers(builder, value);
+    serializationForCSSColorLayers(builder, context, value);
 }
 
 void ComputedStyleDependenciesCollector<ColorLayers>::operator()(ComputedStyleDependencies& dependencies, const ColorLayers& value)

--- a/Source/WebCore/css/values/color/CSSColorLayers.h
+++ b/Source/WebCore/css/values/color/CSSColorLayers.h
@@ -51,7 +51,7 @@ WebCore::Color createColor(const ColorLayers&, PlatformColorResolutionState&);
 bool containsCurrentColor(const ColorLayers&);
 bool containsColorSchemeDependentColor(const ColorLayers&);
 
-template<> struct Serialize<ColorLayers> { void operator()(StringBuilder&, const ColorLayers&); };
+template<> struct Serialize<ColorLayers> { void operator()(StringBuilder&, const SerializationContext&, const ColorLayers&); };
 template<> struct ComputedStyleDependenciesCollector<ColorLayers> { void operator()(ComputedStyleDependencies&, const ColorLayers&); };
 template<> struct CSSValueChildrenVisitor<ColorLayers> { IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const ColorLayers&); };
 

--- a/Source/WebCore/css/values/color/CSSColorLayersSerialization.h
+++ b/Source/WebCore/css/values/color/CSSColorLayersSerialization.h
@@ -33,15 +33,15 @@ namespace CSS {
 
 // https://drafts.csswg.org/css-color-6/#color-layers
 template<typename ColorLayersType>
-void serializationForCSSColorLayers(StringBuilder& builder, const ColorLayersType& colorLayers)
+void serializationForCSSColorLayers(StringBuilder& builder, const SerializationContext& context, const ColorLayersType& colorLayers)
 {
     builder.append("color-layers("_s);
 
     if (colorLayers.blendMode != BlendMode::Normal)
         builder.append(nameLiteralForSerialization(toCSSValueID(colorLayers.blendMode)), ", "_s);
 
-    builder.append(interleave(colorLayers.colors, [](auto& builder, auto& color) {
-        serializationForCSS(builder, color);
+    builder.append(interleave(colorLayers.colors, [&](auto& builder, auto& color) {
+        serializationForCSS(builder, context, color);
     }, ", "_s));
 
     builder.append(')');

--- a/Source/WebCore/css/values/color/CSSColorMix.cpp
+++ b/Source/WebCore/css/values/color/CSSColorMix.cpp
@@ -90,9 +90,9 @@ bool containsColorSchemeDependentColor(const ColorMix& unresolved)
         || containsColorSchemeDependentColor(unresolved.mixComponents2.color);
 }
 
-void Serialize<ColorMix>::operator()(StringBuilder& builder, const ColorMix& value)
+void Serialize<ColorMix>::operator()(StringBuilder& builder, const SerializationContext& context, const ColorMix& value)
 {
-    serializationForCSSColorMix(builder, value);
+    serializationForCSSColorMix(builder, context, value);
 }
 
 void ComputedStyleDependenciesCollector<ColorMix>::operator()(ComputedStyleDependencies& dependencies, const ColorMix& value)

--- a/Source/WebCore/css/values/color/CSSColorMix.h
+++ b/Source/WebCore/css/values/color/CSSColorMix.h
@@ -63,7 +63,7 @@ WebCore::Color createColor(const ColorMix&, PlatformColorResolutionState&);
 bool containsCurrentColor(const ColorMix&);
 bool containsColorSchemeDependentColor(const ColorMix&);
 
-template<> struct Serialize<ColorMix> { void operator()(StringBuilder&, const ColorMix&); };
+template<> struct Serialize<ColorMix> { void operator()(StringBuilder&, const SerializationContext&, const ColorMix&); };
 template<> struct ComputedStyleDependenciesCollector<ColorMix> { void operator()(ComputedStyleDependencies&, const ColorMix&); };
 template<> struct CSSValueChildrenVisitor<ColorMix> { IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const ColorMix&); };
 

--- a/Source/WebCore/css/values/color/CSSColorMixSerialization.cpp
+++ b/Source/WebCore/css/values/color/CSSColorMixSerialization.cpp
@@ -81,24 +81,24 @@ std::optional<PercentageRaw<>> subtractFrom100Percent(const Style::ColorMix::Com
     return PercentageRaw<> { 100.0 - percentage.value };
 }
 
-void serializeColorMixColor(StringBuilder& builder, const ColorMix::Component& component)
+void serializeColorMixColor(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMix::Component& component)
 {
-    serializationForCSS(builder, component.color);
+    serializationForCSS(builder, context, component.color);
 }
 
-void serializeColorMixColor(StringBuilder& builder, const Style::ColorMix::Component& component)
+void serializeColorMixColor(StringBuilder& builder, const CSS::SerializationContext& context, const Style::ColorMix::Component& component)
 {
-    serializationForCSS(builder, component.color);
+    serializationForCSS(builder, context, component.color);
 }
 
-void serializeColorMixPercentage(StringBuilder& builder, const ColorMix::Component::Percentage& percentage)
+void serializeColorMixPercentage(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMix::Component::Percentage& percentage)
 {
-    serializationForCSS(builder, percentage);
+    serializationForCSS(builder, context, percentage);
 }
 
-void serializeColorMixPercentage(StringBuilder& builder, const Style::ColorMix::Component::Percentage& percentage)
+void serializeColorMixPercentage(StringBuilder& builder, const CSS::SerializationContext& context, const Style::ColorMix::Component::Percentage& percentage)
 {
-    serializationForCSS(builder, PercentageRaw<> { percentage.value });
+    serializationForCSS(builder, context, PercentageRaw<> { percentage.value });
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/color/CSSColorMixSerialization.h
+++ b/Source/WebCore/css/values/color/CSSColorMixSerialization.h
@@ -44,25 +44,25 @@ bool sumTo100Percent(const Style::ColorMix::Component::Percentage&, const Style:
 std::optional<PercentageRaw<>> subtractFrom100Percent(const ColorMix::Component::Percentage&);
 std::optional<PercentageRaw<>> subtractFrom100Percent(const Style::ColorMix::Component::Percentage&);
 
-void serializeColorMixColor(StringBuilder&, const ColorMix::Component&);
-void serializeColorMixColor(StringBuilder&, const Style::ColorMix::Component&);
+void serializeColorMixColor(StringBuilder&, const CSS::SerializationContext&, const ColorMix::Component&);
+void serializeColorMixColor(StringBuilder&, const CSS::SerializationContext&, const Style::ColorMix::Component&);
 
-void serializeColorMixPercentage(StringBuilder&, const ColorMix::Component::Percentage&);
-void serializeColorMixPercentage(StringBuilder&, const Style::ColorMix::Component::Percentage&);
+void serializeColorMixPercentage(StringBuilder&, const CSS::SerializationContext&, const ColorMix::Component::Percentage&);
+void serializeColorMixPercentage(StringBuilder&, const CSS::SerializationContext&, const Style::ColorMix::Component::Percentage&);
 
 template<typename ColorMixType>
-void serializationForColorMixPercentage1(StringBuilder& builder, const ColorMixType& colorMix)
+void serializationForColorMixPercentage1(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMixType& colorMix)
 {
     if (colorMix.mixComponents1.percentage && colorMix.mixComponents2.percentage) {
         if (is50Percent(*colorMix.mixComponents1.percentage) && is50Percent(*colorMix.mixComponents2.percentage))
             return;
         builder.append(' ');
-        serializeColorMixPercentage(builder, *colorMix.mixComponents1.percentage);
+        serializeColorMixPercentage(builder, context, *colorMix.mixComponents1.percentage);
     } else if (colorMix.mixComponents1.percentage) {
         if (is50Percent(*colorMix.mixComponents1.percentage))
             return;
         builder.append(' ');
-        serializeColorMixPercentage(builder, *colorMix.mixComponents1.percentage);
+        serializeColorMixPercentage(builder, context, *colorMix.mixComponents1.percentage);
     } else if (colorMix.mixComponents2.percentage) {
         if (is50Percent(*colorMix.mixComponents2.percentage))
             return;
@@ -72,19 +72,19 @@ void serializationForColorMixPercentage1(StringBuilder& builder, const ColorMixT
             return;
 
         builder.append(' ');
-        serializationForCSS(builder, *subtractedPercent);
+        serializationForCSS(builder, context, *subtractedPercent);
     }
 }
 
 template<typename ColorMixType>
-void serializationForColorMixPercentage2(StringBuilder& builder, const ColorMixType& colorMix)
+void serializationForColorMixPercentage2(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMixType& colorMix)
 {
     if (colorMix.mixComponents1.percentage && colorMix.mixComponents2.percentage) {
         if (sumTo100Percent(*colorMix.mixComponents1.percentage, *colorMix.mixComponents2.percentage))
             return;
 
         builder.append(' ');
-        serializeColorMixPercentage(builder, *colorMix.mixComponents2.percentage);
+        serializeColorMixPercentage(builder, context, *colorMix.mixComponents2.percentage);
     } else if (colorMix.mixComponents2.percentage) {
         if (is50Percent(*colorMix.mixComponents2.percentage))
             return;
@@ -92,22 +92,22 @@ void serializationForColorMixPercentage2(StringBuilder& builder, const ColorMixT
             return;
 
         builder.append(' ');
-        serializeColorMixPercentage(builder, *colorMix.mixComponents2.percentage);
+        serializeColorMixPercentage(builder, context, *colorMix.mixComponents2.percentage);
     }
 }
 
 // https://drafts.csswg.org/css-color-5/#serial-color-mix
 template<typename ColorMixType>
-void serializationForCSSColorMix(StringBuilder& builder, const ColorMixType& colorMix)
+void serializationForCSSColorMix(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMixType& colorMix)
 {
     builder.append("color-mix(in "_s);
     serializationForCSS(builder, colorMix.colorInterpolationMethod);
     builder.append(", "_s);
-    serializeColorMixColor(builder, colorMix.mixComponents1);
-    serializationForColorMixPercentage1(builder, colorMix);
+    serializeColorMixColor(builder, context, colorMix.mixComponents1);
+    serializationForColorMixPercentage1(builder, context, colorMix);
     builder.append(", "_s);
-    serializeColorMixColor(builder, colorMix.mixComponents2);
-    serializationForColorMixPercentage2(builder, colorMix);
+    serializeColorMixColor(builder, context, colorMix.mixComponents2);
+    serializationForColorMixPercentage2(builder, context, colorMix);
     builder.append(')');
 }
 

--- a/Source/WebCore/css/values/color/CSSContrastColor.cpp
+++ b/Source/WebCore/css/values/color/CSSContrastColor.cpp
@@ -58,9 +58,9 @@ bool containsColorSchemeDependentColor(const ContrastColor& unresolved)
     return containsColorSchemeDependentColor(unresolved.color);
 }
 
-void Serialize<ContrastColor>::operator()(StringBuilder& builder, const ContrastColor& value)
+void Serialize<ContrastColor>::operator()(StringBuilder& builder, const SerializationContext& context, const ContrastColor& value)
 {
-    serializationForCSSContrastColor(builder, value);
+    serializationForCSSContrastColor(builder, context, value);
 }
 
 void ComputedStyleDependenciesCollector<ContrastColor>::operator()(ComputedStyleDependencies& dependencies, const ContrastColor& value)

--- a/Source/WebCore/css/values/color/CSSContrastColor.h
+++ b/Source/WebCore/css/values/color/CSSContrastColor.h
@@ -47,7 +47,7 @@ WebCore::Color createColor(const ContrastColor&, PlatformColorResolutionState&);
 bool containsCurrentColor(const ContrastColor&);
 bool containsColorSchemeDependentColor(const ContrastColor&);
 
-template<> struct Serialize<ContrastColor> { void operator()(StringBuilder&, const ContrastColor&); };
+template<> struct Serialize<ContrastColor> { void operator()(StringBuilder&, const SerializationContext&, const ContrastColor&); };
 template<> struct ComputedStyleDependenciesCollector<ContrastColor> { void operator()(ComputedStyleDependencies&, const ContrastColor&); };
 template<> struct CSSValueChildrenVisitor<ContrastColor> { IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const ContrastColor&); };
 

--- a/Source/WebCore/css/values/color/CSSContrastColorSerialization.h
+++ b/Source/WebCore/css/values/color/CSSContrastColorSerialization.h
@@ -31,10 +31,10 @@ namespace WebCore {
 namespace CSS {
 
 // https://drafts.csswg.org/css-color-5/#contrast-color
-template<typename ContrastColorType> void serializationForCSSContrastColor(StringBuilder& builder, const ContrastColorType& contrastColor)
+template<typename ContrastColorType> void serializationForCSSContrastColor(StringBuilder& builder, const CSS::SerializationContext& context, const ContrastColorType& contrastColor)
 {
     builder.append("contrast-color("_s);
-    serializationForCSS(builder, contrastColor.color);
+    serializationForCSS(builder, context, contrastColor.color);
 
     if (contrastColor.max)
         builder.append(' ', nameLiteralForSerialization(CSSValueMax));

--- a/Source/WebCore/css/values/color/CSSHexColor.cpp
+++ b/Source/WebCore/css/values/color/CSSHexColor.cpp
@@ -33,7 +33,7 @@ namespace CSS {
 
 // MARK: - Serialize
 
-void Serialize<HexColor>::operator()(StringBuilder& builder, const HexColor& value)
+void Serialize<HexColor>::operator()(StringBuilder& builder, const SerializationContext&, const HexColor& value)
 {
     builder.append(serializationForCSS(WebCore::Color { value.value }));
 }

--- a/Source/WebCore/css/values/color/CSSHexColor.h
+++ b/Source/WebCore/css/values/color/CSSHexColor.h
@@ -57,7 +57,7 @@ constexpr bool containsColorSchemeDependentColor(const HexColor&)
     return false;
 }
 
-template<> struct Serialize<HexColor> { void operator()(StringBuilder&, const HexColor&); };
+template<> struct Serialize<HexColor> { void operator()(StringBuilder&, const SerializationContext&, const HexColor&); };
 template<> struct ComputedStyleDependenciesCollector<HexColor> { constexpr void operator()(ComputedStyleDependencies&, const HexColor&) { } };
 template<> struct CSSValueChildrenVisitor<HexColor> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const HexColor&) { return IterationStatus::Continue; } };
 

--- a/Source/WebCore/css/values/color/CSSKeywordColor.cpp
+++ b/Source/WebCore/css/values/color/CSSKeywordColor.cpp
@@ -135,7 +135,7 @@ bool containsColorSchemeDependentColor(const KeywordColor& unresolved)
     return isSystemColorKeyword(unresolved.valueID);
 }
 
-void Serialize<KeywordColor>::operator()(StringBuilder& builder, const KeywordColor& value)
+void Serialize<KeywordColor>::operator()(StringBuilder& builder, const SerializationContext&, const KeywordColor& value)
 {
     builder.append(nameLiteralForSerialization(value.valueID));
 }

--- a/Source/WebCore/css/values/color/CSSKeywordColor.h
+++ b/Source/WebCore/css/values/color/CSSKeywordColor.h
@@ -64,7 +64,7 @@ WebCore::Color createColor(const KeywordColor&, PlatformColorResolutionState&);
 bool containsCurrentColor(const KeywordColor&);
 bool containsColorSchemeDependentColor(const KeywordColor&);
 
-template<> struct Serialize<KeywordColor> { void operator()(StringBuilder&, const KeywordColor&); };
+template<> struct Serialize<KeywordColor> { void operator()(StringBuilder&, const SerializationContext&, const KeywordColor&); };
 template<> struct ComputedStyleDependenciesCollector<KeywordColor> { constexpr void operator()(ComputedStyleDependencies&, const KeywordColor&) { } };
 template<> struct CSSValueChildrenVisitor<KeywordColor> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const KeywordColor&) { return IterationStatus::Continue; } };
 

--- a/Source/WebCore/css/values/color/CSSLightDarkColor.cpp
+++ b/Source/WebCore/css/values/color/CSSLightDarkColor.cpp
@@ -63,12 +63,12 @@ bool containsCurrentColor(const LightDarkColor& unresolved)
         || containsCurrentColor(unresolved.darkColor);
 }
 
-void Serialize<LightDarkColor>::operator()(StringBuilder& builder, const LightDarkColor& value)
+void Serialize<LightDarkColor>::operator()(StringBuilder& builder, const SerializationContext& context, const LightDarkColor& value)
 {
     builder.append("light-dark("_s);
-    serializationForCSS(builder, value.lightColor);
+    serializationForCSS(builder, context, value.lightColor);
     builder.append(", "_s);
-    serializationForCSS(builder, value.darkColor);
+    serializationForCSS(builder, context, value.darkColor);
     builder.append(')');
 }
 

--- a/Source/WebCore/css/values/color/CSSLightDarkColor.h
+++ b/Source/WebCore/css/values/color/CSSLightDarkColor.h
@@ -54,7 +54,7 @@ constexpr bool containsColorSchemeDependentColor(const LightDarkColor&)
     return true;
 }
 
-template<> struct Serialize<LightDarkColor> { void operator()(StringBuilder&, const LightDarkColor&); };
+template<> struct Serialize<LightDarkColor> { void operator()(StringBuilder&, const SerializationContext&, const LightDarkColor&); };
 template<> struct ComputedStyleDependenciesCollector<LightDarkColor> { void operator()(ComputedStyleDependencies&, const LightDarkColor&); };
 template<> struct CSSValueChildrenVisitor<LightDarkColor> { IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const LightDarkColor&); };
 

--- a/Source/WebCore/css/values/color/CSSRelativeColor.h
+++ b/Source/WebCore/css/values/color/CSSRelativeColor.h
@@ -99,9 +99,9 @@ bool containsCurrentColor(const RelativeColor<Descriptor>& unresolved)
 }
 
 template<typename D> struct Serialize<RelativeColor<D>> {
-    void operator()(StringBuilder& builder, const RelativeColor<D>& value)
+    void operator()(StringBuilder& builder, const SerializationContext& context, const RelativeColor<D>& value)
     {
-        serializationForCSSRelativeColor(builder, value);
+        serializationForCSSRelativeColor(builder, context, value);
     }
 };
 

--- a/Source/WebCore/css/values/color/CSSRelativeColorSerialization.h
+++ b/Source/WebCore/css/values/color/CSSRelativeColorSerialization.h
@@ -37,34 +37,34 @@ namespace CSS {
 
 // https://drafts.csswg.org/css-color-5/#serial-relative-color
 template<typename RelativeColorType>
-void serializationForCSSRelativeColor(StringBuilder& builder, const RelativeColorType& relativeColor)
+void serializationForCSSRelativeColor(StringBuilder& builder, const CSS::SerializationContext& context, const RelativeColorType& relativeColor)
 {
     using Descriptor = typename RelativeColorType::Descriptor;
     using ColorType = typename Descriptor::ColorType;
 
     if constexpr (Descriptor::usesColorFunctionForSerialization) {
         builder.append("color(from "_s);
-        serializationForCSS(builder, relativeColor.origin);
+        serializationForCSS(builder, context, relativeColor.origin);
         builder.append(' ');
         builder.append(serialization(ColorSpaceFor<ColorType>));
     } else {
         builder.append(Descriptor::serializationFunctionName);
         builder.append("(from "_s);
-        serializationForCSS(builder, relativeColor.origin);
+        serializationForCSS(builder, context, relativeColor.origin);
     }
 
     auto [c1, c2, c3, alpha] = relativeColor.components;
 
     builder.append(' ');
-    serializationForCSS(builder, c1);
+    serializationForCSS(builder, context, c1);
     builder.append(' ');
-    serializationForCSS(builder, c2);
+    serializationForCSS(builder, context, c2);
     builder.append(' ');
-    serializationForCSS(builder, c3);
+    serializationForCSS(builder, context, c3);
 
     if (alpha) {
         builder.append(" / "_s);
-        serializationForCSS(builder, *alpha);
+        serializationForCSS(builder, context, *alpha);
     }
 
     builder.append(')');

--- a/Source/WebCore/css/values/color/CSSResolvedColor.cpp
+++ b/Source/WebCore/css/values/color/CSSResolvedColor.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<ResolvedColor>::operator()(StringBuilder& builder, const ResolvedColor& value)
+void Serialize<ResolvedColor>::operator()(StringBuilder& builder, const SerializationContext&, const ResolvedColor& value)
 {
     builder.append(WebCore::serializationForCSS(value.value));
 }

--- a/Source/WebCore/css/values/easing/CSSStepsEasingFunction.h
+++ b/Source/WebCore/css/values/easing/CSSStepsEasingFunction.h
@@ -80,12 +80,12 @@ template<size_t I, typename T, typename K, auto shouldSerializeKeyword> const au
 }
 
 template<typename T, typename K, auto shouldSerializeKeyword> struct Serialize<StepsEasingParameters::Kind<T, K, shouldSerializeKeyword>> {
-    void operator()(StringBuilder& builder, const StepsEasingParameters::Kind<T, K, shouldSerializeKeyword>& value)
+    void operator()(StringBuilder& builder, const SerializationContext& context, const StepsEasingParameters::Kind<T, K, shouldSerializeKeyword>& value)
     {
-        serializationForCSS(builder, value.steps);
+        serializationForCSS(builder, context, value.steps);
         if constexpr (shouldSerializeKeyword == StepsEasingParameters::ShouldSerializeKeyword::Yes) {
             builder.append(", "_s);
-            serializationForCSS(builder, value.keyword);
+            serializationForCSS(builder, context, value.keyword);
         }
     }
 };

--- a/Source/WebCore/css/values/filter-effects/CSSFilterReference.cpp
+++ b/Source/WebCore/css/values/filter-effects/CSSFilterReference.cpp
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<FilterReference>::operator()(StringBuilder& builder, const FilterReference& value)
+void Serialize<FilterReference>::operator()(StringBuilder& builder, const SerializationContext&, const FilterReference& value)
 {
     builder.append(serializeURL(value.url));
 }

--- a/Source/WebCore/css/values/filter-effects/CSSFilterReference.h
+++ b/Source/WebCore/css/values/filter-effects/CSSFilterReference.h
@@ -37,7 +37,7 @@ struct FilterReference {
     bool operator==(const FilterReference&) const = default;
 };
 
-template<> struct Serialize<FilterReference> { void operator()(StringBuilder&, const FilterReference&); };
+template<> struct Serialize<FilterReference> { void operator()(StringBuilder&, const SerializationContext&, const FilterReference&); };
 template<> struct ComputedStyleDependenciesCollector<FilterReference> { constexpr void operator()(ComputedStyleDependencies&, const FilterReference&) { } };
 template<> struct CSSValueChildrenVisitor<FilterReference> { constexpr IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const FilterReference&) { return IterationStatus::Continue; } };
 

--- a/Source/WebCore/css/values/images/CSSGradient.cpp
+++ b/Source/WebCore/css/values/images/CSSGradient.cpp
@@ -44,53 +44,53 @@ namespace CSS {
 
 // MARK: - Gradient Color Stop
 
-template<typename C, typename P> static void colorStopSerializationForCSS(StringBuilder& builder, const GradientColorStop<C, P>& stop)
+template<typename C, typename P> static void colorStopSerializationForCSS(StringBuilder& builder, const SerializationContext& context, const GradientColorStop<C, P>& stop)
 {
     if (stop.color && stop.position) {
-        serializationForCSS(builder, *stop.color);
+        serializationForCSS(builder, context, *stop.color);
         builder.append(' ');
-        serializationForCSS(builder, *stop.position);
+        serializationForCSS(builder, context, *stop.position);
     } else if (stop.color)
-        serializationForCSS(builder, *stop.color);
+        serializationForCSS(builder, context, *stop.color);
     else if (stop.position)
-        serializationForCSS(builder, *stop.position);
+        serializationForCSS(builder, context, *stop.position);
 }
 
-void Serialize<GradientAngularColorStop>::operator()(StringBuilder& builder, const GradientAngularColorStop& stop)
+void Serialize<GradientAngularColorStop>::operator()(StringBuilder& builder, const SerializationContext& context, const GradientAngularColorStop& stop)
 {
-    colorStopSerializationForCSS(builder, stop);
+    colorStopSerializationForCSS(builder, context, stop);
 }
 
-void Serialize<GradientLinearColorStop>::operator()(StringBuilder& builder, const GradientLinearColorStop& stop)
+void Serialize<GradientLinearColorStop>::operator()(StringBuilder& builder, const SerializationContext& context, const GradientLinearColorStop& stop)
 {
-    colorStopSerializationForCSS(builder, stop);
+    colorStopSerializationForCSS(builder, context, stop);
 }
 
-void Serialize<GradientDeprecatedColorStop>::operator()(StringBuilder& builder, const GradientDeprecatedColorStop& stop)
+void Serialize<GradientDeprecatedColorStop>::operator()(StringBuilder& builder, const SerializationContext& context, const GradientDeprecatedColorStop& stop)
 {
     auto appendRaw = [&](const auto& color, NumberRaw<> raw) {
         if (!raw.value) {
             builder.append("from("_s);
-            serializationForCSS(builder, color);
+            serializationForCSS(builder, context, color);
             builder.append(')');
         } else if (raw.value == 1) {
             builder.append("to("_s);
-            serializationForCSS(builder, color);
+            serializationForCSS(builder, context, color);
             builder.append(')');
         } else {
             builder.append("color-stop("_s);
-            serializationForCSS(builder, raw);
+            serializationForCSS(builder, context, raw);
             builder.append(", "_s);
-            serializationForCSS(builder, color);
+            serializationForCSS(builder, context, color);
             builder.append(')');
         }
     };
 
     auto appendCalc = [&](const auto& color, const auto& calc) {
         builder.append("color-stop("_s);
-        serializationForCSS(builder, calc);
+        serializationForCSS(builder, context, calc);
         builder.append(", "_s);
-        serializationForCSS(builder, color);
+        serializationForCSS(builder, context, color);
         builder.append(')');
     };
 
@@ -148,7 +148,7 @@ static bool appendColorInterpolationMethod(StringBuilder& builder, CSS::Gradient
 
 // MARK: - LinearGradient
 
-void Serialize<LinearGradient>::operator()(StringBuilder& builder, const LinearGradient& gradient)
+void Serialize<LinearGradient>::operator()(StringBuilder& builder, const SerializationContext& context, const LinearGradient& gradient)
 {
     bool wroteSomething = false;
 
@@ -159,18 +159,18 @@ void Serialize<LinearGradient>::operator()(StringBuilder& builder, const LinearG
                     if (convertToValueInUnitsOf<AngleUnit::Deg>(angleRaw) == 180)
                         return;
 
-                    serializationForCSS(builder, angleRaw);
+                    serializationForCSS(builder, context, angleRaw);
                     wroteSomething = true;
                 },
                 [&](const Angle<>::Calc& angleCalc) {
-                    serializationForCSS(builder, angleCalc);
+                    serializationForCSS(builder, context, angleCalc);
                     wroteSomething = true;
                 }
             );
         },
         [&](const Horizontal& horizontal) {
             builder.append("to "_s);
-            serializationForCSS(builder, horizontal);
+            serializationForCSS(builder, context, horizontal);
             wroteSomething = true;
         },
         [&](const Vertical& vertical) {
@@ -178,12 +178,12 @@ void Serialize<LinearGradient>::operator()(StringBuilder& builder, const LinearG
                 return;
 
             builder.append("to "_s);
-            serializationForCSS(builder, vertical);
+            serializationForCSS(builder, context, vertical);
             wroteSomething = true;
         },
         [&](const SpaceSeparatedTuple<Horizontal, Vertical>& pair) {
             builder.append("to "_s);
-            serializationForCSS(builder, pair);
+            serializationForCSS(builder, context, pair);
             wroteSomething = true;
         }
     );
@@ -194,45 +194,45 @@ void Serialize<LinearGradient>::operator()(StringBuilder& builder, const LinearG
     if (wroteSomething)
         builder.append(", "_s);
 
-    serializationForCSS(builder, gradient.stops);
+    serializationForCSS(builder, context, gradient.stops);
 }
 
 // MARK: - PrefixedLinearGradient
 
-void Serialize<PrefixedLinearGradient>::operator()(StringBuilder& builder, const PrefixedLinearGradient& gradient)
+void Serialize<PrefixedLinearGradient>::operator()(StringBuilder& builder, const SerializationContext& context, const PrefixedLinearGradient& gradient)
 {
-    serializationForCSS(builder, gradient.gradientLine);
+    serializationForCSS(builder, context, gradient.gradientLine);
     builder.append(", "_s);
-    serializationForCSS(builder, gradient.stops);
+    serializationForCSS(builder, context, gradient.stops);
 }
 
 // MARK: - DeprecatedLinearGradient
 
-void Serialize<DeprecatedLinearGradient>::operator()(StringBuilder& builder, const DeprecatedLinearGradient& gradient)
+void Serialize<DeprecatedLinearGradient>::operator()(StringBuilder& builder, const SerializationContext& context, const DeprecatedLinearGradient& gradient)
 {
     builder.append("linear, "_s);
 
-    serializationForCSS(builder, gradient.gradientLine);
+    serializationForCSS(builder, context, gradient.gradientLine);
 
     if (!gradient.stops.isEmpty()) {
         builder.append(", "_s);
-        serializationForCSS(builder, gradient.stops);
+        serializationForCSS(builder, context, gradient.stops);
     }
 }
 
 // MARK: - RadialGradient
 
-void Serialize<RadialGradient::Ellipse>::operator()(StringBuilder& builder, const RadialGradient::Ellipse& ellipse)
+void Serialize<RadialGradient::Ellipse>::operator()(StringBuilder& builder, const SerializationContext& context, const RadialGradient::Ellipse& ellipse)
 {
     auto lengthBefore = builder.length();
 
     WTF::switchOn(ellipse.size,
         [&](const RadialGradient::Ellipse::Size& size) {
-            serializationForCSS(builder, size);
+            serializationForCSS(builder, context, size);
         },
         [&](const RadialGradient::Extent& extent) {
             if (!std::holds_alternative<Keyword::FarthestCorner>(extent))
-                serializationForCSS(builder, extent);
+                serializationForCSS(builder, context, extent);
         }
     );
 
@@ -243,21 +243,21 @@ void Serialize<RadialGradient::Ellipse>::operator()(StringBuilder& builder, cons
                 builder.append(' ');
 
             builder.append("at "_s);
-            serializationForCSS(builder, *ellipse.position);
+            serializationForCSS(builder, context, *ellipse.position);
         }
     }
 }
 
-void Serialize<RadialGradient::Circle>::operator()(StringBuilder& builder, const RadialGradient::Circle& circle)
+void Serialize<RadialGradient::Circle>::operator()(StringBuilder& builder, const SerializationContext& context, const RadialGradient::Circle& circle)
 {
     WTF::switchOn(circle.size,
         [&](const RadialGradient::Circle::Length& length) {
-            serializationForCSS(builder, length);
+            serializationForCSS(builder, context, length);
         },
         [&](const RadialGradient::Extent& extent) {
             if (!std::holds_alternative<Keyword::FarthestCorner>(extent)) {
                 builder.append("circle "_s);
-                serializationForCSS(builder, extent);
+                serializationForCSS(builder, context, extent);
             } else
                 builder.append("circle"_s);
         }
@@ -266,15 +266,15 @@ void Serialize<RadialGradient::Circle>::operator()(StringBuilder& builder, const
     if (circle.position) {
         if (!isCenterPosition(*circle.position)) {
             builder.append(" at "_s);
-            serializationForCSS(builder, *circle.position);
+            serializationForCSS(builder, context, *circle.position);
         }
     }
 }
 
-void Serialize<RadialGradient>::operator()(StringBuilder& builder, const RadialGradient& gradient)
+void Serialize<RadialGradient>::operator()(StringBuilder& builder, const SerializationContext& context, const RadialGradient& gradient)
 {
     auto lengthBefore = builder.length();
-    serializationForCSS(builder, gradient.gradientBox);
+    serializationForCSS(builder, context, gradient.gradientBox);
     bool wroteSomething = builder.length() != lengthBefore;
 
     if (appendColorInterpolationMethod(builder, gradient.colorInterpolationMethod, wroteSomething))
@@ -283,15 +283,15 @@ void Serialize<RadialGradient>::operator()(StringBuilder& builder, const RadialG
     if (wroteSomething)
         builder.append(", "_s);
 
-    serializationForCSS(builder, gradient.stops);
+    serializationForCSS(builder, context, gradient.stops);
 }
 
 // MARK: - PrefixedRadialGradient
 
-void Serialize<PrefixedRadialGradient::Ellipse>::operator()(StringBuilder& builder, const PrefixedRadialGradient::Ellipse& ellipse)
+void Serialize<PrefixedRadialGradient::Ellipse>::operator()(StringBuilder& builder, const SerializationContext& context, const PrefixedRadialGradient::Ellipse& ellipse)
 {
     if (ellipse.position)
-        serializationForCSS(builder, *ellipse.position);
+        serializationForCSS(builder, context, *ellipse.position);
     else
         builder.append("center"_s);
 
@@ -299,67 +299,67 @@ void Serialize<PrefixedRadialGradient::Ellipse>::operator()(StringBuilder& build
         WTF::switchOn(*ellipse.size,
             [&](const PrefixedRadialGradient::Ellipse::Size& size) {
                 builder.append(", "_s);
-                serializationForCSS(builder, size);
+                serializationForCSS(builder, context, size);
             },
             [&](const PrefixedRadialGradient::Extent& extent) {
                 builder.append(", ellipse "_s);
-                serializationForCSS(builder, extent);
+                serializationForCSS(builder, context, extent);
             }
         );
     }
 }
 
-void Serialize<PrefixedRadialGradient::Circle>::operator()(StringBuilder& builder, const PrefixedRadialGradient::Circle& circle)
+void Serialize<PrefixedRadialGradient::Circle>::operator()(StringBuilder& builder, const SerializationContext& context, const PrefixedRadialGradient::Circle& circle)
 {
     if (circle.position)
-        serializationForCSS(builder, *circle.position);
+        serializationForCSS(builder, context, *circle.position);
     else
         builder.append("center"_s);
 
     builder.append(", circle "_s);
-    serializationForCSS(builder, circle.size.value_or(PrefixedRadialGradient::Extent { CSS::Keyword::Cover { } }));
+    serializationForCSS(builder, context, circle.size.value_or(PrefixedRadialGradient::Extent { CSS::Keyword::Cover { } }));
 }
 
-void Serialize<PrefixedRadialGradient>::operator()(StringBuilder& builder, const PrefixedRadialGradient& gradient)
+void Serialize<PrefixedRadialGradient>::operator()(StringBuilder& builder, const SerializationContext& context, const PrefixedRadialGradient& gradient)
 {
     auto lengthBefore = builder.length();
-    serializationForCSS(builder, gradient.gradientBox);
+    serializationForCSS(builder, context, gradient.gradientBox);
     bool wroteSomething = builder.length() != lengthBefore;
 
     if (wroteSomething)
         builder.append(", "_s);
 
-    serializationForCSS(builder, gradient.stops);
+    serializationForCSS(builder, context, gradient.stops);
 }
 
 // MARK: - DeprecatedRadialGradient
 
-void Serialize<DeprecatedRadialGradient::GradientBox>::operator()(StringBuilder& builder, const DeprecatedRadialGradient::GradientBox& gradientBox)
+void Serialize<DeprecatedRadialGradient::GradientBox>::operator()(StringBuilder& builder, const SerializationContext& context, const DeprecatedRadialGradient::GradientBox& gradientBox)
 {
-    serializationForCSS(builder, gradientBox.first);
+    serializationForCSS(builder, context, gradientBox.first);
     builder.append(", "_s);
-    serializationForCSS(builder, gradientBox.firstRadius);
+    serializationForCSS(builder, context, gradientBox.firstRadius);
     builder.append(", "_s);
-    serializationForCSS(builder, gradientBox.second);
+    serializationForCSS(builder, context, gradientBox.second);
     builder.append(", "_s);
-    serializationForCSS(builder, gradientBox.secondRadius);
+    serializationForCSS(builder, context, gradientBox.secondRadius);
 }
 
-void Serialize<DeprecatedRadialGradient>::operator()(StringBuilder& builder, const DeprecatedRadialGradient& gradient)
+void Serialize<DeprecatedRadialGradient>::operator()(StringBuilder& builder, const SerializationContext& context, const DeprecatedRadialGradient& gradient)
 {
     builder.append("radial, "_s);
 
-    serializationForCSS(builder, gradient.gradientBox);
+    serializationForCSS(builder, context, gradient.gradientBox);
 
     if (!gradient.stops.isEmpty()) {
         builder.append(", "_s);
-        serializationForCSS(builder, gradient.stops);
+        serializationForCSS(builder, context, gradient.stops);
     }
 }
 
 // MARK: - ConicGradient
 
-void Serialize<ConicGradient::GradientBox>::operator()(StringBuilder& builder, const ConicGradient::GradientBox& gradientBox)
+void Serialize<ConicGradient::GradientBox>::operator()(StringBuilder& builder, const SerializationContext& context, const ConicGradient::GradientBox& gradientBox)
 {
     bool wroteSomething = false;
 
@@ -368,13 +368,13 @@ void Serialize<ConicGradient::GradientBox>::operator()(StringBuilder& builder, c
             [&](const Angle<>::Raw& angleRaw) {
                 if (angleRaw.value) {
                     builder.append("from "_s);
-                    serializationForCSS(builder, angleRaw);
+                    serializationForCSS(builder, context, angleRaw);
                     wroteSomething = true;
                 }
             },
             [&](const Angle<>::Calc& angleCalc) {
                 builder.append("from "_s);
-                serializationForCSS(builder, angleCalc);
+                serializationForCSS(builder, context, angleCalc);
                 wroteSomething = true;
             }
         );
@@ -384,14 +384,14 @@ void Serialize<ConicGradient::GradientBox>::operator()(StringBuilder& builder, c
         if (wroteSomething)
             builder.append(' ');
         builder.append("at "_s);
-        serializationForCSS(builder, *gradientBox.position);
+        serializationForCSS(builder, context, *gradientBox.position);
     }
 }
 
-void Serialize<ConicGradient>::operator()(StringBuilder& builder, const ConicGradient& gradient)
+void Serialize<ConicGradient>::operator()(StringBuilder& builder, const SerializationContext& context, const ConicGradient& gradient)
 {
     auto lengthBefore = builder.length();
-    serializationForCSS(builder, gradient.gradientBox);
+    serializationForCSS(builder, context, gradient.gradientBox);
     bool wroteSomething = builder.length() != lengthBefore;
 
     if (appendColorInterpolationMethod(builder, gradient.colorInterpolationMethod, wroteSomething))
@@ -400,7 +400,7 @@ void Serialize<ConicGradient>::operator()(StringBuilder& builder, const ConicGra
     if (wroteSomething)
         builder.append(", "_s);
 
-    serializationForCSS(builder, gradient.stops);
+    serializationForCSS(builder, context, gradient.stops);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/images/CSSGradient.h
+++ b/Source/WebCore/css/values/images/CSSGradient.h
@@ -101,9 +101,9 @@ using GradientDeprecatedColorStopPosition = NumberOrPercentageResolvedToNumber<>
 using GradientDeprecatedColorStop = GradientColorStop<GradientDeprecatedColorStopColor, GradientDeprecatedColorStopPosition>;
 using GradientDeprecatedColorStopList = GradientColorStopList<GradientDeprecatedColorStop>;
 
-template<> struct Serialize<GradientAngularColorStop> { void operator()(StringBuilder&, const GradientAngularColorStop&); };
-template<> struct Serialize<GradientLinearColorStop> { void operator()(StringBuilder&, const GradientLinearColorStop&); };
-template<> struct Serialize<GradientDeprecatedColorStop> { void operator()(StringBuilder&, const GradientDeprecatedColorStop&); };
+template<> struct Serialize<GradientAngularColorStop> { void operator()(StringBuilder&, const SerializationContext&, const GradientAngularColorStop&); };
+template<> struct Serialize<GradientLinearColorStop> { void operator()(StringBuilder&, const SerializationContext&, const GradientLinearColorStop&); };
+template<> struct Serialize<GradientDeprecatedColorStop> { void operator()(StringBuilder&, const SerializationContext&, const GradientDeprecatedColorStop&); };
 
 // MARK: - LinearGradient
 
@@ -117,7 +117,7 @@ struct LinearGradient {
     bool operator==(const LinearGradient&) const = default;
 };
 
-template<> struct Serialize<LinearGradient> { void operator()(StringBuilder&, const LinearGradient&); };
+template<> struct Serialize<LinearGradient> { void operator()(StringBuilder&, const SerializationContext&, const LinearGradient&); };
 
 template<size_t I> const auto& get(const LinearGradient& gradient)
 {
@@ -141,7 +141,7 @@ struct PrefixedLinearGradient {
     bool operator==(const PrefixedLinearGradient&) const = default;
 };
 
-template<> struct Serialize<PrefixedLinearGradient> { void operator()(StringBuilder&, const PrefixedLinearGradient&); };
+template<> struct Serialize<PrefixedLinearGradient> { void operator()(StringBuilder&, const SerializationContext&, const PrefixedLinearGradient&); };
 
 template<size_t I> const auto& get(const PrefixedLinearGradient& gradient)
 {
@@ -165,7 +165,7 @@ struct DeprecatedLinearGradient {
     bool operator==(const DeprecatedLinearGradient&) const = default;
 };
 
-template<> struct Serialize<DeprecatedLinearGradient> { void operator()(StringBuilder&, const DeprecatedLinearGradient&); };
+template<> struct Serialize<DeprecatedLinearGradient> { void operator()(StringBuilder&, const SerializationContext&, const DeprecatedLinearGradient&); };
 
 template<size_t I> const auto& get(const DeprecatedLinearGradient& gradient)
 {
@@ -202,9 +202,9 @@ struct RadialGradient {
     bool operator==(const RadialGradient&) const = default;
 };
 
-template<> struct Serialize<RadialGradient::Ellipse> { void operator()(StringBuilder&, const RadialGradient::Ellipse&); };
-template<> struct Serialize<RadialGradient::Circle> { void operator()(StringBuilder&, const RadialGradient::Circle&); };
-template<> struct Serialize<RadialGradient> { void operator()(StringBuilder&, const RadialGradient&); };
+template<> struct Serialize<RadialGradient::Ellipse> { void operator()(StringBuilder&, const SerializationContext&, const RadialGradient::Ellipse&); };
+template<> struct Serialize<RadialGradient::Circle> { void operator()(StringBuilder&, const SerializationContext&, const RadialGradient::Circle&); };
+template<> struct Serialize<RadialGradient> { void operator()(StringBuilder&, const SerializationContext&, const RadialGradient&); };
 
 template<size_t I> const auto& get(const RadialGradient::Ellipse& ellipse)
 {
@@ -256,9 +256,9 @@ struct PrefixedRadialGradient {
     bool operator==(const PrefixedRadialGradient&) const = default;
 };
 
-template<> struct Serialize<PrefixedRadialGradient::Ellipse> { void operator()(StringBuilder&, const PrefixedRadialGradient::Ellipse&); };
-template<> struct Serialize<PrefixedRadialGradient::Circle> { void operator()(StringBuilder&, const PrefixedRadialGradient::Circle&); };
-template<> struct Serialize<PrefixedRadialGradient> { void operator()(StringBuilder&, const PrefixedRadialGradient&); };
+template<> struct Serialize<PrefixedRadialGradient::Ellipse> { void operator()(StringBuilder&, const SerializationContext&, const PrefixedRadialGradient::Ellipse&); };
+template<> struct Serialize<PrefixedRadialGradient::Circle> { void operator()(StringBuilder&, const SerializationContext&, const PrefixedRadialGradient::Circle&); };
+template<> struct Serialize<PrefixedRadialGradient> { void operator()(StringBuilder&, const SerializationContext&, const PrefixedRadialGradient&); };
 
 template<size_t I> const auto& get(const PrefixedRadialGradient::Ellipse& ellipse)
 {
@@ -305,8 +305,8 @@ struct DeprecatedRadialGradient {
     bool operator==(const DeprecatedRadialGradient&) const = default;
 };
 
-template<> struct Serialize<DeprecatedRadialGradient::GradientBox> { void operator()(StringBuilder&, const DeprecatedRadialGradient::GradientBox&); };
-template<> struct Serialize<DeprecatedRadialGradient> { void operator()(StringBuilder&, const DeprecatedRadialGradient&); };
+template<> struct Serialize<DeprecatedRadialGradient::GradientBox> { void operator()(StringBuilder&, const SerializationContext&, const DeprecatedRadialGradient::GradientBox&); };
+template<> struct Serialize<DeprecatedRadialGradient> { void operator()(StringBuilder&, const SerializationContext&, const DeprecatedRadialGradient&); };
 
 template<size_t I> const auto& get(const DeprecatedRadialGradient::GradientBox& gradientBox)
 {
@@ -347,8 +347,8 @@ struct ConicGradient {
     bool operator==(const ConicGradient&) const = default;
 };
 
-template<> struct Serialize<ConicGradient::GradientBox> { void operator()(StringBuilder&, const ConicGradient::GradientBox&); };
-template<> struct Serialize<ConicGradient> { void operator()(StringBuilder&, const ConicGradient&); };
+template<> struct Serialize<ConicGradient::GradientBox> { void operator()(StringBuilder&, const SerializationContext&, const ConicGradient::GradientBox&); };
+template<> struct Serialize<ConicGradient> { void operator()(StringBuilder&, const SerializationContext&, const ConicGradient&); };
 
 template<size_t I> const auto& get(const ConicGradient::GradientBox& gradientBox)
 {

--- a/Source/WebCore/css/values/motion/CSSRayFunction.cpp
+++ b/Source/WebCore/css/values/motion/CSSRayFunction.cpp
@@ -32,26 +32,26 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Ray>::operator()(StringBuilder& builder, const Ray& value)
+void Serialize<Ray>::operator()(StringBuilder& builder, const SerializationContext& context, const Ray& value)
 {
     // ray() = ray( <angle> && <ray-size>? && contain? && [at <position>]? )
     // https://drafts.fxtf.org/motion-1/#ray-function
 
-    serializationForCSS(builder, value.angle);
+    serializationForCSS(builder, context, value.angle);
 
     if (!std::holds_alternative<Keyword::ClosestSide>(value.size)) {
         builder.append(' ');
-        serializationForCSS(builder, value.size);
+        serializationForCSS(builder, context, value.size);
     }
 
     if (value.contain) {
         builder.append(' ');
-        serializationForCSS(builder, *value.contain);
+        serializationForCSS(builder, context, *value.contain);
     }
 
     if (value.position) {
         builder.append(' ', nameLiteralForSerialization(CSSValueAt), ' ');
-        serializationForCSS(builder, *value.position);
+        serializationForCSS(builder, context, *value.position);
     }
 }
 

--- a/Source/WebCore/css/values/motion/CSSRayFunction.h
+++ b/Source/WebCore/css/values/motion/CSSRayFunction.h
@@ -57,7 +57,7 @@ template<size_t I> const auto& get(const Ray& value)
         return value.position;
 }
 
-template<> struct Serialize<Ray> { void operator()(StringBuilder&, const Ray&); };
+template<> struct Serialize<Ray> { void operator()(StringBuilder&, const SerializationContext&, const Ray&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp
@@ -65,7 +65,7 @@ NEVER_INLINE String formatCSSNumberValue(const SerializableNumber& number)
     return makeString(FormattedCSSNumber::create(number.value), number.suffix);
 }
 
-void Serialize<SerializableNumber>::operator()(StringBuilder& builder, const SerializableNumber& number)
+void Serialize<SerializableNumber>::operator()(StringBuilder& builder, const SerializationContext&, const SerializableNumber& number)
 {
     formatCSSNumberValue(builder, number);
 }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h
@@ -43,28 +43,28 @@ void formatCSSNumberValue(StringBuilder&, const SerializableNumber&);
 String formatCSSNumberValue(const SerializableNumber&);
 
 template<> struct Serialize<SerializableNumber> {
-    void operator()(StringBuilder&, const SerializableNumber&);
+    void operator()(StringBuilder&, const SerializationContext&, const SerializableNumber&);
 };
 
 template<NumericRaw RawType> struct Serialize<RawType> {
-    void operator()(StringBuilder& builder, const RawType& value)
+    void operator()(StringBuilder& builder, const SerializationContext& context, const RawType& value)
     {
-        serializationForCSS(builder, SerializableNumber { value.value, unitString(value.unit) });
+        serializationForCSS(builder, context, SerializableNumber { value.value, unitString(value.unit) });
     }
 };
 
 template<auto nR, auto pR, typename V> struct Serialize<NumberOrPercentageResolvedToNumber<nR, pR, V>> {
-    void operator()(StringBuilder& builder, const NumberOrPercentageResolvedToNumber<nR, pR, V>& value)
+    void operator()(StringBuilder& builder, const SerializationContext& context, const NumberOrPercentageResolvedToNumber<nR, pR, V>& value)
     {
         WTF::switchOn(value,
             [&](const typename NumberOrPercentageResolvedToNumber<nR, pR, V>::Number& number) {
-                serializationForCSS(builder, number);
+                serializationForCSS(builder, context, number);
             },
             [&](const typename NumberOrPercentageResolvedToNumber<nR, pR, V>::Percentage& percentage) {
                 if (auto raw = percentage.raw())
-                    serializationForCSS(builder, NumberRaw<nR, V> { raw->value / 100.0 });
+                    serializationForCSS(builder, context, NumberRaw<nR, V> { raw->value / 100.0 });
                 else
-                    serializationForCSS(builder, percentage);
+                    serializationForCSS(builder, context, percentage);
             }
         );
     }

--- a/Source/WebCore/css/values/primitives/CSSSymbol.cpp
+++ b/Source/WebCore/css/values/primitives/CSSSymbol.cpp
@@ -30,12 +30,12 @@ namespace CSS {
 
 // MARK: - Serialization
 
-void Serialize<SymbolRaw>::operator()(StringBuilder& builder, const SymbolRaw& value)
+void Serialize<SymbolRaw>::operator()(StringBuilder& builder, const SerializationContext&, const SymbolRaw& value)
 {
     builder.append(nameLiteralForSerialization(value.value));
 }
 
-void Serialize<Symbol>::operator()(StringBuilder& builder, const Symbol& value)
+void Serialize<Symbol>::operator()(StringBuilder& builder, const SerializationContext&, const Symbol& value)
 {
     builder.append(nameLiteralForSerialization(value.value));
 }

--- a/Source/WebCore/css/values/primitives/CSSSymbol.h
+++ b/Source/WebCore/css/values/primitives/CSSSymbol.h
@@ -55,8 +55,8 @@ struct Symbol {
 
 template<typename T> struct IsSymbol : public std::integral_constant<bool, std::is_same_v<T, Symbol>> { };
 
-template<> struct Serialize<SymbolRaw> { void operator()(StringBuilder&, const SymbolRaw&); };
-template<> struct Serialize<Symbol> { void operator()(StringBuilder&, const Symbol&); };
+template<> struct Serialize<SymbolRaw> { void operator()(StringBuilder&, const SerializationContext&, const SymbolRaw&); };
+template<> struct Serialize<Symbol> { void operator()(StringBuilder&, const SerializationContext&, const Symbol&); };
 
 template<> struct ComputedStyleDependenciesCollector<SymbolRaw> { constexpr void operator()(ComputedStyleDependencies&, const SymbolRaw&) { } };
 template<> struct ComputedStyleDependenciesCollector<Symbol> { constexpr void operator()(ComputedStyleDependencies&, const Symbol&) { } };

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp
@@ -83,9 +83,9 @@ bool UnevaluatedCalcBase::requiresConversionData() const
     return protectedCalc()->requiresConversionData();
 }
 
-void UnevaluatedCalcBase::serializationForCSS(StringBuilder& builder) const
+void UnevaluatedCalcBase::serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context) const
 {
-    builder.append(protectedCalc()->customCSSText());
+    builder.append(protectedCalc()->customCSSText(context));
 }
 
 void UnevaluatedCalcBase::collectComputedStyleDependencies(ComputedStyleDependencies& dependencies) const

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -75,7 +75,7 @@ struct UnevaluatedCalcBase {
 
     bool requiresConversionData() const;
 
-    void serializationForCSS(StringBuilder&) const;
+    void serializationForCSS(StringBuilder&, const CSS::SerializationContext&) const;
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;
     IterationStatus visitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 
@@ -181,9 +181,9 @@ template<typename T> decltype(auto) simplifyUnevaluatedCalc(const std::optional<
 // MARK: - Serialization
 
 template<Calc T> struct Serialize<T> {
-    inline void operator()(StringBuilder& builder, const T& value)
+    inline void operator()(StringBuilder& builder, const SerializationContext& context, const T& value)
     {
-        value.serializationForCSS(builder);
+        value.serializationForCSS(builder, context);
     }
 };
 

--- a/Source/WebCore/css/values/shapes/CSSCircleFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSCircleFunction.cpp
@@ -44,20 +44,20 @@ static bool hasDefaultValueForCircleRadius(Circle::RadialSize radius)
     );
 }
 
-void Serialize<Circle>::operator()(StringBuilder& builder, const Circle& value)
+void Serialize<Circle>::operator()(StringBuilder& builder, const SerializationContext& context, const Circle& value)
 {
     // <circle()> = circle( <radial-size>? [ at <position> ]? )
 
     auto lengthBefore = builder.length();
 
     if (!hasDefaultValueForCircleRadius(value.radius))
-        serializationForCSS(builder, value.radius);
+        serializationForCSS(builder, context, value.radius);
 
     if (value.position) {
         // FIXME: To match other serialization of Percentage, this should not serialize if equal to the default value of 50% 50%, but this does not match the tests.
         bool wroteSomething = builder.length() != lengthBefore;
         builder.append(wroteSomething ? " at "_s : "at "_s);
-        serializationForCSS(builder, *value.position);
+        serializationForCSS(builder, context, *value.position);
     }
 }
 

--- a/Source/WebCore/css/values/shapes/CSSCircleFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSCircleFunction.h
@@ -54,7 +54,7 @@ template<size_t I> const auto& get(const Circle& value)
         return value.position;
 }
 
-template<> struct Serialize<Circle> { void operator()(StringBuilder&, const Circle&); };
+template<> struct Serialize<Circle> { void operator()(StringBuilder&, const SerializationContext&, const Circle&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp
@@ -44,20 +44,20 @@ static bool hasDefaultValueForEllipseRadius(Ellipse::RadialSize radius)
     );
 }
 
-void Serialize<Ellipse>::operator()(StringBuilder& builder, const Ellipse& value)
+void Serialize<Ellipse>::operator()(StringBuilder& builder, const SerializationContext& context, const Ellipse& value)
 {
     // <ellipse()> = ellipse( <radial-size>? [ at <position> ]? )
 
     auto lengthBefore = builder.length();
 
     if (!hasDefaultValueForEllipseRadius(get<0>(value.radii)) || !hasDefaultValueForEllipseRadius(get<1>(value.radii)))
-        serializationForCSS(builder, value.radii);
+        serializationForCSS(builder, context, value.radii);
 
     if (value.position) {
         // FIXME: To match other serialization of Percentage, this should not serialize if equal to the default value of 50% 50%, but this does not match the tests.
         bool wroteSomething = builder.length() != lengthBefore;
         builder.append(wroteSomething ? " at "_s : "at "_s);
-        serializationForCSS(builder, *value.position);
+        serializationForCSS(builder, context, *value.position);
     }
 }
 

--- a/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
@@ -54,7 +54,7 @@ template<size_t I> const auto& get(const Ellipse& value)
         return value.position;
 }
 
-template<> struct Serialize<Ellipse> { void operator()(StringBuilder&, const Ellipse&); };
+template<> struct Serialize<Ellipse> { void operator()(StringBuilder&, const SerializationContext&, const Ellipse&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSInsetFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSInsetFunction.cpp
@@ -31,15 +31,15 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Inset>::operator()(StringBuilder& builder, const Inset& value)
+void Serialize<Inset>::operator()(StringBuilder& builder, const SerializationContext& context, const Inset& value)
 {
     // <inset()> = inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )
 
-    serializationForCSS(builder, value.insets);
+    serializationForCSS(builder, context, value.insets);
 
     if (!hasDefaultValue(value.radii)) {
         builder.append(' ', nameLiteralForSerialization(CSSValueRound), ' ');
-        serializationForCSS(builder, value.radii);
+        serializationForCSS(builder, context, value.radii);
     }
 }
 

--- a/Source/WebCore/css/values/shapes/CSSInsetFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSInsetFunction.h
@@ -50,7 +50,7 @@ template<size_t I> const auto& get(const Inset& value)
         return value.radii;
 }
 
-template<> struct Serialize<Inset> { void operator()(StringBuilder&, const Inset&); };
+template<> struct Serialize<Inset> { void operator()(StringBuilder&, const SerializationContext&, const Inset&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.cpp
@@ -34,12 +34,12 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Path>::operator()(StringBuilder& builder, const Path& value)
+void Serialize<Path>::operator()(StringBuilder& builder, const SerializationContext& context, const Path& value)
 {
     // <path()> = path( <'fill-rule'>? , <string> )
 
     if (value.fillRule && !std::holds_alternative<Keyword::Nonzero>(*value.fillRule)) {
-        serializationForCSS(builder, *value.fillRule);
+        serializationForCSS(builder, context, *value.fillRule);
         builder.append(", "_s);
     }
 

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.h
@@ -55,7 +55,7 @@ template<size_t I> const auto& get(const Path& value)
         return value.data;
 }
 
-template<> struct Serialize<Path> { void operator()(StringBuilder&, const Path&); };
+template<> struct Serialize<Path> { void operator()(StringBuilder&, const SerializationContext&, const Path&); };
 
 template<> struct ComputedStyleDependenciesCollector<Path::Data> { void operator()(ComputedStyleDependencies&, const Path::Data&); };
 template<> struct CSSValueChildrenVisitor<Path::Data> { IterationStatus operator()(NOESCAPE const Function<IterationStatus(CSSValue&)>&, const Path::Data&); };

--- a/Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp
@@ -31,18 +31,18 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Polygon>::operator()(StringBuilder& builder, const Polygon& value)
+void Serialize<Polygon>::operator()(StringBuilder& builder, const SerializationContext& context, const Polygon& value)
 {
     // <polygon()> = polygon( <'fill-rule'>? [ round <length> ]? , [<length-percentage> <length-percentage>]# )
 
     // FIXME: Add support the "round" clause.
 
     if (value.fillRule && std::holds_alternative<CSS::Keyword::Evenodd>(*value.fillRule)) {
-        serializationForCSS(builder, *value.fillRule);
+        serializationForCSS(builder, context, *value.fillRule);
         builder.append(", "_s);
     }
 
-    serializationForCSS(builder, value.vertices);
+    serializationForCSS(builder, context, value.vertices);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/shapes/CSSPolygonFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSPolygonFunction.h
@@ -52,7 +52,7 @@ template<size_t I> const auto& get(const Polygon& value)
         return value.vertices;
 }
 
-template<> struct Serialize<Polygon> { void operator()(StringBuilder&, const Polygon&); };
+template<> struct Serialize<Polygon> { void operator()(StringBuilder&, const SerializationContext&, const Polygon&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSRectFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSRectFunction.cpp
@@ -31,15 +31,15 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Rect>::operator()(StringBuilder& builder, const Rect& value)
+void Serialize<Rect>::operator()(StringBuilder& builder, const SerializationContext& context, const Rect& value)
 {
     // <rect()> = rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )
 
-    serializationForCSS(builder, value.edges);
+    serializationForCSS(builder, context, value.edges);
 
     if (!hasDefaultValue(value.radii)) {
         builder.append(' ', nameLiteralForSerialization(CSSValueRound), ' ');
-        serializationForCSS(builder, value.radii);
+        serializationForCSS(builder, context, value.radii);
     }
 }
 

--- a/Source/WebCore/css/values/shapes/CSSRectFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSRectFunction.h
@@ -51,7 +51,7 @@ template<size_t I> const auto& get(const Rect& value)
         return value.radii;
 }
 
-template<> struct Serialize<Rect> { void operator()(StringBuilder&, const Rect&); };
+template<> struct Serialize<Rect> { void operator()(StringBuilder&, const SerializationContext&, const Rect&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.cpp
@@ -31,141 +31,141 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<ToPosition>::operator()(StringBuilder& builder, const ToPosition& value)
+void Serialize<ToPosition>::operator()(StringBuilder& builder, const SerializationContext& context, const ToPosition& value)
 {
     // <to-position> = to <position>
 
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 }
 
-void Serialize<ByCoordinatePair>::operator()(StringBuilder& builder, const ByCoordinatePair& value)
+void Serialize<ByCoordinatePair>::operator()(StringBuilder& builder, const SerializationContext& context, const ByCoordinatePair& value)
 {
     // <by-coordinate-pair> = by <coordinate-pair>
 
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 }
 
-void Serialize<RelativeControlPoint>::operator()(StringBuilder& builder, const RelativeControlPoint& value)
+void Serialize<RelativeControlPoint>::operator()(StringBuilder& builder, const SerializationContext& context, const RelativeControlPoint& value)
 {
     // <relative-control-point> = [<coordinate-pair> [from [start | end | origin]]?]
     // Specified https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 
     if (value.anchor) {
         builder.append(' ', nameLiteralForSerialization(CSSValueFrom), ' ');
-        serializationForCSS(builder, *value.anchor);
+        serializationForCSS(builder, context, *value.anchor);
     }
 }
 
-void Serialize<AbsoluteControlPoint>::operator()(StringBuilder& builder, const AbsoluteControlPoint& value)
+void Serialize<AbsoluteControlPoint>::operator()(StringBuilder& builder, const SerializationContext& context, const AbsoluteControlPoint& value)
 {
     // <to-control-point> = [<position> | <relative-control-point>]
     // Specified https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 
     // Representation diverges from grammar due to overlap between <position> and <relative-control-point>.
 
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 
     if (value.anchor) {
         builder.append(' ', nameLiteralForSerialization(CSSValueFrom), ' ');
-        serializationForCSS(builder, *value.anchor);
+        serializationForCSS(builder, context, *value.anchor);
     }
 }
 
-void Serialize<MoveCommand>::operator()(StringBuilder& builder, const MoveCommand& value)
+void Serialize<MoveCommand>::operator()(StringBuilder& builder, const SerializationContext& context, const MoveCommand& value)
 {
     // <move-command> = move [to <position>] | [by <coordinate-pair>]
     // https://drafts.csswg.org/css-shapes-2/#typedef-shape-move-command
     // Modified by https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 
     builder.append(nameLiteralForSerialization(value.name), ' ');
-    serializationForCSS(builder, value.toBy);
+    serializationForCSS(builder, context, value.toBy);
 }
 
-void Serialize<LineCommand>::operator()(StringBuilder& builder, const LineCommand& value)
+void Serialize<LineCommand>::operator()(StringBuilder& builder, const SerializationContext& context, const LineCommand& value)
 {
     // <line-command> = line [to <position>] | [by <coordinate-pair>]
     // https://drafts.csswg.org/css-shapes-2/#typedef-shape-line-command
     // Modified by https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 
     builder.append(nameLiteralForSerialization(value.name), ' ');
-    serializationForCSS(builder, value.toBy);
+    serializationForCSS(builder, context, value.toBy);
 }
 
-void Serialize<HLineCommand::To>::operator()(StringBuilder& builder, const HLineCommand::To& value)
+void Serialize<HLineCommand::To>::operator()(StringBuilder& builder, const SerializationContext& context, const HLineCommand::To& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 }
 
-void Serialize<HLineCommand::By>::operator()(StringBuilder& builder, const HLineCommand::By& value)
+void Serialize<HLineCommand::By>::operator()(StringBuilder& builder, const SerializationContext& context, const HLineCommand::By& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 }
 
-void Serialize<HLineCommand>::operator()(StringBuilder& builder, const HLineCommand& value)
+void Serialize<HLineCommand>::operator()(StringBuilder& builder, const SerializationContext& context, const HLineCommand& value)
 {
     // <horizontal-line-command> = hline [ to [ <length-percentage> | left | center | right | x-start | x-end ] | by <length-percentage> ]
     // https://drafts.csswg.org/css-shapes-2/#typedef-shape-hv-line-command
     // Modified by https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2426552611
 
     builder.append(nameLiteralForSerialization(value.name), ' ');
-    serializationForCSS(builder, value.toBy);
+    serializationForCSS(builder, context, value.toBy);
 }
 
-void Serialize<VLineCommand::To>::operator()(StringBuilder& builder, const VLineCommand::To& value)
+void Serialize<VLineCommand::To>::operator()(StringBuilder& builder, const SerializationContext& context, const VLineCommand::To& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 }
 
-void Serialize<VLineCommand::By>::operator()(StringBuilder& builder, const VLineCommand::By& value)
+void Serialize<VLineCommand::By>::operator()(StringBuilder& builder, const SerializationContext& context, const VLineCommand::By& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 }
 
-void Serialize<VLineCommand>::operator()(StringBuilder& builder, const VLineCommand& value)
+void Serialize<VLineCommand>::operator()(StringBuilder& builder, const SerializationContext& context, const VLineCommand& value)
 {
     // <vertical-line-command> = vline [ to [ <length-percentage> | top | center | bottom | y-start | y-end ] | by <length-percentage> ]
     // https://drafts.csswg.org/css-shapes-2/#typedef-shape-hv-line-command
     // Modified by https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2426552611
 
     builder.append(nameLiteralForSerialization(value.name), ' ');
-    serializationForCSS(builder, value.toBy);
+    serializationForCSS(builder, context, value.toBy);
 }
 
-void Serialize<CurveCommand::To>::operator()(StringBuilder& builder, const CurveCommand::To& value)
+void Serialize<CurveCommand::To>::operator()(StringBuilder& builder, const SerializationContext& context, const CurveCommand::To& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 
     builder.append(' ', nameLiteralForSerialization(CSSValueWith), ' ');
-    serializationForCSS(builder, value.controlPoint1);
+    serializationForCSS(builder, context, value.controlPoint1);
     if (value.controlPoint2) {
         builder.append(" / "_s);
-        serializationForCSS(builder, *value.controlPoint2);
+        serializationForCSS(builder, context, *value.controlPoint2);
     }
 }
 
-void Serialize<CurveCommand::By>::operator()(StringBuilder& builder, const CurveCommand::By& value)
+void Serialize<CurveCommand::By>::operator()(StringBuilder& builder, const SerializationContext& context, const CurveCommand::By& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 
     builder.append(' ', nameLiteralForSerialization(CSSValueWith), ' ');
-    serializationForCSS(builder, value.controlPoint1);
+    serializationForCSS(builder, context, value.controlPoint1);
     if (value.controlPoint2) {
         builder.append(" / "_s);
-        serializationForCSS(builder, *value.controlPoint2);
+        serializationForCSS(builder, context, *value.controlPoint2);
     }
 }
 
-void Serialize<CurveCommand>::operator()(StringBuilder& builder, const CurveCommand& value)
+void Serialize<CurveCommand>::operator()(StringBuilder& builder, const SerializationContext& context, const CurveCommand& value)
 {
     // <curve-command> = curve [to <position> with <to-control-point> [/ <to-control-point>]?]
     //                       | [by <coordinate-pair> with <relative-control-point> [/ <relative-control-point>]?]
@@ -173,32 +173,32 @@ void Serialize<CurveCommand>::operator()(StringBuilder& builder, const CurveComm
     // Modified by https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 
     builder.append(nameLiteralForSerialization(value.name), ' ');
-    serializationForCSS(builder, value.toBy);
+    serializationForCSS(builder, context, value.toBy);
 }
 
-void Serialize<SmoothCommand::To>::operator()(StringBuilder& builder, const SmoothCommand::To& value)
+void Serialize<SmoothCommand::To>::operator()(StringBuilder& builder, const SerializationContext& context, const SmoothCommand::To& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 
     if (value.controlPoint) {
         builder.append(' ', nameLiteralForSerialization(CSSValueWith), ' ');
-        serializationForCSS(builder, *value.controlPoint);
+        serializationForCSS(builder, context, *value.controlPoint);
     }
 }
 
-void Serialize<SmoothCommand::By>::operator()(StringBuilder& builder, const SmoothCommand::By& value)
+void Serialize<SmoothCommand::By>::operator()(StringBuilder& builder, const SerializationContext& context, const SmoothCommand::By& value)
 {
     builder.append(nameLiteralForSerialization(value.affinity.value), ' ');
-    serializationForCSS(builder, value.offset);
+    serializationForCSS(builder, context, value.offset);
 
     if (value.controlPoint) {
         builder.append(' ', nameLiteralForSerialization(CSSValueWith), ' ');
-        serializationForCSS(builder, *value.controlPoint);
+        serializationForCSS(builder, context, *value.controlPoint);
     }
 }
 
-void Serialize<SmoothCommand>::operator()(StringBuilder& builder, const SmoothCommand& value)
+void Serialize<SmoothCommand>::operator()(StringBuilder& builder, const SerializationContext& context, const SmoothCommand& value)
 {
     // <smooth-command> = smooth [to <position> [with <to-control-point>]?]
     //                         | [by <coordinate-pair> [with <relative-control-point>]?]
@@ -206,53 +206,53 @@ void Serialize<SmoothCommand>::operator()(StringBuilder& builder, const SmoothCo
     // Modified by https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 
     builder.append(nameLiteralForSerialization(value.name), ' ');
-    serializationForCSS(builder, value.toBy);
+    serializationForCSS(builder, context, value.toBy);
 }
 
-void Serialize<ArcCommand>::operator()(StringBuilder& builder, const ArcCommand& value)
+void Serialize<ArcCommand>::operator()(StringBuilder& builder, const SerializationContext& context, const ArcCommand& value)
 {
     // <arc-command> = arc [to <position>] | [by <coordinate-pair>] of <length-percentage>{1,2} [<arc-sweep>? || <arc-size>? || [rotate <angle>]?]
     // https://drafts.csswg.org/css-shapes-2/#typedef-shape-arc-command
     // Modified by https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
 
     builder.append(nameLiteralForSerialization(value.name), ' ');
-    serializationForCSS(builder, value.toBy);
+    serializationForCSS(builder, context, value.toBy);
 
     builder.append(' ', nameLiteralForSerialization(CSSValueOf), ' ');
     if (value.size.width() == value.size.height())
-        serializationForCSS(builder, value.size.width());
+        serializationForCSS(builder, context, value.size.width());
     else
-        serializationForCSS(builder, value.size);
+        serializationForCSS(builder, context, value.size);
 
     if (!std::holds_alternative<CSS::Keyword::Ccw>(value.arcSweep)) {
         builder.append(' ');
-        serializationForCSS(builder, value.arcSweep);
+        serializationForCSS(builder, context, value.arcSweep);
     }
 
     if (!std::holds_alternative<CSS::Keyword::Small>(value.arcSize)) {
         builder.append(' ');
-        serializationForCSS(builder, value.arcSize);
+        serializationForCSS(builder, context, value.arcSize);
     }
 
     if (value.rotation != 0_css_deg) {
         builder.append(' ', nameLiteralForSerialization(CSSValueRotate), ' ');
-        serializationForCSS(builder, value.rotation);
+        serializationForCSS(builder, context, value.rotation);
     }
 }
 
-void Serialize<Shape>::operator()(StringBuilder& builder, const Shape& value)
+void Serialize<Shape>::operator()(StringBuilder& builder, const SerializationContext& context, const Shape& value)
 {
     // shape() = shape( <'fill-rule'>? from <coordinate-pair>, <shape-command>#)
 
     if (value.fillRule && !std::holds_alternative<Keyword::Nonzero>(*value.fillRule)) {
-        serializationForCSS(builder, *value.fillRule);
+        serializationForCSS(builder, context, *value.fillRule);
         builder.append(' ');
     }
 
     builder.append(nameLiteralForSerialization(CSSValueFrom), ' ');
-    serializationForCSS(builder, value.startingPoint);
+    serializationForCSS(builder, context, value.startingPoint);
     builder.append(", "_s);
-    serializationForCSS(builder, value.commands);
+    serializationForCSS(builder, context, value.commands);
 }
 
 } // namespace CSS

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.h
@@ -58,7 +58,7 @@ struct ToPosition {
 };
 DEFINE_TYPE_WRAPPER_GET(ToPosition, offset);
 
-template<> struct Serialize<ToPosition> { void operator()(StringBuilder&, const ToPosition&); };
+template<> struct Serialize<ToPosition> { void operator()(StringBuilder&, const SerializationContext&, const ToPosition&); };
 
 // <by-coordinate-pair> = by <coordinate-pair>
 struct ByCoordinatePair {
@@ -70,7 +70,7 @@ struct ByCoordinatePair {
 };
 DEFINE_TYPE_WRAPPER_GET(ByCoordinatePair, offset);
 
-template<> struct Serialize<ByCoordinatePair> { void operator()(StringBuilder&, const ByCoordinatePair&); };
+template<> struct Serialize<ByCoordinatePair> { void operator()(StringBuilder&, const SerializationContext&, const ByCoordinatePair&); };
 
 // <relative-control-point> = [<coordinate-pair> [from [start | end | origin]]?]
 // Specified https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
@@ -89,7 +89,7 @@ template<size_t I> const auto& get(const RelativeControlPoint& value)
     if constexpr (I == 1)
         return value.anchor;
 }
-template<> struct Serialize<RelativeControlPoint> { void operator()(StringBuilder&, const RelativeControlPoint&); };
+template<> struct Serialize<RelativeControlPoint> { void operator()(StringBuilder&, const SerializationContext&, const RelativeControlPoint&); };
 
 // <to-control-point> = [<position> | <relative-control-point>]
 // Specified https://github.com/w3c/csswg-drafts/issues/10649#issuecomment-2412816773
@@ -108,7 +108,7 @@ template<size_t I> const auto& get(const AbsoluteControlPoint& value)
     if constexpr (I == 1)
         return value.anchor;
 }
-template<> struct Serialize<AbsoluteControlPoint> { void operator()(StringBuilder&, const AbsoluteControlPoint&); };
+template<> struct Serialize<AbsoluteControlPoint> { void operator()(StringBuilder&, const SerializationContext&, const AbsoluteControlPoint&); };
 
 // <move-command> = move [to <position>] | [by <coordinate-pair>]
 // https://drafts.csswg.org/css-shapes-2/#typedef-shape-move-command
@@ -123,7 +123,7 @@ struct MoveCommand {
 };
 DEFINE_TYPE_WRAPPER_GET(MoveCommand, toBy);
 
-template<> struct Serialize<MoveCommand> { void operator()(StringBuilder&, const MoveCommand&); };
+template<> struct Serialize<MoveCommand> { void operator()(StringBuilder&, const SerializationContext&, const MoveCommand&); };
 
 // <line-command> = line [to <position>] | [by <coordinate-pair>]
 // https://drafts.csswg.org/css-shapes-2/#typedef-shape-line-command
@@ -138,7 +138,7 @@ struct LineCommand {
 };
 DEFINE_TYPE_WRAPPER_GET(LineCommand, toBy);
 
-template<> struct Serialize<LineCommand> { void operator()(StringBuilder&, const LineCommand&); };
+template<> struct Serialize<LineCommand> { void operator()(StringBuilder&, const SerializationContext&, const LineCommand&); };
 
 // <horizontal-line-command> = hline [ to [ <length-percentage> | left | center | right | x-start | x-end ] | by <length-percentage> ]
 // https://drafts.csswg.org/css-shapes-2/#typedef-shape-hv-line-command
@@ -168,9 +168,9 @@ DEFINE_TYPE_WRAPPER_GET(HLineCommand::By, offset);
 DEFINE_TYPE_WRAPPER_GET(HLineCommand::To, offset);
 DEFINE_TYPE_WRAPPER_GET(HLineCommand, toBy);
 
-template<> struct Serialize<HLineCommand::To> { void operator()(StringBuilder&, const HLineCommand::To&); };
-template<> struct Serialize<HLineCommand::By> { void operator()(StringBuilder&, const HLineCommand::By&); };
-template<> struct Serialize<HLineCommand> { void operator()(StringBuilder&, const HLineCommand&); };
+template<> struct Serialize<HLineCommand::To> { void operator()(StringBuilder&, const SerializationContext&, const HLineCommand::To&); };
+template<> struct Serialize<HLineCommand::By> { void operator()(StringBuilder&, const SerializationContext&, const HLineCommand::By&); };
+template<> struct Serialize<HLineCommand> { void operator()(StringBuilder&, const SerializationContext&, const HLineCommand&); };
 
 // <vertical-line-command> = vline [ to [ <length-percentage> | top | center | bottom | y-start | y-end ] | by <length-percentage> ]
 // https://drafts.csswg.org/css-shapes-2/#typedef-shape-hv-line-command
@@ -199,9 +199,9 @@ DEFINE_TYPE_WRAPPER_GET(VLineCommand::By, offset);
 DEFINE_TYPE_WRAPPER_GET(VLineCommand::To, offset);
 DEFINE_TYPE_WRAPPER_GET(VLineCommand, toBy);
 
-template<> struct Serialize<VLineCommand::To> { void operator()(StringBuilder&, const VLineCommand::To&); };
-template<> struct Serialize<VLineCommand::By> { void operator()(StringBuilder&, const VLineCommand::By&); };
-template<> struct Serialize<VLineCommand> { void operator()(StringBuilder&, const VLineCommand&); };
+template<> struct Serialize<VLineCommand::To> { void operator()(StringBuilder&, const SerializationContext&, const VLineCommand::To&); };
+template<> struct Serialize<VLineCommand::By> { void operator()(StringBuilder&, const SerializationContext&, const VLineCommand::By&); };
+template<> struct Serialize<VLineCommand> { void operator()(StringBuilder&, const SerializationContext&, const VLineCommand&); };
 
 // <curve-command> = curve [to <position> with <to-control-point> [/ <to-control-point>]?]
 //                       | [by <coordinate-pair> with <relative-control-point> [/ <relative-control-point>]?]
@@ -251,9 +251,9 @@ template<size_t I> const auto& get(const CurveCommand::By& value)
 }
 DEFINE_TYPE_WRAPPER_GET(CurveCommand, toBy);
 
-template<> struct Serialize<CurveCommand::To> { void operator()(StringBuilder&, const CurveCommand::To&); };
-template<> struct Serialize<CurveCommand::By> { void operator()(StringBuilder&, const CurveCommand::By&); };
-template<> struct Serialize<CurveCommand> { void operator()(StringBuilder&, const CurveCommand&); };
+template<> struct Serialize<CurveCommand::To> { void operator()(StringBuilder&, const SerializationContext&, const CurveCommand::To&); };
+template<> struct Serialize<CurveCommand::By> { void operator()(StringBuilder&, const SerializationContext&, const CurveCommand::By&); };
+template<> struct Serialize<CurveCommand> { void operator()(StringBuilder&, const SerializationContext&, const CurveCommand&); };
 
 // <smooth-command> = smooth [to <position> [with <to-control-point>]?]
 //                         | [by <coordinate-pair> [with <relative-control-point>]?]
@@ -297,9 +297,9 @@ template<size_t I> const auto& get(const SmoothCommand::By& value)
 }
 DEFINE_TYPE_WRAPPER_GET(SmoothCommand, toBy);
 
-template<> struct Serialize<SmoothCommand::To> { void operator()(StringBuilder&, const SmoothCommand::To&); };
-template<> struct Serialize<SmoothCommand::By> { void operator()(StringBuilder&, const SmoothCommand::By&); };
-template<> struct Serialize<SmoothCommand> { void operator()(StringBuilder&, const SmoothCommand&); };
+template<> struct Serialize<SmoothCommand::To> { void operator()(StringBuilder&, const SerializationContext&, const SmoothCommand::To&); };
+template<> struct Serialize<SmoothCommand::By> { void operator()(StringBuilder&, const SerializationContext&, const SmoothCommand::By&); };
+template<> struct Serialize<SmoothCommand> { void operator()(StringBuilder&, const SerializationContext&, const SmoothCommand&); };
 
 // <arc-command> = arc [to <position>] | [by <coordinate-pair>] of <length-percentage>{1,2} [<arc-sweep>? || <arc-size>? || [rotate <angle>]?]
 // https://drafts.csswg.org/css-shapes-2/#typedef-shape-arc-command
@@ -332,7 +332,7 @@ template<size_t I> const auto& get(const ArcCommand& value)
     if constexpr (I == 4)
         return value.rotation;
 }
-template<> struct Serialize<ArcCommand> { void operator()(StringBuilder&, const ArcCommand&); };
+template<> struct Serialize<ArcCommand> { void operator()(StringBuilder&, const SerializationContext&, const ArcCommand&); };
 
 // <close> = close
 // https://drafts.csswg.org/css-shapes-2/#valdef-shape-close
@@ -366,7 +366,7 @@ template<size_t I> const auto& get(const Shape& value)
         return value.commands;
 }
 
-template<> struct Serialize<Shape> { void operator()(StringBuilder&, const Shape&); };
+template<> struct Serialize<Shape> { void operator()(StringBuilder&, const SerializationContext&, const Shape&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/shapes/CSSXywhFunction.cpp
+++ b/Source/WebCore/css/values/shapes/CSSXywhFunction.cpp
@@ -31,17 +31,17 @@
 namespace WebCore {
 namespace CSS {
 
-void Serialize<Xywh>::operator()(StringBuilder& builder, const Xywh& value)
+void Serialize<Xywh>::operator()(StringBuilder& builder, const SerializationContext& context, const Xywh& value)
 {
     // <xywh()> = xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )
 
-    serializationForCSS(builder, value.location);
+    serializationForCSS(builder, context, value.location);
     builder.append(' ');
-    serializationForCSS(builder, value.size);
+    serializationForCSS(builder, context, value.size);
 
     if (!hasDefaultValue(value.radii)) {
         builder.append(' ', nameLiteralForSerialization(CSSValueRound), ' ');
-        serializationForCSS(builder, value.radii);
+        serializationForCSS(builder, context, value.radii);
     }
 }
 

--- a/Source/WebCore/css/values/shapes/CSSXywhFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSXywhFunction.h
@@ -54,7 +54,7 @@ template<size_t I> const auto& get(const Xywh& value)
         return value.radii;
 }
 
-template<> struct Serialize<Xywh> { void operator()(StringBuilder&, const Xywh&); };
+template<> struct Serialize<Xywh> { void operator()(StringBuilder&, const SerializationContext&, const Xywh&); };
 
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -40,6 +40,7 @@
 #include "CSSParser.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserConsumer+ColorAdjust.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleDeclaration.h"
 #include "CSSStyleSheet.h"
 #include "CSSViewTransitionRule.h"
@@ -5071,7 +5072,7 @@ void Document::metaElementColorSchemeChanged()
     auto colorSchemeString = emptyString();
     for (auto& metaElement : descendantsOfType<HTMLMetaElement>(rootNode())) {
         if (auto colorScheme = parseColorScheme(metaElement)) {
-            colorSchemeString = CSS::serializationForCSS(*colorScheme);
+            colorSchemeString = CSS::serializationForCSS(CSS::defaultSerializationContext(), *colorScheme);
             break;
         }
     }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5607,7 +5607,7 @@ String Element::completeURLsInAttributeValue(const URL& base, const Attribute& a
     return resolveURLStringIfNeeded(attribute.value(), resolveURLs, base);
 }
 
-Attribute Element::replaceURLsInAttributeValue(const Attribute& attribute, const UncheckedKeyHashMap<String, String>&) const
+Attribute Element::replaceURLsInAttributeValue(const Attribute& attribute, const CSS::SerializationContext&) const
 {
     return attribute;
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -152,6 +152,10 @@ namespace Calculation {
 class RandomKeyMap;
 }
 
+namespace CSS {
+struct SerializationContext;
+}
+
 namespace Style {
 class Resolver;
 enum class Change : uint8_t;
@@ -513,7 +517,7 @@ public:
     virtual bool attributeContainsURL(const Attribute& attribute) const { return isURLAttribute(attribute); }
     String resolveURLStringIfNeeded(const String& urlString, ResolveURLs = ResolveURLs::Yes, const URL& base = URL()) const;
     virtual String completeURLsInAttributeValue(const URL& base, const Attribute&, ResolveURLs = ResolveURLs::Yes) const;
-    virtual Attribute replaceURLsInAttributeValue(const Attribute&, const UncheckedKeyHashMap<String, String>&) const;
+    virtual Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const;
     virtual bool isHTMLContentAttribute(const Attribute&) const { return false; }
 
     WEBCORE_EXPORT URL getURLAttribute(const QualifiedName&) const;

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -231,7 +231,7 @@ void ExtensionStyleSheets::maybeAddContentExtensionSheet(const String& identifie
 
 String ExtensionStyleSheets::contentForInjectedStyleSheet(const RefPtr<CSSStyleSheet>& styleSheet) const
 {
-    return m_injectedStyleSheetToSource.get(styleSheet);
+    return m_injectedStyleSheetToSource.get(*styleSheet);
 }
 
 void ExtensionStyleSheets::detachFromDocument()

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -94,7 +94,7 @@ private:
 
     mutable Vector<RefPtr<CSSStyleSheet>> m_injectedUserStyleSheets;
     mutable Vector<RefPtr<CSSStyleSheet>> m_injectedAuthorStyleSheets;
-    mutable UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String> m_injectedStyleSheetToSource;
+    mutable UncheckedKeyHashMap<Ref<CSSStyleSheet>, String> m_injectedStyleSheetToSource;
     mutable bool m_injectedStyleSheetCacheValid { false };
 
     Vector<RefPtr<CSSStyleSheet>> m_userStyleSheets;

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -30,6 +30,7 @@
 #include "CSSParser.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParser.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
 #include "CSSUnparsedValue.h"
 #include "CSSValuePool.h"
@@ -65,7 +66,7 @@ void StyledElement::synchronizeStyleAttributeInternalImpl()
     ASSERT(elementData()->styleAttributeIsDirty());
     elementData()->setStyleAttributeIsDirty(false);
     if (const StyleProperties* inlineStyle = this->inlineStyle())
-        setSynchronizedLazyAttribute(styleAttr, inlineStyle->asTextAtom());
+        setSynchronizedLazyAttribute(styleAttr, inlineStyle->asTextAtom(CSS::defaultSerializationContext()));
 }
 
 StyledElement::~StyledElement() = default;
@@ -168,7 +169,7 @@ void StyledElement::dirtyStyleAttribute()
     if (styleResolver().ruleSets().selectorsForStyleAttribute() != Style::SelectorsForStyleAttribute::None) {
         if (auto* inlineStyle = this->inlineStyle()) {
             elementData()->setStyleAttributeIsDirty(false);
-            auto newValue = inlineStyle->asTextAtom();
+            auto newValue = inlineStyle->asTextAtom(CSS::defaultSerializationContext());
             Style::AttributeChangeInvalidation styleInvalidation(*this, styleAttr, attributeWithoutSynchronization(styleAttr), newValue);
             setSynchronizedLazyAttribute(styleAttr, newValue);
         }
@@ -195,7 +196,7 @@ void StyledElement::invalidateStyleAttribute()
     if (selectorsForStyleAttribute == Style::SelectorsForStyleAttribute::NonSubjectPosition) {
         if (auto* inlineStyle = this->inlineStyle()) {
             elementData()->setStyleAttributeIsDirty(false);
-            auto newValue = inlineStyle->asTextAtom();
+            auto newValue = inlineStyle->asTextAtom(CSS::defaultSerializationContext());
             Style::AttributeChangeInvalidation styleInvalidation(*this, styleAttr, attributeWithoutSynchronization(styleAttr), newValue);
             setSynchronizedLazyAttribute(styleAttr, newValue);
         }
@@ -303,9 +304,9 @@ void StyledElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
     });
 }
 
-Attribute StyledElement::replaceURLsInAttributeValue(const Attribute& attribute, const UncheckedKeyHashMap<String, String>& replacementURLStrings) const
+Attribute StyledElement::replaceURLsInAttributeValue(const Attribute& attribute, const CSS::SerializationContext& serializationContext) const
 {
-    if (replacementURLStrings.isEmpty())
+    if (serializationContext.replacementURLStrings.isEmpty())
         return attribute;
 
     if (attribute.name() != styleAttr)
@@ -315,11 +316,7 @@ Attribute StyledElement::replaceURLsInAttributeValue(const Attribute& attribute,
     if (!properties)
         return attribute;
 
-    auto mutableProperties = properties->mutableCopy();
-    mutableProperties->setReplacementURLForSubresources(replacementURLStrings);
-    auto inlineStyleString = mutableProperties->asText();
-    mutableProperties->clearReplacementURLForSubresources();
-    return Attribute { styleAttr, AtomString { inlineStyleString } };
+    return Attribute { styleAttr, properties->asTextAtom(serializationContext) };
 }
 
 const ImmutableStyleProperties* StyledElement::presentationalHintStyle() const

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -90,7 +90,7 @@ protected:
     void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, Ref<CSSValue>&&);
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
-    Attribute replaceURLsInAttributeValue(const Attribute&, const UncheckedKeyHashMap<String, String>&) const override;
+    Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const override;
 
 private:
     void styleAttributeChanged(const AtomString& newStyleString, AttributeModificationReason);

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -29,6 +29,7 @@
 
 #include "CSSComputedStyleDeclaration.h"
 #include "CSSParser.h"
+#include "CSSSerializationContext.h"
 #include "CSSValuePool.h"
 #include "Document.h"
 #include "Editing.h"
@@ -415,7 +416,7 @@ void ApplyStyleCommand::applyRelativeFontStyleChange(EditingStyle* style)
         }
         if (currentFontSize != desiredFontSize) {
             inlineStyle->setProperty(CSSPropertyFontSize, CSSPrimitiveValue::create(desiredFontSize, CSSUnitType::CSS_PX));
-            setNodeAttribute(*element, styleAttr, inlineStyle->asTextAtom());
+            setNodeAttribute(*element, styleAttr, inlineStyle->asTextAtom(CSS::defaultSerializationContext()));
         }
         if (inlineStyle->isEmpty()) {
             removeNodeAttribute(*element, styleAttr);
@@ -538,7 +539,7 @@ void ApplyStyleCommand::removeEmbeddingUpToEnclosingBlock(Node* node, Node* unsp
             auto inlineStyle = copyStyleOrCreateEmpty(element->inlineStyle());
             inlineStyle->setProperty(CSSPropertyUnicodeBidi, CSSValueNormal);
             inlineStyle->removeProperty(CSSPropertyDirection);
-            setNodeAttribute(*element, styleAttr, inlineStyle->asTextAtom());
+            setNodeAttribute(*element, styleAttr, inlineStyle->asTextAtom(CSS::defaultSerializationContext()));
             if (isSpanWithoutAttributesOrUnstyledStyleSpan(*element))
                 removeNodePreservingChildren(*element);
         }
@@ -792,7 +793,7 @@ void ApplyStyleCommand::applyInlineStyleToNodeRange(EditingStyle& style, Node& s
                 RefPtr inlineStyle = copyStyleOrCreateEmpty(element->inlineStyle());
                 if (RefPtr otherStyle = style.style())
                     inlineStyle->mergeAndOverrideOnConflict(*otherStyle);
-                setNodeAttribute(*element, styleAttr, inlineStyle->asTextAtom());
+                setNodeAttribute(*element, styleAttr, inlineStyle->asTextAtom(CSS::defaultSerializationContext()));
                 next = NodeTraversal::nextSkippingChildren(*element);
                 continue;
             }
@@ -974,7 +975,7 @@ bool ApplyStyleCommand::removeCSSStyle(EditingStyle& style, HTMLElement& element
     if (newInlineStyle->isEmpty())
         removeNodeAttribute(element, styleAttr);
     else
-        setNodeAttribute(element, styleAttr, newInlineStyle->asTextAtom());
+        setNodeAttribute(element, styleAttr, newInlineStyle->asTextAtom(CSS::defaultSerializationContext()));
 
     if (isSpanWithoutAttributesOrUnstyledStyleSpan(element))
         removeNodePreservingChildren(element);
@@ -1020,7 +1021,7 @@ void ApplyStyleCommand::applyInlineStyleToPushDown(Node& node, EditingStyle* sty
     // FIXME: applyInlineStyleToRange should be used here instead.
     if (node.renderer()->isRenderBlockFlow() || node.hasChildNodes()) {
         if (auto* htmlElement = dynamicDowncast<HTMLElement>(node)) {
-            setNodeAttribute(*htmlElement, styleAttr, newInlineStyle->style()->asTextAtom());
+            setNodeAttribute(*htmlElement, styleAttr, newInlineStyle->style()->asTextAtom(CSS::defaultSerializationContext()));
             return;
         }
     }
@@ -1395,7 +1396,7 @@ void ApplyStyleCommand::addBlockStyle(const StyleChange& styleChange, HTMLElemen
 {
     // Do not check for legacy styles here. Those styles, like <B> and <I>, only apply for inline content.
     ASSERT(styleChange.cssStyle());
-    setNodeAttribute(block, styleAttr, joinWithSpace(styleChange.cssStyle()->asText(), block.getAttribute(styleAttr)));
+    setNodeAttribute(block, styleAttr, joinWithSpace(styleChange.cssStyle()->asText(CSS::defaultSerializationContext()), block.getAttribute(styleAttr)));
 }
 
 void ApplyStyleCommand::addInlineStyleIfNeeded(EditingStyle* style, Node& start, Node& end, AddStyledElement addStyledElement)
@@ -1478,12 +1479,12 @@ void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEn
             if (RefPtr existingStyle = styleContainer->inlineStyle()) {
                 Ref inlineStyle = EditingStyle::create(existingStyle.get());
                 inlineStyle->overrideWithStyle(*styleToMerge);
-                setNodeAttribute(*styleContainer, styleAttr, inlineStyle->style()->asTextAtom());
+                setNodeAttribute(*styleContainer, styleAttr, inlineStyle->style()->asTextAtom(CSS::defaultSerializationContext()));
             } else
-                setNodeAttribute(*styleContainer, styleAttr, styleToMerge->asTextAtom());
+                setNodeAttribute(*styleContainer, styleAttr, styleToMerge->asTextAtom(CSS::defaultSerializationContext()));
         } else {
             auto styleElement = createStyleSpanElement(document);
-            styleElement->setAttribute(styleAttr, styleToMerge->asTextAtom());
+            styleElement->setAttribute(styleAttr, styleToMerge->asTextAtom(CSS::defaultSerializationContext()));
             surroundNodeRangeWithElement(*startNode, *endNode, WTFMove(styleElement));
         }
     }

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -35,6 +35,7 @@
 #include "CSSParserIdioms.h"
 #include "CSSPropertyParserConsumer+Font.h"
 #include "CSSRuleList.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleRule.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
@@ -233,7 +234,7 @@ bool HTMLElementEquivalent::valueIsPresentInStyle(Element& element, const Editin
 
 void HTMLElementEquivalent::addToStyle(Element*, EditingStyle* style) const
 {
-    style->setProperty(m_propertyID, m_primitiveValue->cssText());
+    style->setProperty(m_propertyID, m_primitiveValue->cssText(CSS::defaultSerializationContext()));
 }
 
 class HTMLTextDecorationEquivalent : public HTMLElementEquivalent {
@@ -363,7 +364,7 @@ bool HTMLAttributeEquivalent::valueIsPresentInStyle(Element& element, const Edit
 void HTMLAttributeEquivalent::addToStyle(Element* element, EditingStyle* style) const
 {
     if (RefPtr<CSSValue> value = attributeValueAsCSSValue(element))
-        style->setProperty(m_propertyID, value->cssText());
+        style->setProperty(m_propertyID, value->cssText(CSS::defaultSerializationContext()));
 }
 
 RefPtr<CSSValue> HTMLAttributeEquivalent::attributeValueAsCSSValue(Element* element) const
@@ -555,9 +556,9 @@ void EditingStyle::init(Node* node, PropertiesToInclude propertiesToInclude)
 
     if (propertiesToInclude == EditingPropertiesInEffect) {
         if (RefPtr<CSSValue> value = backgroundColorInEffect(node))
-            m_mutableStyle->setProperty(CSSPropertyBackgroundColor, value->cssText());
+            m_mutableStyle->setProperty(CSSPropertyBackgroundColor, value->cssText(CSS::defaultSerializationContext()));
         if (RefPtr<CSSValue> value = computedStyleAtPosition.propertyValue(CSSPropertyWebkitTextDecorationsInEffect)) {
-            m_mutableStyle->setProperty(CSSPropertyTextDecorationLine, value->cssText());
+            m_mutableStyle->setProperty(CSSPropertyTextDecorationLine, value->cssText(CSS::defaultSerializationContext()));
             m_mutableStyle->removeProperty(CSSPropertyWebkitTextDecorationsInEffect);
         }
     }
@@ -567,7 +568,7 @@ void EditingStyle::init(Node* node, PropertiesToInclude propertiesToInclude)
         removeTextFillAndStrokeColorsIfNeeded(renderStyle);
         if (renderStyle->fontDescription().keywordSize()) {
             if (auto cssValue = computedStyleAtPosition.getFontSizeCSSValuePreferringKeyword())
-                m_mutableStyle->setProperty(CSSPropertyFontSize, cssValue->cssText());
+                m_mutableStyle->setProperty(CSSPropertyFontSize, cssValue->cssText(CSS::defaultSerializationContext()));
         }
     }
 
@@ -836,7 +837,7 @@ void EditingStyle::collapseTextDecorationProperties()
         return;
 
     if (textDecorationsInEffect->isValueList())
-        m_mutableStyle->setProperty(CSSPropertyTextDecorationLine, textDecorationsInEffect->cssText(), m_mutableStyle->propertyIsImportant(CSSPropertyTextDecorationLine) ? IsImportant::Yes : IsImportant::No);
+        m_mutableStyle->setProperty(CSSPropertyTextDecorationLine, textDecorationsInEffect->cssText(CSS::defaultSerializationContext()), m_mutableStyle->propertyIsImportant(CSSPropertyTextDecorationLine) ? IsImportant::Yes : IsImportant::No);
     else
         m_mutableStyle->removeProperty(CSSPropertyTextDecorationLine);
     m_mutableStyle->removeProperty(CSSPropertyWebkitTextDecorationsInEffect);
@@ -954,7 +955,7 @@ bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, Ref
                     newInlineStyle->setProperty(CSSPropertyTextDecorationLine, CSSValueList::createSpaceSeparated(WTFMove(newValueList)));
                 if (extractedStyle) {
                     auto isImportant = inlineStyle->propertyIsImportant(CSSPropertyTextDecorationLine) ? IsImportant::Yes : IsImportant::No;
-                    extractedStyle->setProperty(CSSPropertyTextDecorationLine, CSSValueList::createSpaceSeparated(extractedValueList)->cssText(), isImportant);
+                    extractedStyle->setProperty(CSSPropertyTextDecorationLine, CSSValueList::createSpaceSeparated(extractedValueList)->cssText(CSS::defaultSerializationContext()), isImportant);
                 }
             }
         }
@@ -1615,7 +1616,7 @@ RefPtr<EditingStyle> EditingStyle::styleAtSelectionStart(const VisibleSelection&
     if (shouldUseBackgroundColorInEffect && (selection.isRange() || hasTransparentBackgroundColor(style->m_mutableStyle.get()))) {
         if (auto range = selection.toNormalizedRange()) {
             if (RefPtr value = backgroundColorInEffect(RefPtr { commonInclusiveAncestor<ComposedTree>(*range) }.get()))
-                style->setProperty(CSSPropertyBackgroundColor, value->cssText());
+                style->setProperty(CSSPropertyBackgroundColor, value->cssText(CSS::defaultSerializationContext()));
         }
     }
 
@@ -1748,7 +1749,7 @@ static void reconcileTextDecorationProperties(MutableStyleProperties& style)
     // We shouldn't have both text-decoration and -webkit-text-decorations-in-effect because that wouldn't make sense.
     ASSERT(!textDecorationsInEffect || !textDecoration);
     if (textDecorationsInEffect) {
-        style.setProperty(CSSPropertyTextDecorationLine, textDecorationsInEffect->cssText());
+        style.setProperty(CSSPropertyTextDecorationLine, textDecorationsInEffect->cssText(CSS::defaultSerializationContext()));
         style.removeProperty(CSSPropertyWebkitTextDecorationsInEffect);
         textDecoration = textDecorationsInEffect;
     }
@@ -1843,13 +1844,13 @@ bool StyleChange::operator==(const StyleChange& other)
         return false;
 
     return (!m_cssStyle && !other.m_cssStyle)
-        || (m_cssStyle && other.m_cssStyle && m_cssStyle->asText() == other.m_cssStyle->asText());
+        || (m_cssStyle && other.m_cssStyle && m_cssStyle->asText(CSS::defaultSerializationContext()) == other.m_cssStyle->asText(CSS::defaultSerializationContext()));
 }
 
 static void setTextDecorationProperty(MutableStyleProperties& style, const CSSValueList& newTextDecoration, CSSPropertyID propertyID)
 {
     if (newTextDecoration.length())
-        style.setProperty(propertyID, newTextDecoration.cssText(), style.propertyIsImportant(propertyID) ? IsImportant::Yes : IsImportant::No);
+        style.setProperty(propertyID, newTextDecoration.cssText(CSS::defaultSerializationContext()), style.propertyIsImportant(propertyID) ? IsImportant::Yes : IsImportant::No);
     else {
         // text-decoration: none is redundant since it does not remove any text decorations.
         style.removeProperty(propertyID);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -33,6 +33,7 @@
 #include "AttachmentAssociatedElement.h"
 #include "CSSComputedStyleDeclaration.h"
 #include "CSSPropertyNames.h"
+#include "CSSSerializationContext.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "CachedResourceLoader.h"
@@ -4805,7 +4806,7 @@ const RenderStyle* Editor::styleForSelectionStart(RefPtr<Node>& nodeToRemove)
 
     auto styleElement = HTMLSpanElement::create(document);
 
-    auto styleText = makeAtomString(typingStyle->style()->asText(), " display: inline"_s);
+    auto styleText = makeAtomString(typingStyle->style()->asText(CSS::defaultSerializationContext()), " display: inline"_s);
     styleElement->setAttribute(HTMLNames::styleAttr, styleText);
 
     styleElement->appendChild(document->createEditingTextNode(String { emptyString() }));

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
 #include "Element.h"
 #include "markup.h"
@@ -73,7 +74,7 @@ public:
     String serializeNodes(Node& targetNode, SerializedNodes);
 
     static void appendCharactersReplacingEntities(StringBuilder&, const String&, unsigned, unsigned, OptionSet<EntityMask>);
-    void enableURLReplacement(UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet);
+    void enableURLReplacement(UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet);
 
 protected:
     unsigned length() const { return m_markup.length(); }
@@ -125,16 +126,10 @@ private:
     const ResolveURLs m_resolveURLs;
     const SerializationSyntax m_serializationSyntax;
     unsigned m_prefixLevel { 0 };
-    UncheckedKeyHashMap<String, String> m_replacementURLStrings;
-    UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String> m_replacementURLStringsForCSSStyleSheet;
     SerializeShadowRoots m_serializeShadowRoots;
     Vector<Ref<ShadowRoot>> m_explicitShadowRoots;
     Vector<MarkupExclusionRule> m_exclusionRules;
-    struct URLReplacementData {
-        UncheckedKeyHashMap<String, String> replacementURLStrings;
-        UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String> replacementURLStringsForCSSStyleSheet;
-    };
-    std::optional<URLReplacementData> m_urlReplacementData;
+    std::optional<CSS::SerializationContext> m_serializationContext;
 };
 
 inline void MarkupAccumulator::endAppendingNode(const Node& node)

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -33,6 +33,7 @@
 #include "BreakBlockquoteCommand.h"
 #include "CSSComputedStyleDeclaration.h"
 #include "CSSPrimitiveValueMappings.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleDeclaration.h"
 #include "CommonAtomStrings.h"
 #include "DOMWrapperWorld.h"
@@ -201,7 +202,7 @@ ReplacementFragment::ReplacementFragment(RefPtr<DocumentFragment>&& inputFragmen
     ASSERT(stagingDocument->body());
 
     ComputedStyleExtractor computedStyleOfEditableRoot(editableRoot.get());
-    stagingDocument->body()->setAttributeWithoutSynchronization(styleAttr, computedStyleOfEditableRoot.copyProperties()->asTextAtom());
+    stagingDocument->body()->setAttributeWithoutSynchronization(styleAttr, computedStyleOfEditableRoot.copyProperties()->asTextAtom(CSS::defaultSerializationContext()));
 
     RefPtr holder = insertFragmentForTestRendering(stagingDocument->body());
     if (!holder) {
@@ -661,7 +662,7 @@ void ReplaceSelectionCommand::inverseTransformColor(InsertedNodes& insertedNodes
         if (editingStyle.ptr() == transformedStyle.ptr())
             continue;
 
-        setNodeAttribute(*element, styleAttr, transformedStyle->style()->asTextAtom());
+        setNodeAttribute(*element, styleAttr, transformedStyle->style()->asTextAtom(CSS::defaultSerializationContext()));
     }
 }
 
@@ -722,7 +723,7 @@ void ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline(Insert
             }
             removeNodeAttribute(*element, styleAttr);
         } else if (newInlineStyle->style()->propertyCount() != inlineStyle->propertyCount())
-            setNodeAttribute(*element, styleAttr, newInlineStyle->style()->asTextAtom());
+            setNodeAttribute(*element, styleAttr, newInlineStyle->style()->asTextAtom(CSS::defaultSerializationContext()));
 
         // FIXME: Tolerate differences in id, class, and style attributes.
         if (element->parentNode() && isNonTableCellHTMLBlockElement(element.get()) && elementIfEquivalent(*element, *element->parentNode())
@@ -966,7 +967,7 @@ static bool handleStyleSpansBeforeInsertion(ReplacementFragment& fragment, const
 
     Ref wrappingStyleSpan = downcast<HTMLElement>(topNode.releaseNonNull());
     auto styleAtInsertionPos = EditingStyle::create(insertionPos.parentAnchoredEquivalent());
-    String styleText = styleAtInsertionPos->style()->asText();
+    auto styleText = styleAtInsertionPos->style()->asText(CSS::defaultSerializationContext());
 
     // FIXME: This string comparison is a naive way of comparing two styles.
     // We should be taking the diff and check that the diff is empty.
@@ -1031,7 +1032,7 @@ void ReplaceSelectionCommand::handleStyleSpans(InsertedNodes& insertedNodes)
         insertedNodes.willRemoveNodePreservingChildren(wrappingStyleSpan.get());
         removeNodePreservingChildren(*wrappingStyleSpan);
     } else
-        setNodeAttribute(*wrappingStyleSpan, styleAttr, style->style()->asTextAtom());
+        setNodeAttribute(*wrappingStyleSpan, styleAttr, style->style()->asTextAtom(CSS::defaultSerializationContext()));
 }
 
 void ReplaceSelectionCommand::mergeEndIfNeeded()

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -31,6 +31,7 @@
 #import "CSSComputedStyleDeclaration.h"
 #import "CSSParser.h"
 #import "CSSPrimitiveValue.h"
+#import "CSSSerializationContext.h"
 #import "CachedImage.h"
 #import "CharacterData.h"
 #import "ColorCocoa.h"
@@ -467,14 +468,14 @@ static bool stringFromCSSValue(CSSValue& value, String& result)
         auto primitiveType = primitiveValue->primitiveType();
         if (primitiveType == CSSUnitType::CSS_STRING || primitiveType == CSSUnitType::CSS_URI
             || primitiveType == CSSUnitType::CSS_IDENT || primitiveType == CSSUnitType::CSS_ATTR) {
-            auto stringValue = value.cssText();
+            auto stringValue = value.cssText(CSS::defaultSerializationContext());
             if (stringValue.length()) {
                 result = stringValue;
                 return true;
             }
         }
     } else if (value.isValueList() || value.isAppleColorFilterPropertyValue() || value.isFilterPropertyValue() || value.isTextShadowPropertyValue() || value.isBoxShadowPropertyValue()) {
-        result = value.cssText();
+        result = value.cssText(CSS::defaultSerializationContext());
         return true;
     }
     return false;

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -33,6 +33,7 @@
 #include "AttachmentAssociatedElement.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyNames.h"
+#include "CSSSerializationContext.h"
 #include "CSSValue.h"
 #include "CSSValueKeywords.h"
 #include "CacheStorageProvider.h"
@@ -519,7 +520,8 @@ void StyledMarkupAccumulator::appendStyleNodeOpenTag(StringBuilder& out, StylePr
         out.append("<div style=\""_s);
     else
         out.append("<span style=\""_s);
-    appendAttributeValue(out, style->asText(), document.isHTMLDocument());
+
+    appendAttributeValue(out, style->asText(CSS::defaultSerializationContext()), document.isHTMLDocument());
     out.append("\">"_s);
 }
 
@@ -739,7 +741,7 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
 
         if (!newInlineStyle->isEmpty()) {
             out.append(" style=\""_s);
-            appendAttributeValue(out, newInlineStyle->style()->asText(), documentIsHTML);
+            appendAttributeValue(out, newInlineStyle->style()->asText(CSS::defaultSerializationContext()), documentIsHTML);
             out.append('"');
         }
     }
@@ -1253,7 +1255,7 @@ String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node
     return accumulator.serializeNodes(const_cast<Node&>(node), root);
 }
 
-String serializeFragmentWithURLReplacement(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
+String serializeFragmentWithURLReplacement(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
 {
     if (!serializationSyntax)
         serializationSyntax = node.document().isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML;

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -106,7 +106,7 @@ enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren 
 enum class SerializationSyntax : uint8_t { HTML, XML };
 enum class SerializeShadowRoots : uint8_t { Explicit, Serializable, AllForInterchange };
 WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, std::optional<SerializationSyntax> = std::nullopt, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
-WEBCORE_EXPORT String serializeFragmentWithURLReplacement(const Node&, SerializedNodes, Vector<Ref<Node>>*, ResolveURLs, std::optional<SerializationSyntax>, UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
+WEBCORE_EXPORT String serializeFragmentWithURLReplacement(const Node&, SerializedNodes, Vector<Ref<Node>>*, ResolveURLs, std::optional<SerializationSyntax>, UncheckedKeyHashMap<String, String>&& replacementURLStrings, UncheckedKeyHashMap<Ref<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
 
 String urlToMarkup(const URL&, const String& title);
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -24,6 +24,7 @@
 #include "HTMLImageElement.h"
 
 #include "CSSPropertyNames.h"
+#include "CSSSerializationContext.h"
 #include "CSSValueKeywords.h"
 #include "CachedImage.h"
 #include "Chrome.h"
@@ -691,15 +692,15 @@ String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Att
     return HTMLElement::completeURLsInAttributeValue(base, attribute, resolveURLs);
 }
 
-Attribute HTMLImageElement::replaceURLsInAttributeValue(const Attribute& attribute, const UncheckedKeyHashMap<String, String>& replacementURLStrings) const
+Attribute HTMLImageElement::replaceURLsInAttributeValue(const Attribute& attribute, const CSS::SerializationContext& serializationContext) const
 {
     if (attribute.name() != srcsetAttr)
         return attribute;
 
-    if (replacementURLStrings.isEmpty())
+    if (serializationContext.replacementURLStrings.isEmpty())
         return attribute;
 
-    return Attribute { srcsetAttr, AtomString { replaceURLsInSrcsetAttribute(*this, StringView(attribute.value()), replacementURLStrings) } };
+    return Attribute { srcsetAttr, AtomString { replaceURLsInSrcsetAttribute(*this, StringView(attribute.value()), serializationContext) } };
 }
 
 bool HTMLImageElement::matchesUsemap(const AtomString& name) const

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -217,7 +217,7 @@ private:
     bool isURLAttribute(const Attribute&) const override;
     bool attributeContainsURL(const Attribute&) const override;
     String completeURLsInAttributeValue(const URL& base, const Attribute&, ResolveURLs = ResolveURLs::Yes) const override;
-    Attribute replaceURLsInAttributeValue(const Attribute&, const UncheckedKeyHashMap<String, String>&) const override;
+    Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const override;
 
     bool isDraggableIgnoringAttributes() const final { return true; }
 

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "HTMLSourceElement.h"
 
+#include "CSSSerializationContext.h"
 #include "ElementInlines.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -210,15 +211,15 @@ const MQ::MediaQueryList& HTMLSourceElement::parsedMediaAttribute(Document& docu
     return m_cachedParsedMediaAttribute.value();
 }
 
-Attribute HTMLSourceElement::replaceURLsInAttributeValue(const Attribute& attribute, const UncheckedKeyHashMap<String, String>& replacementURLStrings) const
+Attribute HTMLSourceElement::replaceURLsInAttributeValue(const Attribute& attribute, const CSS::SerializationContext& serializationContext) const
 {
     if (attribute.name() != srcsetAttr)
         return attribute;
 
-    if (replacementURLStrings.isEmpty())
+    if (serializationContext.replacementURLStrings.isEmpty())
         return attribute;
 
-    return Attribute { srcsetAttr, AtomString { replaceURLsInSrcsetAttribute(*this, StringView(attribute.value()), replacementURLStrings) } };
+    return Attribute { srcsetAttr, AtomString { replaceURLsInSrcsetAttribute(*this, StringView(attribute.value()), serializationContext) } };
 }
 
 void HTMLSourceElement::addCandidateSubresourceURLs(ListHashSet<URL>& urls) const

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -63,7 +63,7 @@ private:
 
     bool isURLAttribute(const Attribute&) const final;
     bool attributeContainsURL(const Attribute&) const final;
-    Attribute replaceURLsInAttributeValue(const Attribute&, const UncheckedKeyHashMap<String, String>&) const override;
+    Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const override;
     void addCandidateSubresourceURLs(ListHashSet<URL>&) const override;
 
     // ActiveDOMObject.

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -41,6 +41,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParserConsumer+LengthDefinitions.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleImageValue.h"
 #include "CSSTokenizer.h"
 #include "CachedImage.h"
@@ -3144,7 +3145,7 @@ void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
     auto& fontCascade = fontProxy()->fontCascade();
     double pixels = Style::computeUnzoomedNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, &fontCascade);
 
-    modifiableState().letterSpacing = CSS::serializationForCSS(*rawLength);
+    modifiableState().letterSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setLetterSpacing(Length(pixels, LengthType::Fixed));
 }
 
@@ -3169,7 +3170,7 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
     auto& fontCascade = fontProxy()->fontCascade();
     double pixels = Style::computeUnzoomedNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, &fontCascade);
 
-    modifiableState().wordSpacing = CSS::serializationForCSS(*rawLength);
+    modifiableState().wordSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setWordSpacing(Length(pixels, LengthType::Fixed));
 }
 

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "HTMLSrcsetParser.h"
 
+#include "CSSSerializationContext.h"
 #include "Element.h"
 #include "HTMLParserIdioms.h"
 #include <wtf/ListHashSet.h>
@@ -229,9 +230,9 @@ void getURLsFromSrcsetAttribute(const Element& element, StringView attribute, Li
     }
 }
 
-String replaceURLsInSrcsetAttribute(const Element& element, StringView attribute, const UncheckedKeyHashMap<String, String>& replacementURLStrings)
+String replaceURLsInSrcsetAttribute(const Element& element, StringView attribute, const CSS::SerializationContext& context)
 {
-    if (replacementURLStrings.isEmpty())
+    if (context.replacementURLStrings.isEmpty())
         return attribute.toString();
 
     auto imageCandidates = parseImageCandidatesFromSrcsetAttribute(attribute);
@@ -241,7 +242,7 @@ String replaceURLsInSrcsetAttribute(const Element& element, StringView attribute
             result.append(", "_s);
 
         auto resolvedURLString = element.resolveURLStringIfNeeded(candidate.string.toString());
-        auto replacementURLString = replacementURLStrings.get(resolvedURLString);
+        auto replacementURLString = context.replacementURLStrings.get(resolvedURLString);
         if (!replacementURLString.isEmpty())
             result.append(replacementURLString);
         else

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.h
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.h
@@ -36,6 +36,10 @@
 
 namespace WebCore {
 
+namespace CSS {
+struct SerializationContext;
+}
+
 class Element;
 const int UninitializedDescriptor = -1;
 const float DefaultDensityValue = 1.0;
@@ -108,6 +112,6 @@ ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const At
 
 Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(StringView attribute);
 void getURLsFromSrcsetAttribute(const Element&, StringView attribute, ListHashSet<URL>&);
-String replaceURLsInSrcsetAttribute(const Element&, StringView attribute, const UncheckedKeyHashMap<String, String>& replacementURLStrings);
+String replaceURLsInSrcsetAttribute(const Element&, StringView attribute, const CSS::SerializationContext&);
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -35,6 +35,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "CSSSerializationContext.h"
 #include "CommonAtomStrings.h"
 #include "Document.h"
 #include "ISOVTTCue.h"
@@ -391,7 +392,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         return true;
 
     StringBuilder sanitizedStyleSheetBuilder;
-    
+
     for (const auto& rule : childRules) {
         auto styleRule = dynamicDowncast<StyleRule>(rule);
         if (!styleRule)
@@ -410,7 +411,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         if (styleRule->properties().isEmpty())
             continue;
 
-        sanitizedStyleSheetBuilder.append(selectorText, " { "_s, styleRule->properties().asText(), "  }\n"_s);
+        sanitizedStyleSheetBuilder.append(selectorText, " { "_s, styleRule->properties().asText(CSS::defaultSerializationContext()), "  }\n"_s);
     }
 
     // It would be more stylish to parse the stylesheet only once instead of serializing a sanitized version.

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -35,6 +35,7 @@
 #include "CSSGridAutoRepeatValue.h"
 #include "CSSGridIntegerRepeatValue.h"
 #include "CSSGridLineNamesValue.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleDeclaration.h"
 #include "DOMCSSNamespace.h"
 #include "DOMTokenList.h"
@@ -1440,7 +1441,7 @@ static Vector<String> authoredGridTrackSizes(Node* node, GridTrackSizingDirectio
     
     auto handleValueIgnoringLineNames = [&](const CSSValue& currentValue) {
         if (!is<CSSGridLineNamesValue>(currentValue))
-            trackSizes.append(currentValue.cssText());
+            trackSizes.append(currentValue.cssText(CSS::defaultSerializationContext()));
     };
 
     for (auto& currentValue : *cssValueList) {

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -32,6 +32,7 @@
 #include "BlendingKeyframes.h"
 #include "CSSAnimation.h"
 #include "CSSPropertyNames.h"
+#include "CSSSerializationContext.h"
 #include "CSSTransition.h"
 #include "CSSValue.h"
 #include "ComputedStyleExtractor.h"
@@ -161,12 +162,12 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
                     [&] (CSSPropertyID cssPropertyId) {
                         stylePayloadBuilder.append(nameString(cssPropertyId), ": "_s);
                         if (auto value = computedStyleExtractor.valueForPropertyInStyle(style, cssPropertyId, renderer))
-                            stylePayloadBuilder.append(value->cssText());
+                            stylePayloadBuilder.append(value->cssText(CSS::defaultSerializationContext()));
                     },
                     [&] (const AtomString& customProperty) {
                         stylePayloadBuilder.append(customProperty, ": "_s);
                         if (auto value = computedStyleExtractor.customPropertyValue(customProperty))
-                            stylePayloadBuilder.append(value->cssText());
+                            stylePayloadBuilder.append(value->cssText(CSS::defaultSerializationContext()));
                     }
                 );
                 stylePayloadBuilder.append(';');
@@ -190,7 +191,7 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
                 keyframePayload->setEasing(timingFunction->cssText());
 
             if (!parsedKeyframe.style->isEmpty())
-                keyframePayload->setStyle(parsedKeyframe.style->asText());
+                keyframePayload->setStyle(parsedKeyframe.style->asText(CSS::defaultSerializationContext()));
 
             keyframesPayload->addItem(WTFMove(keyframePayload));
         }

--- a/Source/WebCore/style/values/color/StyleColor.cpp
+++ b/Source/WebCore/style/values/color/StyleColor.cpp
@@ -301,14 +301,14 @@ bool containsCurrentColor(const Color& value)
 
 // MARK: - Serialization
 
-String serializationForCSS(const Color& value)
+String serializationForCSS(const CSS::SerializationContext& context, const Color& value)
 {
-    return WTF::switchOn(value, [](const auto& kind) { return WebCore::Style::serializationForCSS(kind); });
+    return WTF::switchOn(value, [&](const auto& kind) { return WebCore::Style::serializationForCSS(context, kind); });
 }
 
-void serializationForCSS(StringBuilder& builder, const Color& value)
+void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context, const Color& value)
 {
-    return WTF::switchOn(value, [&](const auto& kind) { WebCore::Style::serializationForCSS(builder, kind); });
+    return WTF::switchOn(value, [&](const auto& kind) { WebCore::Style::serializationForCSS(builder, context, kind); });
 }
 
 // MARK: - TextStream.

--- a/Source/WebCore/style/values/color/StyleColor.h
+++ b/Source/WebCore/style/values/color/StyleColor.h
@@ -167,8 +167,8 @@ private:
 WebCore::Color resolveColor(const Color&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const Color&);
 
-void serializationForCSS(StringBuilder&, const Color&);
-WEBCORE_EXPORT String serializationForCSS(const Color&);
+void serializationForCSS(StringBuilder&, const CSS::SerializationContext&, const Color&);
+WEBCORE_EXPORT String serializationForCSS(const CSS::SerializationContext&, const Color&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const Color&);
 

--- a/Source/WebCore/style/values/color/StyleColorLayers.cpp
+++ b/Source/WebCore/style/values/color/StyleColorLayers.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSColorLayersResolver.h"
 #include "CSSColorLayersSerialization.h"
+#include "CSSSerializationContext.h"
 #include "ColorSerialization.h"
 #include "StyleBuilderState.h"
 #include "StyleColorResolutionState.h"
@@ -93,15 +94,15 @@ bool containsCurrentColor(const ColorLayers& colorLayers)
 
 // MARK: - Serialization
 
-void serializationForCSS(StringBuilder& builder, const ColorLayers& colorLayers)
+void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context, const ColorLayers& colorLayers)
 {
-    CSS::serializationForCSSColorLayers(builder, colorLayers);
+    CSS::serializationForCSSColorLayers(builder, context, colorLayers);
 }
 
-String serializationForCSS(const ColorLayers& colorLayers)
+String serializationForCSS(const CSS::SerializationContext& context, const ColorLayers& colorLayers)
 {
     StringBuilder builder;
-    serializationForCSS(builder, colorLayers);
+    serializationForCSS(builder, context, colorLayers);
     return builder.toString();
 }
 
@@ -109,7 +110,7 @@ String serializationForCSS(const ColorLayers& colorLayers)
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const ColorLayers& colorLayers)
 {
-    return ts << serializationForCSS(colorLayers);
+    return ts << serializationForCSS(CSS::defaultSerializationContext(), colorLayers);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleColorLayers.h
+++ b/Source/WebCore/style/values/color/StyleColorLayers.h
@@ -56,8 +56,8 @@ Color toStyleColor(const CSS::ColorLayers&, ColorResolutionState&);
 WebCore::Color resolveColor(const ColorLayers&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const ColorLayers&);
 
-void serializationForCSS(StringBuilder&, const ColorLayers&);
-String serializationForCSS(const ColorLayers&);
+void serializationForCSS(StringBuilder&, const CSS::SerializationContext&, const ColorLayers&);
+String serializationForCSS(const CSS::SerializationContext&, const ColorLayers&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ColorLayers&);
 

--- a/Source/WebCore/style/values/color/StyleColorMix.cpp
+++ b/Source/WebCore/style/values/color/StyleColorMix.cpp
@@ -113,15 +113,15 @@ bool containsCurrentColor(const ColorMix& colorMix)
 
 // MARK: - Serialization
 
-void serializationForCSS(StringBuilder& builder, const ColorMix& colorMix)
+void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context, const ColorMix& colorMix)
 {
-    CSS::serializationForCSSColorMix(builder, colorMix);
+    CSS::serializationForCSSColorMix(builder, context, colorMix);
 }
 
-String serializationForCSS(const ColorMix& colorMix)
+String serializationForCSS(const CSS::SerializationContext& context, const ColorMix& colorMix)
 {
     StringBuilder builder;
-    serializationForCSS(builder, colorMix);
+    serializationForCSS(builder, context, colorMix);
     return builder.toString();
 }
 

--- a/Source/WebCore/style/values/color/StyleColorMix.h
+++ b/Source/WebCore/style/values/color/StyleColorMix.h
@@ -67,8 +67,8 @@ Color toStyleColor(const CSS::ColorMix&, ColorResolutionState&);
 WebCore::Color resolveColor(const ColorMix&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const ColorMix&);
 
-void serializationForCSS(StringBuilder&, const ColorMix&);
-String serializationForCSS(const ColorMix&);
+void serializationForCSS(StringBuilder&, const CSS::SerializationContext&, const ColorMix&);
+String serializationForCSS(const CSS::SerializationContext&, const ColorMix&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ColorMix&);
 

--- a/Source/WebCore/style/values/color/StyleContrastColor.cpp
+++ b/Source/WebCore/style/values/color/StyleContrastColor.cpp
@@ -27,6 +27,7 @@
 
 #include "CSSContrastColorResolver.h"
 #include "CSSContrastColorSerialization.h"
+#include "CSSSerializationContext.h"
 #include "ColorSerialization.h"
 #include "StyleBuilderState.h"
 #include "StyleColorResolutionState.h"
@@ -81,15 +82,15 @@ bool containsCurrentColor(const ContrastColor& contrastColor)
 
 // MARK: - Serialization
 
-void serializationForCSS(StringBuilder& builder, const ContrastColor& contrastColor)
+void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context, const ContrastColor& contrastColor)
 {
-    CSS::serializationForCSSContrastColor(builder, contrastColor);
+    CSS::serializationForCSSContrastColor(builder, context, contrastColor);
 }
 
-String serializationForCSS(const ContrastColor& contrastColor)
+String serializationForCSS(const CSS::SerializationContext& context, const ContrastColor& contrastColor)
 {
     StringBuilder builder;
-    serializationForCSS(builder, contrastColor);
+    serializationForCSS(builder, context, contrastColor);
     return builder.toString();
 }
 
@@ -97,7 +98,7 @@ String serializationForCSS(const ContrastColor& contrastColor)
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const ContrastColor& contrastColor)
 {
-    return ts << serializationForCSS(contrastColor);
+    return ts << serializationForCSS(CSS::defaultSerializationContext(), contrastColor);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleContrastColor.h
+++ b/Source/WebCore/style/values/color/StyleContrastColor.h
@@ -54,8 +54,8 @@ Color toStyleColor(const CSS::ContrastColor&, ColorResolutionState&);
 WebCore::Color resolveColor(const ContrastColor&, const WebCore::Color& currentColor);
 bool containsCurrentColor(const ContrastColor&);
 
-void serializationForCSS(StringBuilder&, const ContrastColor&);
-String serializationForCSS(const ContrastColor&);
+void serializationForCSS(StringBuilder&, const CSS::SerializationContext&, const ContrastColor&);
+String serializationForCSS(const CSS::SerializationContext&, const ContrastColor&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ContrastColor&);
 

--- a/Source/WebCore/style/values/color/StyleCurrentColor.cpp
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.cpp
@@ -33,12 +33,12 @@ namespace Style {
 
 // MARK: - Serialization
 
-void serializationForCSS(StringBuilder& builder, const CurrentColor&)
+void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext&, const CurrentColor&)
 {
     builder.append("currentcolor"_s);
 }
 
-String serializationForCSS(const CurrentColor&)
+String serializationForCSS(const CSS::SerializationContext&, const CurrentColor&)
 {
     return "currentcolor"_s;
 }

--- a/Source/WebCore/style/values/color/StyleCurrentColor.h
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.h
@@ -45,8 +45,8 @@ constexpr bool containsCurrentColor(const CurrentColor&)
     return true;
 }
 
-void serializationForCSS(StringBuilder&, const CurrentColor&);
-String serializationForCSS(const CurrentColor&);
+void serializationForCSS(StringBuilder&, const CSS::SerializationContext&, const CurrentColor&);
+String serializationForCSS(const CSS::SerializationContext&, const CurrentColor&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const CurrentColor&);
 

--- a/Source/WebCore/style/values/color/StyleRelativeColor.h
+++ b/Source/WebCore/style/values/color/StyleRelativeColor.h
@@ -29,6 +29,7 @@
 #include "CSSRelativeColor.h"
 #include "CSSRelativeColorResolver.h"
 #include "CSSRelativeColorSerialization.h"
+#include "CSSSerializationContext.h"
 #include "Color.h"
 #include "ColorSerialization.h"
 #include "StyleColor.h"
@@ -100,22 +101,21 @@ template<typename D> bool containsCurrentColor(const RelativeColor<D>& relative)
     return WebCore::Style::containsCurrentColor(relative.origin);
 }
 
-template<typename D> void serializationForCSS(StringBuilder& builder, const RelativeColor<D>& relative)
+template<typename D> void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext& context, const RelativeColor<D>& relative)
 {
-    CSS::serializationForCSSRelativeColor(builder, relative);
+    CSS::serializationForCSSRelativeColor(builder, context, relative);
 }
 
-template<typename D> String serializationForCSS(const RelativeColor<D>& relative)
+template<typename D> String serializationForCSS(const CSS::SerializationContext& context, const RelativeColor<D>& relative)
 {
     StringBuilder builder;
-    serializationForCSS(builder, relative);
+    serializationForCSS(builder, context, relative);
     return builder.toString();
 }
 
 template<typename D> WTF::TextStream& operator<<(WTF::TextStream& ts, const RelativeColor<D>& relative)
 {
-    ts << "relativeColor(" << serializationForCSS(relative) << ")";
-    return ts;
+    return ts << "relativeColor(" << serializationForCSS(CSS::defaultSerializationContext(), relative) << ")";
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleResolvedColor.cpp
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.cpp
@@ -42,12 +42,12 @@ Color toStyleColor(const CSS::ResolvedColor& unresolved, ColorResolutionState&)
 
 // MARK: - Serialization
 
-void serializationForCSS(StringBuilder& builder, const ResolvedColor& absoluteColor)
+void serializationForCSS(StringBuilder& builder, const CSS::SerializationContext&, const ResolvedColor& absoluteColor)
 {
     builder.append(serializationForCSS(absoluteColor.color));
 }
 
-String serializationForCSS(const ResolvedColor& absoluteColor)
+String serializationForCSS(const CSS::SerializationContext&, const ResolvedColor& absoluteColor)
 {
     return serializationForCSS(absoluteColor.color);
 }
@@ -56,8 +56,7 @@ String serializationForCSS(const ResolvedColor& absoluteColor)
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const ResolvedColor& absoluteColor)
 {
-    ts << "absoluteColor(" << absoluteColor.color.debugDescription() << ")";
-    return ts;
+    return ts << "absoluteColor(" << absoluteColor.color.debugDescription() << ")";
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleResolvedColor.h
+++ b/Source/WebCore/style/values/color/StyleResolvedColor.h
@@ -55,8 +55,8 @@ constexpr bool containsCurrentColor(const ResolvedColor&)
     return false;
 }
 
-void serializationForCSS(StringBuilder&, const ResolvedColor&);
-String serializationForCSS(const ResolvedColor&);
+void serializationForCSS(StringBuilder&, const CSS::SerializationContext&, const ResolvedColor&);
+String serializationForCSS(const CSS::SerializationContext&, const ResolvedColor&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ResolvedColor&);
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "CSSPrimitiveNumericTypes+Serialization.h"
+#include "CSSSerializationContext.h"
 #include "StylePrimitiveNumericTypes.h"
 #include <wtf/text/TextStream.h>
 
@@ -38,7 +39,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, Calc auto const& value)
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, Numeric auto const& value)
 {
-    return ts << CSS::serializationForCSS(CSS::SerializableNumber { value.value, CSS::unitString(value.unit) });
+    return ts << CSS::serializationForCSS(CSS::defaultSerializationContext(), CSS::SerializableNumber { value.value, CSS::unitString(value.unit) });
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, DimensionPercentageNumeric auto const& value)

--- a/Source/WebCore/svg/properties/SVGPropertyAnimator.h
+++ b/Source/WebCore/svg/properties/SVGPropertyAnimator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSPropertyParser.h"
+#include "CSSSerializationContext.h"
 #include "ComputedStyleExtractor.h"
 #include "SVGAttributeAnimator.h"
 #include "SVGElement.h"
@@ -86,7 +87,10 @@ protected:
         targetElement.setUseOverrideComputedStyle(true);
         RefPtr<CSSValue> value = ComputedStyleExtractor(&targetElement).propertyValue(id);
         targetElement.setUseOverrideComputedStyle(false);
-        return value ? value->cssText() : String();
+        if (!value)
+            return String();
+
+        return value->cssText(CSS::defaultSerializationContext());
     }
 
     String computeInheritedCSSPropertyValue(SVGElement& targetElement) const

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
@@ -30,6 +30,7 @@
 #include <WebCore/CSSCustomPropertyValue.h>
 #include <WebCore/CSSGridIntegerRepeatValue.h>
 #include <WebCore/CSSParser.h>
+#include <WebCore/CSSSerializationContext.h>
 #include <WebCore/CSSValueList.h>
 #include <WebCore/Color.h>
 #include <WebCore/MutableStyleProperties.h>
@@ -78,7 +79,7 @@ TEST(CSSParser, ParseCustomPropertyWithNewlineInput)
     auto customPropValue = downcast<CSSCustomPropertyValue>(properties->propertyAt(0).value());
 
     ASSERT_TRUE(is<CSSCustomPropertyValue>(customPropValue));
-    auto customText = customPropValue->cssText();
+    auto customText = customPropValue->cssText(CSS::defaultSerializationContext());
     customText.convertTo16Bit();
 
     EXPECT_EQ("ValueHere\nWithAnotherValue"_s, customText);
@@ -93,7 +94,7 @@ TEST(CSSParser, ParseCustomPropertyWithNewlineAndWhitespacesInput)
     auto customPropValue = downcast<CSSCustomPropertyValue>(properties->propertyAt(0).value());
 
     ASSERT_TRUE(is<CSSCustomPropertyValue>(customPropValue));
-    auto customText = customPropValue->cssText();
+    auto customText = customPropValue->cssText(CSS::defaultSerializationContext());
     customText.convertTo16Bit();
 
     EXPECT_EQ("ValueHere\nWithAnotherValue         ShouldPreserveAllWhitespace"_s, customText);
@@ -108,7 +109,7 @@ TEST(CSSParser, ParseCustomPropertyWithNewlineBetweenIdentInput)
     auto customPropValue = downcast<CSSCustomPropertyValue>(properties->propertyAt(0).value());
 
     ASSERT_TRUE(is<CSSCustomPropertyValue>(customPropValue));
-    auto customText = customPropValue->cssText();
+    auto customText = customPropValue->cssText(CSS::defaultSerializationContext());
     customText.convertTo16Bit();
 
     EXPECT_EQ("foo\nbar"_s, customText);
@@ -150,7 +151,7 @@ TEST(CSSParser, ParseTextTransformPropertyWithNewlineBetweenTwoIdentInput)
     check(properties);
 
     auto value = properties->propertyAt(0).value();
-    auto serialized = value->cssText();
+    auto serialized = value->cssText(CSS::defaultSerializationContext());
     EXPECT_EQ(serialized, "capitalize full-width"_s);
 
     CSSParser parser2(strictCSSParserContext());


### PR DESCRIPTION
#### 9e3372cb622a8d4497cbe9d1d5c6341869f48af6
<pre>
Pipe a context through the CSS serialization code
<a href="https://bugs.webkit.org/show_bug.cgi?id=287219">https://bugs.webkit.org/show_bug.cgi?id=287219</a>

Reviewed by Simon Fraser.

Adds a new type, CSS::SerializationContext and pipes it through
CSS serialization code.

Initially, this allows removing the set/clear replacement URL
functions as well as some unnecessary StyleProperties copies,
by instead having the replacement URL state on the new context.
This is an important step to removing mutability from CSS values.

Eventually, this will also allow passing down things like the
stage of cascade so we can differentiate serialization of
specified vs. computed styles, and potentially even a builder.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/animation/WebAnimation.cpp:
* Source/WebCore/css/CSSAppleColorFilterPropertyValue.cpp:
* Source/WebCore/css/CSSAppleColorFilterPropertyValue.h:
* Source/WebCore/css/CSSAspectRatioValue.cpp:
* Source/WebCore/css/CSSAspectRatioValue.h:
* Source/WebCore/css/CSSAttrValue.cpp:
* Source/WebCore/css/CSSAttrValue.h:
* Source/WebCore/css/CSSBackgroundRepeatValue.cpp:
* Source/WebCore/css/CSSBackgroundRepeatValue.h:
* Source/WebCore/css/CSSBasicShapeValue.cpp:
* Source/WebCore/css/CSSBasicShapeValue.h:
* Source/WebCore/css/CSSBorderImageSliceValue.cpp:
* Source/WebCore/css/CSSBorderImageSliceValue.h:
* Source/WebCore/css/CSSBorderImageWidthValue.cpp:
* Source/WebCore/css/CSSBorderImageWidthValue.h:
* Source/WebCore/css/CSSBoxShadowPropertyValue.cpp:
* Source/WebCore/css/CSSBoxShadowPropertyValue.h:
* Source/WebCore/css/CSSCanvasValue.cpp:
* Source/WebCore/css/CSSCanvasValue.h:
* Source/WebCore/css/CSSColorSchemeValue.cpp:
* Source/WebCore/css/CSSColorSchemeValue.h:
* Source/WebCore/css/CSSColorValue.cpp:
* Source/WebCore/css/CSSColorValue.h:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
* Source/WebCore/css/CSSContentDistributionValue.cpp:
* Source/WebCore/css/CSSContentDistributionValue.h:
* Source/WebCore/css/CSSCounterValue.cpp:
* Source/WebCore/css/CSSCounterValue.h:
* Source/WebCore/css/CSSCrossfadeValue.cpp:
* Source/WebCore/css/CSSCrossfadeValue.h:
* Source/WebCore/css/CSSCursorImageValue.cpp:
* Source/WebCore/css/CSSCursorImageValue.h:
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSEasingFunctionValue.cpp:
* Source/WebCore/css/CSSEasingFunctionValue.h:
* Source/WebCore/css/CSSFilterImageValue.cpp:
* Source/WebCore/css/CSSFilterImageValue.h:
* Source/WebCore/css/CSSFilterPropertyValue.cpp:
* Source/WebCore/css/CSSFilterPropertyValue.h:
* Source/WebCore/css/CSSFontFaceRule.cpp:
* Source/WebCore/css/CSSFontFaceRule.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSFontFeatureValue.cpp:
* Source/WebCore/css/CSSFontFeatureValue.h:
* Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.cpp:
* Source/WebCore/css/CSSFontPaletteValuesOverrideColorsValue.h:
* Source/WebCore/css/CSSFontStyleRangeValue.cpp:
* Source/WebCore/css/CSSFontStyleRangeValue.h:
* Source/WebCore/css/CSSFontStyleWithAngleValue.cpp:
* Source/WebCore/css/CSSFontStyleWithAngleValue.h:
* Source/WebCore/css/CSSFontValue.cpp:
* Source/WebCore/css/CSSFontValue.h:
* Source/WebCore/css/CSSFontVariantAlternatesValue.cpp:
* Source/WebCore/css/CSSFontVariantAlternatesValue.h:
* Source/WebCore/css/CSSFontVariationValue.cpp:
* Source/WebCore/css/CSSFontVariationValue.h:
* Source/WebCore/css/CSSFunctionValue.cpp:
* Source/WebCore/css/CSSFunctionValue.h:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSGradientValue.h:
* Source/WebCore/css/CSSGridAutoRepeatValue.cpp:
* Source/WebCore/css/CSSGridAutoRepeatValue.h:
* Source/WebCore/css/CSSGridIntegerRepeatValue.cpp:
* Source/WebCore/css/CSSGridIntegerRepeatValue.h:
* Source/WebCore/css/CSSGridLineNamesValue.cpp:
* Source/WebCore/css/CSSGridLineNamesValue.h:
* Source/WebCore/css/CSSGridLineValue.cpp:
* Source/WebCore/css/CSSGridLineValue.h:
* Source/WebCore/css/CSSGridTemplateAreasValue.cpp:
* Source/WebCore/css/CSSGridTemplateAreasValue.h:
* Source/WebCore/css/CSSGroupingRule.cpp:
* Source/WebCore/css/CSSGroupingRule.h:
* Source/WebCore/css/CSSImageSetOptionValue.cpp:
* Source/WebCore/css/CSSImageSetOptionValue.h:
* Source/WebCore/css/CSSImageSetValue.cpp:
* Source/WebCore/css/CSSImageSetValue.h:
* Source/WebCore/css/CSSImageValue.cpp:
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSImportRule.cpp:
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSKeyframeRule.cpp:
* Source/WebCore/css/CSSLineBoxContainValue.cpp:
* Source/WebCore/css/CSSLineBoxContainValue.h:
* Source/WebCore/css/CSSMediaRule.cpp:
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/CSSNamedImageValue.cpp:
* Source/WebCore/css/CSSNamedImageValue.h:
* Source/WebCore/css/CSSNestedDeclarations.cpp:
* Source/WebCore/css/CSSOffsetRotateValue.cpp:
* Source/WebCore/css/CSSOffsetRotateValue.h:
* Source/WebCore/css/CSSPageRule.cpp:
* Source/WebCore/css/CSSPaintImageValue.cpp:
* Source/WebCore/css/CSSPaintImageValue.h:
* Source/WebCore/css/CSSPathValue.cpp:
* Source/WebCore/css/CSSPathValue.h:
* Source/WebCore/css/CSSPendingSubstitutionValue.h:
* Source/WebCore/css/CSSPositionTryRule.cpp:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSQuadValue.cpp:
* Source/WebCore/css/CSSQuadValue.h:
* Source/WebCore/css/CSSRayValue.cpp:
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/css/CSSRectValue.cpp:
* Source/WebCore/css/CSSRectValue.h:
* Source/WebCore/css/CSSReflectValue.cpp:
* Source/WebCore/css/CSSReflectValue.h:
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSScrollValue.cpp:
* Source/WebCore/css/CSSScrollValue.h:
* Source/WebCore/css/CSSStyleRule.cpp:
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSSubgridValue.cpp:
* Source/WebCore/css/CSSSubgridValue.h:
* Source/WebCore/css/CSSSupportsRule.cpp:
* Source/WebCore/css/CSSSupportsRule.h:
* Source/WebCore/css/CSSTextShadowPropertyValue.cpp:
* Source/WebCore/css/CSSTextShadowPropertyValue.h:
* Source/WebCore/css/CSSTransformListValue.h:
* Source/WebCore/css/CSSUnicodeRangeValue.cpp:
* Source/WebCore/css/CSSUnicodeRangeValue.h:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSValueList.cpp:
* Source/WebCore/css/CSSValueList.h:
* Source/WebCore/css/CSSValuePair.cpp:
* Source/WebCore/css/CSSValuePair.h:
* Source/WebCore/css/CSSVariableReferenceValue.cpp:
* Source/WebCore/css/CSSVariableReferenceValue.h:
* Source/WebCore/css/CSSViewValue.cpp:
* Source/WebCore/css/CSSViewValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/DeprecatedCSSOMBoxShadowValue.cpp:
* Source/WebCore/css/DeprecatedCSSOMFilterFunctionValue.cpp:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.h:
* Source/WebCore/css/DeprecatedCSSOMTextShadowValue.cpp:
* Source/WebCore/css/DeprecatedCSSOMValue.cpp:
* Source/WebCore/css/DeprecatedCSSOMValue.h:
* Source/WebCore/css/MutableStyleProperties.cpp:
* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
* Source/WebCore/css/Quad.h:
* Source/WebCore/css/Rect.h:
* Source/WebCore/css/ShorthandSerializer.cpp:
* Source/WebCore/css/ShorthandSerializer.h:
* Source/WebCore/css/StyleProperties.cpp:
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/css/StylePropertiesInlines.h:
* Source/WebCore/css/StyleRule.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Serialization.h:
* Source/WebCore/css/calc/CSSCalcTree.cpp:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
* Source/WebCore/css/typedom/CSSStyleImageValue.cpp:
* Source/WebCore/css/typedom/CSSStyleValue.cpp:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
* Source/WebCore/css/values/CSSSerializationContext.cpp: Added.
* Source/WebCore/css/values/CSSSerializationContext.h: Added.
* Source/WebCore/css/values/CSSValueTypes.cpp:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/backgrounds/CSSBorderRadius.cpp:
* Source/WebCore/css/values/backgrounds/CSSBorderRadius.h:
* Source/WebCore/css/values/color-adjust/CSSColorScheme.cpp:
* Source/WebCore/css/values/color-adjust/CSSColorScheme.h:
* Source/WebCore/css/values/color/CSSAbsoluteColor.h:
* Source/WebCore/css/values/color/CSSAbsoluteColorSerialization.h:
* Source/WebCore/css/values/color/CSSColor.cpp:
* Source/WebCore/css/values/color/CSSColor.h:
* Source/WebCore/css/values/color/CSSColorLayers.cpp:
* Source/WebCore/css/values/color/CSSColorLayers.h:
* Source/WebCore/css/values/color/CSSColorLayersSerialization.h:
* Source/WebCore/css/values/color/CSSColorMix.cpp:
* Source/WebCore/css/values/color/CSSColorMix.h:
* Source/WebCore/css/values/color/CSSColorMixSerialization.cpp:
* Source/WebCore/css/values/color/CSSColorMixSerialization.h:
* Source/WebCore/css/values/color/CSSContrastColor.cpp:
* Source/WebCore/css/values/color/CSSContrastColor.h:
* Source/WebCore/css/values/color/CSSContrastColorSerialization.h:
* Source/WebCore/css/values/color/CSSHexColor.cpp:
* Source/WebCore/css/values/color/CSSHexColor.h:
* Source/WebCore/css/values/color/CSSKeywordColor.cpp:
* Source/WebCore/css/values/color/CSSKeywordColor.h:
* Source/WebCore/css/values/color/CSSLightDarkColor.cpp:
* Source/WebCore/css/values/color/CSSLightDarkColor.h:
* Source/WebCore/css/values/color/CSSRelativeColor.h:
* Source/WebCore/css/values/color/CSSRelativeColorSerialization.h:
* Source/WebCore/css/values/color/CSSResolvedColor.cpp:
* Source/WebCore/css/values/color/CSSResolvedColor.h:
* Source/WebCore/css/values/easing/CSSStepsEasingFunction.h:
* Source/WebCore/css/values/filter-effects/CSSFilterReference.cpp:
* Source/WebCore/css/values/filter-effects/CSSFilterReference.h:
* Source/WebCore/css/values/images/CSSGradient.cpp:
* Source/WebCore/css/values/images/CSSGradient.h:
* Source/WebCore/css/values/motion/CSSRayFunction.cpp:
* Source/WebCore/css/values/motion/CSSRayFunction.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes+Serialization.h:
* Source/WebCore/css/values/primitives/CSSSymbol.cpp:
* Source/WebCore/css/values/primitives/CSSSymbol.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.cpp:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/css/values/shapes/CSSCircleFunction.cpp:
* Source/WebCore/css/values/shapes/CSSCircleFunction.h:
* Source/WebCore/css/values/shapes/CSSEllipseFunction.cpp:
* Source/WebCore/css/values/shapes/CSSEllipseFunction.h:
* Source/WebCore/css/values/shapes/CSSInsetFunction.cpp:
* Source/WebCore/css/values/shapes/CSSInsetFunction.h:
* Source/WebCore/css/values/shapes/CSSPathFunction.cpp:
* Source/WebCore/css/values/shapes/CSSPathFunction.h:
* Source/WebCore/css/values/shapes/CSSPolygonFunction.cpp:
* Source/WebCore/css/values/shapes/CSSPolygonFunction.h:
* Source/WebCore/css/values/shapes/CSSRectFunction.cpp:
* Source/WebCore/css/values/shapes/CSSRectFunction.h:
* Source/WebCore/css/values/shapes/CSSShapeFunction.cpp:
* Source/WebCore/css/values/shapes/CSSShapeFunction.h:
* Source/WebCore/css/values/shapes/CSSXywhFunction.cpp:
* Source/WebCore/css/values/shapes/CSSXywhFunction.h:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ExtensionStyleSheets.cpp:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/StyledElement.cpp:
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
* Source/WebCore/editing/EditingStyle.cpp:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/editing/MarkupAccumulator.cpp:
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
* Source/WebCore/editing/markup.cpp:
* Source/WebCore/editing/markup.h:
* Source/WebCore/html/HTMLImageElement.cpp:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLSourceElement.cpp:
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
* Source/WebCore/html/parser/HTMLSrcsetParser.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
* Source/WebCore/style/values/color/StyleColor.cpp:
* Source/WebCore/style/values/color/StyleColor.h:
* Source/WebCore/style/values/color/StyleColorLayers.cpp:
* Source/WebCore/style/values/color/StyleColorLayers.h:
* Source/WebCore/style/values/color/StyleColorMix.cpp:
* Source/WebCore/style/values/color/StyleColorMix.h:
* Source/WebCore/style/values/color/StyleContrastColor.cpp:
* Source/WebCore/style/values/color/StyleContrastColor.h:
* Source/WebCore/style/values/color/StyleCurrentColor.cpp:
* Source/WebCore/style/values/color/StyleCurrentColor.h:
* Source/WebCore/style/values/color/StyleRelativeColor.h:
* Source/WebCore/style/values/color/StyleResolvedColor.cpp:
* Source/WebCore/style/values/color/StyleResolvedColor.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Logging.h:
* Source/WebCore/svg/properties/SVGPropertyAnimator.h:
* Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp:

Canonical link: <a href="https://commits.webkit.org/290141@main">https://commits.webkit.org/290141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6e319587d4fab9b7ad08aac3582233f87a7ff7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89084 "65 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94062 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16794 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68639 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26312 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6630 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16520 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76805 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18934 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21206 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21589 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->