### PR TITLE
Use cached glyph buffer for computing total advance

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2782,6 +2782,7 @@ rendering/BorderPainter.cpp
 rendering/BorderShape.cpp
 rendering/BreakLines.cpp
 rendering/CSSFilter.cpp
+rendering/GlyphBufferCache.cpp
 rendering/CaretRectComputation.cpp
 rendering/ClipRect.cpp
 rendering/ContentfulPaintChecker.cpp

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -239,10 +239,12 @@ public:
 
     unsigned generation() const { return m_generation; }
 
-private:
     enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
 
     GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+    GlyphBuffer layoutTextFromCache(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+
+private:
     GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -36,6 +36,8 @@
 #include <climits>
 #include <limits>
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -44,7 +46,9 @@ static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
 
 class Font;
 
-class GlyphBuffer {
+class GlyphBuffer : public CanMakeCheckedPtr<GlyphBuffer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GlyphBuffer);
 public:
     bool isEmpty() const { return m_fonts.isEmpty(); }
     unsigned size() const { return m_fonts.size(); }
@@ -246,6 +250,13 @@ public:
         return true;
     }
 #endif
+    float totalAdvance() const
+    {
+        auto result { 0.f };
+        for (auto advance : m_advances)
+            result += WebCore::width(advance);
+        return result;
+    }
 
 private:
     void swap(unsigned index1, unsigned index2)

--- a/Source/WebCore/rendering/GlyphBufferCache.cpp
+++ b/Source/WebCore/rendering/GlyphBufferCache.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GlyphBufferCache.h"
+
+#include "platform/graphics/FontCascade.h"
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+GlyphBufferCache& GlyphBufferCache::singleton()
+{
+    static NeverDestroyed<GlyphBufferCache> cache;
+    return cache;
+}
+
+void GlyphBufferCache::clear()
+{
+    m_entries.clear();
+}
+
+unsigned GlyphBufferCache::size() const
+{
+    return m_entries.size();
+}
+
+GlyphBuffer GlyphBufferCache::glyphBuffer(const FontCascade& font, FontCascade::CodePath codePath, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot, const TextRun& textRun, unsigned from, unsigned to)
+{
+    if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
+        if (!m_entries.isEmpty()) {
+            LOG(MemoryPressure, "GlyphBufferCache::%s - Under memory pressure - size: %d", __FUNCTION__, size());
+            clear();
+        }
+        return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+    }
+
+    if (from || to != textRun.length())
+        return font.layoutText(codePath, textRun, from, to);
+
+    if (font.isLoadingCustomFonts() || !font.fonts())
+        return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+
+    GlyphBufferCacheKey key { codePath, textRun, font, forTextEmphasisOrNot };
+    if (auto entry = m_entries.find(key); entry != m_entries.end())
+        return *entry->value;
+
+    auto glyphBuffer = font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+    return *m_entries.add(key, WTF::makeUniqueRef<GlyphBuffer>(WTFMove((glyphBuffer)))).iterator->value;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/GlyphBufferCache.h
+++ b/Source/WebCore/rendering/GlyphBufferCache.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatSizeHash.h"
+#include "FontCascade.h"
+#include "GlyphBuffer.h"
+#include "Logging.h"
+#include "TextRun.h"
+#include "TextRunHash.h"
+#include <memory>
+#include <wtf/GetPtr.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/MemoryPressureHandler.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/UniqueRef.h>
+
+namespace WebCore {
+
+class GlyphBufferCacheKey {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend struct GlyphBufferCacheEntryHashTraits;
+    friend void add(Hasher&, const GlyphBufferCacheKey&);
+public:
+    bool operator==(const GlyphBufferCacheKey& other) const
+    {
+        return m_textRun == other.m_textRun
+            && m_fontCascadeGeneration == other.m_fontCascadeGeneration
+            && m_forTextEmphasisOrNot == other.m_forTextEmphasisOrNot;
+    }
+
+    GlyphBufferCacheKey(WTF::HashTableEmptyValueType)
+        : m_textRun(WTF::HashTableEmptyValue)
+    { }
+
+    GlyphBufferCacheKey(WTF::HashTableDeletedValueType)
+        : m_textRun(WTF::HashTableDeletedValue)
+    { }
+
+    GlyphBufferCacheKey(FontCascade::CodePath codePath, const TextRun& textRun, const FontCascade& font, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot)
+        : m_textRun(textRun)
+        , m_fontCascadeGeneration(font.generation())
+        , m_codePath(codePath)
+        , m_forTextEmphasisOrNot(forTextEmphasisOrNot)
+    {
+    }
+
+private:
+    TextRun m_textRun;
+    unsigned m_fontCascadeGeneration;
+    FontCascade::CodePath m_codePath;
+    FontCascade::ForTextEmphasisOrNot m_forTextEmphasisOrNot;
+};
+
+inline void add(Hasher& hasher, const GlyphBufferCacheKey& key)
+{
+    add(hasher, key.m_textRun, key.m_fontCascadeGeneration, key.m_codePath, key.m_forTextEmphasisOrNot);
+}
+
+struct GlyphBufferCacheEntryHash {
+    static unsigned hash(const GlyphBufferCacheKey& key) { return computeHash(key); }
+    static bool equal (const GlyphBufferCacheKey& a, const GlyphBufferCacheKey& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+struct GlyphBufferCacheEntryHashTraits : WTF::GenericHashTraits<GlyphBufferCacheKey> {
+    static const bool emptyValueIsZero = false;
+    static const bool hasIsEmptyValueFunction = true;
+    static GlyphBufferCacheKey emptyValue() { return GlyphBufferCacheKey(WTF::HashTableEmptyValue); }
+    static void constructDeletedValue(GlyphBufferCacheKey& slot) { new (NotNull, &slot) GlyphBufferCacheKey(WTF::HashTableDeletedValue); }
+    static const bool hasIsDeletedValueFunction = true;
+    static bool isDeletedValue(const GlyphBufferCacheKey& key) { return key.m_textRun.isHashTableDeletedValue(); }
+    static bool isEmptyValue(const GlyphBufferCacheKey& key) { return key.m_textRun.isHashTableEmptyValue(); }
+};
+
+class GlyphBufferCache {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend class GlyphBufferCacheKey;
+public:
+    GlyphBufferCache() = default;
+
+    static GlyphBufferCache& singleton();
+
+    // DisplayList::DisplayList* getDisplayList(const FontCascade&, GraphicsContext&, const TextRun&);
+    GlyphBuffer glyphBuffer(const FontCascade&, FontCascade::CodePath, FontCascade::ForTextEmphasisOrNot, const TextRun&, unsigned, unsigned);
+
+    void clear();
+    unsigned size() const;
+
+private:
+    // static bool canShareDisplayList(const DisplayList::DisplayList&);
+    HashMap<GlyphBufferCacheKey, WTF::UniqueRef<GlyphBuffer>, GlyphBufferCacheEntryHash, GlyphBufferCacheEntryHashTraits> m_entries;
+    // HashMap<GlyphBufferCacheKey,std::unique_ptr<GlyphBuffer>, GlyphBufferCacheEntryHash, GlyphBufferCacheEntryHashTraits> m_entries;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct DefaultHash<WebCore::GlyphBufferCacheKey> : WebCore::GlyphBufferCacheEntryHash { };
+
+} // namespace WTF


### PR DESCRIPTION
#### ea519d397553cc0c6ad3814d57049255e2106731
<pre>
Use cached glyph buffer for computing total advance
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutTextFromCache const):
(WebCore::FontCascade::drawText const):
(WebCore::FontCascade::drawEmphasisMarks const):
(WebCore::FontCascade::displayListForTextRun const):
(WebCore::FontCascade::widthForSimpleText const):
(WebCore::FontCascade::widthForComplexText const):
(WebCore::FontCascade::lineSegmentsForIntersectionsWithRect const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::totalAdvance const):
* Source/WebCore/rendering/GlyphBufferCache.cpp: Added.
(WebCore::GlyphBufferCache::singleton):
(WebCore::GlyphBufferCache::clear):
(WebCore::GlyphBufferCache::size const):
(WebCore::GlyphBufferCache::glyphBuffer):
* Source/WebCore/rendering/GlyphBufferCache.h: Added.
(WebCore::GlyphBufferCacheKey::operator== const):
(WebCore::GlyphBufferCacheKey::GlyphBufferCacheKey):
(WebCore::add):
(WebCore::GlyphBufferCacheEntryHash::hash):
(WebCore::GlyphBufferCacheEntryHash::equal):
(WebCore::GlyphBufferCacheEntryHashTraits::emptyValue):
(WebCore::GlyphBufferCacheEntryHashTraits::constructDeletedValue):
(WebCore::GlyphBufferCacheEntryHashTraits::isDeletedValue):
(WebCore::GlyphBufferCacheEntryHashTraits::isEmptyValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea519d397553cc0c6ad3814d57049255e2106731

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16519 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68454 "Found 74 new test failures: css1/text_properties/word_spacing.html css2.1/20110323/c541-word-sp-001.htm fast/borders/rtl-border-04.html fast/borders/rtl-border-05.html fast/css/word-spacing-characters-complex-text.html fast/css/word-spacing-characters.html fast/lists/bidi-text-as-list-marker.html fast/text/arabic-times-new-roman.html fast/text/atsui-negative-spacing-features.html fast/text/atsui-spacing-features.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26138 "Found 10 new test failures: fast/canvas/canvas-composite-fill-with-shadow.html fast/css/parsing-css-is-6.html fast/css/word-spacing-characters-complex-text.html fast/css/word-spacing-characters.html fast/text/initial-advance-in-intermediate-run-complex.html fast/text/international/hebrew-selection.html fast/workers/worker-structure-message.html imported/w3c/web-platform-tests/css/selectors/i18n/css3-selectors-lang-001.html imported/w3c/web-platform-tests/x-frame-options/multiple.html storage/indexeddb/cursor-continue.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91813 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6664 "Found 39 new test failures: css1/text_properties/word_spacing.html css2.1/20110323/c541-word-sp-001.htm fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html fast/css/word-spacing-characters-complex-text.html fast/css/word-spacing-characters.html fast/lists/bidi-text-as-list-marker.html fast/text/arabic-times-new-roman.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80311 "Found 1 new API test failure: TestWebKitAPI.WebKitLegacy.StringTruncator (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48819 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6419 "Found 13 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-005.html imported/w3c/web-platform-tests/css/css-content/quotes-009.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-join-001.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-join-002.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-001.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-002.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-003.html imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-tatweel-001.html imported/w3c/web-platform-tests/css/css-ui/text-overflow-022.html imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34726 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html css1/text_properties/word_spacing.html css2.1/20110323/c541-word-sp-001.htm editing/undo/redo-reapply-edit-command-crash.html fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html fast/css/word-spacing-characters-complex-text.html fast/css/word-spacing-characters.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76782 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35623 "Found 60 new test failures: css1/text_properties/word_spacing.html css2.1/20110323/c541-word-sp-001.htm css3/masking/reference-clip-path-animate-transform-repaint.html fast/css/text-decoration-in-second-order-descendants.html fast/css/text-decoration-inheritance-pseudo.html fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html fast/css/word-spacing-characters-complex-text.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95619 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15991 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11689 "Found 60 new test failures: css1/text_properties/word_spacing.html css2.1/20110323/c541-word-sp-001.htm fast/canvas/webgl/compositing-without-drawing.html fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html fast/css/word-spacing-characters-complex-text.html fast/css/word-spacing-characters.html fast/forms/switch/click-animation-twice-fast.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77321 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76603 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20992 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19417 "Found 60 new test failures: accessibility/mac/native-text-control-set-selected-textmarker-range.html css1/text_properties/word_spacing.html css2.1/20110323/c541-word-sp-001.htm fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html fast/css/word-spacing-characters-complex-text.html fast/css/word-spacing-characters.html fast/lists/bidi-text-as-list-marker.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9056 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21315 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15746 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17527 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->