### PR TITLE
[WebGPU] Bind group lengths are not validated in RenderBundles

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287200-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287200-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287200.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287200.html
@@ -1,0 +1,201 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+// START
+adapter0 = await navigator.gpu.requestAdapter();
+device0 = await adapter0.requestDevice();
+texture1 = device0.createTexture({
+  size : {width : 11},
+  format : 'rgba32sint',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT |
+              GPUTextureUsage});
+bindGroupLayout1 = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 46,
+      visibility : GPUShaderStage.FRAGMENT,
+      texture :
+          {viewDimension : '3d', }},
+    {
+      binding : 120,
+      visibility : GPUShaderStage.COMPUTE,
+      storageTexture : {
+        format : 'rg32uint',
+        viewDimension : '2d-array'
+      }},
+    {
+      binding : 24,
+      visibility : GPUShaderStage.VERTEX,
+      buffer : {type : 'read-only-storage', }},
+    {
+      binding : 156,
+      visibility : GPUShaderStage.COMPUTE,
+      texture : {
+        viewDimension : 'cube-array',
+        sampleType : 'uint',
+        }}]});
+texture6 = device0.createTexture({
+  size : [],
+  dimension : '3d',
+  format : 'rgba8snorm',
+  usage : GPUTextureUsage.TEXTURE_BINDING,
+  });
+textureView4 = texture6.createView();
+texture21 = device0.createTexture({
+  size : [],
+  format : 'rg32uint',
+  usage : GPUTextureUsage.STORAGE_BINDING,
+  });
+textureView9 = texture1.createView();
+texture29 = device0.createTexture({
+  size : [ 256, 256, 13 ],
+  mipLevelCount : 2,
+  format : 'stencil8',
+  usage : GPUTextureUsage.TEXTURE_BINDING,
+  });
+textureView13 = texture29.createView({
+  dimension : 'cube-array',
+  arrayLayerCount : 6});
+commandEncoder24 = device0.createCommandEncoder();
+renderPassEncoder12 = commandEncoder24.beginRenderPass({
+  colorAttachments : [ {
+    view : textureView9,
+    clearValue : {
+      r : 611.5,
+      g : 589.5,
+      b : 245.7,
+      a : 753.4},
+    loadOp : 'load',
+    storeOp : 'discard'} ]});
+{
+}
+buffer20 = device0.createBuffer({
+  size : 17127,
+  usage : GPUBufferUsage.STORAGE});
+device0;
+textureView25 = texture21.createView({dimension : '2d-array'});
+pipelineLayout4 =
+    device0.createPipelineLayout({bindGroupLayouts : [ bindGroupLayout1 ]});
+{
+}
+bindGroup16 = device0.createBindGroup({
+  layout : bindGroupLayout1,
+  entries : [
+    {binding : 120, resource : textureView25},
+    {binding : 46, resource : textureView4},
+    {binding : 156, resource : textureView13},
+    {binding : 24, resource : {buffer : buffer20, size : 1456}}]});
+shaderModule0 = device0.createShaderModule({
+  code : ` ;
+                     fn unconst_u32(v: u32) -> u32 {
+                  return v;
+                  }
+                     @group(0) @binding(24) var<storage> buffer29: array<array<array<FragmentOutput0, 10>, 5>>;
+                     struct VertexOutput0 {
+                    @location(4) f0: vec2h,   @builtin(position) f1: vec4f}
+                     struct FragmentOutput0 {
+                    @location(0) f0: vec4i,   @location(4) f1: f32}
+                     @vertex fn vertex0() -> VertexOutput0 {
+                    var out: VertexOutput0;
+                    let ptr5= &buffer29[bitcast<u32>((buffer29)[((134))][4][9].f1)][4][9].f0;
+                    out.f0 = vec2h((ptr5).gr);
+                    return out;
+                  }
+                     @fragment fn fragment0() -> FragmentOutput0 {
+                    var out: FragmentOutput0;
+                    return out;
+                  }
+                    `,
+  });
+pipeline0 = await device0.createRenderPipelineAsync({
+  layout : pipelineLayout4,
+  fragment : {
+    module : shaderModule0,
+    targets : [ {
+      format : 'rgba32sint',
+      } ]},
+  vertex : {module : shaderModule0, }});
+{
+}
+renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  colorFormats : [ 'rgba32sint' ],
+  });
+try {
+  renderBundleEncoder16.setPipeline(pipeline0);
+  renderBundleEncoder16.setBindGroup(0, bindGroup16)} catch {
+}
+try {
+  renderBundleEncoder16.draw(139)} catch {
+}
+renderBundle16 = renderBundleEncoder16.finish();
+try {
+  renderPassEncoder12.executeBundles([ renderBundle16 ])} catch {
+}
+try {
+  renderPassEncoder12.end()} catch {
+}
+commandBuffer10 = commandEncoder24.finish();
+try {
+  device0.queue.submit([ commandBuffer10 ])} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### 701c253163699ea9f0493a32935ca9b526b72888
<pre>
[WebGPU] Bind group lengths are not validated in RenderBundles
<a href="https://bugs.webkit.org/show_bug.cgi?id=287200">https://bugs.webkit.org/show_bug.cgi?id=287200</a>
<a href="https://rdar.apple.com/144310054">rdar://144310054</a>

Reviewed by Tadeu Zagallo.

RenderBundleEncoder incorrectly skipped buffer length validation
of bind groups.

* LayoutTests/fast/webgpu/nocrash/fuzz-287200-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-287200.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):

Canonical link: <a href="https://commits.webkit.org/290007@main">https://commits.webkit.org/290007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b565cbdca7952a7682babcfeac6ee83587edf135

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39415 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68357 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26056 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6316 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34595 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38523 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35495 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95461 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15836 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11590 "Found 6 new test failures: fullscreen/full-screen-remove-ancestor-after.html http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77220 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76501 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18842 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19309 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8875 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15852 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->