### PR TITLE
Abort FileSystem writables in case of network process crash or storage clearing

### DIFF
--- a/LayoutTests/storage/filesystemaccess/writable-file-stream-abort-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/writable-file-stream-abort-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Validate stream gets errored in case of network process crash
+PASS Validate stream gets errored in case of clearing storage
+PASS Validate stream gets errored in case of network process crash in a worker
+PASS Validate stream gets errored in case of clearing storage in a worker
+

--- a/LayoutTests/storage/filesystemaccess/writable-file-stream-abort.html
+++ b/LayoutTests/storage/filesystemaccess/writable-file-stream-abort.html
@@ -1,0 +1,81 @@
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async t => {
+    const dir = await navigator.storage.getDirectory();
+    const handle = await dir.getFileHandle("file", {create: true});
+    const stream = await handle.createWritable();
+    const writer = stream.getWriter();
+
+    if (!window.testRunner)
+        return;
+
+    testRunner.terminateNetworkProcess();
+
+    return promise_rejects_dom(t, "AbortError", writer.closed);
+}, "Validate stream gets errored in case of network process crash");
+
+promise_test(async t => {
+    const dir = await navigator.storage.getDirectory();
+    const handle = await dir.getFileHandle("file", {create: true});
+    const stream = await handle.createWritable();
+    const writer = stream.getWriter();
+
+    if (!window.testRunner)
+        return;
+
+    testRunner.clearStorage();
+
+    return promise_rejects_dom(t, "AbortError", writer.closed);
+}, "Validate stream gets errored in case of clearing storage");
+
+function createWorkerWithWritable()
+{
+    return new Worker(URL.createObjectURL(new Blob([`
+        async function test() {
+            try {
+                const dir = await navigator.storage.getDirectory();
+                const handle = await dir.getFileHandle("file", {create: true});
+                const stream = await handle.createWritable();
+                const writer = stream.getWriter();
+                self.postMessage("ready");
+                setTimeout(() => self.postMessage("test timed out"), 2000);
+                await writer.closed;
+            } catch(e) {
+                self.postMessage(e);
+            }
+        };
+        test();
+    `], { type: "text/javascript" })));
+}
+
+promise_test(async t => {
+    const worker = createWorkerWithWritable();
+    assert_equals(await new Promise(resolve => worker.onmessage = e => resolve(e.data)), "ready");
+
+    const promise = new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    if (window.testRunner)
+        testRunner.terminateNetworkProcess();
+
+    const data = await promise;
+    assert_equals(data.name, "AbortError");
+}, "Validate stream gets errored in case of network process crash in a worker");
+
+promise_test(async t => {
+    const worker = createWorkerWithWritable();
+    assert_equals(await new Promise(resolve => worker.onmessage = e => resolve(e.data)), "ready");
+
+    const promise = new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    if (window.testRunner)
+        testRunner.clearStorage();
+
+    const data = await promise;
+    assert_equals(data.name, "AbortError");
+}, "Validate stream gets errored in case of clearing storage in a worker");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "config.h"
+#include "FileSystemStorageConnection.h"
+
+namespace WebCore {
+
+bool FileSystemStorageConnection::errorFileSystemWritable(FileSystemWritableFileStreamIdentifier identifier)
+{
+    RefPtr writable = m_writables.take(identifier).get();
+    if (writable)
+        writable->errorIfPossible(Exception { ExceptionCode::AbortError });
+    return writable;
+}
+
+void FileSystemStorageConnection::registerFileSystemWritable(FileSystemWritableFileStreamIdentifier identifier, FileSystemWritableFileStream& writer)
+{
+    ASSERT(!m_writables.contains(identifier));
+    m_writables.add(identifier, WeakPtr { writer });
+}
+
+void FileSystemStorageConnection::unregisterFileSystemWritable(FileSystemWritableFileStreamIdentifier identifier)
+{
+    m_writables.remove(identifier);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
@@ -34,6 +34,7 @@
 #include "ProcessQualified.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/HashMap.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
@@ -43,6 +44,7 @@ class FileSystemFileHandle;
 class FileHandle;
 class FileSystemHandleCloseScope;
 class FileSystemSyncAccessHandle;
+class FileSystemWritableFileStream;
 template<typename> class ExceptionOr;
 
 class FileSystemStorageConnection : public ThreadSafeRefCounted<FileSystemStorageConnection> {
@@ -81,11 +83,18 @@ public:
     virtual void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, ScriptExecutionContextIdentifier) = 0;
     virtual void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) = 0;
     virtual void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) = 0;
-    virtual void createWritable(FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) = 0;
+    virtual void createWritable(ScriptExecutionContextIdentifier, FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) = 0;
     virtual void closeWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCloseReason, VoidCallback&&) = 0;
     virtual void executeCommandForWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) = 0;
     virtual void getHandleNames(FileSystemHandleIdentifier, GetHandleNamesCallback&&) = 0;
     virtual void getHandle(FileSystemHandleIdentifier, const String& name, GetHandleCallback&&) = 0;
+
+    WEBCORE_EXPORT bool errorFileSystemWritable(FileSystemWritableFileStreamIdentifier);
+    void registerFileSystemWritable(FileSystemWritableFileStreamIdentifier, FileSystemWritableFileStream&);
+    void unregisterFileSystemWritable(FileSystemWritableFileStreamIdentifier);
+
+private:
+    HashMap<FileSystemWritableFileStreamIdentifier, WeakPtr<FileSystemWritableFileStream>> m_writables;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
@@ -79,7 +79,7 @@ private:
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, uint64_t, RequestCapacityCallback&&) final;
-    void createWritable(FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) final;
+    void createWritable(ScriptExecutionContextIdentifier, FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) final;
     void closeWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCloseReason, VoidCallback&&) final;
     void executeCommandForWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) final;
 

--- a/Source/WebCore/Modules/streams/WritableStream.cpp
+++ b/Source/WebCore/Modules/streams/WritableStream.cpp
@@ -97,6 +97,11 @@ void WritableStream::closeIfPossible()
     m_internalWritableStream->closeIfPossible();
 }
 
+void WritableStream::errorIfPossible(Exception&& e)
+{
+    m_internalWritableStream->errorIfPossible(WTFMove(e));
+}
+
 JSC::JSValue JSWritableStream::abort(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)
 {
     return wrapped().internalWritableStream().abortForBindings(globalObject, callFrame.argument(0));

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -49,6 +49,7 @@ public:
     bool locked() const;
 
     void closeIfPossible();
+    void errorIfPossible(Exception&&);
 
     InternalWritableStream& internalWritableStream();
     enum class Type : bool {

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -208,6 +208,16 @@ function writableStreamAbort(stream, reason)
     return abortPromiseCapability.promise;
 }
 
+function writableStreamErrorIfPossible(stream, reason)
+{
+    const state = @getByIdDirectPrivate(stream, "state");
+    if (state !== "writable")
+        return;
+
+    const controller = @getByIdDirectPrivate(stream, "controller");
+    @writableStreamDefaultControllerError(controller, reason);
+}
+
 function writableStreamCloseIfPossible(stream)
 {
     const state = @getByIdDirectPrivate(stream, "state");

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -140,6 +140,7 @@ Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
 Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
 Modules/filesystemaccess/FileSystemFileHandle.cpp
 Modules/filesystemaccess/FileSystemHandle.cpp
+Modules/filesystemaccess/FileSystemStorageConnection.cpp
 Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
 Modules/filesystemaccess/FileSystemWritableFileStream.cpp
 Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp

--- a/Source/WebCore/bindings/js/InternalWritableStream.h
+++ b/Source/WebCore/bindings/js/InternalWritableStream.h
@@ -45,6 +45,7 @@ public:
     JSC::JSValue getWriter(JSC::JSGlobalObject&);
 
     void closeIfPossible();
+    void errorIfPossible(Exception&&);
 
 private:
     InternalWritableStream(JSDOMGlobalObject& globalObject, JSC::JSObject& jsObject)

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -355,6 +355,11 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::executeCommandFor
     return error;
 }
 
+Vector<WebCore::FileSystemWritableFileStreamIdentifier> FileSystemStorageHandle::writables() const
+{
+    return copyToVector(m_activeWritableFiles.keys());
+}
+
 Expected<Vector<String>, FileSystemStorageError> FileSystemStorageHandle::getHandleNames()
 {
     if (m_type != Type::Directory)

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -77,6 +77,7 @@ public:
     Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError> createWritable(bool keepExistingData);
     std::optional<FileSystemStorageError> closeWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason);
     std::optional<FileSystemStorageError> executeCommandForWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError);
+    Vector<WebCore::FileSystemWritableFileStreamIdentifier> writables() const;
 
 private:
     FileSystemStorageHandle(FileSystemStorageManager&, Type, String&& path, String&& name);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -216,9 +216,12 @@ void FileSystemStorageManager::close()
             if (RefPtr registry = m_registry.get())
                 registry->unregisterHandle(identifier);
 
-            // Send message to web process to invalidate active sync access handle.
+            // Send messages to web process to invalidate active sync access handle and writables.
             if (auto accessHandleIdentifier = takenHandle->activeSyncAccessHandle())
                 IPC::Connection::send(connectionID, Messages::WebFileSystemStorageConnection::InvalidateAccessHandle(*accessHandleIdentifier), 0);
+
+            for (auto writableIdentifier : takenHandle->writables())
+                IPC::Connection::send(connectionID, Messages::WebFileSystemStorageConnection::InvalidateWritable(writableIdentifier), 0);
         }
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -97,11 +97,15 @@ private:
     void registerSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::ScriptExecutionContextIdentifier) final;
     void unregisterSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
-    void createWritable(WebCore::FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) final;
+    void createWritable(WebCore::ScriptExecutionContextIdentifier, WebCore::FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) final;
     void closeWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason, VoidCallback&&) final;
     void executeCommandForWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) final;
 
+    void invalidateWritable(WebCore::FileSystemWritableFileStreamIdentifier);
+    void errorWritable(WebCore::ScriptExecutionContextIdentifier, WebCore::FileSystemWritableFileStreamIdentifier);
+
     HashMap<WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::ScriptExecutionContextIdentifier> m_syncAccessHandles;
+    HashMap<WebCore::FileSystemWritableFileStreamIdentifier, WebCore::ScriptExecutionContextIdentifier> m_writableIdentifiers;
     RefPtr<IPC::Connection> m_connection;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
@@ -26,4 +26,5 @@
 ]
 messages -> WebFileSystemStorageConnection {
     InvalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier identifier)
+    InvalidateWritable(WebCore::FileSystemWritableFileStreamIdentifier identifier)
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -76,6 +76,8 @@ interface TestRunner {
     undefined dumpResourceLoadStatistics();
     undefined dumpPrivateClickMeasurement();
 
+    undefined clearStorage();
+
     undefined clearDOMCaches();
     undefined clearDOMCache(DOMString origin);
     boolean hasDOMCache(DOMString origin);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1820,6 +1820,11 @@ void TestRunner::clearDOMCache(JSStringRef origin)
     postSynchronousMessage("ClearDOMCache", toWK(origin));
 }
 
+void TestRunner::clearStorage()
+{
+    postSynchronousMessage("ClearStorage");
+}
+
 void TestRunner::clearDOMCaches()
 {
     postSynchronousMessage("ClearDOMCaches");

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -194,6 +194,8 @@ public:
     JSRetainPtr<JSStringRef> pathToLocalResource(JSStringRef);
     void syncLocalStorage();
 
+    void clearStorage();
+
     void clearDOMCache(JSStringRef origin);
     void clearDOMCaches();
     bool hasDOMCache(JSStringRef origin);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1218,6 +1218,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return result;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "ClearStorage")) {
+        TestController::singleton().clearStorage();
+        return nullptr;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "ClearDOMCache")) {
         auto origin = stringValue(messageBody);
         TestController::singleton().clearDOMCache(origin);


### PR DESCRIPTION
#### daadfcfb7025c547ebeff695223e0fdaa41c6101
<pre>
Abort FileSystem writables in case of network process crash or storage clearing
<a href="https://bugs.webkit.org/show_bug.cgi?id=287235">https://bugs.webkit.org/show_bug.cgi?id=287235</a>
<a href="https://rdar.apple.com/problem/144380830">rdar://problem/144380830</a>

Reviewed by Sihui Liu.

When a writable is open, it may be aborted in case the network process crashes or in case the underlying file is deleted.
To support this mechanism, we allow networking process to invalidate a writable like done for sync access handles.
Similarly, if a network process crashes, we add the same mechanism for writables as for sync access handles.

When a writable (aka FileSystemWritableFileStream) gets crated, we register it in its FileSystemStorageConnection.
When a writable is closed, we unregister it as well.

When a FileSystemStorageConnection is instructed to error a writable, it will call the new WritableStream errorIfPossible method.

Covered by added test.

* LayoutTests/storage/filesystemaccess/writable-file-stream-abort-expected.txt: Added.
* LayoutTests/storage/filesystemaccess/writable-file-stream-abort.html: Added.
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp:
(WebCore::FileSystemFileHandle::createWritable):
(WebCore::FileSystemFileHandle::closeWritable):
* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp: Added.
(WebCore::FileSystemStorageConnection::errorFileSystemWritable):
(WebCore::FileSystemStorageConnection::registerFileSystemWritable):
(WebCore::FileSystemStorageConnection::unregisterFileSystemWritable):
* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h:
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp:
(WebCore::WorkerFileSystemStorageConnection::createWritable):
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h:
* Source/WebCore/Modules/streams/WritableStream.cpp:
(WebCore::WritableStream::errorIfPossible):
* Source/WebCore/Modules/streams/WritableStream.h:
* Source/WebCore/Modules/streams/WritableStreamInternals.js:
(writableStreamErrorIfPossible):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
(WebCore::InternalWritableStream::errorIfPossible):
* Source/WebCore/bindings/js/InternalWritableStream.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::writables const):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::close):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::errorWritable):
(WebKit::WebFileSystemStorageConnection::connectionClosed):
(WebKit::WebFileSystemStorageConnection::createWritable):
(WebKit::WebFileSystemStorageConnection::invalidateWritable):
(WebKit::WebFileSystemStorageConnection::closeWritable):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::clearStorage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/290915@main">https://commits.webkit.org/290915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/663e178d1fd55f20dea7af80682369281c4ce3e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69870 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27402 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93870 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8213 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36767 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40784 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37833 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97862 "Failed to compile WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78087 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19405 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11370 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23418 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17812 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->