### PR TITLE
REGRESSION(288737@main): YouTube embed stays fully sized when exiting fullscreen from system control

### DIFF
--- a/LayoutTests/fullscreen/iframe-fullscreen-system-exit-expected.txt
+++ b/LayoutTests/fullscreen/iframe-fullscreen-system-exit-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test that WebFullScreenManagerProxy::RequestExitFullscreen works when fullscreen was initiated from an iframe
+

--- a/LayoutTests/fullscreen/iframe-fullscreen-system-exit.html
+++ b/LayoutTests/fullscreen/iframe-fullscreen-system-exit.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that WebFullScreenManagerProxy::RequestExitFullscreen works when fullscreen was initiated from an iframe</title>
+    <style>
+        ::backdrop {
+            background: red;
+        }
+    </style>
+</head>
+<body>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <script src="../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+    <script src="../imported/w3c/web-platform-tests/resources/testdriver-vendor.js"></script>
+    <script>
+        addEventListener("load", () => {
+            promise_test(async () => {
+                await new Promise(resolve => {
+                    test_driver.bless("fullscreen", () => { iframe.contentDocument.documentElement.requestFullscreen() }, iframe.contentWindow);
+                    iframe.contentDocument.documentElement.addEventListener("fullscreenchange", resolve);
+                });
+                assert_equals(document.fullscreenElement, iframe, "iframe is fullscreen");
+                assert_equals(iframe.contentDocument.fullscreenElement, iframe.contentDocument.documentElement, "iframe content is fullscreen");
+                await new Promise(resolve => {
+                    // Simulate clicking on the system fullscreen button.
+                    testRunner.requestExitFullscreenFromUIProcess();
+                    iframe.contentDocument.documentElement.addEventListener("fullscreenchange", resolve);
+                });
+                assert_equals(document.fullscreenElement, null, "iframe is no longer fullscreen");
+                assert_equals(iframe.contentDocument.fullscreenElement, null, "iframe content is no longer fullscreen");
+                assert_false(iframe.contentDocument.documentElement.matches(":fullscreen"));
+            });
+        });
+    </script>
+    <iframe allowfullscreen id="iframe" srcdoc="<button onclick='document.documentElement.requestFullscreen();'>Go fullscreen</button><p>This test passes if there is no red after exiting fullscreen from the system control.</p>"></iframe>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1039,6 +1039,9 @@ http/tests/local/blob/navigate-blob.html [ Skip ]
 # Not supported on WK1
 media/no-fullscreen-when-hidden.html [ Skip ]
 
+# Multi-process test
+fullscreen/iframe-fullscreen-system-exit.html [ Skip ]
+
 # The Trusted Types API is not supported in WebKit1.
 imported/w3c/web-platform-tests/trusted-types [ Skip ]
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -362,6 +362,8 @@ static void clearFullscreenFlags(Element& element)
     element.setFullscreenFlag(false);
     if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element))
         iframe->setIFrameFullscreenFlag(false);
+
+    element.document().fullscreenManager().updatePageFullscreenStatusIfTopDocument();
 }
 
 void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
@@ -388,7 +390,6 @@ void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
         queueFullscreenChangeEventForDocument(exitingDocument);
         clearFullscreenFlags(*element);
         element->removeFromTopLayer();
-        updatePageFullscreenStatusIfTopDocument();
     }
 
     m_pendingExitFullscreen = true;
@@ -485,8 +486,6 @@ void FullscreenManager::finishExitFullscreen(Document& currentDocument, ExitMode
         queueFullscreenChangeEventForDocument(descendantDocument);
         unfullscreenDocument(descendantDocument);
     }
-
-    updatePageFullscreenStatusIfTopDocument();
 }
 
 bool FullscreenManager::isFullscreenEnabled() const
@@ -571,12 +570,12 @@ bool FullscreenManager::willEnterFullscreen(Element& element, HTMLMediaElementEn
             ancestor->removeFromTopLayer();
         ancestor->addToTopLayer();
 
+        ancestor->document().fullscreenManager().updatePageFullscreenStatusIfTopDocument();
+
         queueFullscreenChangeEventForDocument(ancestor->document());
 
         RenderElement::markRendererDirtyAfterTopLayerChange(ancestor->checkedRenderer().get(), containingBlockBeforeStyleResolution.get());
     }
-
-    updatePageFullscreenStatusIfTopDocument();
 
     if (auto* iframe = dynamicDowncast<HTMLIFrameElement>(element))
         iframe->setIFrameFullscreenFlag(true);

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -93,6 +93,8 @@ public:
     void clear();
     void emptyEventQueue();
 
+    void updatePageFullscreenStatusIfTopDocument();
+
 protected:
     friend class Document;
 
@@ -111,8 +113,6 @@ private:
 
     Document* mainFrameDocument();
     RefPtr<Document> protectedMainFrameDocument();
-
-    void updatePageFullscreenStatusIfTopDocument();
 
     RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1265,6 +1265,15 @@ void WKPageDidExitFullScreen(WKPageRef pageRef)
 #endif
 }
 
+void WKPageRequestExitFullScreen(WKPageRef pageRef)
+{
+    CRASH_IF_SUSPENDED;
+#if ENABLE(FULLSCREEN_API)
+    if (RefPtr manager = toImpl(pageRef)->fullScreenManager())
+        manager->requestExitFullScreen();
+#endif
+}
+
 void WKPageSaveScrollPositionForFullScreen(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -235,6 +235,7 @@ WK_EXPORT void WKPageWillExitFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageDidExitFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageSaveScrollPositionForFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageRestoreScrollPositionAfterFullScreen(WKPageRef pageRef);
+WK_EXPORT void WKPageRequestExitFullScreen(WKPageRef pageRef);
 
 // A client can implement either a navigation client or loader and policy clients, but never both.
 WK_EXPORT void WKPageSetPageLoaderClient(WKPageRef page, const WKPageLoaderClientBase* client) WK_C_API_DEPRECATED_WITH_REPLACEMENT(WKPageSetPageNavigationClient, macos(10.14.4));

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -461,6 +461,7 @@ interface TestRunner {
 
     undefined waitBeforeFinishingFullscreenExit();
     undefined finishFullscreenExit();
+    undefined requestExitFullscreenFromUIProcess();
 
     Promise<undefined> setTopContentInset(double contentInset);
     Promise<undefined> setPageScaleFactor(unrestricted double scaleFactor, long x, long y);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2105,6 +2105,11 @@ void TestRunner::finishFullscreenExit()
     postPageMessage("FinishFullscreenExit");
 }
 
+void TestRunner::requestExitFullscreenFromUIProcess()
+{
+    postPageMessage("RequestExitFullscreenFromUIProcess");
+}
+
 void TestRunner::setPageScaleFactor(JSContextRef context, double scaleFactor, long x, long y, JSValueRef callback)
 {
     postMessageWithAsyncReply(context, "SetPageScaleFactor", createWKDictionary({

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -548,6 +548,7 @@ public:
     void updatePresentation(JSContextRef, JSValueRef callback);
     void waitBeforeFinishingFullscreenExit();
     void finishFullscreenExit();
+    void requestExitFullscreenFromUIProcess();
 
     // Reporting API
     void generateTestReport(JSContextRef, JSStringRef message, JSStringRef group);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -533,6 +533,11 @@ void TestController::finishFullscreenExit(WKPageRef page)
     WKPageRestoreScrollPositionAfterFullScreen(page);
 }
 
+void TestController::requestExitFullscreenFromUIProcess(WKPageRef page)
+{
+    WKPageRequestExitFullScreen(page);
+}
+
 PlatformWebView* TestController::createOtherPlatformWebView(PlatformWebView* parentView, WKPageConfigurationRef configuration, WKNavigationActionRef, WKWindowFeaturesRef)
 {
     RefPtr currentInvocation = m_currentInvocation;

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -199,6 +199,7 @@ public:
     void dumpFullScreenCallbacks() { m_dumpFullScreenCallbacks = true; }
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
     void finishFullscreenExit(WKPageRef);
+    void requestExitFullscreenFromUIProcess(WKPageRef);
 
     static bool willEnterFullScreen(WKPageRef, const void*);
     bool willEnterFullScreen(WKPageRef);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -712,6 +712,11 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "RequestExitFullscreenFromUIProcess")) {
+        TestController::singleton().requestExitFullscreenFromUIProcess(TestController::singleton().mainWebView()->page());
+        return;
+    }
+
     ASSERT_NOT_REACHED();
 }
 


### PR DESCRIPTION
#### daad2275a5d51c2c4bde7776c695e3b02bc3e623
<pre>
REGRESSION(288737@main): YouTube embed stays fully sized when exiting fullscreen from system control
<a href="https://bugs.webkit.org/show_bug.cgi?id=287309">https://bugs.webkit.org/show_bug.cgi?id=287309</a>
<a href="https://rdar.apple.com/144420790">rdar://144420790</a>

Reviewed by Darin Adler.

290048@main identified the correct issue with the code, but didn&apos;t call updatePageFullscreenStatusIfTopDocument() from the correct documents.

Add WebKitTestRunner helper to emulate exiting fullscreen from the UI Process to test this.

* LayoutTests/fullscreen/iframe-fullscreen-system-exit-expected.txt: Added.
* LayoutTests/fullscreen/iframe-fullscreen-system-exit.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::clearFullscreenFlags):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::finishExitFullscreen):
(WebCore::FullscreenManager::willEnterFullscreen):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageRequestExitFullScreen):
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::requestExitFullscreenFromUIProcess):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::requestExitFullscreenFromUIProcess):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/290177@main">https://commits.webkit.org/290177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ad8362bc3d7f2a7a381de9cb6dd2c93c9ce62e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68691 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26361 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6688 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35287 "Found 3 new test failures: editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77051 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36273 "Found 1 new test failure: fast/webgpu/regression/repro_284238.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11965 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77567 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21263 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19875 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9429 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16337 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21648 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16078 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19529 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->