### PR TITLE
[Materials] Use custom parsing for `-apple-visual-effect`

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1029,6 +1029,7 @@ css/parser/CSSPropertyParserConsumer+Align.cpp
 css/parser/CSSPropertyParserConsumer+Angle.cpp
 css/parser/CSSPropertyParserConsumer+AnglePercentage.cpp
 css/parser/CSSPropertyParserConsumer+Animations.cpp
+css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp
 css/parser/CSSPropertyParserConsumer+Attr.cpp
 css/parser/CSSPropertyParserConsumer+Background.cpp
 css/parser/CSSPropertyParserConsumer+Box.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9618,26 +9618,12 @@
             "status": "non-standard"
         },
         "-apple-visual-effect": {
-            "values": [
-                "none",
-                "-apple-system-blur-material-ultra-thin",
-                "-apple-system-blur-material-thin",
-                "-apple-system-blur-material",
-                "-apple-system-blur-material-thick",
-                "-apple-system-blur-material-chrome",
-                "-apple-system-vibrancy-label",
-                "-apple-system-vibrancy-secondary-label",
-                "-apple-system-vibrancy-tertiary-label",
-                "-apple-system-vibrancy-quaternary-label",
-                "-apple-system-vibrancy-fill",
-                "-apple-system-vibrancy-secondary-fill",
-                "-apple-system-vibrancy-tertiary-fill",
-                "-apple-system-vibrancy-separator"
-            ],
             "codegen-properties": {
                 "enable-if": "HAVE_CORE_MATERIAL",
                 "settings-flag": "useSystemAppearance",
-                "parser-grammar": "<<values>>"
+                "parser-function": "consumeAppleVisualEffect",
+                "parser-grammar-unused": "<<values>>",
+                "parser-grammar-unused-reason": "Needs support for internal values"
             },
             "status": "non-standard"
         },

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -49,6 +49,7 @@
 #include "CSSPrimitiveNumericTypes+CSSValueCreation.h"
 #include "CSSPropertyParserConsumer+Align.h"
 #include "CSSPropertyParserConsumer+Angle.h"
+#include "CSSPropertyParserConsumer+AppleVisualEffect.h"
 #include "CSSPropertyParserConsumer+Background.h"
 #include "CSSPropertyParserConsumer+Color.h"
 #include "CSSPropertyParserConsumer+Conditional.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSPropertyParserConsumer+AppleVisualEffect.h"
+
+#if HAVE(CORE_MATERIAL)
+
+#include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSValueKeywords.h"
+
+namespace WebCore::CSSPropertyParserHelpers {
+
+static bool isKeywordValidForAppleVisualEffect(CSSValueID keyword)
+{
+    switch (keyword) {
+    case CSSValueID::CSSValueNone:
+    case CSSValueID::CSSValueAppleSystemBlurMaterial:
+    case CSSValueID::CSSValueAppleSystemBlurMaterialChrome:
+    case CSSValueID::CSSValueAppleSystemBlurMaterialThick:
+    case CSSValueID::CSSValueAppleSystemBlurMaterialThin:
+    case CSSValueID::CSSValueAppleSystemBlurMaterialUltraThin:
+    case CSSValueID::CSSValueAppleSystemVibrancyFill:
+    case CSSValueID::CSSValueAppleSystemVibrancyLabel:
+    case CSSValueID::CSSValueAppleSystemVibrancyQuaternaryLabel:
+    case CSSValueID::CSSValueAppleSystemVibrancySecondaryFill:
+    case CSSValueID::CSSValueAppleSystemVibrancySecondaryLabel:
+    case CSSValueID::CSSValueAppleSystemVibrancySeparator:
+    case CSSValueID::CSSValueAppleSystemVibrancyTertiaryFill:
+    case CSSValueID::CSSValueAppleSystemVibrancyTertiaryLabel:
+        return true;
+    default:
+        return false;
+    }
+}
+
+RefPtr<CSSValue> consumeAppleVisualEffect(CSSParserTokenRange& range, const CSSParserContext&)
+{
+    return consumeIdent(range, isKeywordValidForAppleVisualEffect);
+}
+
+} // namespace WebCore::CSSPropertyParserHelpers
+
+#endif // HAVE(CORE_MATERIAL)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(CORE_MATERIAL)
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class CSSParserTokenRange;
+class CSSValue;
+struct CSSParserContext;
+
+namespace CSSPropertyParserHelpers {
+
+RefPtr<CSSValue> consumeAppleVisualEffect(CSSParserTokenRange&, const CSSParserContext&);
+
+} // namespace CSSPropertyParserHelpers
+} // namespace WebCore
+
+#endif // HAVE(CORE_MATERIAL)

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3961,6 +3961,7 @@ class GenerateCSSPropertyParsing:
                     "CSSPropertyParserConsumer+Align.h",
                     "CSSPropertyParserConsumer+Angle.h",
                     "CSSPropertyParserConsumer+Animations.h",
+                    "CSSPropertyParserConsumer+AppleVisualEffect.h",
                     "CSSPropertyParserConsumer+Attr.h",
                     "CSSPropertyParserConsumer+Background.h",
                     "CSSPropertyParserConsumer+Box.h",


### PR DESCRIPTION
#### b0f30ae12f8c1c0b662c05f1b62eb8dc8a1c6ba0
<pre>
[Materials] Use custom parsing for `-apple-visual-effect`
<a href="https://bugs.webkit.org/show_bug.cgi?id=287273">https://bugs.webkit.org/show_bug.cgi?id=287273</a>
<a href="https://rdar.apple.com/144400935">rdar://144400935</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Use custom parsing to allow for keywords from WebKitAdditions.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp: Added.
(WebCore::CSSPropertyParserHelpers::isKeywordValidForAppleVisualEffect):
(WebCore::CSSPropertyParserHelpers::consumeAppleVisualEffect):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.h: Added.
* Source/WebCore/css/process-css-properties.py:

Canonical link: <a href="https://commits.webkit.org/290090@main">https://commits.webkit.org/290090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e66929ae67ded6b48c15309ec68c90af579f1a22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68452 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26140 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6421 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34723 "Found 3 new test failures: editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38679 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95620 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77320 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76167 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76602 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20991 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9057 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13933 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16006 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15747 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->