### PR TITLE
[scroll-animations] pending `timeline-scope` attachment operations should be processed once style resolution has completed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query.html
@@ -65,9 +65,9 @@
     assert_equals(getComputedStyle(element).backgroundColor, 'rgb(100, 100, 100)');
     // This causes the timeline to be created.
     outer.style.width = '250px';
-    // Check value with getComputedStyle immediately, which is the unanimated
+    // Check value with getComputedStyle immediately, which is the same
     // value since the scroll timeline is inactive before the next frame.
-    assert_equals(getComputedStyle(element).backgroundColor, 'rgb(0, 0, 0)');
+    assert_equals(getComputedStyle(element).backgroundColor, 'rgb(100, 100, 100)');
     // Also check value after one frame.
     await waitForNextFrame();
     assert_equals(getComputedStyle(element).backgroundColor, 'rgb(150, 150, 150)');

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
@@ -1,7 +1,4 @@
 CONSOLE MESSAGE: Error: assert_equals: expected "1px" but got "100px"
-CONSOLE MESSAGE: Error: assert_equals: expected "1px" but got "100px"
-
-Harness Error (FAIL), message = Error: assert_equals: expected "1px" but got "100px"
 
 FAIL Multiple style/layout passes occur when necessary assert_equals: expected 100 but got 1
 

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -464,7 +464,6 @@ void AnimationTimelinesController::registerNamedScrollTimeline(const AtomString&
         updateTimelineForTimelineScope(newScrollTimeline, name);
         timelines.append(WTFMove(newScrollTimeline));
     }
-    attachPendingOperations();
 
     if (!hasExistingTimeline)
         updateCSSAnimationsAssociatedWithNamedTimeline(name);
@@ -493,10 +492,10 @@ void AnimationTimelinesController::updateCSSAnimationsAssociatedWithNamedTimelin
         cssAnimation->syncStyleOriginatedTimeline();
 }
 
-void AnimationTimelinesController::attachPendingOperations()
+void AnimationTimelinesController::documentDidResolveStyle()
 {
-    auto queries = std::exchange(m_pendingAttachOperations, { });
-    for (auto& operation : queries) {
+    auto operations = std::exchange(m_pendingAttachOperations, { });
+    for (auto& operation : operations) {
         if (WeakPtr animation = operation.animation) {
             if (auto styleable = operation.element.styleable())
                 setTimelineForName(operation.name, *styleable, *animation);
@@ -528,7 +527,6 @@ void AnimationTimelinesController::registerNamedViewTimeline(const AtomString& n
         updateTimelineForTimelineScope(newViewTimeline, name);
         timelines.append(WTFMove(newViewTimeline));
     }
-    attachPendingOperations();
 
     if (!hasExistingTimeline)
         updateCSSAnimationsAssociatedWithNamedTimeline(name);
@@ -563,7 +561,6 @@ void AnimationTimelinesController::unregisterNamedTimeline(const AtomString& nam
 
     if (timelines.isEmpty())
         m_nameToTimelineMap.remove(it);
-    attachPendingOperations();
 }
 
 void AnimationTimelinesController::setTimelineForName(const AtomString& name, const Styleable& styleable, CSSAnimation& animation)
@@ -631,7 +628,6 @@ void AnimationTimelinesController::updateNamedTimelineMapForTimelineScope(const 
         m_timelineScopeEntries.append(std::make_pair(scope, styleable));
         break;
     }
-    attachPendingOperations();
 }
 
 bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimation& animation) const

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -86,6 +86,7 @@ public:
     void updateNamedTimelineMapForTimelineScope(const TimelineScope&, const Styleable&);
     void updateTimelineForTimelineScope(const Ref<ScrollTimeline>&, const AtomString&);
     void unregisterNamedTimelinesAssociatedWithElement(const Styleable&);
+    void documentDidResolveStyle();
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
@@ -100,7 +101,6 @@ private:
 
     Vector<Ref<ScrollTimeline>>& timelinesForName(const AtomString&);
     Vector<WeakStyleable> relatedTimelineScopeElements(const AtomString&);
-    void attachPendingOperations();
     bool isPendingTimelineAttachment(const WebAnimation&) const;
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2748,6 +2748,9 @@ void Document::resolveStyle(ResolveStyleType type)
 #if ENABLE(DARK_MODE_CSS)
     frameView->updateBaseBackgroundColorIfNecessary();
 #endif
+
+    if (CheckedPtr timelinesController = this->timelinesController())
+        timelinesController->documentDidResolveStyle();
 }
 
 void Document::updateTextRenderer(Text& text, unsigned offsetOfReplacedText, unsigned lengthOfReplacedText)


### PR DESCRIPTION
#### c6be1b1070ae5eb89e94914451dab6a919a759f4
<pre>
[scroll-animations] pending `timeline-scope` attachment operations should be processed once style resolution has completed
<a href="https://bugs.webkit.org/show_bug.cgi?id=287237">https://bugs.webkit.org/show_bug.cgi?id=287237</a>

Reviewed by Dean Jackson.

The `AnimationTimelinesController` code related to `timeline-scope` attachment operations had
multiple call sites for its `attachPendingOperations()` method which processes pending operations.
However, we need to wait for a document&apos;s style resolution to have completed to be able to correctly
process those operations

We make this process both simpler and correct with a new `documentDidResolveStyle()` method called
when `Document::resolveStyle()` completes.

This does not result in much progress in terms of WPT results because the code in place to handle
`timeline-scope` resolution is buggy, but this patch is a necessary foundation for further improvements.

One WPT test that did change behavior is `scroll-animations/css/scroll-timeline-in-container-query.html`.
As it turns out, this test does not adhere to existing specifications since it assumes that making the
`animation-timeline` property resolve to an in-scope timeline name dynamically will lead to a change in
state for the animation upon style resolution, but it will not until the next frame.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::documentDidResolveStyle):
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
(WebCore::AnimationTimelinesController::unregisterNamedTimeline):
(WebCore::AnimationTimelinesController::updateNamedTimelineMapForTimelineScope):
(WebCore::AnimationTimelinesController::attachPendingOperations): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):

Canonical link: <a href="https://commits.webkit.org/290046@main">https://commits.webkit.org/290046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95aa1f6b88630a4c948a3cab672442bd06eb1026

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68390 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26082 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6352 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34645 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html fast/workers/worker-page-cache.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/security/file-system-access-via-dataTransfer.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38570 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76538 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8953 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13899 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21212 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15640 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->