### PR TITLE
[Gardening] [ iOS ] media/deactivate-audio-session.html is a constant timeout.

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2830,7 +2830,6 @@ http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies-ephe
 # Skipped in general expectations since they only work on iOS and Mac, WK2.
 http/tests/security/strip-referrer-to-origin-for-third-party-redirects-in-private-mode.html [ Pass ]
 http/tests/security/strip-referrer-to-origin-for-third-party-requests-in-private-mode.html [ Pass ]
-media/deactivate-audio-session.html [ Pass ]
 
 webkit.org/b/175273 imported/w3c/web-platform-tests/html/browsers/windows/noreferrer-window-name.html [ Failure ]
 
@@ -7693,3 +7692,5 @@ fast/forms/switch/pointer-tracking-there-and-back-again.html [ Timeout ]
 webkit.org/b/287204 [ Release ] fast/forms/date/date-input-rendering-basic.html [ Pass Failure ]
 
 webkit.org/b/287291 http/tests/site-isolation/selection-focus.html [ ImageOnlyFailure ]
+
+webkit.org/b/287308 media/deactivate-audio-session.html [ Timeout ]


### PR DESCRIPTION
#### 57e98ebc17f6a80393ad825bf9cb53b18710807b
<pre>
[Gardening][ iOS ] media/deactivate-audio-session.html is a constant timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287308">https://bugs.webkit.org/show_bug.cgi?id=287308</a>
<a href="https://rdar.apple.com/144420425">rdar://144420425</a>

Unreviewed test gardening.

Removing a test expectation for a now passing test.

* LayoutTests/platform/ios/TestExpectations:
</pre>