### PR TITLE
[Materials] Add support for vibrancy effects without a backing material

### DIFF
--- a/LayoutTests/apple-visual-effects/apple-visual-effect-automatic-vibrancy-expected-mismatch.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-automatic-vibrancy-expected-mismatch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that vibrancy can be used without an explicitly specified backing material.</title>
+<style>
+
+div {
+    background: linear-gradient(90deg, red, blue) fixed;
+}
+
+p {
+    -apple-visual-effect: none;
+}
+
+</style>
+</head>
+<body>
+<div><p>-apple-system-vibrancy-secondary-label</p></div>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-automatic-vibrancy.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-automatic-vibrancy.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that vibrancy can be used without an explicitly specified backing material.</title>
+<style>
+
+div {
+    background: linear-gradient(90deg, red, blue) fixed;
+}
+
+p {
+    -apple-visual-effect: -apple-system-vibrancy-secondary-label;
+}
+
+</style>
+</head>
+<body>
+<div><p>-apple-system-vibrancy-secondary-label</p></div>
+</body>
+</html>

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -228,6 +228,13 @@ static MTCoreMaterialVisualStyleCategory materialVisualStyleCategoryForAppleVisu
 static void applyVisualStylingToLayer(CALayer *layer, AppleVisualEffect material, AppleVisualEffect visualStyling)
 {
     MTCoreMaterialRecipe recipe = materialRecipeForAppleVisualEffect(material);
+    if ([recipe isEqualToString:PAL::get_CoreMaterial_MTCoreMaterialRecipeNone()]) {
+#if PLATFORM(VISION)
+        recipe = PAL::get_CoreMaterial_MTCoreMaterialRecipePlatformContentUltraThinLight();
+#else
+        recipe = PAL::get_CoreMaterial_MTCoreMaterialRecipePlatformContentThickLight();
+#endif
+    }
 
     // Despite the name, MTVisualStylingCreateDictionaryRepresentation returns an autoreleased object.
     RetainPtr visualStylingDescription = PAL::softLink_CoreMaterial_MTVisualStylingCreateDictionaryRepresentation(recipe, materialVisualStyleCategoryForAppleVisualEffect(visualStyling), materialVisualStyleForAppleVisualEffect(visualStyling), nil);


### PR DESCRIPTION
#### c027aef2f2a020036d01f92cbed4b091a29045be
<pre>
[Materials] Add support for vibrancy effects without a backing material
<a href="https://bugs.webkit.org/show_bug.cgi?id=287222">https://bugs.webkit.org/show_bug.cgi?id=287222</a>
<a href="https://rdar.apple.com/144363980">rdar://144363980</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

It should be possible to use vibrancy without also using a material effect.

Supply a default material recipe when resolving vibrancy effects. The default
matches what is specified in UIKit.

* LayoutTests/apple-visual-effects/apple-visual-effect-automatic-vibrancy-expected-mismatch.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-automatic-vibrancy.html: Added.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::applyVisualStylingToLayer):

Canonical link: <a href="https://commits.webkit.org/290018@main">https://commits.webkit.org/290018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68f3595171decaa88d9f8064bd8806b3782364cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39406 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68351 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6311 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34588 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38514 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95452 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76494 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8866 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13877 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15843 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21151 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15584 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->