### PR TITLE
[Site Isolation] getDisplayMedia does not work in a out of process iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mediastream/getDisplayMedia-starts-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mediastream/getDisplayMedia-starts-expected.txt
@@ -1,0 +1,10 @@
+Tests that getDisplayMedia starts in an OOP iframe.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'success'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mediastream/getDisplayMedia-starts.html
+++ b/LayoutTests/http/tests/site-isolation/mediastream/getDisplayMedia-starts.html
@@ -1,0 +1,16 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that getDisplayMedia starts in an OOP iframe.");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    window.testRunner.setUserMediaPermission(true);
+}
+
+window.addEventListener("message", function (event) {
+    shouldBe("event.data", "'success'");
+    finishJSTest();
+});
+</script>
+<iframe allow="display-capture *" src="http://localhost:8000/site-isolation/resources/getDisplayMedia-starts-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-audio-starts-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-audio-starts-expected.txt
@@ -1,0 +1,10 @@
+Tests that getUserMedia for audio starts in an OOP iframe.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'success'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-audio-starts.html
+++ b/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-audio-starts.html
@@ -1,0 +1,16 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that getUserMedia for audio starts in an OOP iframe.");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    window.testRunner.setUserMediaPermission(true);
+}
+
+window.addEventListener("message", function (event) {
+    shouldBe("event.data", "'success'");
+    finishJSTest();
+});
+</script>
+<iframe allow="microphone *" src="http://localhost:8000/site-isolation/resources/getUserMedia-audio-starts-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-video-starts-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-video-starts-expected.txt
@@ -1,0 +1,10 @@
+Tests that getUserMedia for video starts in an OOP iframe.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'success'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-video-starts.html
+++ b/LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-video-starts.html
@@ -1,0 +1,16 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that getUserMedia for video starts in an OOP iframe.");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    window.testRunner.setUserMediaPermission(true);
+}
+
+window.addEventListener("message", function (event) {
+    shouldBe("event.data", "'success'");
+    finishJSTest();
+});
+</script>
+<iframe allow="camera *" src="http://localhost:8000/site-isolation/resources/getUserMedia-video-starts-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-starts-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-starts-frame.html
@@ -1,0 +1,10 @@
+<script>
+window.internals.settings.setScreenCaptureEnabled(true);
+var streamPromise = null;
+window.internals.withUserGesture(() => {
+    streamPromise = navigator.mediaDevices.getDisplayMedia({ video: true });
+});
+streamPromise
+    .then(() => { window.parent.postMessage('success', '*'); })
+    .catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/getUserMedia-audio-starts-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getUserMedia-audio-starts-frame.html
@@ -1,0 +1,9 @@
+<script>
+var streamPromise = null;
+window.internals.withUserGesture(() => {
+    streamPromise = navigator.mediaDevices.getUserMedia({ audio: true });
+});
+streamPromise
+    .then(() => { window.parent.postMessage('success', '*'); })
+    .catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/getUserMedia-video-starts-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getUserMedia-video-starts-frame.html
@@ -1,0 +1,9 @@
+<script>
+var streamPromise = null;
+window.internals.withUserGesture(() => {
+    streamPromise = navigator.mediaDevices.getUserMedia({ video: true });
+});
+streamPromise
+    .then(() => { window.parent.postMessage('success', '*'); })
+    .catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
+</script>

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -24,6 +24,7 @@
 #include <WebCore/MediaProducer.h>
 #include <WebCore/PermissionDescriptor.h>
 #include <WebCore/PermissionState.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RealtimeMediaSourceCenter.h>
 #include <WebCore/RealtimeMediaSourceFactory.h>
 #include <WebCore/SecurityOrigin.h>
@@ -31,6 +32,7 @@
 #include <wtf/Deque.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RunLoop.h>
@@ -223,7 +225,7 @@ private:
     const uint64_t m_logIdentifier;
 #endif
 #if PLATFORM(COCOA)
-    bool m_hasCreatedSandboxExtensionForTCCD { false };
+    HashSet<WebCore::ProcessIdentifier> m_hasCreatedSandboxExtensionForTCCD;
 #endif
     uint64_t m_hasPendingCapture { 0 };
     std::optional<bool> m_mockDevicesEnabledOverride;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2344,6 +2344,7 @@ public:
 #endif
 
 #if ENABLE(MEDIA_STREAM)
+    UserMediaPermissionRequestManagerProxy* userMediaPermissionRequestManagerIfExists();
     WebCore::CaptureSourceOrError createRealtimeMediaSourceForSpeechRecognition();
     void clearUserMediaPermissionRequestHistory(WebCore::PermissionName);
     bool shouldListenToVoiceActivity() const { return m_shouldListenToVoiceActivity; }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -127,6 +127,10 @@
 #include "APIPageConfiguration.h"
 #endif
 
+#if ENABLE(MEDIA_STREAM)
+#include "UserMediaProcessManager.h"
+#endif
+
 #if ENABLE(SEC_ITEM_SHIM)
 #include "SecItemShimProxy.h"
 #endif
@@ -910,6 +914,10 @@ void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore en
     updateMediaStreamingActivity();
     updateBackgroundResponsivenessTimer();
     protectedWebsiteDataStore()->propagateSettingUpdates();
+
+#if ENABLE(MEDIA_STREAM)
+    UserMediaProcessManager::singleton().revokeSandboxExtensionsIfNeeded(Ref { *this });
+#endif
 
     maybeShutDown();
 }


### PR DESCRIPTION
#### 1935a83b4fdaacb26d179f4189020bd39efcc04e
<pre>
[Site Isolation] getDisplayMedia does not work in a out of process iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=287299">https://bugs.webkit.org/show_bug.cgi?id=287299</a>
<a href="https://rdar.apple.com/129194055">rdar://129194055</a>

Reviewed by Charlie Wolfe and Eric Carlson.

Starting a display stream via getDisplayMedia does not work in an OOP iframe when site isolation is
enabled. This is because many of the related operations assumed that only the main frame&apos;s process
could start a capture.

Fix this by making various parts of setting up a display stream (such as `updateCaptureAccess`,
`UserMediaAccessWasGranted`, `UserMediaAccessWasDenied`, extending sandbox to allow capture, etc.)
to use the process associated with the frame in the UserMediaRequest, rather than unconditionally
using the main frame&apos;s process.

Since a WebProcessProxy associated with an OOP iframe can enter the process cache while the main
page is still has an active capture session, also make `WebProcessProxy::removeWebPage` check to see
if it&apos;s okay to remove capture sandbox extensions when pages are removed from the process.

* LayoutTests/http/tests/site-isolation/mediastream/getDisplayMedia-starts-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mediastream/getDisplayMedia-starts.html: Added.
* LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-audio-starts-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-audio-starts.html: Added.
* LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-video-starts-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mediastream/getUserMedia-video-starts.html: Added.
* LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-starts-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/getUserMedia-audio-starts-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/getUserMedia-video-starts-frame.html: Added.
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::isPlayingMediaDidChange):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::revokeSandboxExtensionsIfNeededForPage):
(WebKit::UserMediaPermissionRequestManagerProxy::disconnectFromPage):
(WebKit::UserMediaPermissionRequestManagerProxy::captureDevicesChanged):
(WebKit::UserMediaPermissionRequestManagerProxy::denyRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::finishGrantingRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::captureStateChanged):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::willCreateMediaStream):
(WebKit::UserMediaProcessManager::revokeSandboxExtensionsIfNeeded):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::userMediaPermissionRequestManagerIfExists):
(WebKit::WebPageProxy::willStartCapture):
(WebKit::WebPageProxy::setOrientationForMediaCapture):
(WebKit::WebPageProxy::gpuProcessExited):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::removeWebPage):

Canonical link: <a href="https://commits.webkit.org/290715@main">https://commits.webkit.org/290715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933544585ded23823ebed4d8d7abc06b84206c4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36732 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97824 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78867 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78065 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21156 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23380 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->