### PR TITLE
Address safer C++ static analysis warnings in PlatformSpeechSynthesizer

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1084,7 +1084,6 @@ platform/audio/cocoa/AudioSampleDataSource.mm
 platform/audio/cocoa/AudioSessionCocoa.mm
 platform/audio/cocoa/MediaSessionManagerCocoa.mm
 platform/cocoa/DragImageCocoa.mm
-platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/PowerSourceNotifier.mm
 platform/cocoa/SharedBufferCocoa.mm
@@ -1226,7 +1225,6 @@ platform/mock/MockAudioDestinationCocoa.cpp
 platform/mock/MockRealtimeAudioSource.cpp
 platform/mock/MockRealtimeMediaSourceCenter.cpp
 platform/mock/MockRealtimeVideoSource.cpp
-platform/mock/PlatformSpeechSynthesizerMock.cpp
 platform/mock/RTCNotifiersMock.cpp
 platform/mock/TimerEventBasedMock.h
 platform/mock/mediasource/MockMediaPlayerMediaSource.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -613,7 +613,6 @@ platform/ThreadGlobalData.h
 platform/animation/AcceleratedEffect.cpp
 platform/animation/AcceleratedEffectValues.cpp
 platform/audio/AudioBus.cpp
-platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/graphics/BitmapImageDescriptor.cpp

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -28,6 +28,7 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include "PlatformSpeechSynthesisVoice.h"
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -66,7 +67,7 @@ protected:
     virtual ~PlatformSpeechSynthesizerClient() = default;
 };
 
-class WEBCORE_EXPORT PlatformSpeechSynthesizer : public RefCounted<PlatformSpeechSynthesizer> {
+class WEBCORE_EXPORT PlatformSpeechSynthesizer : public RefCountedAndCanMakeWeakPtr<PlatformSpeechSynthesizer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(PlatformSpeechSynthesizer, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<PlatformSpeechSynthesizer> create(PlatformSpeechSynthesizerClient&);

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -70,7 +70,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
 #define AVSpeechUtteranceMaximumSpeechRate getAVSpeechUtteranceMaximumSpeechRate()
 
 @interface WebSpeechSynthesisWrapper : NSObject<AVSpeechSynthesizerDelegate> {
-    WebCore::PlatformSpeechSynthesizer* m_synthesizerObject;
+    WeakPtr<WebCore::PlatformSpeechSynthesizer> m_synthesizerObject;
     // Hold a Ref to the utterance so that it won't disappear until the synth is done with it.
     RefPtr<WebCore::PlatformSpeechSynthesisUtterance> m_utterance;
 
@@ -102,7 +102,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
 
 - (void)availableVoicesDidChange
 {
-    m_synthesizerObject->voicesDidChange();
+    Ref { *m_synthesizerObject }->voicesDidChange();
 }
 
 #endif
@@ -133,7 +133,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     
     // Choose the best voice, by first looking at the utterance voice, then the utterance language,
     // then choose the default language.
-    WebCore::PlatformSpeechSynthesisVoice* utteranceVoice = utterance->voice();
+    RefPtr utteranceVoice = utterance->voice();
     NSString *voiceLanguage = nil;
     if (!utteranceVoice || utteranceVoice->voiceURI().isEmpty()) {
         if (utterance->lang().isEmpty())
@@ -162,7 +162,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     // macOS won't send a did start speaking callback for empty strings.
 #if !HAVE(UNIFIED_SPEECHSYNTHESIS_FIX_FOR_81465164)
     if (!m_utterance->text().length())
-        m_synthesizerObject->client().didStartSpeaking(*m_utterance);
+        m_synthesizerObject->client().didStartSpeaking(Ref { *m_utterance });
 #endif
 
     [m_synthesizer speakUtterance:avUtterance];
@@ -212,7 +212,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!m_utterance || m_utterance->wrapper() != utterance)
         return;
 
-    m_synthesizerObject->client().didStartSpeaking(*m_utterance);
+    m_synthesizerObject->client().didStartSpeaking(Ref { *m_utterance });
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didFinishSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -234,7 +234,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!m_utterance || m_utterance->wrapper() != utterance)
         return;
 
-    m_synthesizerObject->client().didPauseSpeaking(*m_utterance);
+    m_synthesizerObject->client().didPauseSpeaking(Ref { *m_utterance });
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didContinueSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -243,7 +243,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!m_utterance || m_utterance->wrapper() != utterance)
         return;
 
-    m_synthesizerObject->client().didResumeSpeaking(*m_utterance);
+    m_synthesizerObject->client().didResumeSpeaking(Ref { *m_utterance });
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didCancelSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -266,7 +266,7 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
         return;
 
     // AVSpeechSynthesizer only supports word boundaries.
-    m_synthesizerObject->client().boundaryEventOccurred(*m_utterance, WebCore::SpeechBoundary::SpeechWordBoundary, characterRange.location, characterRange.length);
+    m_synthesizerObject->client().boundaryEventOccurred(Ref { *m_utterance }, WebCore::SpeechBoundary::SpeechWordBoundary, characterRange.location, characterRange.length);
 }
 
 @end

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -63,12 +63,12 @@ void PlatformSpeechSynthesizerMock::initializeVoiceList()
 void PlatformSpeechSynthesizerMock::speak(RefPtr<PlatformSpeechSynthesisUtterance>&& utterance)
 {
     ASSERT(!m_utterance);
-    m_utterance = WTFMove(utterance);
-    client().didStartSpeaking(*m_utterance);
+    m_utterance = utterance;
+    client().didStartSpeaking(*utterance);
 
     // Fire a fake word and then sentence boundary event. Since the entire sentence is the full length, pick arbitrary (3) length for the word.
-    client().boundaryEventOccurred(*m_utterance, SpeechBoundary::SpeechWordBoundary, 0, 3);
-    client().boundaryEventOccurred(*m_utterance, SpeechBoundary::SpeechSentenceBoundary, 0, m_utterance->text().length());
+    client().boundaryEventOccurred(*utterance, SpeechBoundary::SpeechWordBoundary, 0, 3);
+    client().boundaryEventOccurred(*utterance, SpeechBoundary::SpeechSentenceBoundary, 0, utterance->text().length());
 
     // Give the fake speech job some time so that pause and other functions have time to be called.
     m_speakingFinishedTimer.startOneShot(m_utteranceDuration);
@@ -80,24 +80,20 @@ void PlatformSpeechSynthesizerMock::cancel()
         return;
 
     m_speakingFinishedTimer.stop();
-    auto utterance = std::exchange(m_utterance, nullptr);
+    RefPtr utterance = std::exchange(m_utterance, nullptr);
     client().speakingErrorOccurred(*utterance);
 }
 
 void PlatformSpeechSynthesizerMock::pause()
 {
-    if (!m_utterance)
-        return;
-
-    client().didPauseSpeaking(*m_utterance);
+    if (RefPtr utterance = m_utterance)
+        client().didPauseSpeaking(*utterance);
 }
 
 void PlatformSpeechSynthesizerMock::resume()
 {
-    if (!m_utterance)
-        return;
-
-    client().didResumeSpeaking(*m_utterance);
+    if (RefPtr utterance = m_utterance)
+        client().didResumeSpeaking(*utterance);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### f38101017942a5038eb4a9ce14e17cba4bcd1e65
<pre>
Address safer C++ static analysis warnings in PlatformSpeechSynthesizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=287267">https://bugs.webkit.org/show_bug.cgi?id=287267</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/PlatformSpeechSynthesizer.h:
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper availableVoicesDidChange]):
(-[WebSpeechSynthesisWrapper speakUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didStartSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didPauseSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didContinueSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:willSpeakRangeOfSpeechString:utterance:]):
* Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp:
(WebCore::PlatformSpeechSynthesizerMock::speak):
(WebCore::PlatformSpeechSynthesizerMock::cancel):
(WebCore::PlatformSpeechSynthesizerMock::pause):
(WebCore::PlatformSpeechSynthesizerMock::resume):

Canonical link: <a href="https://commits.webkit.org/290052@main">https://commits.webkit.org/290052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/735a240f04728e4491cf1ff46b0d0b20698e3075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39527 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26124 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80285 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48803 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6400 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34698 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95575 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15948 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11662 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77303 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76583 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9013 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15962 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->