### PR TITLE
Address safer C++ static analysis warnings in FilterEffect

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -79,7 +79,6 @@ platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/TileController.h
 platform/graphics/controls/PlatformControl.h
 platform/graphics/cv/GraphicsContextGLCVCocoa.h
-platform/graphics/filters/FilterEffectApplier.h
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
 platform/graphics/filters/software/FELightingSoftwareApplier.h
 platform/graphics/filters/software/FEMorphologySoftwareApplier.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1166,13 +1166,11 @@ platform/graphics/controls/SwitchTrackPart.h
 platform/graphics/controls/TextAreaPart.h
 platform/graphics/controls/TextFieldPart.h
 platform/graphics/controls/ToggleButtonPart.h
-platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
 platform/graphics/coretext/ComplexTextControllerCoreText.mm
 platform/graphics/coretext/FontCascadeCoreText.cpp
 platform/graphics/cv/GraphicsContextGLCVCocoa.mm
 platform/graphics/displaylists/DisplayListItem.cpp
 platform/graphics/filters/FEDisplacementMap.cpp
-platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
 platform/graphics/filters/software/FELightingSoftwareApplier.cpp
 platform/graphics/filters/software/FELightingSoftwareApplierInlines.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -650,7 +650,6 @@ platform/graphics/displaylists/DisplayListItems.cpp
 platform/graphics/displaylists/DisplayListRecorder.cpp
 platform/graphics/displaylists/DisplayListRecorderImpl.cpp
 platform/graphics/displaylists/DisplayListResourceHeap.h
-platform/graphics/filters/FilterEffect.cpp
 platform/graphics/filters/FilterOperations.cpp
 platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
 platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp

--- a/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEColorMatrixCoreImageApplier.mm
@@ -62,10 +62,10 @@ bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector
     if (!inputImage)
         return false;
 
-    auto values = FEColorMatrix::normalizedFloats(m_effect.values());
+    auto values = FEColorMatrix::normalizedFloats(m_effect->values());
     std::array<float, 9> components;
 
-    switch (m_effect.type()) {
+    switch (m_effect->type()) {
     case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
         FEColorMatrix::calculateSaturateComponents(components, values[0]);
         break;
@@ -85,7 +85,7 @@ bool FEColorMatrixCoreImageApplier::apply(const Filter&, const FilterImageVector
     auto *colorMatrixFilter = [CIFilter filterWithName:@"CIColorMatrix"];
     [colorMatrixFilter setValue:inputImage.get() forKey:kCIInputImageKey];
 
-    switch (m_effect.type()) {
+    switch (m_effect->type()) {
     case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
     case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
         [colorMatrixFilter setValue:[CIVector vectorWithX:components[0] Y:components[1] Z:components[2] W:0] forKey:@"inputRVector"];

--- a/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
@@ -75,10 +75,10 @@ bool FEComponentTransferCoreImageApplier::apply(const Filter&, const FilterImage
             [componentTransferFilter setValue:[CIVector vectorWithX:function.intercept Y:function.slope Z:0 W:0] forKey:key];
     };
 
-    setCoefficients(@"inputRedCoefficients", m_effect.redFunction());
-    setCoefficients(@"inputGreenCoefficients", m_effect.greenFunction());
-    setCoefficients(@"inputBlueCoefficients", m_effect.blueFunction());
-    setCoefficients(@"inputAlphaCoefficients", m_effect.alphaFunction());
+    setCoefficients(@"inputRedCoefficients", m_effect->redFunction());
+    setCoefficients(@"inputGreenCoefficients", m_effect->greenFunction());
+    setCoefficients(@"inputBlueCoefficients", m_effect->blueFunction());
+    setCoefficients(@"inputAlphaCoefficients", m_effect->alphaFunction());
 
     result.setCIImage(componentTransferFilter.outputImage);
     return true;

--- a/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.h
+++ b/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.h
@@ -28,11 +28,10 @@
 #if USE(CORE_IMAGE)
 
 #import "FilterEffectApplier.h"
+#import "SourceGraphic.h"
 #import <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-
-class SourceGraphic;
 
 class SourceGraphicCoreImageApplier final : public FilterEffectConcreteApplier<SourceGraphic> {
     WTF_MAKE_TZONE_ALLOCATED(SourceGraphicCoreImageApplier);

--- a/Source/WebCore/platform/graphics/filters/FEBlend.h
+++ b/Source/WebCore/platform/graphics/filters/FEBlend.h
@@ -28,7 +28,9 @@
 
 namespace WebCore {
 
-class FEBlend : public FilterEffect {
+class FEBlend final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEBlend);
 public:
     WEBCORE_EXPORT static Ref<FEBlend> create(BlendMode, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -35,7 +35,9 @@ enum class ColorMatrixType : uint8_t {
     FECOLORMATRIX_TYPE_LUMINANCETOALPHA = 4
 };
 
-class FEColorMatrix : public FilterEffect {
+class FEColorMatrix final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEColorMatrix);
 public:
     WEBCORE_EXPORT static Ref<FEColorMatrix> create(ColorMatrixType, Vector<float>&&, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -59,7 +59,9 @@ namespace WebCore {
 
 using ComponentTransferFunctions = EnumeratedArray<ComponentTransferChannel, ComponentTransferFunction, ComponentTransferChannel::Alpha>;
 
-class FEComponentTransfer : public FilterEffect {
+class FEComponentTransfer final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEComponentTransfer);
 public:
     WEBCORE_EXPORT static Ref<FEComponentTransfer> create(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc, DestinationColorSpace = DestinationColorSpace::SRGB());
     static Ref<FEComponentTransfer> create(ComponentTransferFunctions&&);

--- a/Source/WebCore/platform/graphics/filters/FEComposite.h
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.h
@@ -38,7 +38,9 @@ enum class CompositeOperationType : uint8_t {
     FECOMPOSITE_OPERATOR_LIGHTER    = 7
 };
 
-class FEComposite : public FilterEffect {
+class FEComposite final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEComposite);
 public:
     WEBCORE_EXPORT static Ref<FEComposite> create(const CompositeOperationType&, float k1, float k2, float k3, float k4, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
@@ -36,7 +36,9 @@ enum class EdgeModeType : uint8_t {
     None
 };
 
-class FEConvolveMatrix : public FilterEffect {
+class FEConvolveMatrix final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEConvolveMatrix);
 public:
     WEBCORE_EXPORT static Ref<FEConvolveMatrix> create(const IntSize& kernelSize, float divisor, float bias, const IntPoint& targetOffset, EdgeModeType, const FloatPoint& kernelUnitLength, bool preserveAlpha, const Vector<float>& kernelMatrix, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h
+++ b/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h
@@ -28,7 +28,9 @@ namespace WebCore {
 
 class LightSource;
 
-class FEDiffuseLighting : public FELighting {
+class FEDiffuseLighting final : public FELighting {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEDiffuseLighting);
 public:
     WEBCORE_EXPORT static Ref<FEDiffuseLighting> create(const Color& lightingColor, float surfaceScale, float diffuseConstant, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
@@ -35,7 +35,9 @@ enum class ChannelSelectorType : uint8_t {
     CHANNEL_A = 4
 };
 
-class FEDisplacementMap : public FilterEffect {
+class FEDisplacementMap final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEDisplacementMap);
 public:
     WEBCORE_EXPORT static Ref<FEDisplacementMap> create(ChannelSelectorType xChannelSelector, ChannelSelectorType yChannelSelector, float scale, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.h
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.h
@@ -25,7 +25,9 @@
 
 namespace WebCore {
     
-class FEDropShadow : public FilterEffect {
+class FEDropShadow final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEDropShadow);
 public:
     WEBCORE_EXPORT static Ref<FEDropShadow> create(float stdX, float stdY, float dx, float dy, const Color& shadowColor, float shadowOpacity, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEFlood.h
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.h
@@ -27,7 +27,9 @@
 
 namespace WebCore {
 
-class FEFlood : public FilterEffect {
+class FEFlood final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEFlood);
 public:
     WEBCORE_EXPORT static Ref<FEFlood> create(const Color& floodColor, float floodOpacity, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -27,7 +27,9 @@
 
 namespace WebCore {
 
-class FEGaussianBlur : public FilterEffect {
+class FEGaussianBlur final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEGaussianBlur);
 public:
     WEBCORE_EXPORT static Ref<FEGaussianBlur> create(float x, float y, EdgeModeType, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEImage.h
+++ b/Source/WebCore/platform/graphics/filters/FEImage.h
@@ -35,6 +35,8 @@ class Image;
 class ImageBuffer;
 
 class FEImage final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEImage);
 public:
     WEBCORE_EXPORT static Ref<FEImage> create(SourceImage&&, const FloatRect& sourceImageRect, const SVGPreserveAspectRatioValue&);
 

--- a/Source/WebCore/platform/graphics/filters/FELighting.h
+++ b/Source/WebCore/platform/graphics/filters/FELighting.h
@@ -38,6 +38,8 @@ namespace WebCore {
 struct FELightingPaintingDataForNeon;
 
 class FELighting : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FELighting);
 public:
     bool operator==(const FELighting&) const;
 

--- a/Source/WebCore/platform/graphics/filters/FEMerge.h
+++ b/Source/WebCore/platform/graphics/filters/FEMerge.h
@@ -26,7 +26,9 @@
 
 namespace WebCore {
 
-class FEMerge : public FilterEffect {
+class FEMerge final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEMerge);
 public:
     WEBCORE_EXPORT static Ref<FEMerge> create(unsigned numberOfEffectInputs, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.h
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.h
@@ -32,7 +32,9 @@ enum class MorphologyOperatorType : uint8_t {
     Dilate
 };
 
-class FEMorphology : public FilterEffect {
+class FEMorphology final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEMorphology);
 public:
     WEBCORE_EXPORT static Ref<FEMorphology> create(MorphologyOperatorType, float radiusX, float radiusY, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FEOffset.h
+++ b/Source/WebCore/platform/graphics/filters/FEOffset.h
@@ -26,7 +26,9 @@
 
 namespace WebCore {
 
-class FEOffset : public FilterEffect {
+class FEOffset final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEOffset);
 public:
     WEBCORE_EXPORT static Ref<FEOffset> create(float dx, float dy, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FESpecularLighting.h
+++ b/Source/WebCore/platform/graphics/filters/FESpecularLighting.h
@@ -26,7 +26,9 @@
 
 namespace WebCore {
 
-class FESpecularLighting : public FELighting {
+class FESpecularLighting final : public FELighting {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FESpecularLighting);
 public:
     WEBCORE_EXPORT static Ref<FESpecularLighting> create(const Color& lightingColor, float surfaceScale, float specularConstant, float specularExponent, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FETile.h
+++ b/Source/WebCore/platform/graphics/filters/FETile.h
@@ -26,7 +26,9 @@
 
 namespace WebCore {
     
-class FETile : public FilterEffect {
+class FETile final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FETile);
 public:
     WEBCORE_EXPORT static Ref<FETile> create(DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FETurbulence.h
+++ b/Source/WebCore/platform/graphics/filters/FETurbulence.h
@@ -35,7 +35,9 @@ enum class TurbulenceType : uint8_t {
     Turbulence
 };
 
-class FETurbulence : public FilterEffect {
+class FETurbulence final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FETurbulence);
 public:
     WEBCORE_EXPORT static Ref<FETurbulence> create(TurbulenceType, float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, bool stitchTiles, DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -149,7 +149,7 @@ RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, const FilterImageV
 {
     ASSERT(inputs.size() == numberOfImageInputs());
 
-    if (auto result = results.effectResult(*this))
+    if (RefPtr result = results.effectResult(*this))
         return result;
 
     auto primitiveSubregion = calculatePrimitiveSubregion(filter, inputPrimitiveSubregions(inputs), geometry);

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.h
@@ -26,6 +26,7 @@
 #include "FilterEffectApplier.h"
 #include "FilterFunction.h"
 #include "FilterImageVector.h"
+#include <wtf/CheckedPtr.h>
 
 namespace WTF {
 class TextStream;
@@ -37,9 +38,10 @@ class Filter;
 class FilterEffectGeometry;
 class FilterResults;
 
-class FilterEffect : public FilterFunction {
+class FilterEffect : public FilterFunction, public CanMakeCheckedPtr<FilterEffect> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FilterEffect);
     using FilterFunction::apply;
-
 public:
     virtual bool operator==(const FilterEffect&) const;
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffectApplier.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffectApplier.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "FilterImageVector.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -54,7 +55,7 @@ public:
     }
     
 protected:
-    const FilterEffectType& m_effect;
+    const CheckedRef<const FilterEffectType> m_effect;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/SourceAlpha.h
+++ b/Source/WebCore/platform/graphics/filters/SourceAlpha.h
@@ -24,7 +24,9 @@
 
 namespace WebCore {
 
-class SourceAlpha : public FilterEffect {
+class SourceAlpha final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SourceAlpha);
 public:
     WEBCORE_EXPORT static Ref<SourceAlpha> create(const DestinationColorSpace& = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/SourceGraphic.h
+++ b/Source/WebCore/platform/graphics/filters/SourceGraphic.h
@@ -25,7 +25,9 @@
 
 namespace WebCore {
 
-class SourceGraphic : public FilterEffect {
+class SourceGraphic final : public FilterEffect {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SourceGraphic);
 public:        
     WEBCORE_EXPORT static Ref<SourceGraphic> create(DestinationColorSpace = DestinationColorSpace::SRGB());
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
@@ -57,12 +57,12 @@ bool FEColorMatrixSkiaApplier::apply(const Filter&, const FilterImageVector& inp
     if (!nativeImage || !nativeImage->platformImage())
         return false;
 
-    auto values = FEColorMatrix::normalizedFloats(m_effect.values());
+    auto values = FEColorMatrix::normalizedFloats(m_effect->values());
     Vector<float> matrix;
 
     std::array<float, 9> components;
 
-    switch (m_effect.type()) {
+    switch (m_effect->type()) {
     case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
         matrix = values;
         break;

--- a/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
@@ -57,10 +57,10 @@ bool FEComponentTransferSkiaApplier::apply(const Filter&, const FilterImageVecto
     if (!nativeImage || !nativeImage->platformImage())
         return false;
 
-    auto alphaTable = m_effect.computeLookupTable(m_effect.alphaFunction());
-    auto redTable = m_effect.computeLookupTable(m_effect.redFunction());
-    auto greenTable = m_effect.computeLookupTable(m_effect.greenFunction());
-    auto blueTable = m_effect.computeLookupTable(m_effect.blueFunction());
+    auto alphaTable = m_effect->computeLookupTable(m_effect->alphaFunction());
+    auto redTable = m_effect->computeLookupTable(m_effect->redFunction());
+    auto greenTable = m_effect->computeLookupTable(m_effect->greenFunction());
+    auto blueTable = m_effect->computeLookupTable(m_effect->blueFunction());
 
     SkPaint paint;
     paint.setColorFilter(SkColorFilters::TableARGB(alphaTable.data(), redTable.data(), greenTable.data(), blueTable.data()));

--- a/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
@@ -58,12 +58,12 @@ bool FEDropShadowSkiaApplier::apply(const Filter& filter, const FilterImageVecto
     if (!nativeImage || !nativeImage->platformImage())
         return false;
 
-    auto offset = filter.scaledByFilterScale(filter.resolvedSize({ m_effect.dx(), m_effect.dy() }));
-    auto sigma = filter.scaledByFilterScale(filter.resolvedSize({ m_effect.stdDeviationX(), m_effect.stdDeviationY() }));
+    auto offset = filter.scaledByFilterScale(filter.resolvedSize({ m_effect->dx(), m_effect->dy() }));
+    auto sigma = filter.scaledByFilterScale(filter.resolvedSize({ m_effect->stdDeviationX(), m_effect->stdDeviationY() }));
 
     SkPaint paint;
 
-    auto shadowColorWithAlpha = m_effect.shadowColor().colorWithAlphaMultipliedBy(m_effect.shadowOpacity());
+    auto shadowColorWithAlpha = m_effect->shadowColor().colorWithAlphaMultipliedBy(m_effect->shadowOpacity());
     paint.setImageFilter(SkImageFilters::DropShadow(offset.width(), offset.height(), sigma.width(), sigma.height(), shadowColorWithAlpha, nullptr));
 
     auto inputOffsetWithinResult = input.absoluteImageRectRelativeTo(result).location();

--- a/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
@@ -57,7 +57,7 @@ bool FEGaussianBlurSkiaApplier::apply(const Filter& filter, const FilterImageVec
     if (!nativeImage || !nativeImage->platformImage())
         return false;
 
-    FloatSize sigma = FloatSize(m_effect.stdDeviationX(), m_effect.stdDeviationY()) * filter.filterScale();
+    FloatSize sigma = FloatSize(m_effect->stdDeviationX(), m_effect->stdDeviationY()) * filter.filterScale();
 
     SkPaint paint;
     paint.setImageFilter(SkImageFilters::Blur(sigma.width(), sigma.height(), nullptr));

--- a/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.h
@@ -28,11 +28,10 @@
 #if USE(SKIA)
 
 #include "FilterEffectApplier.h"
+#include "SourceGraphic.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-
-class SourceGraphic;
 
 class SourceGraphicSkiaApplier final : public FilterEffectConcreteApplier<SourceGraphic> {
     WTF_MAKE_TZONE_ALLOCATED(SourceGraphicSkiaApplier);

--- a/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
@@ -57,7 +57,7 @@ bool FEBlendSoftwareApplier::apply(const Filter&, const FilterImageVector& input
     auto inputImageRect2 = input2.absoluteImageRectRelativeTo(result);
 
     filterContext.drawImageBuffer(*inputImage2, inputImageRect2);
-    filterContext.drawImageBuffer(*inputImage, inputImageRect, { { }, inputImage->logicalSize() }, { CompositeOperator::SourceOver, m_effect.blendMode() });
+    filterContext.drawImageBuffer(*inputImage, inputImageRect, { { }, inputImage->logicalSize() }, { CompositeOperator::SourceOver, m_effect->blendMode() });
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -42,10 +42,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FEColorMatrixSoftwareApplier);
 FEColorMatrixSoftwareApplier::FEColorMatrixSoftwareApplier(const FEColorMatrix& effect)
     : Base(effect)
 {
-    if (m_effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE)
-        FEColorMatrix::calculateSaturateComponents(m_components, m_effect.values()[0]);
-    else if (m_effect.type() == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE)
-        FEColorMatrix::calculateHueRotateComponents(m_components, m_effect.values()[0]);
+    if (m_effect->type() == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE)
+        FEColorMatrix::calculateSaturateComponents(m_components, m_effect->values()[0]);
+    else if (m_effect->type() == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE)
+        FEColorMatrix::calculateHueRotateComponents(m_components, m_effect->values()[0]);
 }
 
 inline void FEColorMatrixSoftwareApplier::matrix(float& red, float& green, float& blue, float& alpha) const
@@ -55,7 +55,7 @@ inline void FEColorMatrixSoftwareApplier::matrix(float& red, float& green, float
     float b = blue;
     float a = alpha;
 
-    const auto& values = m_effect.values();
+    const auto& values = m_effect->values();
 
     red   = values[ 0] * r + values[ 1] * g + values[ 2] * b + values[ 3] * a + values[ 4] * 255;
     green = values[ 5] * r + values[ 6] * g + values[ 7] * b + values[ 8] * a + values[ 9] * 255;
@@ -102,12 +102,12 @@ void FEColorMatrixSoftwareApplier::applyPlatformAccelerated(PixelBuffer& pixelBu
     dest.rowBytes = bufferSize.width() * 4;
     dest.data = pixelBytes;
 
-    switch (m_effect.type()) {
+    switch (m_effect->type()) {
     case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
         break;
 
     case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX: {
-        const auto& values = m_effect.values();
+        const auto& values = m_effect->values();
 
         const int16_t matrix[4 * 4] = {
             static_cast<int16_t>(roundf(values[ 0] * divisor)),
@@ -193,7 +193,7 @@ void FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated(PixelBuffer& pixel
 {
     auto pixelByteLength = pixelBuffer.bytes().size();
 
-    switch (m_effect.type()) {
+    switch (m_effect->type()) {
     case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
         break;
 
@@ -245,11 +245,11 @@ void FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated(PixelBuffer& pixel
 void FEColorMatrixSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
 {
 #if USE(ACCELERATE)
-    const auto& values = m_effect.values();
+    const auto& values = m_effect->values();
 
     // vImageMatrixMultiply_ARGB8888 takes a 4x4 matrix, if any value in the last column of the FEColorMatrix 5x4 matrix
     // is not zero, fall back to non-vImage code.
-    if (m_effect.type() != ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX || (!values[4] && !values[9] && !values[14] && !values[19])) {
+    if (m_effect->type() != ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX || (!values[4] && !values[9] && !values[14] && !values[19])) {
         applyPlatformAccelerated(pixelBuffer);
         return;
     }

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -42,10 +42,10 @@ void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer)
     auto data = pixelBuffer.bytes();
     auto pixelByteLength = pixelBuffer.bytes().size();
 
-    auto redTable   = FEComponentTransfer::computeLookupTable(m_effect.redFunction());
-    auto greenTable = FEComponentTransfer::computeLookupTable(m_effect.greenFunction());
-    auto blueTable  = FEComponentTransfer::computeLookupTable(m_effect.blueFunction());
-    auto alphaTable = FEComponentTransfer::computeLookupTable(m_effect.alphaFunction());
+    auto redTable   = FEComponentTransfer::computeLookupTable(m_effect->redFunction());
+    auto greenTable = FEComponentTransfer::computeLookupTable(m_effect->greenFunction());
+    auto blueTable  = FEComponentTransfer::computeLookupTable(m_effect->blueFunction());
+    auto alphaTable = FEComponentTransfer::computeLookupTable(m_effect->alphaFunction());
 
     for (unsigned pixelOffset = 0; pixelOffset < pixelByteLength; pixelOffset += 4) {
         data[pixelOffset]     = redTable[data[pixelOffset]];

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FECompositeSoftwareApplier);
 FECompositeSoftwareApplier::FECompositeSoftwareApplier(const FEComposite& effect)
     : Base(effect)
 {
-    ASSERT(m_effect.operation() != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
+    ASSERT(m_effect->operation() != CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
 }
 
 bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
@@ -60,7 +60,7 @@ bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& i
     auto inputImageRect = input.absoluteImageRectRelativeTo(result);
     auto inputImageRect2 = input2.absoluteImageRectRelativeTo(result);
 
-    switch (m_effect.operation()) {
+    switch (m_effect->operation()) {
     case CompositeOperationType::FECOMPOSITE_OPERATOR_UNKNOWN:
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FECompositeSoftwareArithmeticApplier);
 FECompositeSoftwareArithmeticApplier::FECompositeSoftwareArithmeticApplier(const FEComposite& effect)
     : Base(effect)
 {
-    ASSERT(m_effect.operation() == CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
+    ASSERT(m_effect->operation() == CompositeOperationType::FECOMPOSITE_OPERATOR_ARITHMETIC);
 }
 
 uint8_t FECompositeSoftwareArithmeticApplier::clampByte(int c)
@@ -141,7 +141,7 @@ bool FECompositeSoftwareArithmeticApplier::apply(const Filter&, const FilterImag
         return false;
 
     IntRect effectADrawingRect = result.absoluteImageRectRelativeTo(input);
-    auto sourcePixelBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectADrawingRect, m_effect.operatingColorSpace());
+    auto sourcePixelBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectADrawingRect, m_effect->operatingColorSpace());
     if (!sourcePixelBuffer)
         return false;
 
@@ -154,7 +154,7 @@ bool FECompositeSoftwareArithmeticApplier::apply(const Filter&, const FilterImag
     auto length = sourcePixelBuffer->bytes().size();
     ASSERT(length == destinationPixelBuffer->bytes().size());
 
-    applyPlatform(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
+    applyPlatform(sourcePixelBytes, destinationPixelBytes, length, m_effect->k1(), m_effect->k2(), m_effect->k3(), m_effect->k4());
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
@@ -96,7 +96,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FEConvolveMatrixSoftwareApplier);
 FEConvolveMatrixSoftwareApplier::FEConvolveMatrixSoftwareApplier(const FEConvolveMatrix& effect)
     : Base(effect)
 {
-    ASSERT(IntRect(IntPoint::zero(), m_effect.kernelSize()).contains(m_effect.targetOffset()));
+    ASSERT(IntRect(IntPoint::zero(), m_effect->kernelSize()).contains(m_effect->targetOffset()));
 }
 
 inline uint8_t FEConvolveMatrixSoftwareApplier::clampRGBAValue(float channel, uint8_t max)
@@ -306,13 +306,13 @@ bool FEConvolveMatrixSoftwareApplier::apply(const Filter&, const FilterImageVect
 {
     auto& input = inputs[0].get();
 
-    auto alphaFormat = m_effect.preserveAlpha() ? AlphaPremultiplication::Unpremultiplied : AlphaPremultiplication::Premultiplied;
+    auto alphaFormat = m_effect->preserveAlpha() ? AlphaPremultiplication::Unpremultiplied : AlphaPremultiplication::Premultiplied;
     auto destinationPixelBuffer = result.pixelBuffer(alphaFormat);
     if (!destinationPixelBuffer)
         return false;
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
-    auto sourcePixelBuffer = input.getPixelBuffer(alphaFormat, effectDrawingRect, m_effect.operatingColorSpace());
+    auto sourcePixelBuffer = input.getPixelBuffer(alphaFormat, effectDrawingRect, m_effect->operatingColorSpace());
     if (!sourcePixelBuffer)
         return false;
 
@@ -323,13 +323,13 @@ bool FEConvolveMatrixSoftwareApplier::apply(const Filter&, const FilterImageVect
         *destinationPixelBuffer,
         paintSize.width(),
         paintSize.height(),
-        m_effect.kernelSize(),
-        m_effect.divisor(),
-        m_effect.bias() * 255,
-        m_effect.targetOffset(),
-        m_effect.edgeMode(),
-        m_effect.preserveAlpha(),
-        FEColorMatrix::normalizedFloats(m_effect.kernel())
+        m_effect->kernelSize(),
+        m_effect->divisor(),
+        m_effect->bias() * 255,
+        m_effect->targetOffset(),
+        m_effect->edgeMode(),
+        m_effect->preserveAlpha(),
+        FEColorMatrix::normalizedFloats(m_effect->kernel())
     };
 
     applyPlatform(paintingData);

--- a/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
@@ -39,18 +39,18 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FEDisplacementMapSoftwareApplier);
 FEDisplacementMapSoftwareApplier::FEDisplacementMapSoftwareApplier(const FEDisplacementMap& effect)
     : Base(effect)
 {
-    ASSERT(m_effect.xChannelSelector() != ChannelSelectorType::CHANNEL_UNKNOWN);
-    ASSERT(m_effect.yChannelSelector() != ChannelSelectorType::CHANNEL_UNKNOWN);
+    ASSERT(m_effect->xChannelSelector() != ChannelSelectorType::CHANNEL_UNKNOWN);
+    ASSERT(m_effect->yChannelSelector() != ChannelSelectorType::CHANNEL_UNKNOWN);
 }
 
 int FEDisplacementMapSoftwareApplier::xChannelIndex() const
 {
-    return static_cast<int>(m_effect.xChannelSelector()) - 1;
+    return static_cast<int>(m_effect->xChannelSelector()) - 1;
 }
 
 int FEDisplacementMapSoftwareApplier::yChannelIndex() const
 {
-    return static_cast<int>(m_effect.yChannelSelector()) - 1;
+    return static_cast<int>(m_effect->yChannelSelector()) - 1;
 }
 
 bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
@@ -75,7 +75,7 @@ bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterI
     ASSERT(inputPixelBuffer->bytes().size() == displacementPixelBuffer->bytes().size());
 
     auto paintSize = result.absoluteImageRect().size();
-    auto scale = filter.resolvedSize({ m_effect.scale(), m_effect.scale() });
+    auto scale = filter.resolvedSize({ m_effect->scale(), m_effect->scale() });
     auto absoluteScale = filter.scaledByFilterScale(scale);
 
     float scaleForColorX = absoluteScale.width() / 255.0;

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
@@ -41,10 +41,10 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageV
     if (!resultImage)
         return false;
 
-    auto stdDeviation = filter.resolvedSize({ m_effect.stdDeviationX(), m_effect.stdDeviationY() });
+    auto stdDeviation = filter.resolvedSize({ m_effect->stdDeviationX(), m_effect->stdDeviationY() });
     auto blurRadius = 2 * filter.scaledByFilterScale(stdDeviation);
     
-    auto offset = filter.resolvedSize({ m_effect.dx(), m_effect.dy() });
+    auto offset = filter.resolvedSize({ m_effect->dx(), m_effect->dy() });
     auto absoluteOffset = filter.scaledByFilterScale(offset);
 
     FloatRect inputImageRect = input.absoluteImageRectRelativeTo(result);
@@ -56,11 +56,11 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageV
         return false;
 
     auto& resultContext = resultImage->context();
-    resultContext.setAlpha(m_effect.shadowOpacity());
+    resultContext.setAlpha(m_effect->shadowOpacity());
     resultContext.drawImageBuffer(*inputImage, inputImageRectWithOffset);
     resultContext.setAlpha(1);
 
-    ShadowBlur contextShadow(blurRadius, absoluteOffset, m_effect.shadowColor());
+    ShadowBlur contextShadow(blurRadius, absoluteOffset, m_effect->shadowColor());
 
     PixelBufferFormat format { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, result.colorSpace() };
     IntRect shadowArea(IntPoint(), resultImage->truncatedLogicalSize());
@@ -73,7 +73,7 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageV
     resultImage->putPixelBuffer(*pixelBuffer, shadowArea);
 
     resultContext.setCompositeOperation(CompositeOperator::SourceIn);
-    resultContext.fillRect(FloatRect(FloatPoint(), result.absoluteImageRect().size()), m_effect.shadowColor());
+    resultContext.fillRect(FloatRect(FloatPoint(), result.absoluteImageRect().size()), m_effect->shadowColor());
     resultContext.setCompositeOperation(CompositeOperator::DestinationOver);
 
     resultImage->context().drawImageBuffer(*inputImage, inputImageRect);

--- a/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.cpp
@@ -39,7 +39,7 @@ bool FEFloodSoftwareApplier::apply(const Filter&, const FilterImageVector&, Filt
     if (!resultImage)
         return false;
 
-    auto color = m_effect.floodColor().colorWithAlphaMultipliedBy(m_effect.floodOpacity());
+    auto color = m_effect->floodColor().colorWithAlphaMultipliedBy(m_effect->floodOpacity());
     resultImage->context().fillRect(FloatRect(FloatPoint(), result.absoluteImageRect().size()), color);
 
     return true;

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -440,17 +440,17 @@ bool FEGaussianBlurSoftwareApplier::apply(const Filter& filter, const FilterImag
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
     input.copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
-    if (!m_effect.stdDeviationX() && !m_effect.stdDeviationY())
+    if (!m_effect->stdDeviationX() && !m_effect->stdDeviationY())
         return true;
 
-    auto kernelSize = m_effect.calculateKernelSize(filter, { m_effect.stdDeviationX(), m_effect.stdDeviationY() });
+    auto kernelSize = m_effect->calculateKernelSize(filter, { m_effect->stdDeviationX(), m_effect->stdDeviationY() });
 
     IntSize paintSize = result.absoluteImageRect().size();
     auto tempBuffer = destinationPixelBuffer->createScratchPixelBuffer(paintSize);
     if (!tempBuffer)
         return false;
 
-    applyPlatform(*destinationPixelBuffer, *tempBuffer, kernelSize.width(), kernelSize.height(), paintSize, result.isAlphaImage(), m_effect.edgeMode());
+    applyPlatform(*destinationPixelBuffer, *tempBuffer, kernelSize.width(), kernelSize.height(), paintSize, result.isAlphaImage(), m_effect->edgeMode());
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
@@ -41,14 +41,14 @@ bool FEImageSoftwareApplier::apply(const Filter& filter, const FilterImageVector
     if (!resultImage)
         return false;
 
-    auto& sourceImage = m_effect.sourceImage();
+    auto& sourceImage = m_effect->sourceImage();
     auto primitiveSubregion = result.primitiveSubregion();
     auto& context = resultImage->context();
 
     if (auto nativeImage = sourceImage.nativeImageIfExists()) {
         auto imageRect = primitiveSubregion;
-        auto srcRect = m_effect.sourceImageRect();
-        m_effect.preserveAspectRatio().transformRect(imageRect, srcRect);
+        auto srcRect = m_effect->sourceImageRect();
+        m_effect->preserveAspectRatio().transformRect(imageRect, srcRect);
         imageRect.scale(filter.filterScale());
         imageRect = IntRect(imageRect) - result.absoluteImageRect().location();
         context.drawNativeImage(*nativeImage, imageRect, srcRect);
@@ -57,7 +57,7 @@ bool FEImageSoftwareApplier::apply(const Filter& filter, const FilterImageVector
 
     if (auto imageBuffer = sourceImage.imageBufferIfExists()) {
         auto imageRect = primitiveSubregion;
-        imageRect.moveBy(m_effect.sourceImageRect().location());
+        imageRect.moveBy(m_effect->sourceImageRect().location());
         imageRect.scale(filter.filterScale());
         imageRect = IntRect(imageRect) - result.absoluteImageRect().location();
         context.drawImageBuffer(*imageBuffer, imageRect.location());

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -197,14 +197,14 @@ bool FELightingSoftwareApplier::apply(const Filter& filter, const FilterImageVec
     LightingData data;
     data.filter = &filter;
     data.result = &result;
-    data.filterType = m_effect.filterType();
-    data.lightingColor = m_effect.lightingColor();
-    data.surfaceScale = m_effect.surfaceScale() / 255.0f;
-    data.diffuseConstant = m_effect.diffuseConstant();
-    data.specularConstant = m_effect.specularConstant();
-    data.specularExponent = m_effect.specularExponent();
-    data.lightSource = m_effect.lightSource().ptr();
-    data.operatingColorSpace = &m_effect.operatingColorSpace();
+    data.filterType = m_effect->filterType();
+    data.lightingColor = m_effect->lightingColor();
+    data.surfaceScale = m_effect->surfaceScale() / 255.0f;
+    data.diffuseConstant = m_effect->diffuseConstant();
+    data.specularConstant = m_effect->specularConstant();
+    data.specularExponent = m_effect->specularExponent();
+    data.lightSource = m_effect->lightSource().ptr();
+    data.operatingColorSpace = &m_effect->operatingColorSpace();
 
     data.pixels = destinationPixelBuffer;
     data.widthMultipliedByPixelSize = size.width() * cPixelSize;

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "Color.h"
+#include "FELighting.h"
 #include "FilterEffect.h"
 #include "FilterEffectApplier.h"
 #include "FilterImageVector.h"
@@ -35,8 +36,6 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-
-class FELighting;
 
 class FELightingSoftwareApplier : public FilterEffectConcreteApplier<FELighting> {
     WTF_MAKE_TZONE_ALLOCATED(FELightingSoftwareApplier);

--- a/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
@@ -34,7 +34,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FEMergeSoftwareApplier);
 
 bool FEMergeSoftwareApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
 {
-    ASSERT(inputs.size() == m_effect.numberOfEffectInputs());
+    ASSERT(inputs.size() == m_effect->numberOfEffectInputs());
 
     RefPtr resultImage = result.imageBuffer();
     if (!resultImage)

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
@@ -159,7 +159,7 @@ bool FEMorphologySoftwareApplier::apply(const Filter& filter, const FilterImageV
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
 
-    auto radius = filter.resolvedSize({ m_effect.radiusX(), m_effect.radiusY() });
+    auto radius = filter.resolvedSize({ m_effect->radiusX(), m_effect->radiusY() });
     auto absoluteRadius = flooredIntSize(filter.scaledByFilterScale(radius));
 
     if (isDegenerate(absoluteRadius)) {
@@ -175,12 +175,12 @@ bool FEMorphologySoftwareApplier::apply(const Filter& filter, const FilterImageV
         return true;
     }
 
-    auto sourcePixelBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectDrawingRect, m_effect.operatingColorSpace());
+    auto sourcePixelBuffer = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectDrawingRect, m_effect->operatingColorSpace());
     if (!sourcePixelBuffer)
         return false;
 
     PaintingData paintingData;
-    paintingData.type = m_effect.morphologyOperator();
+    paintingData.type = m_effect->morphologyOperator();
     paintingData.srcPixelBuffer = &*sourcePixelBuffer;
     paintingData.dstPixelBuffer = destinationPixelBuffer;
     paintingData.width = effectDrawingRect.width();

--- a/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
@@ -46,7 +46,7 @@ bool FEOffsetSoftwareApplier::apply(const Filter& filter, const FilterImageVecto
 
     FloatRect inputImageRect = input.absoluteImageRectRelativeTo(result);
 
-    auto offset = filter.resolvedSize({ m_effect.dx(), m_effect.dy() });
+    auto offset = filter.resolvedSize({ m_effect->dx(), m_effect->dy() });
     auto absoluteOffset = filter.scaledByFilterScale(offset);
 
     inputImageRect.move(absoluteOffset);

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -359,11 +359,11 @@ bool FETurbulenceSoftwareApplier::apply(const Filter& filter, const FilterImageV
 
     auto tileSize = roundedIntSize(result.primitiveSubregion().size());
 
-    float baseFrequencyX = m_effect.baseFrequencyX();
-    float baseFrequencyY = m_effect.baseFrequencyY();
-    auto stitchData = computeStitching(tileSize, baseFrequencyX, baseFrequencyY, m_effect.stitchTiles());
+    float baseFrequencyX = m_effect->baseFrequencyX();
+    float baseFrequencyY = m_effect->baseFrequencyY();
+    auto stitchData = computeStitching(tileSize, baseFrequencyX, baseFrequencyY, m_effect->stitchTiles());
 
-    auto paintingData = initPaintingData(m_effect.type(), baseFrequencyX, baseFrequencyY, m_effect.numOctaves(), m_effect.seed(), m_effect.stitchTiles(), tileSize);
+    auto paintingData = initPaintingData(m_effect->type(), baseFrequencyX, baseFrequencyY, m_effect->numOctaves(), m_effect->seed(), m_effect->stitchTiles(), tileSize);
 
     applyPlatform(result.absoluteImageRect(), filter.filterScale(), *destinationPixelBuffer, paintingData, stitchData);
     return true;

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.h
@@ -22,11 +22,10 @@
 #pragma once
 
 #include "FilterEffectApplier.h"
+#include "SourceGraphic.h"
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-
-class SourceGraphic;
 
 class SourceGraphicSoftwareApplier final : public FilterEffectConcreteApplier<SourceGraphic> {
     WTF_MAKE_TZONE_ALLOCATED(SourceGraphicSoftwareApplier);


### PR DESCRIPTION
#### 3bd23d6856e444c8cb85034088fed711b9d14894
<pre>
Address safer C++ static analysis warnings in FilterEffect
<a href="https://bugs.webkit.org/show_bug.cgi?id=287314">https://bugs.webkit.org/show_bug.cgi?id=287314</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::apply):
* Source/WebCore/platform/graphics/filters/FilterEffect.h:
* Source/WebCore/platform/graphics/filters/FilterEffectApplier.h:
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp:
(WebCore::FETurbulenceSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.h:

Canonical link: <a href="https://commits.webkit.org/290095@main">https://commits.webkit.org/290095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f42a89604c97da6807b8ead0fed0f2c4c7da743b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16662 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68532 "Failure limit exceed. At least found 233 new test failures: compositing/filters/invert-transparent.html compositing/filters/simple-image-with-svg-filter.html compositing/shared-backing/shared-layer-has-filter.html css3/blending/svg-blend-layer-filter.html css3/color-filters/svg/color-filter-inline-svg.html css3/filters/blur-clipped-by-ancestor.html css3/filters/blur-clipped-with-overflow.html css3/filters/blur-various-radii.html css3/filters/change-filter-style.html css3/filters/color-interpolation-filters.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26206 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6509 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38822 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35870 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95765 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11778 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77409 "Failure limit exceed. At least found 272 new test failures: compositing/filters/invert-transparent.html compositing/filters/opacity-change-on-filtered-paints-into-ancestor.html compositing/filters/simple-image-with-svg-filter.html compositing/shared-backing/shared-layer-has-filter.html css3/color-filters/svg/color-filter-inline-svg.html css3/filters/blur-clipped-by-ancestor.html css3/filters/blur-clipped-with-overflow.html css3/filters/blur-various-radii.html css3/filters/change-filter-style.html css3/filters/clipping-overflow-scroll-with-pixel-moving-effect-on-parent.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16390 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76697 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21087 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9215 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13937 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21459 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15889 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->