### PR TITLE
[JSC] Add MayNeedDestruction mode

### DIFF
--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -75,7 +75,6 @@ public:
     void assertNoUnswept();
     size_t cellSize() const { return m_cellSize; }
     CellAttributes attributes() const { return m_attributes; }
-    bool needsDestruction() const { return m_attributes.destruction == NeedsDestruction; }
     DestructionMode destruction() const { return m_attributes.destruction; }
     HeapCell::Kind cellKind() const { return m_attributes.cellKind; }
 

--- a/Source/JavaScriptCore/heap/DestructionMode.cpp
+++ b/Source/JavaScriptCore/heap/DestructionMode.cpp
@@ -41,6 +41,9 @@ void printInternal(PrintStream& out, DestructionMode mode)
     case DoesNotNeedDestruction:
         out.print("DoesNotNeedDestruction");
         return;
+    case MayNeedDestruction:
+        out.print("MayNeedDestruction");
+        return;
     }
     
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/heap/DestructionMode.h
+++ b/Source/JavaScriptCore/heap/DestructionMode.h
@@ -27,10 +27,13 @@
 
 namespace JSC {
 
-enum DestructionMode : int8_t {
+enum class DestructionMode : uint8_t {
     DoesNotNeedDestruction,
-    NeedsDestruction
+    NeedsDestruction,
+    MayNeedDestruction,
 };
+
+using enum DestructionMode;
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/HeapCell.h
+++ b/Source/JavaScriptCore/heap/HeapCell.h
@@ -62,6 +62,8 @@ public:
     }
     bool isZapped() const { return !*std::bit_cast<const uint32_t*>(this); }
 
+    void notifyNeedsDestruction() const;
+
     // isPendingDestruction returns true iff the cell is no longer alive but has not yet
     // been swept and therefore its destructor (if it has one) has not yet run.
     bool isPendingDestruction();

--- a/Source/JavaScriptCore/heap/HeapCellInlines.h
+++ b/Source/JavaScriptCore/heap/HeapCellInlines.h
@@ -97,5 +97,12 @@ ALWAYS_INLINE Subspace* HeapCell::subspace() const
     return markedBlock().subspace();
 }
 
+ALWAYS_INLINE void HeapCell::notifyNeedsDestruction() const
+{
+    ASSERT(!isPreciseAllocation());
+    ASSERT(destructionMode() == MayNeedDestruction);
+    markedBlock().handle().setIsDestructible(true);
+}
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/IsoHeapCellType.h
+++ b/Source/JavaScriptCore/heap/IsoHeapCellType.h
@@ -41,7 +41,7 @@ public:
     template<typename CellType>
     struct Args {
         Args()
-            : mode(CellType::needsDestruction ? NeedsDestruction : DoesNotNeedDestruction)
+            : mode(CellType::needsDestruction)
             , functionPtr(&CellType::destroy)
         { }
 

--- a/Source/JavaScriptCore/heap/IsoInlinedHeapCellTypeInlines.h
+++ b/Source/JavaScriptCore/heap/IsoInlinedHeapCellTypeInlines.h
@@ -33,7 +33,7 @@ namespace JSC {
 
 template<typename CellType>
 inline IsoInlinedHeapCellType<CellType>::IsoInlinedHeapCellType()
-    : HeapCellType(CellAttributes(CellType::needsDestruction ? NeedsDestruction : DoesNotNeedDestruction, HeapCell::JSCell))
+    : HeapCellType(CellAttributes(CellType::needsDestruction, HeapCell::JSCell))
 {
 }
 

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -155,7 +155,7 @@ void MarkedBlock::Handle::stopAllocating(const FreeList& freeList)
         [&] (HeapCell* cell) {
             if constexpr (MarkedBlockInternal::verbose)
                 dataLog("Free cell: ", RawPointer(cell), "\n");
-            if (m_attributes.destruction == NeedsDestruction)
+            if (m_attributes.destruction != DoesNotNeedDestruction)
                 cell->zap(HeapCell::StopAllocating);
             block().clearNewlyAllocated(cell);
         });
@@ -470,8 +470,7 @@ void MarkedBlock::Handle::sweep(FreeList* freeList)
     ASSERT(m_directory->isInUse(this));
 
     SweepMode sweepMode = freeList ? SweepToFreeList : SweepOnly;
-    bool needsDestruction = m_attributes.destruction == NeedsDestruction
-        && m_directory->isDestructible(this);
+    bool needsDestruction = m_attributes.destruction != DoesNotNeedDestruction && m_directory->isDestructible(this);
 
     m_weakSet.sweep();
 

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -128,6 +128,7 @@ public:
         void* cellAlign(void*);
             
         bool isEmpty();
+        void setIsDestructible(bool);
 
         void lastChanceToFinalize();
 
@@ -549,7 +550,7 @@ inline CellAttributes MarkedBlock::attributes() const
 
 inline bool MarkedBlock::Handle::needsDestruction() const
 {
-    return m_attributes.destruction == NeedsDestruction;
+    return m_attributes.destruction != DoesNotNeedDestruction;
 }
 
 inline DestructionMode MarkedBlock::Handle::destruction() const

--- a/Source/JavaScriptCore/heap/PreciseAllocation.cpp
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.cpp
@@ -272,7 +272,7 @@ void PreciseAllocation::sweep()
     m_weakSet.sweep();
     
     if (m_hasValidCell && !isLive()) {
-        if (m_attributes.destruction == NeedsDestruction)
+        if (m_attributes.destruction != DoesNotNeedDestruction)
             m_subspace->destroy(vm(), static_cast<JSCell*>(cell()));
         // We should clear IsoCellSet's bit before actually destroying PreciseAllocation
         // since PreciseAllocation's destruction can be delayed until its WeakSet is cleared.

--- a/Source/JavaScriptCore/runtime/ClonedArguments.h
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.h
@@ -48,7 +48,7 @@ public:
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
-        static_assert(!CellType::needsDestruction);
+        static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
         return &vm.clonedArgumentsSpace();
     }
 

--- a/Source/JavaScriptCore/runtime/DirectArguments.h
+++ b/Source/JavaScriptCore/runtime/DirectArguments.h
@@ -51,7 +51,7 @@ public:
     template<typename CellType, SubspaceAccess>
     static CompleteSubspace* subspaceFor(VM& vm)
     {
-        static_assert(!CellType::needsDestruction);
+        static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
         return &vm.variableSizedCellSpace();
     }
 

--- a/Source/JavaScriptCore/runtime/JSLexicalEnvironment.h
+++ b/Source/JavaScriptCore/runtime/JSLexicalEnvironment.h
@@ -45,7 +45,7 @@ public:
     template<typename CellType, SubspaceAccess>
     static CompleteSubspace* subspaceFor(VM& vm)
     {
-        static_assert(!CellType::needsDestruction);
+        static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
         return &vm.variableSizedCellSpace();
     }
 

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -60,7 +60,7 @@ inline Structure* JSFinalObject::createStructure(VM& vm, JSGlobalObject* globalO
 template<typename CellType, SubspaceAccess>
 CompleteSubspace* JSFinalObject::subspaceFor(VM& vm)
 {
-    static_assert(!CellType::needsDestruction);
+    static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
     return &vm.cellSpace();
 }
 

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -323,6 +323,7 @@ class JSRopeString final : public JSString {
     friend class RegExpObject;
     friend class RegExpSubstringGlobalAtomCache;
 public:
+    static constexpr DestructionMode needsDestruction = MayNeedDestruction;
     static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
     static void destroy(JSCell*);
 

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -25,9 +25,11 @@
 
 #pragma once
 
+#include "HeapCellInlines.h"
 #include "JSGlobalObjectInlines.h"
 #include "JSString.h"
 #include "KeyAtomStringCacheInlines.h"
+#include "MarkedBlockInlines.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
 
@@ -205,6 +207,7 @@ inline void JSRopeString::convertToNonRope(String&& string) const
     static_assert(sizeof(String) == sizeof(RefPtr<StringImpl>), "JSString's String initialization must be done in one pointer move.");
     // We do not clear the trailing fibers and length information (fiber1 and fiber2) because we could be reading the length concurrently.
     ASSERT(!JSString::isRope());
+    notifyNeedsDestruction();
 }
 
 // Overview: These functions convert a JSString from holding a string in rope form

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -35,7 +35,7 @@ public:
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
-        static_assert(!CellType::needsDestruction);
+        static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
         return &vm.regExpObjectSpace();
     }
 

--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -48,7 +48,7 @@ public:
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
-        static_assert(!CellType::needsDestruction);
+        static_assert(CellType::needsDestruction == DoesNotNeedDestruction);
         return &vm.scopedArgumentsSpace();
     }
 

--- a/Source/JavaScriptCore/testRegExp.cpp
+++ b/Source/JavaScriptCore/testRegExp.cpp
@@ -108,8 +108,6 @@ public:
 
     DECLARE_INFO;
 
-    static constexpr bool needsDestructor = true;
-
     static Structure* createStructure(VM& vm, JSValue prototype)
     {
         return Structure::create(vm, nullptr, prototype, TypeInfo(GlobalObjectType, StructureFlags), info());

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -216,7 +216,7 @@ ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, GetClient
     if (!space) {
         JSC::Heap& heap = vm.heap;
         std::unique_ptr<JSC::IsoSubspace> uniqueSubspace;
-        static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || !T::needsDestruction);
+        static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || T::needsDestruction == JSC::DoesNotNeedDestruction);
         if constexpr (useCustomHeapCellType == UseCustomHeapCellType::Yes)
             uniqueSubspace = makeUnique<JSC::IsoSubspace> ISO_SUBSPACE_INIT(heap, getCustomHeapCellType(heapData), T);
         else {


### PR DESCRIPTION
#### af0c5b6afa7e865b98f5900f8531e6ea2bc9b197
<pre>
[JSC] Add MayNeedDestruction mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=287318">https://bugs.webkit.org/show_bug.cgi?id=287318</a>
<a href="https://rdar.apple.com/144428259">rdar://144428259</a>

Reviewed by Yijia Huang.

This patch introduces MayNeedDestruction destruction mode. When this
mode is set, each cells need to manually track whether it should get
destruction. We use this in JSRopeString and we can mark MarkedBlock as
destructible only when we resolve JSRopeString contained in the
MarkedBlock. It is really common that we create massive amount of
JSRopeStrings and only a few gets resolved. In this case, most of
JSRopeStrings in many MarkedBlocks are not resolved. We can skip calling
destructors for these blocks.

Currently this mode is allowed only for types which only allocate cells
from MarkedBlocks. So JSRopeString is specifically made as it always
allocate cells from MarkedBlocks (not from PreciseAllocations).

* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::endMarking):
* Source/JavaScriptCore/heap/BlockDirectory.h:
(JSC::BlockDirectory::attributes const):
(JSC::BlockDirectory::needsDestruction const): Deleted.
* Source/JavaScriptCore/heap/DestructionMode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/heap/DestructionMode.h:
(): Deleted.
* Source/JavaScriptCore/heap/HeapCell.h:
* Source/JavaScriptCore/heap/HeapCellInlines.h:
(JSC::HeapCell::notifyNeedsDestruction const):
* Source/JavaScriptCore/heap/IsoHeapCellType.h:
* Source/JavaScriptCore/heap/IsoInlinedHeapCellTypeInlines.h:
(JSC::IsoInlinedHeapCellType&lt;CellType&gt;::IsoInlinedHeapCellType):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::stopAllocating):
(JSC::MarkedBlock::Handle::sweep):
* Source/JavaScriptCore/heap/MarkedBlock.h:
(JSC::MarkedBlock::Handle::needsDestruction const):
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::specializedSweep):
(JSC::MarkedBlock::Handle::sweepDestructionMode):
(JSC::MarkedBlock::Handle::setIsDestructible):
* Source/JavaScriptCore/heap/PreciseAllocation.cpp:
(JSC::PreciseAllocation::sweep):
* Source/JavaScriptCore/runtime/ClonedArguments.h:
* Source/JavaScriptCore/runtime/DirectArguments.h:
* Source/JavaScriptCore/runtime/JSLexicalEnvironment.h:
(JSC::JSLexicalEnvironment::subspaceFor):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSFinalObject::subspaceFor):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::convertToNonRope const):
* Source/JavaScriptCore/runtime/RegExpObject.h:
* Source/JavaScriptCore/runtime/ScopedArguments.h:
* Source/JavaScriptCore/testRegExp.cpp:
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
(WebCore::subspaceForImpl):

Canonical link: <a href="https://commits.webkit.org/290094@main">https://commits.webkit.org/290094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7da4e1374b3c8d1648ae3ef9535972f85e273d75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26188 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6484 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38796 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81727 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95739 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87704 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77390 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16364 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76678 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21062 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9174 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13936 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21433 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110197 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15863 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26450 "Found 6 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->