### PR TITLE
Address WTF_ALLOW_UNSAFE_BUFFER_USAGE and static analysis warnings in StringImplCF.cpp

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -10,4 +10,3 @@ wtf/text/AtomStringImpl.cpp
 wtf/text/CString.cpp
 wtf/text/StringImpl.cpp
 wtf/text/SymbolImpl.cpp
-wtf/text/cf/StringImplCF.cpp

--- a/Source/WTF/wtf/text/cf/StringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringImplCF.cpp
@@ -37,7 +37,15 @@ namespace StringWrapperCFAllocator {
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(StringWrapperCFAllocator, WTF_INTERNAL);
     DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringWrapperCFAllocator);
 
-    static StringImpl* currentString;
+    static RefPtr<StringImpl>& currentString()
+    {
+        static NeverDestroyed<RefPtr<StringImpl>> currentString;
+        return currentString;
+    }
+
+    struct StringImplWrapper {
+        RefPtr<StringImpl> m_stringImpl;
+    };
 
     static const void* retain(const void* info)
     {
@@ -55,46 +63,35 @@ namespace StringWrapperCFAllocator {
         return CFSTR("WTF::String-based allocator");
     }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     static void* allocate(CFIndex size, CFOptionFlags, void*)
     {
-        StringImpl* underlyingString = nullptr;
-        if (isMainThread()) {
-            underlyingString = currentString;
-            if (underlyingString) {
-                currentString = nullptr;
-                underlyingString->ref(); // Balanced by call to deref in deallocate below.
-            }
-        }
-        StringImpl** header = static_cast<StringImpl**>(StringWrapperCFAllocatorMalloc::malloc(sizeof(StringImpl*) + size));
-        *header = underlyingString;
-        return header + 1;
+        RefPtr<StringImpl> underlyingString;
+        if (isMainThread())
+            underlyingString = std::exchange(currentString(), nullptr);
+
+        auto [ wrapper, trailingBytes ] = createWithTrailingBytes<StringImplWrapper, StringWrapperCFAllocatorMalloc>(size, StringImplWrapper { WTFMove(underlyingString) });
+        return trailingBytes;
     }
 
     static void* reallocate(void* pointer, CFIndex newSize, CFOptionFlags, void*)
     {
-        size_t newAllocationSize = sizeof(StringImpl*) + newSize;
-        StringImpl** header = static_cast<StringImpl**>(pointer) - 1;
-        ASSERT(!*header);
-        header = static_cast<StringImpl**>(StringWrapperCFAllocatorMalloc::realloc(header, newAllocationSize));
-        return header + 1;
+        auto [ prevWrapper, prevTrailingBytes ] = fromTrailingBytes<StringImplWrapper>(pointer);
+        auto [ wrapper, trailingBytes ] = reallocWithTrailingBytes<StringImplWrapper, StringWrapperCFAllocatorMalloc>(prevWrapper, newSize);
+        ASSERT(!wrapper->m_stringImpl);
+        return trailingBytes;
     }
 
     static void deallocate(void* pointer, void*)
     {
-        StringImpl** header = static_cast<StringImpl**>(pointer) - 1;
-        if (!*header)
-            StringWrapperCFAllocatorMalloc::free(header);
+        auto [ wrapper, trailingBytes ] = fromTrailingBytes<StringImplWrapper>(pointer);
+        if (!wrapper->m_stringImpl)
+            destroyWithTrailingBytes<StringImplWrapper, StringWrapperCFAllocatorMalloc>(wrapper);
         else {
-            ensureOnMainThread([header] {
-                StringImpl* underlyingString = *header;
-                ASSERT(underlyingString);
-                underlyingString->deref(); // Balanced by call to ref in allocate above.
-                StringWrapperCFAllocatorMalloc::free(header);
+            ensureOnMainThread([wrapper = wrapper] {
+                destroyWithTrailingBytes<StringImplWrapper, StringWrapperCFAllocatorMalloc>(wrapper);
             });
         }
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     static CFIndex preferredSize(CFIndex size, CFOptionFlags, void*)
     {
@@ -130,8 +127,8 @@ RetainPtr<CFStringRef> StringImpl::createCFString()
     CFAllocatorRef allocator = StringWrapperCFAllocator::allocator();
 
     // Put pointer to the StringImpl in a global so the allocator can store it with the CFString.
-    ASSERT(!StringWrapperCFAllocator::currentString);
-    StringWrapperCFAllocator::currentString = this;
+    ASSERT(!StringWrapperCFAllocator::currentString());
+    StringWrapperCFAllocator::currentString() = this;
 
     RetainPtr<CFStringRef> string;
     if (is8Bit()) {
@@ -141,8 +138,8 @@ RetainPtr<CFStringRef> StringImpl::createCFString()
         auto characters = span16();
         string = adoptCF(CFStringCreateWithCharactersNoCopy(allocator, reinterpret_cast<const UniChar*>(characters.data()), characters.size(), kCFAllocatorNull));
     }
-    // CoreFoundation might not have to allocate anything, we clear currentString in case we did not execute allocate().
-    StringWrapperCFAllocator::currentString = nullptr;
+    // CoreFoundation might not have to allocate anything, we clear currentString() in case we did not execute allocate().
+    StringWrapperCFAllocator::currentString() = nullptr;
 
     return string;
 }


### PR DESCRIPTION
#### adef225a2b98479de735c4839850a0b0118ff689
<pre>
Address WTF_ALLOW_UNSAFE_BUFFER_USAGE and static analysis warnings in StringImplCF.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287287">https://bugs.webkit.org/show_bug.cgi?id=287287</a>
<a href="https://rdar.apple.com/144407846">rdar://144407846</a>

Reviewed by Ryosuke Niwa.

This operation will never be totally safe because it interacts with malloc-like
APIs. But we can compose it on top of lower level primitives to avoid scattering
WTF_ALLOW_UNSAFE_BUFFER_USAGE across the codebase, and to ensure some more
safety details than before.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::destroyWithTrailingBytes): New helpers for dealing with an allocation that
requires trailing bytes. (This is kinda like TrailingArray, but not quite.)

These new helpers are a little safer than what we had before because
* they honor constructor/destructor semantics, including smart pointers
* they enable the caller to express itself in terms of (mostly) safe abstractions

* Source/WTF/wtf/text/cf/StringImplCF.cpp:
(WTF::StringWrapperCFAllocator::allocate):
(WTF::StringWrapperCFAllocator::reallocate):
(WTF::StringWrapperCFAllocator::deallocate): Use our (mostly) safe abstractions

* Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
Fixed a failure.

Canonical link: <a href="https://commits.webkit.org/290172@main">https://commits.webkit.org/290172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49f072be99ff57aed36c29e4ca22936142c8d776

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39772 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68579 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26256 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48942 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35236 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38880 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81811 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95823 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87788 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11835 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77461 "Failure limit exceed. At least found 1 new test failure: svg/dynamic-updates/SVGFEPointLightElement-svgdom-y-prop.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76751 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21139 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9275 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13974 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21517 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110281 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15947 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26470 "Found 14 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.no-llint, microbenchmarks/set-delete-add.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-slow-memory, wasm.yaml/wasm/stress/js-wasm-js-varying-arities.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->