### PR TITLE
Deploy Smart Pointers in NetworkLoadScheduler.cpp

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp
@@ -90,7 +90,7 @@ void NetworkLoadScheduler::HostContext::unschedule(NetworkLoad& load)
     if (shouldDelayLowPriority())
         return;
 
-    if (auto* firstPendingLoad = m_pendingLoads.tryTakeFirst())
+    if (RefPtr firstPendingLoad = m_pendingLoads.tryTakeFirst())
         start(*firstPendingLoad);
 }
 
@@ -114,7 +114,7 @@ void NetworkLoadScheduler::HostContext::start(NetworkLoad& load)
 
 NetworkLoadScheduler::HostContext::~HostContext()
 {
-    for (auto& load : m_pendingLoads)
+    for (Ref load : m_pendingLoads)
         start(load);
 }
 
@@ -229,9 +229,9 @@ void NetworkLoadScheduler::finishedPreconnectForMainResource(const URL& url, con
 
     PendingMainResourcePreconnectInfo& info = iter->value;
     if (!info.pendingLoads.isEmptyIgnoringNullReferences()) {
-        auto& load = info.pendingLoads.takeFirst();
-        RELEASE_LOG(Network, "%p - NetworkLoadScheduler::finishedPreconnectForMainResource (error: %d) starting delayed main resource load %p; %u pending preconnects; %u total pending loads", this, static_cast<int>(error.type()), &load, info.pendingPreconnects, info.pendingLoads.computeSize());
-        load.start();
+        Ref load = info.pendingLoads.takeFirst();
+        RELEASE_LOG(Network, "%p - NetworkLoadScheduler::finishedPreconnectForMainResource (error: %d) starting delayed main resource load %p; %u pending preconnects; %u total pending loads", this, static_cast<int>(error.type()), load.ptr(), info.pendingPreconnects, info.pendingLoads.computeSize());
+        load->start();
     } else
         --info.pendingPreconnects;
 
@@ -280,7 +280,7 @@ void NetworkLoadScheduler::setResourceLoadSchedulingMode(WebCore::PageIdentifier
 
 void NetworkLoadScheduler::prioritizeLoads(const Vector<NetworkLoad*>& loads)
 {
-    for (auto* load : loads) {
+    for (RefPtr load : loads) {
         if (auto* context = contextForLoad(*load))
             context->prioritize(*load);
     }


### PR DESCRIPTION
#### 727c47ce01053e8e303a49ae7dc0190b541779e3
<pre>
Deploy Smart Pointers in NetworkLoadScheduler.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287260">https://bugs.webkit.org/show_bug.cgi?id=287260</a>

Reviewed by Chris Dumez.

Addressed the smart pointer static analyzer warnings in NetworkLoadScheduler.cpp

* Source/WebKit/NetworkProcess/NetworkLoadScheduler.cpp:
(WebKit::NetworkLoadScheduler::HostContext::unschedule):
(WebKit::NetworkLoadScheduler::HostContext::~HostContext):
(WebKit::NetworkLoadScheduler::finishedPreconnectForMainResource):
(WebKit::NetworkLoadScheduler::prioritizeLoads):

Canonical link: <a href="https://commits.webkit.org/290066@main">https://commits.webkit.org/290066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d41822029a2b22f189a978c0b4af5ea61a8bcba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39529 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68439 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26126 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48804 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6402 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15950 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11663 "Found 1 new test failure: media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77317 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76598 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20971 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19397 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9015 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13917 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15964 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15705 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->