### PR TITLE
Implement support for setting dialog's returnValue with command button's value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative-expected.txt
@@ -13,25 +13,25 @@ PASS invoking (with command attribute as sHoW-mOdAl) closed dialog opens as moda
 PASS invoking (with command attribute as sHoW-mOdAl) closed dialog with preventDefault is noop
 PASS invoking (with command attribute as sHoW-mOdAl) while changing command still opens as modal
 PASS invoking to close (with command property as close) open dialog closes
-FAIL invoking to close (with command property as close) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
+PASS invoking to close (with command property as close) open dialog closes and sets returnValue
 PASS invoking to close (with command property as close) open dialog with preventDefault is no-op
 PASS invoking to close (with command property as close) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command property as close) open dialog while changing command still closes
 PASS invoking to close (with command property as close) open modal dialog while changing command still closes
 PASS invoking to close (with command attribute as close) open dialog closes
-FAIL invoking to close (with command attribute as close) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
+PASS invoking to close (with command attribute as close) open dialog closes and sets returnValue
 PASS invoking to close (with command attribute as close) open dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as close) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as close) open dialog while changing command still closes
 PASS invoking to close (with command attribute as close) open modal dialog while changing command still closes
 PASS invoking to close (with command property as cLoSe) open dialog closes
-FAIL invoking to close (with command property as cLoSe) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
+PASS invoking to close (with command property as cLoSe) open dialog closes and sets returnValue
 PASS invoking to close (with command property as cLoSe) open dialog with preventDefault is no-op
 PASS invoking to close (with command property as cLoSe) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command property as cLoSe) open dialog while changing command still closes
 PASS invoking to close (with command property as cLoSe) open modal dialog while changing command still closes
 PASS invoking to close (with command attribute as cLoSe) open dialog closes
-FAIL invoking to close (with command attribute as cLoSe) open dialog closes and sets returnValue assert_equals: expected "foo" but got ""
+PASS invoking to close (with command attribute as cLoSe) open dialog closes and sets returnValue
 PASS invoking to close (with command attribute as cLoSe) open dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as cLoSe) open modal dialog with preventDefault is no-op
 PASS invoking to close (with command attribute as cLoSe) open dialog while changing command still closes

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -64,9 +64,9 @@ class ElementData;
 class ElementRareData;
 class FormAssociatedCustomElement;
 class FormListedElement;
+class HTMLButtonElement;
 class HTMLDocument;
 class HTMLElement;
-class HTMLFormControlElement;
 class IntSize;
 class JSCustomElementInterface;
 class KeyframeEffectStack;
@@ -677,7 +677,7 @@ public:
     bool isPopoverShowing() const;
 
     virtual bool isValidCommandType(const CommandType) { return false; }
-    virtual bool handleCommandInternal(const HTMLFormControlElement&, const CommandType&) { return false; }
+    virtual bool handleCommandInternal(const HTMLButtonElement&, const CommandType&) { return false; }
 
     ExceptionOr<void> setPointerCapture(int32_t);
     ExceptionOr<void> releasePointerCapture(int32_t);

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -31,6 +31,7 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FocusOptions.h"
+#include "HTMLButtonElement.h"
 #include "HTMLElement.h"
 #include "HTMLNames.h"
 #include "Logging.h"
@@ -197,7 +198,7 @@ bool HTMLDialogElement::isValidCommandType(const CommandType command)
     return HTMLElement::isValidCommandType(command) || command == CommandType::ShowModal || command == CommandType::Close;
 }
 
-bool HTMLDialogElement::handleCommandInternal(const HTMLFormControlElement& invoker, const CommandType& command)
+bool HTMLDialogElement::handleCommandInternal(const HTMLButtonElement& invoker, const CommandType& command)
 {
     if (HTMLElement::handleCommandInternal(invoker, command))
         return true;
@@ -207,7 +208,7 @@ bool HTMLDialogElement::handleCommandInternal(const HTMLFormControlElement& invo
 
     if (isOpen()) {
         if (command == CommandType::Close) {
-            close(nullString());
+            close(invoker.value().string());
             return true;
         }
     } else {

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -55,7 +55,7 @@ public:
     void runFocusingSteps();
 
     bool isValidCommandType(const CommandType) final;
-    bool handleCommandInternal(const HTMLFormControlElement& invoker, const CommandType&) final;
+    bool handleCommandInternal(const HTMLButtonElement& invoker, const CommandType&) final;
 
     void queueDialogToggleEventTask(ToggleState oldState, ToggleState newState);
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1296,7 +1296,7 @@ bool HTMLElement::isValidCommandType(const CommandType command)
     return Element::isValidCommandType(command) || command == CommandType::TogglePopover || command == CommandType::ShowPopover || command == CommandType::HidePopover;
 }
 
-bool HTMLElement::handleCommandInternal(const HTMLFormControlElement& invoker, const CommandType& command)
+bool HTMLElement::handleCommandInternal(const HTMLButtonElement& invoker, const CommandType& command)
 {
     if (popoverState() == PopoverState::None)
         return false;

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class ElementInternals;
 class FormListedElement;
 class FormAssociatedElement;
-class HTMLFormControlElement;
+class HTMLButtonElement;
 class HTMLFormElement;
 class VisibleSelection;
 
@@ -169,7 +169,7 @@ public:
     void popoverAttributeChanged(const AtomString& value);
 
     bool isValidCommandType(const CommandType) override;
-    bool handleCommandInternal(const HTMLFormControlElement& invoker, const CommandType&) override;
+    bool handleCommandInternal(const HTMLButtonElement& invoker, const CommandType&) override;
 
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);


### PR DESCRIPTION
#### d7e26d13ce41e3841ce00d005823ff78581bf02d
<pre>
Implement support for setting dialog&apos;s returnValue with command button&apos;s value
<a href="https://bugs.webkit.org/show_bug.cgi?id=287148">https://bugs.webkit.org/show_bug.cgi?id=287148</a>

Reviewed by Basuke Suzuki.

The close command now correctly passes through the button&apos;s value to the close function,
this sets the dialog&apos;s returnValue property.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.tentative-expected.txt:
* Source/WebCore/dom/Element.h:
(WebCore::Element::handleCommandInternal):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::handleCommandInternal):
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::handleCommandInternal):
* Source/WebCore/html/HTMLElement.h:

Canonical link: <a href="https://commits.webkit.org/290767@main">https://commits.webkit.org/290767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e82ff33447e7cdcf7c4fcf7b0dc27a0f121e4026

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69767 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27317 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36602 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78788 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77984 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19320 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21058 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11160 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23194 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17590 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->