### PR TITLE
Update button activation and reflection behavior with command or commandfor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/button-type-popovertarget-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/button-type-popovertarget-expected.txt
@@ -2,12 +2,12 @@
 reset  submit  type=button  invalid  missing
 reset submit type=button invalid missing  reset submit type=button invalid missing
 
-FAIL Button type=reset in form should trigger form reset and not toggle popover assert_false: type=reset should not toggle the popover expected false got true
+PASS Button type=reset in form should trigger form reset and not toggle popover
 PASS Button type=submit in form should trigger form submit and not toggle popover
 PASS Button type=button in form should toggle popover
 PASS Button type=invalid in form should trigger form submit and not toggle popover
 PASS Button missing type in form should trigger form submit and not toggle popover
-FAIL Button type=reset with form attr should trigger form reset and not toggle popover assert_false: type=reset should not toggle the popover expected false got true
+PASS Button type=reset with form attr should trigger form reset and not toggle popover
 PASS Button type=submit with form attr should trigger form submit and not toggle popover
 PASS Button type=button with form attr should toggle popover
 PASS Button type=invalid with form attr should trigger form submit and not toggle popover

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/input-type-popovertarget-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/input-type-popovertarget-expected.txt
@@ -2,11 +2,11 @@
 
 
 
-FAIL input type=reset in form should trigger form reset and not toggle popover assert_false: type=reset should not toggle the popover expected false got true
+PASS input type=reset in form should trigger form reset and not toggle popover
 PASS input type=submit in form should trigger form submit and not toggle popover
 PASS input type=button in form should toggle popover
 PASS input type=image in form should trigger form submit and not toggle popover
-FAIL input type=reset with form attr should trigger form reset and not toggle popover assert_false: type=reset should not toggle the popover expected false got true
+PASS input type=reset with form attr should trigger form reset and not toggle popover
 PASS input type=submit with form attr should trigger form submit and not toggle popover
 PASS input type=button with form attr should toggle popover
 PASS input type=image with form attr should trigger form submit and not toggle popover

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior-expected.txt
@@ -2,23 +2,23 @@
 reset  submit  type=button  invalid  invalid with command only  invalid with commandfor only  missing missing with command only  missing with commandfor only
 reset submit type=button invalid invalid with command only invalid with commandfor only missing missing with command only missing with commandfor only  reset submit type=button invalid missing
 
-FAIL Button type=reset in form should trigger form reset and not toggle popover assert_true: type=reset should trigger form reset event expected true got false
-FAIL Button type=submit in form should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=reset in form should trigger form reset and not toggle popover
+PASS Button type=submit in form should trigger form submit and not toggle popover
 PASS Button type=button in form should not toggle popover
 PASS Button type=invalid in form should not trigger form submit and not toggle popover
-FAIL Button type=invalid in form with only command should not trigger form submit and not toggle popover assert_false: type=invalid should not trigger form submit event expected false got true
+PASS Button type=invalid in form with only command should not trigger form submit and not toggle popover
 PASS Button type=invalid in form with only commandfor should not trigger form submit and not toggle popover
 PASS Button missing type in form should not trigger form submit and not toggle popover
-FAIL Button missing type in form with only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type in form with only command should not trigger form submit and not toggle popover
 PASS Button missing type in form with only commandfor should not trigger form submit and not toggle popover
-FAIL Button type=reset with form attr should trigger form reset and not toggle popover assert_true: type=reset should trigger form reset event expected true got false
-FAIL Button type=submit with form attr should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=reset with form attr should trigger form reset and not toggle popover
+PASS Button type=submit with form attr should trigger form submit and not toggle popover
 PASS Button type=button with form attr should toggle popover
 PASS Button type=invalid with form attr should not trigger form submit and not toggle popover
-FAIL Button type=invalid with form attr and only command should not trigger form submit and not toggle popover assert_false: type=invalid should not trigger form submit event expected false got true
+PASS Button type=invalid with form attr and only command should not trigger form submit and not toggle popover
 PASS Button type=invalid with form attr and only commandfor should not trigger form submit and not toggle popover
 PASS Button missing type with form attr should not trigger form submit and not toggle popover
-FAIL Button missing type with form attr and only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type with form attr and only command should not trigger form submit and not toggle popover
 PASS Button missing type with form attr and only commandfor should not trigger form submit and not toggle popover
 PASS Button type=reset outside form should toggle popover
 PASS Button type=submit outside form should toggle popover

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection-expected.txt
@@ -5,28 +5,28 @@ reset submit type=button invalid invalid with command only invalid with commandf
 PASS Button with id reset-in-form should reflect type correctly
 PASS Button with id submit-in-form should reflect type correctly
 PASS Button with id button-in-form should reflect type correctly
-FAIL Button with id invalid-in-form should reflect type correctly assert_equals: type of invalid-in-form should be button expected "button" but got "submit"
-FAIL Button with id invalid-in-form-command-only should reflect type correctly assert_equals: type of invalid-in-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id invalid-in-form-commandfor-only should reflect type correctly assert_equals: type of invalid-in-form-commandfor-only should be button expected "button" but got "submit"
-FAIL Button with id missing-in-form should reflect type correctly assert_equals: type of missing-in-form should be button expected "button" but got "submit"
-FAIL Button with id missing-in-form-command-only should reflect type correctly assert_equals: type of missing-in-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id missing-in-form-commandfor-only should reflect type correctly assert_equals: type of missing-in-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id invalid-in-form should reflect type correctly
+PASS Button with id invalid-in-form-command-only should reflect type correctly
+PASS Button with id invalid-in-form-commandfor-only should reflect type correctly
+PASS Button with id missing-in-form should reflect type correctly
+PASS Button with id missing-in-form-command-only should reflect type correctly
+PASS Button with id missing-in-form-commandfor-only should reflect type correctly
 PASS Button with id reset-attr-form should reflect type correctly
 PASS Button with id submit-attr-form should reflect type correctly
 PASS Button with id button-attr-form should reflect type correctly
-FAIL Button with id invalid-attr-form should reflect type correctly assert_equals: type of invalid-attr-form should be button expected "button" but got "submit"
-FAIL Button with id invalid-attr-form-command-only should reflect type correctly assert_equals: type of invalid-attr-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id invalid-attr-form-commandfor-only should reflect type correctly assert_equals: type of invalid-attr-form-commandfor-only should be button expected "button" but got "submit"
-FAIL Button with id missing-attr-form should reflect type correctly assert_equals: type of missing-attr-form should be button expected "button" but got "submit"
-FAIL Button with id missing-attr-form-command-only should reflect type correctly assert_equals: type of missing-attr-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id missing-attr-form-commandfor-only should reflect type correctly assert_equals: type of missing-attr-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id invalid-attr-form should reflect type correctly
+PASS Button with id invalid-attr-form-command-only should reflect type correctly
+PASS Button with id invalid-attr-form-commandfor-only should reflect type correctly
+PASS Button with id missing-attr-form should reflect type correctly
+PASS Button with id missing-attr-form-command-only should reflect type correctly
+PASS Button with id missing-attr-form-commandfor-only should reflect type correctly
 PASS Button with id reset-outside-form should reflect type correctly
 PASS Button with id submit-outside-form should reflect type correctly
 PASS Button with id button-outside-form should reflect type correctly
-FAIL Button with id invalid-outside-form should reflect type correctly assert_equals: type of invalid-outside-form should be button expected "button" but got "submit"
-FAIL Button with id invalid-outside-form-command-only should reflect type correctly assert_equals: type of invalid-outside-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id invalid-outside-form-commandfor-only should reflect type correctly assert_equals: type of invalid-outside-form-commandfor-only should be button expected "button" but got "submit"
-FAIL Button with id missing-outside-form should reflect type correctly assert_equals: type of missing-outside-form should be button expected "button" but got "submit"
-FAIL Button with id missing-outside-form-command-only should reflect type correctly assert_equals: type of missing-outside-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id missing-outside-form-commandfor-only should reflect type correctly assert_equals: type of missing-outside-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id invalid-outside-form should reflect type correctly
+PASS Button with id invalid-outside-form-command-only should reflect type correctly
+PASS Button with id invalid-outside-form-commandfor-only should reflect type correctly
+PASS Button with id missing-outside-form should reflect type correctly
+PASS Button with id missing-outside-form-command-only should reflect type correctly
+PASS Button with id missing-outside-form-commandfor-only should reflect type correctly
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior-expected.txt
@@ -2,23 +2,23 @@
 reset  submit  type=button  invalid  invalid with command only  invalid with commandfor only missing  missing with command only  missing with commandfor only
 reset submit type=button invalid invalid with command only invalid with commandfor only missing missing with command only missing with commandfor only  reset submit type=button invalid missing
 
-FAIL Button type=reset in form should trigger form reset and not toggle popover assert_true: type=reset should trigger form reset event expected true got false
-FAIL Button type=submit in form should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=reset in form should trigger form reset and not toggle popover
+PASS Button type=submit in form should trigger form submit and not toggle popover
 PASS Button type=button in form should not toggle popover
 PASS Button type=invalid in form should not trigger form submit and not toggle popover
-FAIL Button type=invalid in form with only command should not trigger form submit and not toggle popover assert_false: type=invalid should not trigger form submit event expected false got true
+PASS Button type=invalid in form with only command should not trigger form submit and not toggle popover
 PASS Button type=invalid in form with only commandfor should not trigger form submit and not toggle popover
 PASS Button missing type in form should not trigger form submit and not toggle popover
-FAIL Button missing type in form with only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type in form with only command should not trigger form submit and not toggle popover
 PASS Button missing type in form with only commandfor should not trigger form submit and not toggle popover
-FAIL Button type=reset with form attr should trigger form reset and not toggle popover assert_true: type=reset should trigger form reset event expected true got false
-FAIL Button type=submit with form attr should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=reset with form attr should trigger form reset and not toggle popover
+PASS Button type=submit with form attr should trigger form submit and not toggle popover
 PASS Button type=button with form attr should toggle popover
 PASS Button type=invalid with form attr should not trigger form submit and not toggle popover
-FAIL Button type=invalid with form attr and only command should not trigger form submit and not toggle popover assert_false: type=invalid should not trigger form submit event expected false got true
+PASS Button type=invalid with form attr and only command should not trigger form submit and not toggle popover
 PASS Button type=invalid with form attr and only commandfor should not trigger form submit and not toggle popover
 PASS Button missing type with form attr should not trigger form submit and not toggle popover
-FAIL Button missing type with form attr and only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type with form attr and only command should not trigger form submit and not toggle popover
 PASS Button missing type with form attr and only commandfor should not trigger form submit and not toggle popover
 PASS Button type=reset outside form should toggle popover
 PASS Button type=submit outside form should toggle popover

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection-expected.txt
@@ -5,28 +5,28 @@ reset submit type=button invalid invalid with command only invalid with commandf
 PASS Button with id reset-in-form should reflect type correctly
 PASS Button with id submit-in-form should reflect type correctly
 PASS Button with id button-in-form should reflect type correctly
-FAIL Button with id invalid-in-form should reflect type correctly assert_equals: type of invalid-in-form should be button expected "button" but got "submit"
-FAIL Button with id invalid-in-form-command-only should reflect type correctly assert_equals: type of invalid-in-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id invalid-in-form-commandfor-only should reflect type correctly assert_equals: type of invalid-in-form-commandfor-only should be button expected "button" but got "submit"
-FAIL Button with id missing-in-form should reflect type correctly assert_equals: type of missing-in-form should be button expected "button" but got "submit"
-FAIL Button with id missing-in-form-command-only should reflect type correctly assert_equals: type of missing-in-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id missing-in-form-commandfor-only should reflect type correctly assert_equals: type of missing-in-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id invalid-in-form should reflect type correctly
+PASS Button with id invalid-in-form-command-only should reflect type correctly
+PASS Button with id invalid-in-form-commandfor-only should reflect type correctly
+PASS Button with id missing-in-form should reflect type correctly
+PASS Button with id missing-in-form-command-only should reflect type correctly
+PASS Button with id missing-in-form-commandfor-only should reflect type correctly
 PASS Button with id reset-attr-form should reflect type correctly
 PASS Button with id submit-attr-form should reflect type correctly
 PASS Button with id button-attr-form should reflect type correctly
-FAIL Button with id invalid-attr-form should reflect type correctly assert_equals: type of invalid-attr-form should be button expected "button" but got "submit"
-FAIL Button with id invalid-attr-form-command-only should reflect type correctly assert_equals: type of invalid-attr-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id invalid-attr-form-commandfor-only should reflect type correctly assert_equals: type of invalid-attr-form-commandfor-only should be button expected "button" but got "submit"
-FAIL Button with id missing-attr-form should reflect type correctly assert_equals: type of missing-attr-form should be button expected "button" but got "submit"
-FAIL Button with id missing-attr-form-command-only should reflect type correctly assert_equals: type of missing-attr-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id missing-attr-form-commandfor-only should reflect type correctly assert_equals: type of missing-attr-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id invalid-attr-form should reflect type correctly
+PASS Button with id invalid-attr-form-command-only should reflect type correctly
+PASS Button with id invalid-attr-form-commandfor-only should reflect type correctly
+PASS Button with id missing-attr-form should reflect type correctly
+PASS Button with id missing-attr-form-command-only should reflect type correctly
+PASS Button with id missing-attr-form-commandfor-only should reflect type correctly
 PASS Button with id reset-outside-form should reflect type correctly
 PASS Button with id submit-outside-form should reflect type correctly
 PASS Button with id button-outside-form should reflect type correctly
-FAIL Button with id invalid-outside-form should reflect type correctly assert_equals: type of invalid-outside-form should be button expected "button" but got "submit"
-FAIL Button with id invalid-outside-form-command-only should reflect type correctly assert_equals: type of invalid-outside-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id invalid-outside-form-commandfor-only should reflect type correctly assert_equals: type of invalid-outside-form-commandfor-only should be button expected "button" but got "submit"
-FAIL Button with id missing-outside-form should reflect type correctly assert_equals: type of missing-outside-form should be button expected "button" but got "submit"
-FAIL Button with id missing-outside-form-command-only should reflect type correctly assert_equals: type of missing-outside-form-command-only should be button expected "button" but got "submit"
-FAIL Button with id missing-outside-form-commandfor-only should reflect type correctly assert_equals: type of missing-outside-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id invalid-outside-form should reflect type correctly
+PASS Button with id invalid-outside-form-command-only should reflect type correctly
+PASS Button with id invalid-outside-form-commandfor-only should reflect type correctly
+PASS Button with id missing-outside-form should reflect type correctly
+PASS Button with id missing-outside-form-command-only should reflect type correctly
+PASS Button with id missing-outside-form-commandfor-only should reflect type correctly
 

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -91,6 +91,8 @@ private:
 
     bool isSubmitButton() const final;
 
+    void computeType(const AtomString& typeAttrValue);
+
     Type m_type;
     bool m_isActivatedSubmit;
 };

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1357,6 +1357,8 @@ void HTMLInputElement::defaultEventHandler(Event& event)
     // must dispatch a DOMActivate event - a click event will not do the job.
     if (event.type() == eventNames().DOMActivateEvent) {
         m_inputType->handleDOMActivateEvent(event);
+        if (form() && m_inputType->type() != InputType::Type::Button)
+            return;
         handlePopoverTargetAction(event.target());
         if (event.defaultHandled())
             return;


### PR DESCRIPTION
#### b4d27c3a21dab43e99a8c79d24a59aed7c0761e4
<pre>
Update button activation and reflection behavior with command or commandfor
<a href="https://bugs.webkit.org/show_bug.cgi?id=287288">https://bugs.webkit.org/show_bug.cgi?id=287288</a>

Reviewed by Anne van Kesteren.

This patch correctly updates the button activation steps to match the spec,
missing and invalid type buttons no longer submit forms when they have a command or commandfor
attribute. They also correctly don&apos;t act as command buttons.

This patch also updates form associated reset buttons and inputs to not trigger
popovertarget or commandfor behavior.

The button elements type reflection also correctly reflects as button
when it has a missing or invalid type attribute and has command or commandfor.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/button-type-popovertarget-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/input-type-popovertarget-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection-expected.txt:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::attributeChanged):
(WebCore::HTMLButtonElement::defaultEventHandler):
(WebCore::HTMLButtonElement::computeType):
* Source/WebCore/html/HTMLButtonElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::defaultEventHandler):

Canonical link: <a href="https://commits.webkit.org/292010@main">https://commits.webkit.org/292010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5e8c91c6a83fd9527f651fbde89ae5ba67c4d5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99534 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29445 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3054 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21821 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80500 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25053 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2450 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14794 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26683 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115829 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21227 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/115829 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->