### PR TITLE
[visionOS] YouTube.com: leaving docked mode after an ad results in black video inline

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1869,8 +1869,7 @@ RefPtr<VideoMediaSampleRenderer> MediaPlayerPrivateMediaSourceAVFObjC::layerOrVi
 void MediaPlayerPrivateMediaSourceAVFObjC::setVideoTarget(const PlatformVideoTarget& videoTarget)
 {
     ALWAYS_LOG(LOGIDENTIFIER, !!videoTarget);
-    if (!!videoTarget)
-        m_usingLinearMediaPlayer = true;
+    m_usingLinearMediaPlayer = !!videoTarget;
     m_videoTarget = videoTarget;
     updateDisplayLayer();
 }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1991,8 +1991,7 @@ WebSampleBufferVideoRendering *MediaPlayerPrivateWebM::layerOrVideoRenderer() co
 void MediaPlayerPrivateWebM::setVideoTarget(const PlatformVideoTarget& videoTarget)
 {
     ALWAYS_LOG(LOGIDENTIFIER, !!videoTarget);
-    if (!!videoTarget)
-        m_usingLinearMediaPlayer = true;
+    m_usingLinearMediaPlayer = !!videoTarget;
     m_videoTarget = videoTarget;
     updateDisplayLayer();
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -30,6 +30,7 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
+#include "Logging.h"
 #include "RemoteMediaPlayerConfiguration.h"
 #include "RemoteMediaPlayerManagerProxyMessages.h"
 #include "RemoteMediaPlayerProxy.h"
@@ -40,7 +41,7 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerPrivate.h>
-#include <wtf/Logger.h>
+#include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UniqueRef.h>
@@ -57,6 +58,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerManagerProxy);
 
 RemoteMediaPlayerManagerProxy::RemoteMediaPlayerManagerProxy(GPUConnectionToWebProcess& connection)
     : m_gpuConnectionToWebProcess(connection)
+#if !RELEASE_LOG_DISABLED
+    , m_logIdentifier { LoggerHelper::uniqueLogIdentifier() }
+    , m_logger { connection.logger() }
+#endif
 {
 }
 
@@ -179,15 +184,9 @@ RefPtr<MediaPlayer> RemoteMediaPlayerManagerProxy::mediaPlayer(std::optional<Med
 }
 
 #if !RELEASE_LOG_DISABLED
-Logger& RemoteMediaPlayerManagerProxy::logger()
+WTFLogChannel& RemoteMediaPlayerManagerProxy::logChannel() const
 {
-    if (!m_logger) {
-        m_logger = Logger::create(this);
-        RefPtr connection { m_gpuConnectionToWebProcess.get() };
-        m_logger->setEnabled(this, connection && connection->isAlwaysOnLoggingAllowed());
-    }
-
-    return *m_logger;
+    return WebKit2LogMedia;
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -81,7 +81,7 @@ public:
     void clear();
 
 #if !RELEASE_LOG_DISABLED
-    Logger& logger();
+    Logger& logger() { return m_logger; }
 #endif
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
@@ -94,7 +94,7 @@ public:
     std::optional<WebCore::ShareableBitmap::Handle> bitmapImageForCurrentTime(WebCore::MediaPlayerIdentifier);
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-    WebCore::PlatformVideoTarget videoTargetForMediaElementIdentifier(WebCore::HTMLMediaElementIdentifier);
+    WebCore::PlatformVideoTarget takeVideoTargetForMediaElementIdentifier(WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier);
     void handleVideoReceiverEndpointMessage(const VideoReceiverEndpointMessage&);
 #endif
 
@@ -120,6 +120,12 @@ private:
     void supportsTypeAndCodecs(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const WebCore::MediaEngineSupportParameters&&, CompletionHandler<void(WebCore::MediaPlayer::SupportsType)>&&);
     void supportsKeySystem(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const String&&, const String&&, CompletionHandler<void(bool)>&&);
 
+#if !RELEASE_LOG_DISABLED
+    ASCIILiteral logClassName() const { return "RemoteMediaPlayerManagerProxy"; }
+    WTFLogChannel& logChannel() const;
+    uint64_t logIdentifier() const { return m_logIdentifier; }
+#endif
+
     HashMap<WebCore::MediaPlayerIdentifier, Ref<RemoteMediaPlayerProxy>> m_proxies;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 
@@ -137,7 +143,8 @@ private:
 #endif
 
 #if !RELEASE_LOG_DISABLED
-    RefPtr<Logger> m_logger;
+    uint64_t m_logIdentifier { 0 };
+    Ref<Logger> m_logger;
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -950,7 +950,7 @@ WebCore::PlatformVideoTarget RemoteMediaPlayerProxy::mediaPlayerVideoTarget() co
 {
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     if (m_manager)
-        return m_manager->videoTargetForMediaElementIdentifier(m_clientIdentifier);
+        return m_manager->takeVideoTargetForMediaElementIdentifier(m_clientIdentifier, m_id);
 #endif
     return nullptr;
 }


### PR DESCRIPTION
#### 81ef4249c852641b68977525653f409b52fec5b5
<pre>
[visionOS] YouTube.com: leaving docked mode after an ad results in black video inline
<a href="https://rdar.apple.com/133617493">rdar://133617493</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287298">https://bugs.webkit.org/show_bug.cgi?id=287298</a>

Reviewed by Eric Carlson.

Two problems combined to cause the user visible behavior in this report:

1) When moving a PlatformVideoTarget between two MediaPlayers, the original holder of
the PlatformVideoTarget does not have it&apos;s video target cleared, and the new holder of
the PlatformVideoTarget is not added to the &quot;cached holder of the video target&quot;. This
means when the PlatformVideoTarget is torn down, we tell the wrong MediaPlayer to clear
its copy of the video target.

2) When we pass a valid video target to MediaPlayerPrivateMediaSourceAVFObjC, a bool
ivar is set that is never cleared when that video target is subsequently cleared. This
causes us to never re-create a layer backing for the MediaPlayer.

Drive-by fix: Make RemoteMediaPlayerManagerProxy compatible with LoggerHelper, so that
logs can be added to RemoteMediaPlayerManagerProxyCocoa.mm.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoTarget):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setVideoTarget):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::RemoteMediaPlayerManagerProxy):
(WebKit::RemoteMediaPlayerManagerProxy::logChannel const):
(WebKit::RemoteMediaPlayerManagerProxy::logger): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
(WebKit::RemoteMediaPlayerManagerProxy::logger):
(WebKit::RemoteMediaPlayerManagerProxy::logClassName const):
(WebKit::RemoteMediaPlayerManagerProxy::logIdentifier const):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerVideoTarget const):
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerManagerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerManagerProxy::takeVideoTargetForMediaElementIdentifier):
(WebKit::RemoteMediaPlayerManagerProxy::handleVideoReceiverEndpointMessage):
(WebKit::RemoteMediaPlayerManagerProxy::videoTargetForMediaElementIdentifier): Deleted.

Canonical link: <a href="https://commits.webkit.org/290173@main">https://commits.webkit.org/290173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c9cd35588924b3b353fde58042ac8f8e0746086

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68702 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26374 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49064 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39028 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16340 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16596 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76872 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18956 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21279 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9454 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16354 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->