### PR TITLE
Unreviewed, reverting 290060@main (637c4dc64e64)

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -68,7 +68,7 @@ GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
 WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wreorder-init-list -Wundef -Wvla;
 WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS) $(WK_SANITIZER_WARNING_CFLAGS);
 
-WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL = ;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL = -Wno-unknown-warning-option -Wno-unsafe-buffer-usage-in-libc-call;
 WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx13*] = ;
 WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx14*] = ;
 WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx15.0*] = ;

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -622,9 +622,7 @@
 #if COMPILER(CLANG)
 #define WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
     _Pragma("clang diagnostic push") \
-    _Pragma("clang diagnostic ignored \"-Wunknown-warning-option\"") \
-    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage\"") \
-    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage-in-libc-call\"")
+    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage\"")
 
 #define WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
     _Pragma("clang diagnostic pop")

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1268,20 +1268,9 @@ template <class T> inline typename std::enable_if<std::is_pointer<T>::value, T>:
 
 #define SAFE_PRINTF_TYPE(...) WTF_FOR_EACH(WTF::safePrintfType, __VA_ARGS__)
 
-#define SAFE_PRINTF(format, ...) \
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
-    printf(format __VA_OPT__(, SAFE_PRINTF_TYPE(__VA_ARGS__))) \
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-#define SAFE_FPRINTF(file, format, ...) \
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
-    fprintf(file, format __VA_OPT__(, SAFE_PRINTF_TYPE(__VA_ARGS__))) \
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-#define SAFE_SPRINTF(destinationSpan, format, ...) \
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
-    snprintf(destinationSpan.data(), destinationSpan.size_bytes(), format, SAFE_PRINTF_TYPE(__VA_ARGS__)) \
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+#define SAFE_PRINTF(format, ...) printf(format __VA_OPT__(, SAFE_PRINTF_TYPE(__VA_ARGS__)))
+#define SAFE_FPRINTF(file, format, ...) fprintf(file, format __VA_OPT__(, SAFE_PRINTF_TYPE(__VA_ARGS__)))
+#define SAFE_SPRINTF(destinationSpan, format, ...) snprintf(destinationSpan.data(), destinationSpan.size_bytes(), format, SAFE_PRINTF_TYPE(__VA_ARGS__))
 
 template<typename T> concept ByteType = sizeof(T) == 1 && ((std::is_integral_v<T> && !std::same_as<T, bool>) || std::same_as<T, std::byte>) && !std::is_const_v<T>;
 

--- a/Source/WebCore/bridge/objc/objc_class.mm
+++ b/Source/WebCore/bridge/objc/objc_class.mm
@@ -119,7 +119,7 @@ Method* ObjcClass::methodNamed(PropertyName propertyName, Instance*) const
         auto objcMethodList = class_copyMethodListSpan(thisClass);
         for (auto& objcMethod : objcMethodList.span()) {
             SEL objcMethodSelector = method_getName(objcMethod);
-            auto objcMethodSelectorName = unsafeSpan(sel_getName(objcMethodSelector));
+            const char* objcMethodSelectorName = sel_getName(objcMethodSelector);
             NSString* mappedName = nil;
 
             // See if the class wants to exclude the selector from visibility in JavaScript.
@@ -133,7 +133,7 @@ Method* ObjcClass::methodNamed(PropertyName propertyName, Instance*) const
             if ([thisClass respondsToSelector:@selector(webScriptNameForSelector:)])
                 mappedName = [thisClass webScriptNameForSelector:objcMethodSelector];
 
-            if ((mappedName && [mappedName isEqual:methodName.get()]) || equalSpans(objcMethodSelectorName, buffer.span())) {
+            if ((mappedName && [mappedName isEqual:methodName.get()]) || !strcmp(objcMethodSelectorName, buffer.data())) {
                 auto method = makeUnique<ObjcMethod>(thisClass, objcMethodSelector);
                 methodPtr = method.get();
                 m_methodCache.add(name.impl(), WTFMove(method));
@@ -213,7 +213,7 @@ Field* ObjcClass::fieldNamed(PropertyName propertyName, Instance* instance) cons
                 if ([thisClass respondsToSelector:@selector(webScriptNameForKey:)])
                     mappedName = [thisClass webScriptNameForKey:objcIvarName];
 
-                if ((mappedName && [mappedName isEqual:fieldName.get()]) || equalSpans(unsafeSpan(objcIvarName), jsName.span())) {
+                if ((mappedName && [mappedName isEqual:fieldName.get()]) || !strcmp(objcIvarName, jsName.data())) {
                     auto newField = makeUnique<ObjcField>(objcIVar);
                     field = newField.get();
                     m_fieldCache.add(name.impl(), WTFMove(newField));

--- a/Source/WebCore/bridge/objc/objc_utility.mm
+++ b/Source/WebCore/bridge/objc/objc_utility.mm
@@ -149,7 +149,7 @@ ObjcValue convertValueToObjcValue(JSGlobalObject* lexicalGlobalObject, JSValue v
             result.doubleValue = (double)d;
             break;
         case ObjcVoidType:
-            zeroBytes(result);
+            bzero(&result, sizeof(ObjcValue));
             break;
 
         case ObjcInvalidType:

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2118,7 +2118,7 @@ static ContainerNode* parentOrShadowHostOrFrameOwner(const Node* node)
 static void showSubTreeAcrossFrame(const Node* node, const Node* markedNode, const String& indent)
 {
     if (node == markedNode)
-        SAFE_FPRINTF(stderr, "*");
+        fputs("*", stderr);
     SAFE_FPRINTF(stderr, "%s\n", indent.utf8());
     node->showNode();
     if (!node->isShadowRoot()) {

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -723,7 +723,7 @@ void VisibleSelection::debugPosition() const
     fprintf(stderr, "VisibleSelection ===============\n");
 
     if (!m_start.anchorNode())
-        SAFE_FPRINTF(stderr, "pos:   null");
+        fputs("pos:   null", stderr);
     else if (m_start == m_end) {
         SAFE_FPRINTF(stderr, "pos:   %s ", m_start.anchorNode()->nodeName().utf8());
         m_start.showAnchorTypeAndOffset();
@@ -748,9 +748,9 @@ void VisibleSelection::showTreeForThis() const
 {
     if (RefPtr startAnchorNode = start().anchorNode()) {
         startAnchorNode->showTreeAndMark(startAnchorNode.get(), "S"_s, end().protectedAnchorNode().get(), "E"_s);
-        SAFE_FPRINTF(stderr, "start: ");
+        fputs("start: ", stderr);
         start().showAnchorTypeAndOffset();
-        SAFE_FPRINTF(stderr, "end: ");
+        fputs("end: ", stderr);
         end().showAnchorTypeAndOffset();
     }
 }

--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -146,9 +146,7 @@ FTPEntryType parseOneFTPLine(std::span<LChar> line, ListState& state, ListResult
                                 pos++;
                             if (pos < linelen && line[pos] == ',') {
                                 unsigned long long seconds = 0;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                                 sscanf(byteCast<char>(p.subspan(1)).data(), "%llu", &seconds);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                                 time_t t = static_cast<time_t>(seconds);
 
                                 // FIXME: This code has the year 2038 bug
@@ -425,9 +423,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                              * So its rounded up to the next block, so what, its better
                              * than not showing the size at all.
                              */
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                             uint64_t size = strtoull(byteCast<char>(tokens[1]).data(), 0, 10) * 512;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                             result.fileSize = String::number(size);
                         }
 

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -195,9 +195,7 @@ String preferredExtensionForImageType(const String& uti)
     if (UNLIKELY(oldExtension != extension)) {
         std::array<uint64_t, 6> values { 0, 0, 0, 0, 0, 0 };
         auto utiInfo = makeString(uti, '~', oldExtension, '~', extension);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         strncpy(reinterpret_cast<char*>(values.data()), utiInfo.utf8().data(), sizeof(values));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         CRASH_WITH_INFO(values[0], values[1], values[2], values[3], values[4], values[5]);
     }
     return extension;

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -984,7 +984,6 @@ void XMLDocumentParser::error(XMLErrors::Type type, const char* message, va_list
     if (isStopped())
         return;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     va_list preflightArgs;
     va_copy(preflightArgs, args);
     size_t stringLength = vsnprintf(nullptr, 0, message, preflightArgs);
@@ -992,7 +991,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
     Vector<char, 1024> buffer(stringLength + 1);
     vsnprintf(buffer.data(), stringLength + 1, message, args);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     TextPosition position = textPosition();
     if (m_parserPaused)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1116,7 +1116,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (metrics._establishmentReport) {
             if (auto endpoint = nw_establishment_report_copy_proxy_endpoint(metrics._establishmentReport)) {
                 if (const char *hostname = nw_endpoint_get_hostname(endpoint))
-                    proxyName = String::fromUTF8(unsafeSpan(hostname));
+                    proxyName = String::fromUTF8(unsafeMakeSpan(hostname, strlen(hostname)));
             }
         }
 


### PR DESCRIPTION
#### f4e528dfdf0837bba0a271a679acb40c7a54054b
<pre>
Unreviewed, reverting 290060@main (637c4dc64e64)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287316">https://bugs.webkit.org/show_bug.cgi?id=287316</a>
<a href="https://rdar.apple.com/144427700">rdar://144427700</a>

REGRESSION(290060@main): Broke Internal JSC builds

Reverted change:

    Enable -Wunsafe-buffer-usage-in-libc-call
    <a href="https://bugs.webkit.org/show_bug.cgi?id=287209">https://bugs.webkit.org/show_bug.cgi?id=287209</a>
    <a href="https://rdar.apple.com/144351483">rdar://144351483</a>
    290060@main (637c4dc64e64)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4e528dfdf0837bba0a271a679acb40c7a54054b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88900 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39659 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68493 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34798 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38768 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81699 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95711 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87676 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11738 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77380 "Found 1 new test failure: http/tests/inspector/network/har/har-page.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76668 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9146 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21405 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110169 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15835 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26443 "Found 4 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->