### PR TITLE
Address safer C++ static analysis warnings in ScrollingTree

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -107,7 +107,6 @@ page/NavigatorLoginStatus.cpp
 page/mac/EventHandlerMac.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
-page/scrolling/mac/ScrollingTreeMac.mm
 platform/SharedBuffer.cpp
 platform/ThreadGlobalData.cpp
 platform/ThreadGlobalData.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1049,11 +1049,9 @@ page/scrolling/ScrollingCoordinator.cpp
 page/scrolling/ScrollingStateNode.h
 page/scrolling/ScrollingStateTree.cpp
 page/scrolling/ScrollingThread.cpp
-page/scrolling/ScrollingTree.cpp
 page/scrolling/ScrollingTreeGestureState.cpp
 page/scrolling/ScrollingTreeScrollingNodeDelegate.h
 page/scrolling/ThreadedScrollingCoordinator.cpp
-page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/mac/ScrollerMac.mm
 page/scrolling/mac/ScrollingCoordinatorMac.mm
 page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -595,13 +595,10 @@ page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollingCoordinator.cpp
-page/scrolling/ScrollingTree.cpp
 page/scrolling/ScrollingTreeFixedNode.cpp
 page/scrolling/ScrollingTreeOverflowScrollProxyNode.cpp
 page/scrolling/ScrollingTreePositionedNode.cpp
 page/scrolling/ScrollingTreeStickyNode.cpp
-page/scrolling/ThreadedScrollingTree.cpp
-page/scrolling/mac/ScrollingTreeMac.mm
 page/text-extraction/TextExtraction.cpp
 platform/CaretAnimator.cpp
 platform/DictationCaretAnimator.cpp

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -79,7 +79,8 @@ ScrollingTree::~ScrollingTree() = default;
 
 bool ScrollingTree::isUserScrollInProgressAtEventLocation(const PlatformWheelEvent& wheelEvent)
 {
-    if (!m_rootNode)
+    RefPtr rootNode = m_rootNode;
+    if (!rootNode)
         return false;
 
     // This method is invoked by the event handling thread
@@ -89,7 +90,7 @@ bool ScrollingTree::isUserScrollInProgressAtEventLocation(const PlatformWheelEve
         return false;
 
     FloatPoint position = wheelEvent.position();
-    position.move(m_rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
+    position.move(rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
     if (auto node = scrollingNodeForPoint(position))
         return m_treeState.nodesWithActiveUserScrolls.contains(node->scrollingNodeID());
 
@@ -98,11 +99,12 @@ bool ScrollingTree::isUserScrollInProgressAtEventLocation(const PlatformWheelEve
 
 OptionSet<WheelEventProcessingSteps> ScrollingTree::computeWheelProcessingSteps(const PlatformWheelEvent& wheelEvent)
 {
-    if (!m_rootNode)
+    RefPtr rootNode = m_rootNode;
+    if (!rootNode)
         return { WheelEventProcessingSteps::AsyncScrolling };
 
     FloatPoint position = wheelEvent.position();
-    position.move(m_rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
+    position.move(rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
 
     if (!m_treeState.eventTrackingRegions.isEmpty()) {
         IntPoint roundedPosition = roundedIntPoint(position);
@@ -167,13 +169,14 @@ WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEven
     m_latchingController.receivedWheelEvent(wheelEvent, processingSteps, m_allowLatching);
 
     auto result = [&] {
-        if (!m_rootNode)
+        RefPtr rootNode = m_rootNode;
+        if (!rootNode)
             return WheelEventHandlingResult::unhandled();
 
         if (!asyncFrameOrOverflowScrollingEnabled()) {
-            auto result = m_rootNode->handleWheelEvent(wheelEvent);
+            auto result = rootNode->handleWheelEvent(wheelEvent);
             if (result.wasHandled)
-                m_gestureState.nodeDidHandleEvent(m_rootNode->scrollingNodeID(), wheelEvent);
+                m_gestureState.nodeDidHandleEvent(rootNode->scrollingNodeID(), wheelEvent);
             return result;
         }
 
@@ -186,7 +189,7 @@ WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEven
 
         if (auto latchedNodeAndSteps = m_latchingController.latchingDataForEvent(wheelEvent, m_allowLatching)) {
             LOG_WITH_STREAM(ScrollLatching, stream << "ScrollingTree::handleWheelEvent: has latched node " << latchedNodeAndSteps->scrollingNodeID);
-            if (auto* node = dynamicDowncast<ScrollingTreeScrollingNode>(nodeForID(latchedNodeAndSteps->scrollingNodeID))) {
+            if (RefPtr node = dynamicDowncast<ScrollingTreeScrollingNode>(nodeForID(latchedNodeAndSteps->scrollingNodeID))) {
                 auto result = node->handleWheelEvent(wheelEvent);
                 if (result.wasHandled) {
                     m_latchingController.nodeDidHandleEvent(latchedNodeAndSteps->scrollingNodeID, processingSteps, wheelEvent, m_allowLatching);
@@ -199,7 +202,7 @@ WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEven
         FloatPoint position = wheelEvent.position();
         {
             Locker locker { m_treeStateLock };
-            position.move(m_rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
+            position.move(rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
         }
         auto node = scrollingNodeForPoint(position);
 
@@ -218,7 +221,7 @@ WheelEventHandlingResult ScrollingTree::handleWheelEventWithNode(const PlatformW
     auto adjustedWheelEvent = wheelEvent;
     RefPtr node = startingNode;
     while (node) {
-        if (auto* scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(*node)) {
+        if (RefPtr scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(*node)) {
             auto result = scrollingNode->handleWheelEvent(adjustedWheelEvent, eventTargeting);
 
             if (result.wasHandled) {
@@ -243,9 +246,9 @@ WheelEventHandlingResult ScrollingTree::handleWheelEventWithNode(const PlatformW
             adjustedWheelEvent = scrollingNode->eventForPropagation(adjustedWheelEvent);
         }
 
-        if (auto* scrollProxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(*node)) {
-            if (auto relatedNode = nodeForID(scrollProxyNode->overflowScrollingNodeID())) {
-                node = relatedNode;
+        if (RefPtr scrollProxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(*node)) {
+            if (RefPtr relatedNode = nodeForID(scrollProxyNode->overflowScrollingNodeID())) {
+                node = WTFMove(relatedNode);
                 continue;
             }
         }
@@ -271,18 +274,19 @@ OptionSet<EventListenerRegionType> ScrollingTree::eventListenerRegionTypesForPoi
 void ScrollingTree::traverseScrollingTree(VisitorFunction&& visitorFunction)
 {
     Locker locker { m_treeLock };
-    if (!m_rootNode)
+    RefPtr rootNode = m_rootNode;
+    if (!rootNode)
         return;
 
     auto function = WTFMove(visitorFunction);
-    traverseScrollingTreeRecursive(*m_rootNode, function);
+    traverseScrollingTreeRecursive(*rootNode, function);
 }
 
 void ScrollingTree::traverseScrollingTreeRecursive(ScrollingTreeNode& node, const VisitorFunction& visitorFunction)
 {
     bool scrolledSinceLastCommit = false;
     std::optional<FloatPoint> scrollPosition;
-    if (auto* scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(node)) {
+    if (RefPtr scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(node)) {
         scrollPosition = scrollingNode->currentScrollPosition();
         scrolledSinceLastCommit = scrollingNode->scrolledSinceLastCommit();
     }
@@ -307,10 +311,8 @@ void ScrollingTree::mainFrameViewportChangedViaDelegatedScrolling(const FloatPoi
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::viewportChangedViaDelegatedScrolling - layoutViewport " << layoutViewport);
     
-    if (!m_rootNode)
-        return;
-
-    m_rootNode->wasScrolledByDelegatedScrolling(scrollPosition, layoutViewport);
+    if (RefPtr rootNode = m_rootNode)
+        rootNode->wasScrolledByDelegatedScrolling(scrollPosition, layoutViewport);
 }
 
 void ScrollingTree::setOverlayScrollbarsEnabled(bool enabled)
@@ -354,8 +356,8 @@ bool ScrollingTree::commitTreeStateInternal(std::unique_ptr<ScrollingStateTree>&
 
     if (hostingContextIdentifier) {
         LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::commitTreeState - starting hosted tree commit for hosting context ID:  " << *hostingContextIdentifier);
-        if (auto scrollingNode = m_hostedSubtrees.get(*hostingContextIdentifier))
-            commitState.frameHostingNode = scrollingNode;
+        if (RefPtr scrollingNode = m_hostedSubtrees.get(*hostingContextIdentifier))
+            commitState.frameHostingNode = WTFMove(scrollingNode);
         else {
             LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::commitTreeState - parent not present for hosted tree commit");
             // Add to hosted subtrees needing pairing since the hosting node is not in the scrolling tree yet
@@ -365,8 +367,8 @@ bool ScrollingTree::commitTreeStateInternal(std::unique_ptr<ScrollingStateTree>&
             return true;
         }
         if (!rootNode) {
-            if (commitState.frameHostingNode)
-                commitState.frameHostingNode->removeHostedChildren();
+            if (RefPtr frameHostingNode = commitState.frameHostingNode)
+                frameHostingNode->removeHostedChildren();
             return true;
         }
     }
@@ -542,7 +544,7 @@ bool ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
     node->didCompleteCommitForNode();
 
 #if ENABLE(SCROLLING_THREAD)
-    if (auto* scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(*node); scrollingNode && !scrollingNode->synchronousScrollingReasons().isEmpty())
+    if (RefPtr scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(*node); scrollingNode && !scrollingNode->synchronousScrollingReasons().isEmpty())
         state.synchronousScrollingNodes.add(nodeID);
 #endif
 
@@ -592,10 +594,8 @@ void ScrollingTree::applyLayerPositions()
 void ScrollingTree::applyLayerPositionsInternal()
 {
     ASSERT(m_treeLock.isLocked());
-    if (!m_rootNode)
-        return;
-
-    applyLayerPositionsRecursive(*m_rootNode);
+    if (RefPtr rootNode = m_rootNode)
+        applyLayerPositionsRecursive(*rootNode);
 }
 
 void ScrollingTree::applyLayerPositionsRecursive(ScrollingTreeNode& node)
@@ -624,8 +624,7 @@ void ScrollingTree::notifyRelatedNodesAfterScrollPositionChange(ScrollingTreeScr
     notifyRelatedNodesRecursive(changedNode);
     
     for (auto positionedNodeID : additionalUpdateRoots) {
-        auto* positionedNode = nodeForID(positionedNodeID);
-        if (positionedNode)
+        if (RefPtr positionedNode = nodeForID(positionedNodeID))
             notifyRelatedNodesRecursive(*positionedNode);
     }
 }
@@ -656,8 +655,8 @@ void ScrollingTree::clearLatchedNode()
 FloatBoxExtent ScrollingTree::mainFrameObscuredContentInsets() const
 {
     Locker locker { m_treeStateLock };
-    if (m_rootNode)
-        return m_rootNode->obscuredContentInsets();
+    if (RefPtr rootNode = m_rootNode)
+        return rootNode->obscuredContentInsets();
     return { };
 }
 
@@ -970,10 +969,8 @@ void ScrollingTree::scrollBySimulatingWheelEventForTesting(ScrollingNodeID nodeI
 {
     Locker locker { m_treeLock };
 
-    auto* node = dynamicDowncast<ScrollingTreeScrollingNode>(nodeForID(nodeID));
-    if (!node)
-        return;
-    node->scrollBy(delta);
+    if (RefPtr node = dynamicDowncast<ScrollingTreeScrollingNode>(nodeForID(nodeID)))
+        node->scrollBy(delta);
 }
 
 void ScrollingTree::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFramesPerSecond)
@@ -1064,9 +1061,9 @@ String ScrollingTree::scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBeha
         if (!m_treeState.mainFrameScrollPosition.isZero())
             ts.dumpProperty("main frame scroll position", m_treeState.mainFrameScrollPosition);
         
-        if (m_rootNode) {
+        if (RefPtr rootNode = m_rootNode) {
             TextStream::GroupScope scope(ts);
-            m_rootNode->dump(ts, behavior | ScrollingStateTreeAsTextBehavior::IncludeLayerPositions);
+            rootNode->dump(ts, behavior | ScrollingStateTreeAsTextBehavior::IncludeLayerPositions);
         }
         
         if (behavior & ScrollingStateTreeAsTextBehavior::IncludeNodeIDs) {

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -58,6 +58,9 @@ public:
     virtual void viewWillStartLiveResize() { }
     virtual void viewWillEndLiveResize() { }
     virtual void viewSizeDidChange() { }
+
+    virtual bool isScrollingTreeFrameScrollingNodeMac() const { return false; };
+
 protected:
     ScrollingTreeFrameScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -152,7 +152,7 @@ void ThreadedScrollingTree::invalidate()
     // Since this can potentially be the last reference to the scrolling coordinator,
     // we need to release it on the main thread since it has member variables (such as timers)
     // that expect to be destroyed from the main thread.
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(m_scrollingCoordinator)] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(m_scrollingCoordinator)] {
     });
 }
 
@@ -229,7 +229,7 @@ void ThreadedScrollingTree::propagateSynchronousScrollingReasons(const Unchecked
     m_hasNodesWithSynchronousScrollingReasons = !synchronousScrollingNodes.isEmpty();
 
     for (auto nodeID : synchronousScrollingNodes) {
-        if (auto node = nodeForID(nodeID))
+        if (RefPtr node = nodeForID(nodeID))
             propagateStateToAncestors(*node);
     }
 }
@@ -243,7 +243,8 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
 {
     ScrollingTree::scrollingTreeNodeDidScroll(node, scrollingLayerPositionAction);
 
-    if (!m_scrollingCoordinator)
+    RefPtr scrollingCoordinator = m_scrollingCoordinator;
+    if (!scrollingCoordinator)
         return;
 
     if (isHandlingProgrammaticScroll())
@@ -257,7 +258,7 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
     auto scrollUpdate = ScrollUpdate { node.scrollingNodeID(), scrollPosition, layoutViewportOrigin, ScrollUpdateType::PositionUpdate, scrollingLayerPositionAction };
 
     if (RunLoop::isMain()) {
-        m_scrollingCoordinator->applyScrollUpdate(WTFMove(scrollUpdate));
+        scrollingCoordinator->applyScrollUpdate(WTFMove(scrollUpdate));
         return;
     }
 
@@ -266,15 +267,16 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
     addPendingScrollUpdate(WTFMove(scrollUpdate));
 
     auto deferrer = ScrollingTreeWheelEventTestMonitorCompletionDeferrer { *this, node.scrollingNodeID(), WheelEventTestMonitor::DeferReason::ScrollingThreadSyncNeeded };
-    RunLoop::main().dispatch([protectedThis = Ref { *this }, deferrer = WTFMove(deferrer)] {
-        if (auto* scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
+    RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, deferrer = WTFMove(deferrer)] {
+        if (RefPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
             scrollingCoordinator->scrollingThreadAddedPendingUpdate();
     });
 }
 
 void ThreadedScrollingTree::scrollingTreeNodeScrollUpdated(ScrollingTreeScrollingNode& node, const ScrollUpdateType& scrollUpdateType)
 {
-    if (!m_scrollingCoordinator)
+    RefPtr scrollingCoordinator = m_scrollingCoordinator;
+    if (!scrollingCoordinator)
         return;
 
     LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::scrollingTreeNodeScrollUpdated " << node.scrollingNodeID() << " update type " << scrollUpdateType);
@@ -282,14 +284,14 @@ void ThreadedScrollingTree::scrollingTreeNodeScrollUpdated(ScrollingTreeScrollin
     auto scrollUpdate = ScrollUpdate { node.scrollingNodeID(), { }, { }, scrollUpdateType };
 
     if (RunLoop::isMain()) {
-        m_scrollingCoordinator->applyScrollUpdate(WTFMove(scrollUpdate));
+        scrollingCoordinator->applyScrollUpdate(WTFMove(scrollUpdate));
         return;
     }
 
     addPendingScrollUpdate(WTFMove(scrollUpdate));
 
-    RunLoop::main().dispatch([protectedThis = Ref { *this }] {
-        if (auto* scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
+    RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }] {
+        if (RefPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
             scrollingCoordinator->scrollingThreadAddedPendingUpdate();
     });
 }
@@ -320,7 +322,7 @@ void ThreadedScrollingTree::reportSynchronousScrollingReasonsChanged(MonotonicTi
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), timestamp, reasons] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), timestamp, reasons] {
         scrollingCoordinator->reportSynchronousScrollingReasonsChanged(timestamp, reasons);
     });
 }
@@ -330,7 +332,7 @@ void ThreadedScrollingTree::reportExposedUnfilledArea(MonotonicTime timestamp, u
     auto scrollingCoordinator = m_scrollingCoordinator;
     if (!scrollingCoordinator)
         return;
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), timestamp, unfilledArea] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), timestamp, unfilledArea] {
         scrollingCoordinator->reportExposedUnfilledArea(timestamp, unfilledArea);
     });
 }
@@ -342,7 +344,7 @@ void ThreadedScrollingTree::currentSnapPointIndicesDidChange(ScrollingNodeID nod
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, horizontal, vertical] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, horizontal, vertical] {
         scrollingCoordinator->setActiveScrollSnapIndices(nodeID, horizontal, vertical);
     });
 }
@@ -355,7 +357,7 @@ void ThreadedScrollingTree::handleWheelEventPhase(ScrollingNodeID nodeID, Platfo
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, phase] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, phase] {
         scrollingCoordinator->handleWheelEventPhase(nodeID, phase);
     });
 }
@@ -367,7 +369,7 @@ void ThreadedScrollingTree::setActiveScrollSnapIndices(ScrollingNodeID nodeID, s
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, horizontalIndex, verticalIndex] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, horizontalIndex, verticalIndex] {
         scrollingCoordinator->setActiveScrollSnapIndices(nodeID, horizontalIndex, verticalIndex);
     });
 }
@@ -417,7 +419,7 @@ void ThreadedScrollingTree::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAni
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), hasNodeWithAnimatedScroll] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), hasNodeWithAnimatedScroll] {
         scrollingCoordinator->hasNodeWithAnimatedScrollChanged(hasNodeWithAnimatedScroll);
     });
 }
@@ -485,7 +487,7 @@ void ThreadedScrollingTree::scheduleDelayedRenderingUpdateDetectionTimer(Seconds
     ASSERT(m_treeLock.isLocked());
 
     if (!m_delayedRenderingUpdateDetectionTimer)
-        m_delayedRenderingUpdateDetectionTimer = makeUnique<RunLoop::Timer>(RunLoop::current(), this, &ThreadedScrollingTree::delayedRenderingUpdateDetectionTimerFired);
+        m_delayedRenderingUpdateDetectionTimer = makeUnique<RunLoop::Timer>(RunLoop::protectedCurrent(), this, &ThreadedScrollingTree::delayedRenderingUpdateDetectionTimerFired);
 
     m_delayedRenderingUpdateDetectionTimer->startOneShot(delay);
 }
@@ -564,7 +566,7 @@ void ThreadedScrollingTree::receivedWheelEventWithPhases(PlatformWheelEventPhase
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), phase, momentumPhase] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), phase, momentumPhase] {
         scrollingCoordinator->receivedWheelEventWithPhases(phase, momentumPhase);
     });
 }
@@ -578,7 +580,7 @@ void ThreadedScrollingTree::deferWheelEventTestCompletionForReason(ScrollingNode
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, reason] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, reason] {
         scrollingCoordinator->deferWheelEventTestCompletionForReason(nodeID, reason);
     });
 }
@@ -592,7 +594,7 @@ void ThreadedScrollingTree::removeWheelEventTestCompletionDeferralForReason(Scro
     if (!scrollingCoordinator)
         return;
 
-    RunLoop::main().dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, reason] {
+    RunLoop::protectedMain()->dispatch([scrollingCoordinator = WTFMove(scrollingCoordinator), nodeID, reason] {
         scrollingCoordinator->removeWheelEventTestCompletionDeferralForReason(nodeID, reason);
     });
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -71,6 +71,7 @@ private:
 
     void willBeDestroyed() final;
     void willDoProgrammaticScroll(const FloatPoint&) final;
+    bool isScrollingTreeFrameScrollingNodeMac() const final { return true; };
 
     void currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction) final;
     void repositionScrollingLayers() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
@@ -87,5 +88,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ScrollingTreeFrameScrollingNodeMac) \
+    static bool isType(const WebCore::ScrollingTreeFrameScrollingNode& node) { return node.isScrollingTreeFrameScrollingNodeMac(); } \
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -112,14 +112,14 @@ static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNod
         if (nodeID == scrollingNodeID)
             return true;
 
-        auto* scrollingNode = tree.nodeForID(nodeID);
-        if (auto* proxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
+        RefPtr scrollingNode = tree.nodeForID(nodeID);
+        if (RefPtr proxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
             auto actingOverflowScrollingNodeID = proxyNode->overflowScrollingNodeID();
             if (actingOverflowScrollingNodeID == scrollingNodeID)
                 return true;
         }
 
-        if (auto* positionedNode = dynamicDowncast<ScrollingTreePositionedNode>(scrollingNode)) {
+        if (RefPtr positionedNode = dynamicDowncast<ScrollingTreePositionedNode>(scrollingNode)) {
             if (positionedNode->relatedOverflowScrollingNodes().contains(scrollingNodeID))
                 return false;
         }
@@ -136,7 +136,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
 
     Locker locker { m_layerHitTestMutex };
 
-    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeMac*>(rootScrollingNode.get())->rootContentsLayer();
+    auto rootContentsLayer = downcast<ScrollingTreeFrameScrollingNodeMac>(rootScrollingNode.get())->rootContentsLayer();
     FloatPoint scrollOrigin = rootScrollingNode->scrollOrigin();
     auto pointInContentsLayer = point;
     pointInContentsLayer.moveBy(scrollOrigin);
@@ -197,13 +197,13 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
 #if ENABLE(WHEEL_EVENT_REGIONS)
 OptionSet<EventListenerRegionType> ScrollingTreeMac::eventListenerRegionTypesForPoint(FloatPoint point) const
 {
-    auto* rootScrollingNode = rootNode();
+    RefPtr rootScrollingNode = rootNode();
     if (!rootScrollingNode)
         return { };
 
     Locker locker { m_layerHitTestMutex };
 
-    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeMac*>(rootScrollingNode)->rootContentsLayer();
+    auto rootContentsLayer = downcast<ScrollingTreeFrameScrollingNodeMac>(rootScrollingNode)->rootContentsLayer();
 
     Vector<LayerAndPoint, 16> layersAtPoint;
     collectDescendantLayersAtPoint(layersAtPoint, rootContentsLayer.get(), point, layerEventRegionContainsPoint);


### PR DESCRIPTION
#### 2c285f57fee3a73cfa6175ffe37b5ccdb571c51e
<pre>
Address safer C++ static analysis warnings in ScrollingTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=287323">https://bugs.webkit.org/show_bug.cgi?id=287323</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::isUserScrollInProgressAtEventLocation):
(WebCore::ScrollingTree::computeWheelProcessingSteps):
(WebCore::ScrollingTree::handleWheelEvent):
(WebCore::ScrollingTree::handleWheelEventWithNode):
(WebCore::ScrollingTree::traverseScrollingTree):
(WebCore::ScrollingTree::traverseScrollingTreeRecursive):
(WebCore::ScrollingTree::mainFrameViewportChangedViaDelegatedScrolling):
(WebCore::ScrollingTree::commitTreeStateInternal):
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
(WebCore::ScrollingTree::applyLayerPositionsInternal):
(WebCore::ScrollingTree::notifyRelatedNodesAfterScrollPositionChange):
(WebCore::ScrollingTree::mainFrameObscuredContentInsets const):
(WebCore::ScrollingTree::scrollBySimulatingWheelEventForTesting):
(WebCore::ScrollingTree::scrollingTreeAsText):
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::invalidate):
(WebCore::ThreadedScrollingTree::propagateSynchronousScrollingReasons):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeScrollUpdated):
(WebCore::ThreadedScrollingTree::reportSynchronousScrollingReasonsChanged):
(WebCore::ThreadedScrollingTree::reportExposedUnfilledArea):
(WebCore::ThreadedScrollingTree::currentSnapPointIndicesDidChange):
(WebCore::ThreadedScrollingTree::handleWheelEventPhase):
(WebCore::ThreadedScrollingTree::setActiveScrollSnapIndices):
(WebCore::ThreadedScrollingTree::hasNodeWithAnimatedScrollChanged):
(WebCore::ThreadedScrollingTree::scheduleDelayedRenderingUpdateDetectionTimer):
(WebCore::ThreadedScrollingTree::receivedWheelEventWithPhases):
(WebCore::ThreadedScrollingTree::deferWheelEventTestCompletionForReason):
(WebCore::ThreadedScrollingTree::removeWheelEventTestCompletionDeferralForReason):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
(isType):
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(isScrolledBy):
(ScrollingTreeMac::scrollingNodeForPoint):
(ScrollingTreeMac::eventListenerRegionTypesForPoint const):

Canonical link: <a href="https://commits.webkit.org/290091@main">https://commits.webkit.org/290091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91b62538a0c723c9555845b9c33a3e6122f333a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88957 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93929 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68533 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6761 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48897 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6510 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38825 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95768 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77410 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16393 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76698 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18901 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21085 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9218 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21462 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19343 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->