### PR TITLE
[fullscreen] Most non-HTML elements should not be supported

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces-expected.txt
@@ -1,16 +1,8 @@
 
-FAIL requestFullscreen() fails for an element in null namespace assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL requestFullscreen() fails for an element in https://unknown.namespace namespace promise_rejects_js: function "function() { throw e }" threw object "Error: element click intercepted error" ("Error") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL requestFullscreen() fails for an element in  namespace promise_rejects_js: function "function() { throw e }" threw object "Error: element click intercepted error" ("Error") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL requestFullscreen() succeed for an element in http://www.w3.org/1999/xhtml namespace promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
-FAIL requestFullscreen() succeed for an element in http://www.w3.org/2000/svg namespace promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
-FAIL requestFullscreen() succeed for an element in http://www.w3.org/1998/Math/MathML namespace promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
-click to continue test
-click to continue test
-click to continue test
-click to continue test
-click to continue test
+PASS requestFullscreen() fails for an element in null namespace
+PASS requestFullscreen() fails for an element in https://unknown.namespace namespace
+PASS requestFullscreen() fails for an element in  namespace
+PASS requestFullscreen() succeed for an element in http://www.w3.org/1999/xhtml namespace
+PASS requestFullscreen() succeed for an element in http://www.w3.org/2000/svg namespace
+PASS requestFullscreen() succeed for an element in http://www.w3.org/1998/Math/MathML namespace
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-svg-rect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-svg-rect-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Element#requestFullscreen() for SVG rect element assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Element#requestFullscreen() for SVG rect element
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -39,15 +39,19 @@
 #include "HTMLDialogElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLMediaElement.h"
+#include "HTMLNames.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "Logging.h"
+#include "MathMLMathElement.h"
 #include "Page.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "QualifiedName.h"
 #include "Quirks.h"
 #include "RenderBlock.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGSVGElement.h"
 #include "Settings.h"
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -116,6 +120,11 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
     // If any of the following conditions are true, terminate these steps and queue a task to fire
     // an event named fullscreenerror with its bubbles attribute set to true on the context object's
     // node document:
+    if (!element->isHTMLElement() && !is<SVGSVGElement>(element) && !is<MathMLMathElement>(element)) {
+        handleError("Cannot request fullscreen on a non-HTML element."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
+        return;
+    }
+
     if (is<HTMLDialogElement>(element)) {
         handleError("Cannot request fullscreen on a <dialog> element."_s, EmitErrorEvent::Yes, WTFMove(element), WTFMove(promise), WTFMove(completionHandler));
         return;

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -800,9 +800,11 @@ sub printTypeHelpersHeaderFile
     print F "#pragma once\n\n";
     print F "#include \"".$parameters{namespace}."Names.h\"\n\n";
 
-    # FIXME: Remove `if` condition below once HTMLElementTypeHeaders.h is made inline.
+    # FIXME: Remove `if` condition below once HTMLElementTypeHelpers.h is made inline.
     if ($parameters{namespace} eq "SVG") {
-        print F "#include \"".$parameters{namespace}."ElementInlines.h\"\n\n";
+        print F "#include \"SVGElementInlines.h\"\n\n";
+    } elsif ($parameters{namespace} eq "MathML") {
+        print F "#include \"MathMLElement.h\"\n\n";
     }
     printTypeHelpers($F, \%allElements);
 


### PR DESCRIPTION
#### 4645ce50d593b3b0e2c4ba1dbcdec23aa0140b8e
<pre>
[fullscreen] Most non-HTML elements should not be supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=276856">https://bugs.webkit.org/show_bug.cgi?id=276856</a>
<a href="https://rdar.apple.com/132661463">rdar://132661463</a>

Reviewed by Aditya Keerthi.

<a href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen</a>

&gt; If any of the following conditions are false, then set error to true:
&gt; This’s namespace is the HTML namespace or this is an SVG svg or MathML math element.

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-svg-rect-expected.txt:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
* Source/WebCore/dom/make_names.pl:
(printTypeHelpersHeaderFile):

Canonical link: <a href="https://commits.webkit.org/289994@main">https://commits.webkit.org/289994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcd1ea9a13c28d1207c685bb85ea42402668dd94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26062 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6564 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48730 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6321 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38529 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95467 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15842 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16098 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76508 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20898 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15858 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->