### PR TITLE
[scroll-animations] CSS Animations with an `animation-timeline` matching a `timeline-scope` should default to an inactive scroll timeline

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Animation.timeline returns attached timeline
-FAIL Animation.timeline returns null for inactive deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
-FAIL Animation.timeline returns null for inactive (overattached) deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
+FAIL Animation.timeline returns a timeline with no source for inactive deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
+PASS Animation.timeline returns a timeline with no source for inactive (overattached) deferred timeline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred.html
@@ -83,8 +83,8 @@
     let scroller = main.querySelector('.scroller');
     let animating = main.querySelector('.animating');
 
-    assert_equals(animating.getAnimations()[0].timeline, null);
-  }, 'Animation.timeline returns null for inactive deferred timeline');
+    assert_equals(animating.getAnimations()[0].timeline.source, null);
+  }, 'Animation.timeline returns a timeline with no source for inactive deferred timeline');
 </script>
 
 <template id=animation_timeline_overattached>
@@ -104,6 +104,6 @@
     let scroller = main.querySelector('.scroller');
     let animating = main.querySelector('.animating');
 
-    assert_equals(animating.getAnimations()[0].timeline, null);
-  }, 'Animation.timeline returns null for inactive (overattached) deferred timeline');
+    assert_equals(animating.getAnimations()[0].timeline.source, null);
+  }, 'Animation.timeline returns a timeline with no source for inactive (overattached) deferred timeline');
 </script>

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -104,6 +104,10 @@ private:
     bool isPendingTimelineAttachment(const WebAnimation&) const;
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
 
+    ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
+    ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
+    ScrollTimeline& inactiveNamedTimeline(const AtomString&);
+
     Ref<Document> protectedDocument() const { return m_document.get(); }
 
     Vector<TimelineMapAttachOperation> m_pendingAttachOperations;

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -74,6 +74,13 @@ Ref<ScrollTimeline> ScrollTimeline::create(Scroller scroller, ScrollAxis axis)
     return adoptRef(*new ScrollTimeline(scroller, axis));
 }
 
+Ref<ScrollTimeline> ScrollTimeline::createInactiveStyleOriginatedTimeline(const AtomString& name)
+{
+    auto timeline = adoptRef(*new ScrollTimeline(name, ScrollAxis::Block));
+    timeline->m_isInactiveStyleOriginatedTimeline = true;
+    return timeline;
+}
+
 // https://drafts.csswg.org/web-animations-2/#timelines
 // For a monotonic timeline, there is no upper bound on current time, and
 // timeline duration is unresolved. For a non-monotonic (e.g. scroll) timeline,

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -51,6 +51,7 @@ public:
     static Ref<ScrollTimeline> create(Document&, ScrollTimelineOptions&& = { });
     static Ref<ScrollTimeline> create(const AtomString&, ScrollAxis);
     static Ref<ScrollTimeline> create(Scroller, ScrollAxis);
+    static Ref<ScrollTimeline> createInactiveStyleOriginatedTimeline(const AtomString& name);
 
     const WeakStyleable& sourceStyleable() const { return m_source; }
     virtual Element* source() const;
@@ -62,6 +63,8 @@ public:
 
     const AtomString& name() const { return m_name; }
     void setName(const AtomString& name) { m_name = name; }
+
+    bool isInactiveStyleOriginatedTimeline() const { return m_isInactiveStyleOriginatedTimeline; }
 
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
 
@@ -117,6 +120,7 @@ private:
     Scroller m_scroller { Scroller::Self };
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_timelineScopeElement;
     CurrentTimeData m_cachedCurrentTimeData { };
+    bool m_isInactiveStyleOriginatedTimeline { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d46cee42c3f48247c3f92be3a13882e25c33e56c
<pre>
[scroll-animations] CSS Animations with an `animation-timeline` matching a `timeline-scope` should default to an inactive scroll timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=287239">https://bugs.webkit.org/show_bug.cgi?id=287239</a>

Reviewed by Dean Jackson.

When dealing with an `animation-timeline` value that did not match a `scroll-timeline-name`
within a scope defined by `timeline-scope`, our code would assign a null timeline. But the
Scroll-driven Animations specification says [0] that this should result in assigning an inactive
timeline, or in other words a scroll timeline without a source:

    Declares the name of a matching named timeline defined by a descendant – ​whose scope is not
    already explicitly declared by a descendant using timeline-scope – ​to be in scope for this
    element and its descendants.

    If no such timeline exists, or if more than one such timeline exists, instead declares an
    inactive timeline with the specified name.

So we update our code to correctly create an inactive scroll timeline if we fail to determine
an existing timeline or we have multiple options.

Since we may create multiple such timelines as elements are awaiting the definition of a named
timeline, we identify those with a specific flag and purge them after dealing with pending
attachment operations.

To be able to track those inactive timelines, we must have access to the instance&apos;s name-to-timeline
map, so we change previously static methods to be instance methods.

This change highlighted that an existing WPT assertion was incorrectly expecting a null timeline
instead of an inactive timeline in the scenario outlined above, so we modify that test to correctly
check for a null timeline source instead of a null timeline.

[0] <a href="https://drafts.csswg.org/scroll-animations-1/#valdef-timeline-scope-dashed-ident">https://drafts.csswg.org/scroll-animations-1/#valdef-timeline-scope-dashed-ident</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred.html:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::inactiveNamedTimeline):
(WebCore::AnimationTimelinesController::determineTreeOrder):
(WebCore::AnimationTimelinesController::determineTimelineForElement):
(WebCore::AnimationTimelinesController::attachPendingOperations):
(WebCore::AnimationTimelinesController::setTimelineForName):
(WebCore::determineTreeOrder): Deleted.
(WebCore::determineTimelineForElement): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::createInactiveStyleOriginatedTimeline):
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::isInactiveStyleOriginatedTimeline const):

Canonical link: <a href="https://commits.webkit.org/290082@main">https://commits.webkit.org/290082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ccaa101b825c0b1da12342878d936cec26fdd05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68468 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26153 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6434 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34753 "Found 2 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76797 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95650 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77345 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76630 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9086 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13930 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16035 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->