### PR TITLE
Add quota check for FileSystem writables

### DIFF
--- a/LayoutTests/storage/filesystemaccess/writable-quota-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/writable-quota-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Validate write quota
+PASS Validate truncate quota
+

--- a/LayoutTests/storage/filesystemaccess/writable-quota.html
+++ b/LayoutTests/storage/filesystemaccess/writable-quota.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+const quota = 1024 * 1024;
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
+    testRunner.setQuota(quota);
+    testRunner.setAllowStorageQuotaIncrease(false);
+}
+
+promise_test(async (test) => {
+    var rootHandle = await navigator.storage.getDirectory();
+    // Create a new file for this test.
+    await rootHandle.removeEntry("writable-quota.txt").then(() => { }, () => { });
+    const fileHandle = await rootHandle.getFileHandle("writable-quota.txt", { "create" : true  });
+    const writable = await fileHandle.createWritable();
+
+    await writable.write(new Uint8Array(512 * 1024));
+
+    return promise_rejects_dom(test, 'QuotaExceededError', writable.write(new Uint8Array(1024 * 1024)));
+}, "Validate write quota");
+
+promise_test(async (test) => {
+    var rootHandle = await navigator.storage.getDirectory();
+    // Create a new file for this test.
+    await rootHandle.removeEntry("writable-quota1.txt").then(() => { }, () => { });
+    await rootHandle.removeEntry("writable-quota2.txt").then(() => { }, () => { });
+    const fileHandle1 = await rootHandle.getFileHandle("writable-quota1.txt", { "create" : true  });
+    const fileHandle2 = await rootHandle.getFileHandle("writable-quota2.txt", { "create" : true  });
+
+    const writable1 = await fileHandle1.createWritable();
+    const writable2 = await fileHandle2.createWritable();
+
+    await writable1.truncate(512 * 1024);
+
+    let counter = 0;
+    return Promise.all([
+        writable1.truncate(1532 * 1024).then(() => assert_not_reached("should reject"), e => {
+            assert_equals(counter++, 0);
+            assert_equals(e.name, "QuotaExceededError");
+        }),
+        writable2.truncate(0).then(() => assert_equals(counter, 1))
+    ]);
+}, "Validate truncate quota");
+</script>
+</body>
+</html>

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h
@@ -39,6 +39,7 @@ enum class FileSystemStorageError : uint8_t {
     InvalidState,
     MissingArgument,
     TypeMismatch,
+    QuotaError,
     Unknown
 };
 
@@ -63,6 +64,8 @@ inline WebCore::Exception convertToException(FileSystemStorageError error)
         return WebCore::Exception { WebCore::ExceptionCode::TypeError, "Required argument is missing"_s };
     case FileSystemStorageError::TypeMismatch:
         return WebCore::Exception { WebCore::ExceptionCode::TypeMismatchError, "File type is incompatible with handle type"_s };
+    case FileSystemStorageError::QuotaError:
+        return WebCore::Exception { WebCore::ExceptionCode::QuotaExceededError, "Requested space above quota"_s };
     case FileSystemStorageError::Unknown:
         break;
     }

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.serialization.in
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageError.serialization.in
@@ -31,5 +31,6 @@ enum class WebKit::FileSystemStorageError : uint8_t {
     InvalidState,
     MissingArgument,
     TypeMismatch,
+    QuotaError,
     Unknown
 }

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -76,14 +76,15 @@ public:
 
     Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError> createWritable(bool keepExistingData);
     std::optional<FileSystemStorageError> closeWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason);
-    std::optional<FileSystemStorageError> executeCommandForWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError);
+    void executeCommandForWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     Vector<WebCore::FileSystemWritableFileStreamIdentifier> writables() const;
 
 private:
     FileSystemStorageHandle(FileSystemStorageManager&, Type, String&& path, String&& name);
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> requestCreateHandle(IPC::Connection::UniqueID, Type, String&& name, bool createIfNecessary);
     bool isActiveSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier);
-    std::optional<FileSystemStorageError> executeCommandForWritableInternal(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError);
+    std::optional<FileSystemStorageError> executeCommandForWritableInternal(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t>, bool hasDataError);
+    std::optional<size_t> computeCommandSpace(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t>, bool hasDataError);
 
     WeakPtr<FileSystemStorageManager> m_manager;
     Type m_type;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1053,7 +1053,7 @@ void NetworkStorageManager::executeCommandForWritable(WebCore::FileSystemHandleI
     if (!handle)
         return completionHandler(FileSystemStorageError::Unknown);
 
-    completionHandler(handle->executeCommandForWritable(streamIdentifier, type, position, size, dataBytes, hasDataError));
+    handle->executeCommandForWritable(streamIdentifier, type, position, size, dataBytes, hasDataError, WTFMove(completionHandler));
 }
 
 void NetworkStorageManager::getHandleNames(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&& completionHandler)


### PR DESCRIPTION
#### a33fd49e6aeff21a4e139088fc38ddcec176d78e
<pre>
Add quota check for FileSystem writables
<a href="https://rdar.apple.com/144381471">rdar://144381471</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287238">https://bugs.webkit.org/show_bug.cgi?id=287238</a>

Reviewed by Sihui Liu.

Add a quota check when writing data, and for truncate since truncate can increase the file size.
We also do a zero quota check for other commands to make sure the order of operation is preserved.

Covered by added test.

* LayoutTests/storage/filesystemaccess/writable-quota-expected.txt: Added.
* LayoutTests/storage/filesystemaccess/writable-quota.html: Added.
* Source/WebKit/NetworkProcess/storage/FileSystemStorageError.h:
(WebKit::convertToException):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageError.serialization.in:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::executeCommandForWritableInternal):
(WebKit::FileSystemStorageHandle::executeCommandForWritable):
(WebKit::FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::executeCommandForWritable):

Canonical link: <a href="https://commits.webkit.org/291304@main">https://commits.webkit.org/291304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd8b4837b1135679a35db7c0c50c38ff8f5122bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42907 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70815 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28274 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42237 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99410 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79082 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23628 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12452 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19435 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24607 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->