### PR TITLE
Address safer C++ static analysis warnings in IDBServer

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -147,7 +147,7 @@ void IDBServer::openDatabase(const IDBOpenRequestData& requestData)
     if (!connectionIdentifier)
         return;
 
-    auto connection = m_connectionMap.get(*connectionIdentifier);
+    RefPtr connection = m_connectionMap.get(*connectionIdentifier);
     if (!connection) {
         // If the connection back to the client is gone, there's no way to open the database as
         // well as no way to message back failure.
@@ -167,7 +167,7 @@ void IDBServer::deleteDatabase(const IDBOpenRequestData& requestData)
     if (!connectionIdentifier)
         return;
 
-    auto connection = m_connectionMap.get(*connectionIdentifier);
+    RefPtr connection = m_connectionMap.get(*connectionIdentifier);
     if (!connection) {
         // If the connection back to the client is gone, there's no way to delete the database as
         // well as no way to message back failure.
@@ -189,7 +189,7 @@ void IDBServer::abortTransaction(const IDBResourceIdentifier& transactionIdentif
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(transactionIdentifier);
+    RefPtr transaction = m_transactions.get(transactionIdentifier);
     if (!transaction) {
         // If there is no transaction there is nothing to abort.
         // We also have no access to a connection over which to message failure-to-abort.
@@ -210,7 +210,7 @@ void IDBServer::createObjectStore(const IDBRequestData& requestData, const IDBOb
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -224,7 +224,7 @@ void IDBServer::deleteObjectStore(const IDBRequestData& requestData, const Strin
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -238,7 +238,7 @@ void IDBServer::renameObjectStore(const IDBRequestData& requestData, IDBObjectSt
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -252,7 +252,7 @@ void IDBServer::clearObjectStore(const IDBRequestData& requestData, IDBObjectSto
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -265,7 +265,7 @@ void IDBServer::createIndex(const IDBRequestData& requestData, const IDBIndexInf
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -279,7 +279,7 @@ void IDBServer::deleteIndex(const IDBRequestData& requestData, IDBObjectStoreIde
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -293,7 +293,7 @@ void IDBServer::renameIndex(const IDBRequestData& requestData, IDBObjectStoreIde
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -307,7 +307,7 @@ void IDBServer::putOrAdd(const IDBRequestData& requestData, const IDBKeyData& ke
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -320,7 +320,7 @@ void IDBServer::getRecord(const IDBRequestData& requestData, const IDBGetRecordD
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -333,7 +333,7 @@ void IDBServer::getAllRecords(const IDBRequestData& requestData, const IDBGetAll
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -346,7 +346,7 @@ void IDBServer::getCount(const IDBRequestData& requestData, const IDBKeyRangeDat
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -359,7 +359,7 @@ void IDBServer::deleteRecord(const IDBRequestData& requestData, const IDBKeyRang
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -372,7 +372,7 @@ void IDBServer::openCursor(const IDBRequestData& requestData, const IDBCursorInf
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -385,7 +385,7 @@ void IDBServer::iterateCursor(const IDBRequestData& requestData, const IDBIterat
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData);
     if (!transaction)
         return;
 
@@ -414,7 +414,7 @@ void IDBServer::commitTransaction(const IDBResourceIdentifier& transactionIdenti
     ASSERT(!isMainThread());
     ASSERT(m_lock.isHeld());
 
-    auto transaction = m_transactions.get(transactionIdentifier);
+    RefPtr transaction = m_transactions.get(transactionIdentifier);
     if (!transaction) {
         // If there is no transaction there is nothing to commit.
         // We also have no access to a connection over which to message failure-to-commit.
@@ -473,7 +473,7 @@ void IDBServer::abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier databa
     ASSERT(m_lock.isHeld());
 
     if (transactionIdentifier) {
-        if (auto transaction = m_transactions.get(*transactionIdentifier))
+        if (RefPtr transaction = m_transactions.get(*transactionIdentifier))
             transaction->abortWithoutCallback();
     }
 
@@ -548,7 +548,7 @@ void IDBServer::getAllDatabaseNamesAndVersions(IDBConnectionIdentifier serverCon
     auto directory = IDBDatabaseIdentifier::databaseDirectoryRelativeToRoot(origin, m_databaseDirectoryPath, "v1"_s);
     getDatabaseNameAndVersionFromOriginDirectory(directory, visitedDatabasePaths, result);
 
-    auto connection = m_connectionMap.get(serverConnectionIdentifier);
+    RefPtr connection = m_connectionMap.get(serverConnectionIdentifier);
     if (!connection)
         return;
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -25,7 +25,6 @@ Modules/indexeddb/IDBObjectStore.cpp
 Modules/indexeddb/IDBTransaction.cpp
 Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
 Modules/indexeddb/client/IDBConnectionProxy.cpp
-Modules/indexeddb/server/IDBServer.cpp
 Modules/indexeddb/server/MemoryIDBBackingStore.cpp
 Modules/indexeddb/server/UniqueIDBDatabase.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,4 +1,3 @@
-Storage/InProcessIDBServer.cpp
 Storage/StorageAreaImpl.cpp
 Storage/StorageAreaSync.cpp
 Storage/StorageNamespaceImpl.cpp

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -76,13 +76,14 @@ InProcessIDBServer::InProcessIDBServer(PAL::SessionID sessionID, const String& d
     ASSERT(isMainThread());
     m_connectionToServer = IDBClient::IDBConnectionToServer::create(*this, sessionID);
     dispatchTask([this, protectedThis = Ref { *this }, directory = databaseDirectoryPath.isolatedCopy()] () mutable {
-        m_connectionToClient = IDBServer::IDBConnectionToClient::create(*this);
+        Ref connectionToClient = IDBServer::IDBConnectionToClient::create(*this);
+        m_connectionToClient = connectionToClient.copyRef();
 
         Locker locker { m_serverLock };
         m_server = makeUnique<IDBServer::IDBServer>(directory, [](const ClientOrigin&, uint64_t) {
             return true;
         }, m_serverLock);
-        m_server->registerConnection(*m_connectionToClient);
+        m_server->registerConnection(connectionToClient);
     });
 }
 

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -133,5 +133,5 @@ private:
     std::unique_ptr<WebCore::IDBServer::IDBServer> m_server;
     RefPtr<WebCore::IDBClient::IDBConnectionToServer> m_connectionToServer;
     RefPtr<WebCore::IDBServer::IDBConnectionToClient> m_connectionToClient;
-    Ref<WTF::WorkQueue> m_queue;
+    const Ref<WTF::WorkQueue> m_queue;
 };


### PR DESCRIPTION
#### e0ed96bfd62bac4fc8475d05913182c3f3d1646f
<pre>
Address safer C++ static analysis warnings in IDBServer
<a href="https://bugs.webkit.org/show_bug.cgi?id=287258">https://bugs.webkit.org/show_bug.cgi?id=287258</a>

Reviewed by Sihui Liu.

* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::openDatabase):
(WebCore::IDBServer::IDBServer::deleteDatabase):
(WebCore::IDBServer::IDBServer::abortTransaction):
(WebCore::IDBServer::IDBServer::createObjectStore):
(WebCore::IDBServer::IDBServer::deleteObjectStore):
(WebCore::IDBServer::IDBServer::renameObjectStore):
(WebCore::IDBServer::IDBServer::clearObjectStore):
(WebCore::IDBServer::IDBServer::createIndex):
(WebCore::IDBServer::IDBServer::deleteIndex):
(WebCore::IDBServer::IDBServer::renameIndex):
(WebCore::IDBServer::IDBServer::putOrAdd):
(WebCore::IDBServer::IDBServer::getRecord):
(WebCore::IDBServer::IDBServer::getAllRecords):
(WebCore::IDBServer::IDBServer::getCount):
(WebCore::IDBServer::IDBServer::deleteRecord):
(WebCore::IDBServer::IDBServer::openCursor):
(WebCore::IDBServer::IDBServer::iterateCursor):
(WebCore::IDBServer::IDBServer::commitTransaction):
(WebCore::IDBServer::IDBServer::abortOpenAndUpgradeNeeded):
(WebCore::IDBServer::IDBServer::getAllDatabaseNamesAndVersions):
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKitLegacy/Storage/InProcessIDBServer.cpp:
(InProcessIDBServer::InProcessIDBServer):
* Source/WebKitLegacy/Storage/InProcessIDBServer.h:

Canonical link: <a href="https://commits.webkit.org/290042@main">https://commits.webkit.org/290042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa643b2da29a764a588fe5494a33067c869f6f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39510 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68431 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48796 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95553 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15932 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76573 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19386 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15946 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->