### PR TITLE
UnifiedPDF: Unbounded page preview rendering causes out of memory

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -33,6 +33,7 @@
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/TiledBacking.h>
+#include <limits>
 #include <wtf/HashMap.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/TZoneMalloc.h>
@@ -84,11 +85,28 @@ struct TileRenderData {
 
 WTF::TextStream& operator<<(WTF::TextStream&, const TileRenderData&);
 
-struct PagePreviewRequest {
+struct PDFPagePreviewRenderKey {
+    PDFDocumentLayout::PageIndex pageIndex { std::numeric_limits<PDFDocumentLayout::PageIndex>::max() };
+    bool operator==(const PDFPagePreviewRenderKey&) const = default;
+};
+
+struct PDFPagePreviewRenderRequest {
     PDFDocumentLayout::PageIndex pageIndex;
     WebCore::FloatRect normalizedPageBounds;
     float scale { 1.0f };
     bool showDebugIndicators { false };
+};
+
+struct PDFPagePreviewRenderKeyHash {
+    static unsigned hash(const PDFPagePreviewRenderKey& value)
+    {
+        return WTF::computeHash(value.pageIndex);
+    }
+    static bool equal(const PDFPagePreviewRenderKey& a, const PDFPagePreviewRenderKey& b)
+    {
+        return a == b;
+    }
+    static const bool safeToCompareToEmptyOrDeleted = true;
 };
 
 } // namespace WebKit
@@ -121,6 +139,16 @@ template<> struct HashTraits<WebKit::TileRenderData> : SimpleClassHashTraits<Web
     static constexpr bool hasIsEmptyValueFunction = true;
     static WebKit::TileRenderData emptyValue() { return { HashTraits<WebKit::PDFTileRenderIdentifier>::emptyValue(), { } }; }
     static bool isEmptyValue(const WebKit::TileRenderData& data) { return HashTraits<WebKit::PDFTileRenderIdentifier>::isEmptyValue(data.renderIdentifier); }
+};
+
+template<> struct HashTraits<WebKit::PDFPagePreviewRenderKey> : GenericHashTraits<WebKit::PDFPagePreviewRenderKey> {
+    static constexpr bool emptyValueIsZero = false;
+    static WebKit::PDFPagePreviewRenderKey emptyValue() { return { std::numeric_limits<WebKit::PDFDocumentLayout::PageIndex>::max() }; }
+    static void constructDeletedValue(WebKit::PDFPagePreviewRenderKey& slot) { slot = { std::numeric_limits<WebKit::PDFDocumentLayout::PageIndex>::max() - 1 }; }
+    static bool isDeletedValue(WebKit::PDFPagePreviewRenderKey value) { return value.pageIndex == std::numeric_limits<WebKit::PDFDocumentLayout::PageIndex>::max() - 1; }
+};
+
+template<> struct DefaultHash<WebKit::PDFPagePreviewRenderKey> : WebKit::PDFPagePreviewRenderKeyHash {
 };
 
 } // namespace WTF
@@ -188,7 +216,7 @@ private:
     std::optional<PDFTileRenderIdentifier> enqueueTileRenderForTileGridRepaint(WebCore::TiledBacking&, WebCore::TileGridIdentifier, WebCore::TileIndex, const WebCore::FloatRect& tileRect, const WebCore::FloatRect& tileDirtyRect);
     std::optional<PDFTileRenderIdentifier> enqueueTileRenderIfNecessary(const TileForGrid&, TileRenderInfo&&);
 
-    void serviceRequestQueue();
+    void serviceRequestQueues();
 
     void didCompleteTileRender(RefPtr<WebCore::NativeImage>&&, const TileForGrid&, const TileRenderData&);
 
@@ -205,10 +233,8 @@ private:
 
     void clearRequestsAndCachedTiles();
 
-    void didCompletePagePreviewRender(RefPtr<WebCore::NativeImage>&&, const PagePreviewRequest&);
+    void didCompletePagePreviewRender(RefPtr<WebCore::NativeImage>&&, const PDFPagePreviewRenderRequest&);
     void removePagePreviewsOutsideCoverageRect(const WebCore::FloatRect&, const std::optional<PDFLayoutRow>& = { });
-
-    Ref<ConcurrentWorkQueue> protectedPaintingWorkQueue() { return m_paintingWorkQueue; }
 
     static WebCore::FloatRect convertTileRectToPaintingCoords(const WebCore::FloatRect&, float pageScaleFactor);
     static WebCore::AffineTransform tileToPaintingTransform(float tilingScaleFactor);
@@ -219,14 +245,11 @@ private:
     HashMap<WebCore::PlatformLayerIdentifier, Ref<WebCore::GraphicsLayer>> m_layerIDtoLayerMap;
     HashMap<WebCore::TileGridIdentifier, WebCore::PlatformLayerIdentifier> m_tileGridToLayerIDMap;
 
-    Ref<ConcurrentWorkQueue> m_paintingWorkQueue;
+    const Ref<ConcurrentWorkQueue> m_workQueue;
+    int m_workQueueSlots { 4 };
 
-    HashMap<TileForGrid, TileRenderData> m_currentValidTileRenders;
-
-    const int m_maxConcurrentTileRenders { 4 };
-    int m_numConcurrentTileRenders { 0 };
-    ListHashSet<TileForGrid> m_requestWorkQueue;
-
+    ListHashSet<TileForGrid> m_pendingTileRenderOrder;
+    HashMap<TileForGrid, TileRenderData> m_pendingTileRenders;
     struct RenderedTile {
         RefPtr<WebCore::NativeImage> image;
         TileRenderInfo tileInfo;
@@ -236,20 +259,16 @@ private:
 
     HashMap<WebCore::TileGridIdentifier, std::unique_ptr<RevalidationStateForGrid>> m_gridRevalidationState;
 
-    struct RenderedPagePreview {
+    struct RenderedPDFPagePreview {
         RefPtr<WebCore::NativeImage> image;
         float scale { 1.0f };
     };
-    using PDFPageIndexSet = HashSet<PDFDocumentLayout::PageIndex, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;
-    using PDFPageIndexToPreviewHash = HashMap<PDFDocumentLayout::PageIndex, PagePreviewRequest, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;
-    using PDFPageIndexToBufferHash = HashMap<PDFDocumentLayout::PageIndex, RenderedPagePreview, IntHash<PDFDocumentLayout::PageIndex>, WTF::UnsignedWithZeroKeyHashTraits<PDFDocumentLayout::PageIndex>>;
-
-    PDFPageIndexToPreviewHash m_enqueuedPagePreviews;
-    PDFPageIndexToBufferHash m_pagePreviews;
+    ListHashSet<PDFPagePreviewRenderKey> m_pendingPagePreviewOrder;
+    HashMap<PDFPagePreviewRenderKey, PDFPagePreviewRenderRequest> m_pendingPagePreviews;
+    HashMap<PDFPagePreviewRenderKey, RenderedPDFPagePreview> m_pagePreviews;
 
     bool m_showDebugBorders { false };
 };
-
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 216a4697632bd08c6d2c087b2009789f3f078a56
<pre>
UnifiedPDF: Unbounded page preview rendering causes out of memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=287232">https://bugs.webkit.org/show_bug.cgi?id=287232</a>
<a href="https://rdar.apple.com/143750712">rdar://143750712</a>

Reviewed by Abrar Rahman Protyasha.

Limit PDF page previews render tasks to max concurrent task, similar to
rendering normal PDF layer content.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
(WebKit::PDFPagePreviewRenderKeyHash::hash):
(WebKit::PDFPagePreviewRenderKeyHash::equal):
(WTF::HashTraits&lt;WebKit::PDFPagePreviewRenderKey&gt;::emptyValue):
(WTF::HashTraits&lt;WebKit::PDFPagePreviewRenderKey&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebKit::PDFPagePreviewRenderKey&gt;::isDeletedValue):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::AsyncPDFRenderer):
(WebKit::renderPDFPagePreview):
(WebKit::AsyncPDFRenderer::generatePreviewImageForPage):
(WebKit::AsyncPDFRenderer::removePreviewForPage):
(WebKit::AsyncPDFRenderer::didCompletePagePreviewRender):
(WebKit::AsyncPDFRenderer::enqueueTileRenderForTileGridRepaint):
(WebKit::AsyncPDFRenderer::willRemoveTile):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::removePagePreviewsOutsideCoverageRect):
(WebKit::AsyncPDFRenderer::willRemoveGrid):
(WebKit::AsyncPDFRenderer::clearRequestsAndCachedTiles):
(WebKit::AsyncPDFRenderer::enqueueTileRenderIfNecessary):
(WebKit::AsyncPDFRenderer::serviceRequestQueues):
(WebKit::AsyncPDFRenderer::didCompleteTileRender):
(WebKit::AsyncPDFRenderer::paintPagePreview):
(WebKit::AsyncPDFRenderer::serviceRequestQueue): Deleted.

Canonical link: <a href="https://commits.webkit.org/290203@main">https://commits.webkit.org/290203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac02f721732b921b88e41740adf5f46f8eff6744

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39898 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68684 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26355 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6683 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95951 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77560 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18978 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21255 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9420 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21642 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->