### PR TITLE
[web-animations] animations without an associated timeline should have their effects in the effect stack

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
@@ -3,5 +3,5 @@ PASS Changing animation-timeline changes the timeline (sanity check)
 PASS animation-timeline ignored after setting timeline with JS (ScrollTimeline from JS)
 PASS animation-timeline ignored after setting timeline with JS (ScrollTimeline from CSS)
 PASS animation-timeline ignored after setting timeline with JS (document timeline)
-FAIL animation-timeline ignored after setting timeline with JS (null) assert_equals: expected "120px" but got "0px"
+FAIL animation-timeline ignored after setting timeline with JS (null) assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -1,7 +1,7 @@
 
 PASS scroll-timeline-name is referenceable in animation-timeline on the declaring element itself
 PASS scroll-timeline-name is referenceable in animation-timeline on that element's descendants
-FAIL scroll-timeline-name is not referenceable in animation-timeline on that element's siblings assert_equals: Animation with unknown timeline name holds current time at zero expected "50px" but got "none"
+PASS scroll-timeline-name is not referenceable in animation-timeline on that element's siblings
 PASS scroll-timeline-name on an element which is not a scroll-container
 FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected null but got object "[object DocumentTimeline]"
 FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: Failed to remove timeline expected null but got object "[object ScrollTimeline]"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -7,6 +7,6 @@ PASS Dynamically re-attaching
 FAIL Dynamically detaching assert_equals: expected "100px" but got "0px"
 FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
 PASS Ancestor attached element becoming display:none/block
-FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
+FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "0px" but got "100px"
 PASS Animations prefer non-deferred timelines
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup.html
@@ -217,7 +217,7 @@
 <script>
   promise_test(async (t) => {
     await inflate(t, timeline_ancestor_closer_timeline_wins);
-    assert_equals(getComputedStyle(target).zIndex, 'auto');
+    assert_equals(getComputedStyle(target).zIndex, '0');
   }, 'timeline-scope on ancestor sibling, closer timeline wins');
 </script>
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -301,7 +301,6 @@ animation/CSSTransition.cpp
 animation/CustomEffect.cpp
 animation/DocumentTimeline.cpp
 animation/KeyframeEffect.cpp
-animation/KeyframeEffectStack.cpp
 animation/ScrollTimeline.cpp
 animation/StyleOriginatedAnimation.cpp
 animation/StyleOriginatedAnimationEvent.cpp

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -52,7 +52,7 @@ bool KeyframeEffectStack::addEffect(KeyframeEffect& effect)
 {
     // To qualify for membership in an effect stack, an effect must have a target, an animation, a timeline and be relevant.
     // This method will be called in WebAnimation and KeyframeEffect as those properties change.
-    if (!effect.targetStyleable() || !effect.animation() || !effect.animation()->timeline() || !effect.animation()->isRelevant())
+    if (!effect.targetStyleable() || !effect.animation() || !effect.animation()->isRelevant())
         return false;
 
     ASSERT(!m_effects.contains(&effect));
@@ -186,8 +186,8 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
 
         // If one of the effect's resolved property changed it could affect whether that effect's animation is removed.
         if (keyframeRecomputationReason && *keyframeRecomputationReason == KeyframeEffect::RecomputationReason::LogicalPropertyChange) {
-            ASSERT(animation->timeline());
-            animation->timeline()->animationTimingDidChange(*animation);
+            if (RefPtr timeline = animation->timeline())
+                timeline->animationTimingDidChange(*animation);
         }
 
         affectedProperties.formUnion(effect->animatedProperties());

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -83,7 +83,8 @@ private:
     AnimationEffectPhase phaseWithoutEffect() const;
     enum class ShouldFireEvents : uint8_t { No, YesForCSSAnimation, YesForCSSTransition };
     ShouldFireEvents shouldFireDOMEvents() const;
-    void invalidateDOMEvents(ShouldFireEvents, WebAnimationTime elapsedTime = 0_s);
+    template<typename F> void invalidateDOMEvents(F&&);
+    void invalidateDOMEvents(ShouldFireEvents, WebAnimationTime cancelationTime = 0_s);
     void enqueueDOMEvent(const AtomString&, WebAnimationTime elapsedTime, WebAnimationTime scheduledEffectTime);
 
     WebAnimationTime effectTimeAtStart() const;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -878,6 +878,10 @@ void WebAnimation::enqueueAnimationEvent(Ref<AnimationEventBase>&& event)
             if (RefPtr source = scrollTimeline->source())
                 return Ref { source->document() }->existingTimeline();
         }
+        if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(m_effect)) {
+            if (RefPtr target = keyframeEffect->target())
+                return target->protectedDocument()->existingTimeline();
+        }
         return nullptr;
     };
 


### PR DESCRIPTION
#### 95675d2184dce25690106ac45b3e88d3c8ec90e7
<pre>
[web-animations] animations without an associated timeline should have their effects in the effect stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=287327">https://bugs.webkit.org/show_bug.cgi?id=287327</a>

Reviewed by Tim Nguyen.

Prior to the addition of Scroll-driven Animations, there was no real practical purpose to set a null
timeline on an animation, and in fact it wasn&apos;t possible to set one via CSS, only using the Web
Animations API. With that assumption in mind, we incorrectly did not list effects associated with
an animation without a timeline in the effect stack of their associated target. However, with
Scroll-driven Animations, the `animation-timeline` property allows to set various types of timelines
(document, scroll and view) and the interaction with the `timeline-scope` property may also yield null
timelines. Some new WPT tests now rely on effects associated with animations with no timelines to appear
in the effect stack, so we must update our implementation to remove our timeline requirement.

To implement that behavior we remove the timeline check in `KeyframeEffectStack::addEffect()` and
remove the timeline assertion in `KeyframeEffectStack::applyKeyframeEffects()`.

While that is sufficient to allow effects not associated with a timeline through their animation to
appear in an effect stack, this change uncovered an issue in `css/css-animations/event-dispatch.tentative.html`
which checked that an animation that has its timeline set to null via the Web Animations API would
dispatch an `animationcancel` event. Indeed, to dispatch such an event, we simply overloaded the
`setTimeline()` method on `StyleOriginatedAnimation` and called `cancel()` if we switched to a null
timeline. But calling `cancel()` has other implications beyond dispatching an `animationcancel` event,
such as resetting timing properties of the animation. To address this, we refactor the `invalidateDOMEvents()`
method to allow a callback to be evaluated in between computing the current animation time (which will be
used as the cancelation time) and the evaluation of the state change to determine which events to dispatch.
Using this callback, we can have `setTimeline()` and `cancel()` call their respective superclass methods
in that process.

Finally, this uncovered an issue in `scroll-animations/css/view-timeline-lookup.html` where the test
assumed an inactive timeline instead of a &quot;null&quot; timeline, which only started behaving differently in
WebKit with this patch since we now correctly apply the animation in this case.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-lookup.html:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::addEffect):
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::setTimeline):
(WebCore::StyleOriginatedAnimation::cancel):
(WebCore::StyleOriginatedAnimation::invalidateDOMEvents):
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::enqueueAnimationEvent):

Canonical link: <a href="https://commits.webkit.org/290092@main">https://commits.webkit.org/290092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ed3cd290b5a58242b3bd24d4c4c4ffa75b6a93a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68528 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6506 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95761 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16130 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11773 "Found 2 new test failures: fast/dom/crash-with-bad-url.html imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77405 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16386 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76693 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19549 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9207 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13934 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21455 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15885 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->