### PR TITLE
[HDR] Separate "is showing HDR" from screenContentsFormat()

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -60,7 +60,6 @@ class DestinationColorSpace;
 class FloatPoint;
 class FloatRect;
 class FloatSize;
-class PlatformCALayerClient;
 class Widget;
 
 using PlatformDisplayID = uint32_t;
@@ -82,7 +81,7 @@ double screenDPI(PlatformDisplayID); // dpi of the display device, corrected for
 FloatRect screenRect(Widget*);
 FloatRect screenAvailableRect(Widget*);
 
-WEBCORE_EXPORT ContentsFormat screenContentsFormat(Widget* = nullptr, PlatformCALayerClient* = nullptr);
+WEBCORE_EXPORT OptionSet<ContentsFormat> screenContentsFormats(Widget* = nullptr);
 WEBCORE_EXPORT bool screenSupportsExtendedColor(Widget* = nullptr);
 
 enum class DynamicRangeMode : uint8_t {

--- a/Source/WebCore/platform/graphics/ContentsFormat.h
+++ b/Source/WebCore/platform/graphics/ContentsFormat.h
@@ -36,12 +36,12 @@ namespace WebCore {
 class DestinationColorSpace;
 
 enum class ContentsFormat : uint8_t {
-    RGBA8,
+    RGBA8 = 1 << 0,
 #if ENABLE(PIXEL_FORMAT_RGB10)
-    RGBA10,
+    RGBA10 = 1 << 1,
 #endif
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    RGBA16F,
+    RGBA16F = 1 << 2,
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -337,8 +337,10 @@ Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::Lay
 {
     auto result = PlatformCALayerCocoa::create(layerType, owner);
 
-    if (result->canHaveBackingStore())
-        result->setContentsFormat(screenContentsFormat(nullptr, owner));
+    if (result->canHaveBackingStore()) {
+        auto contentsFormat = PlatformCALayer::contentsFormatForLayer(nullptr, owner);
+        result->setContentsFormat(contentsFormat);
+    }
 
     return result;
 }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -345,6 +345,8 @@ public:
     static void drawRepaintIndicator(GraphicsContext&, PlatformCALayer*, int repaintCount, Color customBackgroundColor = { });
     static CGRect frameForLayer(const PlatformLayer*);
 
+    static ContentsFormat contentsFormatForLayer(Widget* = nullptr, PlatformCALayerClient* = nullptr);
+
     virtual void markFrontBufferVolatileForTesting() { }
     void moveToLayerPool();
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -178,6 +178,23 @@ Ref<PlatformCALayer> PlatformCALayer::createCompatibleLayerOrTakeFromPool(Platfo
     return layer;
 }
 
+ContentsFormat PlatformCALayer::contentsFormatForLayer(Widget* widget, PlatformCALayerClient* client)
+{
+    auto contentsFormats = screenContentsFormats(widget);
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (client && client->hdrForImagesEnabled() && contentsFormats.contains(ContentsFormat::RGBA16F))
+        return ContentsFormat::RGBA16F;
+#endif
+#if ENABLE(PIXEL_FORMAT_RGB10)
+    if (contentsFormats.contains(ContentsFormat::RGBA10))
+        return ContentsFormat::RGBA10;
+#endif
+    UNUSED_PARAM(client);
+    UNUSED_PARAM(contentsFormats);
+    ASSERT(contentsFormats.contains(ContentsFormat::RGBA8));
+    return ContentsFormat::RGBA8;
+}
+
 void PlatformCALayer::moveToLayerPool()
 {
     ASSERT(!superlayer());

--- a/Source/WebCore/platform/ios/LegacyTileGridTile.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGridTile.mm
@@ -35,7 +35,7 @@
 #import "LegacyTileGrid.h"
 #import "LegacyTileLayer.h"
 #import "LegacyTileLayerPool.h"
-#import "PlatformScreen.h"
+#import "PlatformCALayer.h"
 #import "WAKWindow.h"
 #import <algorithm>
 #import <functional>
@@ -65,7 +65,7 @@ LegacyTileGridTile::LegacyTileGridTile(LegacyTileGrid* tileGrid, const IntRect& 
     }
     LegacyTileLayer* layer = m_tileLayer.get();
 
-    if (NSString *formatString = contentsFormatString(screenContentsFormat()))
+    if (NSString *formatString = contentsFormatString(PlatformCALayer::contentsFormatForLayer()))
         layer.contentsFormat = formatString;
 
     [layer setTileGrid:tileGrid];

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -36,7 +36,6 @@
 #import "HostWindow.h"
 #import "IntRect.h"
 #import "LocalFrameView.h"
-#import "PlatformCALayerClient.h"
 #import "ScreenProperties.h"
 #import "WAKWindow.h"
 #import "Widget.h"
@@ -73,21 +72,22 @@ bool screenHasInvertedColors()
     return PAL::softLinkUIKitUIAccessibilityIsInvertColorsEnabled();
 }
 
-ContentsFormat screenContentsFormat(Widget* widget, PlatformCALayerClient* client)
+OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 {
+    OptionSet<ContentsFormat> contentsFormats = { ContentsFormat::RGBA8 };
+
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (client && client->hdrForImagesEnabled() && screenSupportsHighDynamicRange(widget))
-        return ContentsFormat::RGBA16F;
+    if (screenSupportsHighDynamicRange(widget))
+        contentsFormats.add(ContentsFormat::RGBA16F);
 #endif
 
 #if ENABLE(PIXEL_FORMAT_RGB10)
     if (screenSupportsExtendedColor(widget))
-        return ContentsFormat::RGBA10;
+        contentsFormats.add(ContentsFormat::RGBA10);
 #endif
 
     UNUSED_PARAM(widget);
-    UNUSED_PARAM(client);
-    return ContentsFormat::RGBA8;
+    return contentsFormats;
 }
 
 bool screenSupportsExtendedColor(Widget*)
@@ -115,7 +115,7 @@ DestinationColorSpace screenColorSpace(Widget* widget)
     UNUSED_PARAM(widget);
 
 #if ENABLE(PIXEL_FORMAT_RGB10) && ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
-    if (screenContentsFormat(widget) == ContentsFormat::RGBA10)
+    if (screenContentsFormats(widget).contains(ContentsFormat::RGBA10))
         return DestinationColorSpace::ExtendedSRGB();
 #endif
 

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -33,7 +33,6 @@
 #import "FloatRect.h"
 #import "HostWindow.h"
 #import "LocalFrameView.h"
-#import "PlatformCALayerClient.h"
 #import "ScreenProperties.h"
 #import "ThermalMitigationNotifier.h"
 #import <ColorSync/ColorSync.h>
@@ -365,21 +364,22 @@ DestinationColorSpace screenColorSpace(Widget* widget)
     return DestinationColorSpace { screen(widget).colorSpace.CGColorSpace };
 }
 
-ContentsFormat screenContentsFormat(Widget* widget, PlatformCALayerClient* client)
+OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 {
+    OptionSet<ContentsFormat> contentsFormats = { ContentsFormat::RGBA8 };
+
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (client && client->hdrForImagesEnabled() && screenSupportsHighDynamicRange(widget))
-        return ContentsFormat::RGBA16F;
+    if (screenSupportsHighDynamicRange(widget))
+        contentsFormats.add(ContentsFormat::RGBA16F);
 #endif
 
 #if ENABLE(PIXEL_FORMAT_RGB10)
     if (screenSupportsExtendedColor(widget))
-        return ContentsFormat::RGBA10;
+        contentsFormats.add(ContentsFormat::RGBA10);
 #endif
 
     UNUSED_PARAM(widget);
-    UNUSED_PARAM(client);
-    return ContentsFormat::RGBA8;
+    return contentsFormats;
 }
 
 bool screenSupportsExtendedColor(Widget* widget)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1485,7 +1485,7 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
 
     auto transform = CATransform3DMakeScale(deviceScale, deviceScale, 1);
 
-    auto snapshotFormat = WebCore::convertToIOSurfaceFormat(WebCore::screenContentsFormat());
+    auto snapshotFormat = WebCore::convertToIOSurfaceFormat(WebCore::PlatformCALayer::contentsFormatForLayer());
     auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::Name::Snapshot, snapshotFormat);
     if (!surface)
         return nullptr;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -75,7 +75,7 @@ Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(PlatformCALaye
 
     if (result->canHaveBackingStore()) {
         auto* localMainFrameView = m_context->webPage().localMainFrameView();
-        result->setContentsFormat(screenContentsFormat(localMainFrameView, owner));
+        result->setContentsFormat(PlatformCALayer::contentsFormatForLayer(localMainFrameView, owner));
     }
 
     return WTFMove(result);

--- a/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
+++ b/Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm
@@ -42,7 +42,7 @@
 #import <WebCore/DestinationColorSpace.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurface.h>
-#import <WebCore/PlatformScreen.h>
+#import <WebCore/PlatformCALayer.h>
 #import <WebKit/WebCoreThread.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
@@ -68,7 +68,7 @@ RefPtr<BitmapContext> createBitmapContextFromWebView(bool onscreen, bool increme
     WebCore::FloatSize snapshotSize(viewSize);
     snapshotSize.scale(deviceScaleFactor);
 
-    auto snapshotFormat = WebCore::convertToIOSurfaceFormat(WebCore::screenContentsFormat());
+    auto snapshotFormat = WebCore::convertToIOSurfaceFormat(WebCore::PlatformCALayer::contentsFormatForLayer());
     auto surface = WebCore::IOSurface::create(nullptr, WebCore::expandedIntSize(snapshotSize), WebCore::DestinationColorSpace::SRGB(), WebCore::IOSurface::Name::Snapshot, snapshotFormat);
     if (!surface)
         return nullptr;


### PR DESCRIPTION
#### 01e5e2df42c3c96d69e335d0ab7cd61a1ea9710a
<pre>
[HDR] Separate &quot;is showing HDR&quot; from screenContentsFormat()
<a href="https://bugs.webkit.org/show_bug.cgi?id=287265">https://bugs.webkit.org/show_bug.cgi?id=287265</a>
<a href="https://rdar.apple.com/144396500">rdar://144396500</a>

Reviewed by Simon Fraser.

screenContentsFormat() is a little confusing. It actually returns the best screen
ContentsFormat for a given optional layer.

I think the right design for this is:

1. screenContentsFormat() should be renamed screenContentsFormats() and it should
return OptionSet&lt;ContentsFormat&gt;. The screen is capable of supporting multiple
ContentsFormat. So it makes sense to return more than one ContentsFormat for the
same screen. The layer should picks whatever suits it.

2. A new static function is added called PlatformCALayer::contentsFormatForLayer().
It will return the best screen ContentsFormat for a given optional layer. This
function will call screenContentsFormats() and it will checks whether the
PlatformCALayerClient wants to show HDR or not. If it does and the screen supports
RGBA16F, it will return RGBA16F.

* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/graphics/ContentsFormat.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createPlatformCALayer):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::contentsFormatForLayer):
* Source/WebCore/platform/ios/LegacyTileGridTile.mm:
(WebCore::LegacyTileGridTile::LegacyTileGridTile):
* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::screenContentsFormats):
(WebCore::screenColorSpace):
(WebCore::screenContentsFormat): Deleted.
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::screenContentsFormats):
(WebCore::screenContentsFormat): Deleted.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _takeViewSnapshot]):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createPlatformCALayer):
* Tools/DumpRenderTree/ios/PixelDumpSupportIOS.mm:
(createBitmapContextFromWebView):

Canonical link: <a href="https://commits.webkit.org/290069@main">https://commits.webkit.org/290069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09ba212785eea007e96a473679e5b4017fed17ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68462 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26147 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48827 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6432 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34739 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95640 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77332 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18895 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9076 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16025 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->