### PR TITLE
Cache only full runs

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2783,6 +2783,7 @@ rendering/BorderPainter.cpp
 rendering/BorderShape.cpp
 rendering/BreakLines.cpp
 rendering/CSSFilter.cpp
+rendering/GlyphBufferCache.cpp
 rendering/CaretRectComputation.cpp
 rendering/ClipRect.cpp
 rendering/ContentfulPaintChecker.cpp

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -34,6 +34,7 @@
 #include "LayoutRect.h"
 #include "TextRun.h"
 #include "WidthIterator.h"
+#include "rendering/GlyphBufferCache.h"
 #include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -163,6 +164,11 @@ GlyphBuffer FontCascade::layoutText(CodePath codePathToUse, const TextRun& run, 
     return layoutComplexText(run, from, to, forTextEmphasis);
 }
 
+GlyphBuffer FontCascade::layoutTextFromCache(CodePath codePathToUse, const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis) const
+{
+    return GlyphBufferCache::singleton().glyphBuffer(*this, codePathToUse, forTextEmphasis, run, from, to);
+}
+
 float FontCascade::letterSpacing() const
 {
     switch (m_spacing.letter.type()) {
@@ -196,7 +202,7 @@ float FontCascade::wordSpacing() const
 FloatSize FontCascade::drawText(GraphicsContext& context, const TextRun& run, const FloatPoint& point, unsigned from, std::optional<unsigned> to, CustomFontNotReadyAction customFontNotReadyAction) const
 {
     unsigned destination = to.value_or(run.length());
-    auto glyphBuffer = layoutText(codePath(run, from, to), run, from, destination);
+    auto glyphBuffer = layoutTextFromCache(codePath(run, from, to), run, from, destination);
     glyphBuffer.flatten();
 
     if (glyphBuffer.isEmpty())
@@ -214,7 +220,7 @@ void FontCascade::drawEmphasisMarks(GraphicsContext& context, const TextRun& run
 
     unsigned destination = to.value_or(run.length());
 
-    auto glyphBuffer = layoutText(codePath(run, from, to), run, from, destination, ForTextEmphasisOrNot::ForTextEmphasis);
+    auto glyphBuffer = layoutTextFromCache(codePath(run, from, to), run, from, destination, ForTextEmphasisOrNot::ForTextEmphasis);
     glyphBuffer.flatten();
 
     if (glyphBuffer.isEmpty())
@@ -234,7 +240,7 @@ std::unique_ptr<DisplayList::DisplayList> FontCascade::displayListForTextRun(Gra
     if (codePathToUse != CodePath::Complex && (enableKerning() || requiresShaping()) && (from || destination != run.length()))
         codePathToUse = CodePath::Complex;
 
-    auto glyphBuffer = layoutText(codePathToUse, run, from, destination);
+    auto glyphBuffer = layoutTextFromCache(codePathToUse, run, from, destination);
     glyphBuffer.flatten();
 
     if (glyphBuffer.isEmpty())
@@ -1863,7 +1869,7 @@ DashArray FontCascade::dashesForIntersectionsWithRect(const TextRun& run, const 
     if (isLoadingCustomFonts())
         return DashArray();
 
-    auto glyphBuffer = layoutText(codePath(run), run, 0, run.length());
+    auto glyphBuffer = layoutTextFromCache(codePath(run), run, 0, run.length());
 
     if (!glyphBuffer.size())
         return DashArray();

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -239,10 +239,12 @@ public:
 
     unsigned generation() const { return m_generation; }
 
-private:
     enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
 
     GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+    GlyphBuffer layoutTextFromCache(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+
+private:
     GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -36,6 +36,8 @@
 #include <climits>
 #include <limits>
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -44,7 +46,9 @@ static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
 
 class Font;
 
-class GlyphBuffer {
+class GlyphBuffer : public CanMakeCheckedPtr<GlyphBuffer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GlyphBuffer);
 public:
     bool isEmpty() const { return m_fonts.isEmpty(); }
     unsigned size() const { return m_fonts.size(); }

--- a/Source/WebCore/rendering/GlyphBufferCache.cpp
+++ b/Source/WebCore/rendering/GlyphBufferCache.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GlyphBufferCache.h"
+
+#include "platform/graphics/FontCascade.h"
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+GlyphBufferCache& GlyphBufferCache::singleton()
+{
+    static NeverDestroyed<GlyphBufferCache> cache;
+    return cache;
+}
+
+void GlyphBufferCache::clear()
+{
+    m_entries.clear();
+}
+
+unsigned GlyphBufferCache::size() const
+{
+    return m_entries.size();
+}
+
+GlyphBuffer GlyphBufferCache::glyphBuffer(const FontCascade& font, FontCascade::CodePath codePath, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot, const TextRun& textRun, unsigned from, unsigned to)
+{
+    if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
+        if (!m_entries.isEmpty()) {
+            LOG(MemoryPressure, "GlyphBufferCache::%s - Under memory pressure - size: %d", __FUNCTION__, size());
+            clear();
+        }
+        return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+    }
+
+    // if (from || to != textRun.length())
+    //     return font.layoutText(codePath, textRun, from, to);
+
+    if (font.isLoadingCustomFonts() || !font.fonts())
+        return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+
+    GlyphBufferCacheKey key { textRun, font, codePath, forTextEmphasisOrNot, from, to };
+    if (auto entry = m_entries.find(key); entry != m_entries.end())
+        return *entry->value;
+
+    auto glyphBuffer = font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+    return *m_entries.add(key, WTF::makeUniqueRef<GlyphBuffer>(WTFMove((glyphBuffer)))).iterator->value;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/GlyphBufferCache.cpp
+++ b/Source/WebCore/rendering/GlyphBufferCache.cpp
@@ -57,13 +57,13 @@ GlyphBuffer GlyphBufferCache::glyphBuffer(const FontCascade& font, FontCascade::
         return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
     }
 
-    // if (from || to != textRun.length())
-    //     return font.layoutText(codePath, textRun, from, to);
+    if (from || to != textRun.length())
+        return font.layoutText(codePath, textRun, from, to);
 
     if (font.isLoadingCustomFonts() || !font.fonts())
         return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
 
-    GlyphBufferCacheKey key { textRun, font, codePath, forTextEmphasisOrNot, from, to };
+    GlyphBufferCacheKey key { codePath, textRun, font, forTextEmphasisOrNot };
     if (auto entry = m_entries.find(key); entry != m_entries.end())
         return *entry->value;
 

--- a/Source/WebCore/rendering/GlyphBufferCache.h
+++ b/Source/WebCore/rendering/GlyphBufferCache.h
@@ -50,10 +50,7 @@ public:
     {
         return m_textRun == other.m_textRun
             && m_fontCascadeGeneration == other.m_fontCascadeGeneration
-            && m_codePath == other.m_codePath
-            && m_forTextEmphasisOrNot == other.m_forTextEmphasisOrNot
-            && from == other.from
-            && to == other.to;
+            && m_forTextEmphasisOrNot == other.m_forTextEmphasisOrNot;
     }
 
     GlyphBufferCacheKey(WTF::HashTableEmptyValueType)
@@ -64,13 +61,11 @@ public:
         : m_textRun(WTF::HashTableDeletedValue)
     { }
 
-    GlyphBufferCacheKey(const TextRun& textRun, const FontCascade& font, FontCascade::CodePath& codePath, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot, unsigned from, unsigned to)
+    GlyphBufferCacheKey(FontCascade::CodePath codePath, const TextRun& textRun, const FontCascade& font, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot)
         : m_textRun(textRun)
         , m_fontCascadeGeneration(font.generation())
         , m_codePath(codePath)
         , m_forTextEmphasisOrNot(forTextEmphasisOrNot)
-        , from(from)
-        , to(to)
     {
     }
 
@@ -79,13 +74,11 @@ private:
     unsigned m_fontCascadeGeneration;
     FontCascade::CodePath m_codePath;
     FontCascade::ForTextEmphasisOrNot m_forTextEmphasisOrNot;
-    unsigned from;
-    unsigned to;
 };
 
 inline void add(Hasher& hasher, const GlyphBufferCacheKey& key)
 {
-    add(hasher, key.m_textRun, key.m_fontCascadeGeneration, key.m_codePath, key.m_forTextEmphasisOrNot, key.from, key.to);
+    add(hasher, key.m_textRun, key.m_fontCascadeGeneration, key.m_codePath, key.m_forTextEmphasisOrNot);
 }
 
 struct GlyphBufferCacheEntryHash {

--- a/Source/WebCore/rendering/GlyphBufferCache.h
+++ b/Source/WebCore/rendering/GlyphBufferCache.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatSizeHash.h"
+#include "FontCascade.h"
+#include "GlyphBuffer.h"
+#include "Logging.h"
+#include "TextRun.h"
+#include "TextRunHash.h"
+#include <memory>
+#include <wtf/GetPtr.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/MemoryPressureHandler.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/UniqueRef.h>
+
+namespace WebCore {
+
+class GlyphBufferCacheKey {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend struct GlyphBufferCacheEntryHashTraits;
+    friend void add(Hasher&, const GlyphBufferCacheKey&);
+public:
+    bool operator==(const GlyphBufferCacheKey& other) const
+    {
+        return m_textRun == other.m_textRun
+            && m_fontCascadeGeneration == other.m_fontCascadeGeneration
+            && m_codePath == other.m_codePath
+            && m_forTextEmphasisOrNot == other.m_forTextEmphasisOrNot
+            && from == other.from
+            && to == other.to;
+    }
+
+    GlyphBufferCacheKey(WTF::HashTableEmptyValueType)
+        : m_textRun(WTF::HashTableEmptyValue)
+    { }
+
+    GlyphBufferCacheKey(WTF::HashTableDeletedValueType)
+        : m_textRun(WTF::HashTableDeletedValue)
+    { }
+
+    GlyphBufferCacheKey(const TextRun& textRun, const FontCascade& font, FontCascade::CodePath& codePath, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot, unsigned from, unsigned to)
+        : m_textRun(textRun)
+        , m_fontCascadeGeneration(font.generation())
+        , m_codePath(codePath)
+        , m_forTextEmphasisOrNot(forTextEmphasisOrNot)
+        , from(from)
+        , to(to)
+    {
+    }
+
+private:
+    TextRun m_textRun;
+    unsigned m_fontCascadeGeneration;
+    FontCascade::CodePath m_codePath;
+    FontCascade::ForTextEmphasisOrNot m_forTextEmphasisOrNot;
+    unsigned from;
+    unsigned to;
+};
+
+inline void add(Hasher& hasher, const GlyphBufferCacheKey& key)
+{
+    add(hasher, key.m_textRun, key.m_fontCascadeGeneration, key.m_codePath, key.m_forTextEmphasisOrNot, key.from, key.to);
+}
+
+struct GlyphBufferCacheEntryHash {
+    static unsigned hash(const GlyphBufferCacheKey& key) { return computeHash(key); }
+    static bool equal (const GlyphBufferCacheKey& a, const GlyphBufferCacheKey& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+struct GlyphBufferCacheEntryHashTraits : WTF::GenericHashTraits<GlyphBufferCacheKey> {
+    static const bool emptyValueIsZero = false;
+    static const bool hasIsEmptyValueFunction = true;
+    static GlyphBufferCacheKey emptyValue() { return GlyphBufferCacheKey(WTF::HashTableEmptyValue); }
+    static void constructDeletedValue(GlyphBufferCacheKey& slot) { new (NotNull, &slot) GlyphBufferCacheKey(WTF::HashTableDeletedValue); }
+    static const bool hasIsDeletedValueFunction = true;
+    static bool isDeletedValue(const GlyphBufferCacheKey& key) { return key.m_textRun.isHashTableDeletedValue(); }
+    static bool isEmptyValue(const GlyphBufferCacheKey& key) { return key.m_textRun.isHashTableEmptyValue(); }
+};
+
+class GlyphBufferCache {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend class GlyphBufferCacheKey;
+public:
+    GlyphBufferCache() = default;
+
+    static GlyphBufferCache& singleton();
+
+    // DisplayList::DisplayList* getDisplayList(const FontCascade&, GraphicsContext&, const TextRun&);
+    GlyphBuffer glyphBuffer(const FontCascade&, FontCascade::CodePath, FontCascade::ForTextEmphasisOrNot, const TextRun&, unsigned, unsigned);
+
+    void clear();
+    unsigned size() const;
+
+private:
+    // static bool canShareDisplayList(const DisplayList::DisplayList&);
+    HashMap<GlyphBufferCacheKey, WTF::UniqueRef<GlyphBuffer>, GlyphBufferCacheEntryHash, GlyphBufferCacheEntryHashTraits> m_entries;
+    // HashMap<GlyphBufferCacheKey,std::unique_ptr<GlyphBuffer>, GlyphBufferCacheEntryHash, GlyphBufferCacheEntryHashTraits> m_entries;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct DefaultHash<WebCore::GlyphBufferCacheKey> : WebCore::GlyphBufferCacheEntryHash { };
+
+} // namespace WTF


### PR DESCRIPTION
#### d4bb825f6b01ebbff348514adb88dea8d53410d3
<pre>
Cache only full runs
</pre>
----------------------------------------------------------------------
#### cad744ef7ad07dc91b99699ba000ea548e19513e
<pre>
GlyphBuffer caching including partial runs Need the bug URL (OOPS!). Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutTextFromCache const):
(WebCore::FontCascade::drawText const):
(WebCore::FontCascade::drawEmphasisMarks const):
(WebCore::FontCascade::displayListForTextRun const):
(WebCore::FontCascade::dashesForIntersectionsWithRect const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/GlyphBuffer.h:
* Source/WebCore/rendering/GlyphBufferCache.cpp: Added.
(WebCore::GlyphBufferCache::singleton):
(WebCore::GlyphBufferCache::clear):
(WebCore::GlyphBufferCache::size const):
(WebCore::GlyphBufferCache::glyphBuffer):
* Source/WebCore/rendering/GlyphBufferCache.h: Added.
(WebCore::GlyphBufferCacheKey::operator== const):
(WebCore::GlyphBufferCacheKey::GlyphBufferCacheKey):
(WebCore::add):
(WebCore::GlyphBufferCacheEntryHash::hash):
(WebCore::GlyphBufferCacheEntryHash::equal):
(WebCore::GlyphBufferCacheEntryHashTraits::emptyValue):
(WebCore::GlyphBufferCacheEntryHashTraits::constructDeletedValue):
(WebCore::GlyphBufferCacheEntryHashTraits::isDeletedValue):
(WebCore::GlyphBufferCacheEntryHashTraits::isEmptyValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4bb825f6b01ebbff348514adb88dea8d53410d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88803 "Failed to checkout and rebase branch from PR 40239") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/8327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90854 "Failed to checkout and rebase branch from PR 40239") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/8714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/16511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/93772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91805 "Failed to checkout and rebase branch from PR 40239") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/8714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/93772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/8714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/38670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/8714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95611 "Failed to checkout and rebase branch from PR 40239") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/15983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/16511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/95611 "Failed to checkout and rebase branch from PR 40239") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/16239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/95611 "Failed to checkout and rebase branch from PR 40239") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/15997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/15738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/17519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->