### PR TITLE
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in SpaceSplitString.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -79,7 +79,6 @@ dom/DocumentStorageAccess.cpp
 dom/ElementRareData.h
 dom/Node.cpp
 dom/NodeRareData.h
-dom/SpaceSplitString.h
 dom/UIEventWithKeyState.cpp
 dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
 domjit/DOMJITHelpers.h

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -89,14 +89,13 @@ private:
     ~SpaceSplitStringData() = default;
     static void destroy(SpaceSplitStringData*);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    std::span<AtomString> tokenArray() { return unsafeMakeSpan(reinterpret_cast<AtomString*>(this + 1), m_size); }
-    std::span<const AtomString> tokenArray() const { return unsafeMakeSpan(reinterpret_cast<const AtomString*>(this + 1), m_size); }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    std::span<AtomString> tokenArray() { return unsafeMakeSpan(m_tokens, m_size); }
+    std::span<const AtomString> tokenArray() const { return unsafeMakeSpan(m_tokens, m_size); }
 
     AtomString m_keyString;
     unsigned m_refCount;
     unsigned m_size;
+    AtomString m_tokens[0];
 };
 
 class SpaceSplitString {


### PR DESCRIPTION
#### c570b4a234cc80142d831c02721664d39d60cbcb
<pre>
Drop use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in SpaceSplitString.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=287311">https://bugs.webkit.org/show_bug.cgi?id=287311</a>

Reviewed by Geoffrey Garen.

Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in SpaceSplitString.h by introducing a
flexible array member to avoid pointer arithmetics.

This tested as performance neutral on the benchmarks we track.

* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitStringData::tokenArray):
(WebCore::SpaceSplitStringData::tokenArray const):

Canonical link: <a href="https://commits.webkit.org/290089@main">https://commits.webkit.org/290089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d703638abfd9b26cc95d4cdfa67302d044eeaabc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26208 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6762 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6511 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95766 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16135 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16391 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21088 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9216 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16149 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21460 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->