### PR TITLE
Add infrastructure for Mac style form controls on Catalyst

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4559,6 +4559,20 @@ LowPowerVideoAudioBufferSizeEnabled:
       default: false
     WebKit:
       default: true
+      
+MacStyleControlsOnCatalyst:
+  type: bool
+  status: internal
+  humanReadableName: "Mac style controls on Catalyst"
+  humanReadableDescription: "Use Mac style controls on Catalyst"
+  condition: ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+  defaultValue:
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
 
 MainContentUserGestureOverrideEnabled:
   type: bool

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -131,6 +131,13 @@ bool RenderThemeIOS::canCreateControlPartForRenderer(const RenderObject& rendere
 
 void RenderThemeIOS::adjustCheckboxStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustCheckboxStyleForCatalyst(style, element))
+        return;
+#else
+    UNUSED_PARAM(element);
+#endif
+
     adjustMinimumIntrinsicSizeForAppearance(StyleAppearance::Checkbox, style);
 
     if (!style.width().isIntrinsicOrAuto() && !style.height().isAuto())
@@ -139,8 +146,6 @@ void RenderThemeIOS::adjustCheckboxStyle(RenderStyle& style, const Element* elem
     auto size = std::max(style.computedFontSize(), 10.f);
     style.setWidth({ size, LengthType::Fixed });
     style.setHeight({ size, LengthType::Fixed });
-
-    UNUSED_PARAM(element);
 }
 
 LayoutRect RenderThemeIOS::adjustedPaintRect(const RenderBox& box, const LayoutRect& paintRect) const
@@ -194,6 +199,13 @@ void RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance(StyleAppearance app
 
 void RenderThemeIOS::adjustRadioStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustRadioStyleForCatalyst(style, element))
+        return;
+#else
+    UNUSED_PARAM(element);
+#endif
+
     adjustMinimumIntrinsicSizeForAppearance(StyleAppearance::Radio, style);
 
     if (!style.width().isIntrinsicOrAuto() && !style.height().isAuto())
@@ -203,12 +215,15 @@ void RenderThemeIOS::adjustRadioStyle(RenderStyle& style, const Element* element
     style.setWidth({ size, LengthType::Fixed });
     style.setHeight({ size, LengthType::Fixed });
     style.setBorderRadius({ static_cast<int>(size / 2), static_cast<int>(size / 2) });
-
-    UNUSED_PARAM(element);
 }
 
 void RenderThemeIOS::adjustTextFieldStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustTextFieldStyleForCatalyst(style, element))
+        return;
+#endif
+
     if (!element)
         return;
 
@@ -270,6 +285,11 @@ void RenderThemeIOS::paintTextFieldInnerShadow(const PaintInfo& paintInfo, const
 
 void RenderThemeIOS::paintTextFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintTextFieldDecorationsForCatalyst(box, paintInfo, rect))
+        return;
+#endif
+
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
@@ -293,6 +313,11 @@ void RenderThemeIOS::paintTextFieldDecorations(const RenderBox& box, const Paint
 
 void RenderThemeIOS::adjustTextAreaStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustTextAreaStyleForCatalyst(style, element))
+        return;
+#endif
+
     if (!element)
         return;
 
@@ -305,6 +330,11 @@ void RenderThemeIOS::adjustTextAreaStyle(RenderStyle& style, const Element* elem
 
 void RenderThemeIOS::paintTextAreaDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintTextAreaDecorationsForCatalyst(box, paintInfo, rect))
+        return;
+#endif
+
     paintTextFieldDecorations(box, paintInfo, rect);
 }
 
@@ -446,6 +476,11 @@ static void adjustInputElementButtonStyle(RenderStyle& style, const HTMLInputEle
 
 void RenderThemeIOS::adjustMenuListButtonStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustMenuListButtonStyleForCatalyst(style, element))
+        return;
+#endif
+
     // Set the min-height to be at least MenuListMinHeight.
     if (style.logicalHeight().isAuto())
         style.setLogicalMinHeight(Length(std::max(MenuListMinHeight, static_cast<int>(MenuListBaseHeight / MenuListBaseFontSize * style.fontDescription().computedSize())), LengthType::Fixed));
@@ -468,6 +503,11 @@ void RenderThemeIOS::adjustMenuListButtonStyle(RenderStyle& style, const Element
 
 void RenderThemeIOS::paintMenuListButtonDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintMenuListButtonDecorationsForCatalyst(box, paintInfo, rect))
+        return;
+#endif
+
     if (is<HTMLInputElement>(box.element()))
         return;
 
@@ -562,6 +602,11 @@ const int kDefaultSliderThumbSize = 16;
 
 void RenderThemeIOS::adjustSliderTrackStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustSliderTrackStyleForCatalyst(style, element))
+        return;
+#endif
+
     RenderTheme::adjustSliderTrackStyle(style, element);
 
     // FIXME: We should not be relying on border radius for the appearance of our controls <rdar://problem/7675493>.
@@ -573,6 +618,11 @@ constexpr auto nativeControlBorderInlineSize = 1.0f;
 
 bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintSliderTrackForCatalyst(box, paintInfo, rect))
+        return false;
+#endif
+
     auto* renderSlider = dynamicDowncast<RenderSlider>(box);
     if (!renderSlider)
         return true;
@@ -645,8 +695,15 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
     return false;
 }
 
-void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element*) const
+void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustSliderThumbSizeForCatalyst(style, element))
+        return;
+#else
+    UNUSED_PARAM(element);
+#endif
+
     if (style.usedAppearance() != StyleAppearance::SliderThumbHorizontal && style.usedAppearance() != StyleAppearance::SliderThumbVertical)
         return;
 
@@ -678,8 +735,15 @@ static bool renderThemePaintSwitchTrack(OptionSet<ControlStyle::State>, const Re
 }
 #endif
 
-void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element*) const
+void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustSwitchStyleForCatalyst(style, element))
+        return;
+#else
+    UNUSED_PARAM(element);
+#endif
+
     // FIXME: Deduplicate sizing with the generic code somehow.
     if (style.width().isAuto() || style.height().isAuto()) {
         style.setLogicalWidth({ logicalSwitchWidth * style.usedZoom(), LengthType::Fixed });
@@ -704,6 +768,11 @@ bool RenderThemeIOS::paintSwitchTrack(const RenderObject& renderer, const PaintI
 
 bool RenderThemeIOS::paintProgressBar(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintProgressBarForCatalyst(renderer, paintInfo, rect))
+        return false;
+#endif
+
     auto* renderProgress = dynamicDowncast<RenderProgress>(renderer);
     if (!renderProgress)
         return true;
@@ -806,6 +875,11 @@ int RenderThemeIOS::sliderTickOffsetFromTrackCenter() const
 
 void RenderThemeIOS::adjustSearchFieldStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustSearchFieldStyleForCatalyst(style, element))
+        return;
+#endif
+
     RenderTheme::adjustSearchFieldStyle(style, element);
 
     if (!element)
@@ -823,6 +897,11 @@ void RenderThemeIOS::adjustSearchFieldStyle(RenderStyle& style, const Element* e
 
 void RenderThemeIOS::paintSearchFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintSearchFieldDecorationsForCatalyst(box, paintInfo, rect))
+        return;
+#endif
+
     paintTextFieldDecorations(box, paintInfo, rect);
 }
 
@@ -870,6 +949,11 @@ void RenderThemeIOS::adjustButtonLikeControlStyle(RenderStyle& style, const Elem
 
 void RenderThemeIOS::adjustButtonStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustButtonStyleForCatalyst(style, element))
+        return;
+#endif
+
     // If no size is specified, ensure the height of the button matches ControlBaseHeight scaled
     // with the font size. min-height is used rather than height to avoid clipping the contents of
     // the button in cases where the button contains more than one line of text.
@@ -1458,6 +1542,11 @@ void RenderThemeIOS::paintCheckboxRadioInnerShadow(const PaintInfo& paintInfo, c
 
 bool RenderThemeIOS::paintCheckbox(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintCheckboxForCatalyst(box, paintInfo, rect))
+        return false;
+#endif
+
     bool isVision = PAL::currentUserInterfaceIdiomIsVision();
 
     auto& context = paintInfo.context();
@@ -1543,6 +1632,11 @@ bool RenderThemeIOS::paintCheckbox(const RenderObject& box, const PaintInfo& pai
 
 bool RenderThemeIOS::paintRadio(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintRadioForCatalyst(box, paintInfo, rect))
+        return false;
+#endif
+
     bool isVision = PAL::currentUserInterfaceIdiomIsVision();
 
     auto& context = paintInfo.context();
@@ -1600,6 +1694,11 @@ bool RenderThemeIOS::supportsMeter(StyleAppearance appearance) const
 
 bool RenderThemeIOS::paintMeter(const RenderObject& renderer, const PaintInfo& paintInfo, const IntRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintMeterForCatalyst(renderer, paintInfo, rect))
+        return false;
+#endif
+
     auto* renderMeter = dynamicDowncast<RenderMeter>(renderer);
     if (!renderMeter)
         return true;
@@ -1652,6 +1751,11 @@ bool RenderThemeIOS::paintMeter(const RenderObject& renderer, const PaintInfo& p
 
 bool RenderThemeIOS::paintListButton(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintListButtonForCatalyst(box, paintInfo, rect))
+        return false;
+#endif
+
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
@@ -1751,8 +1855,15 @@ void RenderThemeIOS::paintSliderTicks(const RenderObject& box, const PaintInfo& 
     }
 }
 
-void RenderThemeIOS::paintColorWellDecorations(const RenderObject&, const PaintInfo& paintInfo, const FloatRect& rect)
+void RenderThemeIOS::paintColorWellDecorations(const RenderObject& renderer, const PaintInfo& paintInfo, const FloatRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintColorWellDecorationsForCatalyst(renderer, paintInfo, rect))
+        return;
+#else
+    UNUSED_PARAM(renderer);
+#endif
+
     constexpr int strokeThickness = 3;
     constexpr std::array colorStops {
         DisplayP3<float> { 1, 1, 0, 1 },
@@ -1785,6 +1896,11 @@ void RenderThemeIOS::paintColorWellDecorations(const RenderObject&, const PaintI
 
 void RenderThemeIOS::adjustSearchFieldDecorationPartStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustSearchFieldDecorationPartStyleForCatalyst(style, element))
+        return;
+#endif
+
     if (!element)
         return;
 
@@ -1803,6 +1919,11 @@ void RenderThemeIOS::adjustSearchFieldDecorationPartStyle(RenderStyle& style, co
 
 bool RenderThemeIOS::paintSearchFieldDecorationPart(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintSearchFieldDecorationPartForCatalyst(box, paintInfo, rect))
+        return false;
+#endif
+
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
@@ -1842,21 +1963,41 @@ bool RenderThemeIOS::paintSearchFieldDecorationPart(const RenderObject& box, con
 
 void RenderThemeIOS::adjustSearchFieldResultsDecorationPartStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustSearchFieldResultsDecorationPartStyleForCatalyst(style, element))
+        return;
+#endif
+
     adjustSearchFieldDecorationPartStyle(style, element);
 }
 
 bool RenderThemeIOS::paintSearchFieldResultsDecorationPart(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintSearchFieldResultsDecorationPartForCatalyst(box, paintInfo, rect))
+        return false;
+#endif
+
     return paintSearchFieldDecorationPart(box, paintInfo, rect);
 }
 
 void RenderThemeIOS::adjustSearchFieldResultsButtonStyle(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (adjustSearchFieldResultsButtonStyleForCatalyst(style, element))
+        return;
+#endif
+
     adjustSearchFieldDecorationPartStyle(style, element);
 }
 
 bool RenderThemeIOS::paintSearchFieldResultsButton(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
 {
+#if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
+    if (paintSearchFieldResultsButtonForCatalyst(box, paintInfo, rect))
+        return false;
+#endif
+
     return paintSearchFieldDecorationPart(box, paintInfo, rect);
 }
 


### PR DESCRIPTION
#### dd00c36d9e5cd0e54d83d24021f71ff708e19da3
<pre>
Add infrastructure for Mac style form controls on Catalyst
<a href="https://bugs.webkit.org/show_bug.cgi?id=287304">https://bugs.webkit.org/show_bug.cgi?id=287304</a>
<a href="https://rdar.apple.com/144417595">rdar://144417595</a>

Reviewed by Aditya Keerthi.

Added codepaths which adjust controls on Catalyst when
possible.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustCheckboxStyle const):
(WebCore::RenderThemeIOS::adjustRadioStyle const):
(WebCore::RenderThemeIOS::adjustTextFieldStyle const):
(WebCore::RenderThemeIOS::paintTextFieldDecorations):
(WebCore::RenderThemeIOS::adjustTextAreaStyle const):
(WebCore::RenderThemeIOS::paintTextAreaDecorations):
(WebCore::RenderThemeIOS::adjustMenuListButtonStyle const):
(WebCore::RenderThemeIOS::paintMenuListButtonDecorations):
(WebCore::RenderThemeIOS::adjustSliderTrackStyle const):
(WebCore::RenderThemeIOS::paintSliderTrack):
(WebCore::RenderThemeIOS::adjustSliderThumbSize const):
(WebCore::RenderThemeIOS::adjustSwitchStyle const):
(WebCore::RenderThemeIOS::paintProgressBar):
(WebCore::RenderThemeIOS::sliderTickOffsetFromTrackCenter const):
(WebCore::RenderThemeIOS::adjustSearchFieldStyle const):
(WebCore::RenderThemeIOS::paintSearchFieldDecorations):
(WebCore::RenderThemeIOS::adjustButtonStyle const):
(WebCore::RenderThemeIOS::paintCheckbox):
(WebCore::RenderThemeIOS::paintRadio):
(WebCore::RenderThemeIOS::paintMeter):
(WebCore::RenderThemeIOS::paintListButton):
(WebCore::RenderThemeIOS::paintColorWellDecorations):
(WebCore::RenderThemeIOS::adjustSearchFieldDecorationPartStyle const):
(WebCore::RenderThemeIOS::paintSearchFieldDecorationPart):
(WebCore::RenderThemeIOS::adjustSearchFieldResultsDecorationPartStyle const):
(WebCore::RenderThemeIOS::paintSearchFieldResultsDecorationPart):
(WebCore::RenderThemeIOS::adjustSearchFieldResultsButtonStyle const):
(WebCore::RenderThemeIOS::paintSearchFieldResultsButton):

Canonical link: <a href="https://commits.webkit.org/290081@main">https://commits.webkit.org/290081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ef79ec75810530cf5c67fb97e84c33cfbcf317a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26175 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6716 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6469 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38772 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81703 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76832 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95715 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87680 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16084 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77376 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16340 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76664 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21043 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9150 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13929 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16098 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110173 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15839 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26445 "Found 5 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19290 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->