### PR TITLE
Fix warnings found by clang-17

### DIFF
--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -96,7 +96,7 @@ public:
     {
         auto count = CFBitVectorGetCount(bitVector);
         for (CFIndex i = 0; i < count; ++i) {
-            if (bool isSet = CFBitVectorGetBitAtIndex(bitVector, i))
+            if (CFBitVectorGetBitAtIndex(bitVector, i))
                 quickSet(i);
         }
     }

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -380,8 +380,10 @@ void Thread::setThreadTimeConstraints(MonotonicTime period, MonotonicTime nomina
     policy.computation = nominalComputation.toMachAbsoluteTime();
     policy.constraint = constraint.toMachAbsoluteTime();
     policy.preemptible = isPremptable;
-    if (auto error = thread_policy_set(machThread(), THREAD_TIME_CONSTRAINT_POLICY, (thread_policy_t)&policy, THREAD_TIME_CONSTRAINT_POLICY_COUNT))
+    if (auto error = thread_policy_set(machThread(), THREAD_TIME_CONSTRAINT_POLICY, (thread_policy_t)&policy, THREAD_TIME_CONSTRAINT_POLICY_COUNT)) {
+        UNUSED_VARIABLE(error);
         LOG_ERROR("Thread %p failed to set time constraints with error %d", this, error);
+    }
 #else
     ASSERT_NOT_REACHED();
 #endif

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -426,7 +426,7 @@ inline std::span<uint8_t> CMBlockBufferGetDataSpan(CMBlockBufferRef theBuffer, s
 {
     char* data = nullptr;
     size_t lengthAtOffset = 0;
-    if (auto error = PAL::CMBlockBufferGetDataPointer(theBuffer, offset, &lengthAtOffset, nullptr, &data))
+    if (PAL::CMBlockBufferGetDataPointer(theBuffer, offset, &lengthAtOffset, nullptr, &data))
         return { };
     return unsafeMakeSpan(byteCast<uint8_t>(data), lengthAtOffset);
 }

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -157,7 +157,7 @@ void attributedStringSetElement(NSMutableAttributedString *string, NSString *att
     id wrapper = object.wrapper();
     if ([attribute isEqualToString:NSAccessibilityAttachmentTextAttribute] && object.isAttachment()) {
         if (id attachmentView = [wrapper attachmentView])
-            wrapper = [wrapper attachmentView];
+            wrapper = attachmentView;
     }
 
     if (RetainPtr axElement = adoptCF(NSAccessibilityCreateAXUIElementRef(wrapper)))

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
@@ -189,7 +189,7 @@ void ScrollLatchingController::removeLatchingStateForFrame(const LocalFrame& fra
         return;
 
     // If the frame was in the latching stack, just clear state.
-    if (auto* frameState = stateForFrame(frame))
+    if (stateForFrame(frame))
         clear();
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2726,6 +2726,10 @@ bool MediaPlayerPrivateAVFoundationObjC::updateLastPixelBuffer()
             .height = static_cast<unsigned>(CVPixelBufferGetHeight(m_lastPixelBuffer.get())),
             .mediaTime = entry.displayTime.toDouble(),
             .presentedFrames = static_cast<unsigned>(++m_sampleCount),
+            .processingDuration = std::nullopt,
+            .captureTime = std::nullopt,
+            .receiveTime = std::nullopt,
+            .rtpTimestamp = std::nullopt,
         };
     }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -107,7 +107,7 @@ void MediaSampleAVFObjC::commonInit()
         }
 
 #if HAVE(FAIRPLAYSTREAMING_MTPS_INITDATA)
-        if (auto transportStreamData = static_cast<CFDataRef>(PAL::CMFormatDescriptionGetExtension(description, CFSTR("TransportStreamEncryptionInitData")))) {
+        if (static_cast<CFDataRef>(PAL::CMFormatDescriptionGetExtension(description, CFSTR("TransportStreamEncryptionInitData")))) {
             // AVStreamDataParser will attach a JSON transport stream encryption
             // description object to each sample. Use a static keyID in this case
             // as MPEG2-TS encryption dose not specify a particular keyID in the

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -313,7 +313,7 @@ Expected<RetainPtr<CMSampleBufferRef>, CString> toCMSampleBuffer(const MediaSamp
     }
 
     CMSampleBufferRef rawSampleBuffer = nullptr;
-    if (auto err = PAL::CMSampleBufferCreateReady(kCFAllocatorDefault, completeBlockBuffers.get(), format.get(), packetSizes.size(), packetTimings.size(), packetTimings.data(), packetSizes.size(), packetSizes.data(), &rawSampleBuffer))
+    if (PAL::CMSampleBufferCreateReady(kCFAllocatorDefault, completeBlockBuffers.get(), format.get(), packetSizes.size(), packetTimings.size(), packetTimings.data(), packetSizes.size(), packetSizes.data(), &rawSampleBuffer))
         return makeUnexpected("CMSampleBufferCreateReady failed: OOM");
 
     if (samples.isVideo() && samples.size()) {

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -712,7 +712,7 @@ void CoreAudioSharedUnit::validateOutputDevice(uint32_t currentOutputDeviceID)
         return;
 
     uint32_t currentDefaultOutputDeviceID = 0;
-    if (auto err = m_ioUnit->defaultOutputDevice(&currentDefaultOutputDeviceID))
+    if (m_ioUnit->defaultOutputDevice(&currentDefaultOutputDeviceID))
         return;
 
     if (!currentDefaultOutputDeviceID || currentOutputDeviceID == currentDefaultOutputDeviceID)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm
@@ -198,10 +198,8 @@ bool CoreAudioSharedInternalUnit::setVoiceActivityDetection(bool shouldEnable)
 #if HAVE(VOICEACTIVITYDETECTION)
 #if PLATFORM(MAC)
     auto deviceID = CoreAudioSharedUnit::singleton().captureDeviceID();
-    if (!deviceID) {
-        if (auto err = defaultInputDevice(&deviceID))
-            return false;
-    }
+    if (!deviceID && defaultInputDevice(&deviceID))
+        return false;
     return manageSpeechActivityListener(deviceID, shouldEnable);
 #else
     const UInt32 outputBus = 0;

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -752,7 +752,7 @@ void WebCoreNSURLSessionDataTaskClient::loadFinished(PlatformMediaResource& reso
 
     // CoreMedia will explicitly add a user agent header. Remove if present.
     RetainPtr<NSMutableURLRequest> mutableRequest;
-    if (auto* userAgentValue = [request valueForHTTPHeaderField:@"User-Agent"]) {
+    if ([request valueForHTTPHeaderField:@"User-Agent"]) {
         mutableRequest = adoptNS([request mutableCopy]);
         [mutableRequest setValue:nil forHTTPHeaderField:@"User-Agent"];
         request = mutableRequest.get();

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -719,7 +719,7 @@ void AttributeValidator::validateStructIO(ShaderStage stage, const Types::Struct
             continue;
         }
 
-        if (auto* structType = std::get_if<Types::Struct>(member.type().inferredType())) {
+        if (auto inferredType = member.type().inferredType(); inferredType && std::holds_alternative<Types::Struct>(*inferredType)) {
             error(span, "nested structures cannot be used for entry point IO"_s);
             continue;
         }

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -2495,7 +2495,7 @@ void RewriteGlobalVariables::storeInitialValue(AST::Expression& target, AST::Sta
         return;
     }
 
-    if (auto* atomicType = std::get_if<Types::Atomic>(type)) {
+    if (type && std::holds_alternative<Types::Atomic>(*type)) {
         auto& callee = m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make("atomicStore"_s));
         callee.m_inferredType = m_shaderModule.types().bottomType();
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -2196,7 +2196,7 @@ Behaviors TypeChecker::analyze(AST::LoopStatement& statement)
         m_breakTargetStack.append(&continuing.value());
         behaviors.add(analyzeStatements(continuing->body));
         m_breakTargetStack.removeLast();
-        if (auto* breakIf = continuing->breakIf)
+        if (continuing->breakIf)
             behaviors.add({ Behavior::Break, Behavior::Continue });
     }
     m_breakTargetStack.removeLast();

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -399,7 +399,7 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
     std::array<id<MTLArgumentEncoder>, stageCount> argumentEncoders;
     for (size_t stage = 0; stage < stageCount; ++stage) {
         auto renderStage = stages[stage];
-        if (auto bufferCountPerStage = bufferCounts[stage]) {
+        if (bufferCounts[stage]) {
             auto descriptor = [MTLArgumentDescriptor new];
             descriptor.dataType = MTLDataTypeInt;
             descriptor.access = BindGroupLayout::BindingAccessReadOnly;

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -142,7 +142,7 @@ bool RenderBundle::validateRenderPass(bool depthReadOnly, bool stencilReadOnly, 
         defaultRasterSampleCount = attachmentView->sampleCount();
     }
 
-    if (auto* depthStencil = descriptor.depthStencilAttachment) {
+    if (descriptor.depthStencilAttachment) {
         if (!depthStencilView) {
             if (m_descriptor.depthStencilFormat != WGPUTextureFormat_Undefined)
                 return false;

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -795,7 +795,7 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndexedIndir
     if (!executePreDrawCommands(needsValidationLayerWorkaround, splitPass))
         return finalizeRenderCommand();
     id<MTLBuffer> indexBuffer = m_indexBuffer ? m_indexBuffer->buffer() : nil;
-    if (id<MTLIndirectRenderCommand> icbCommand = currentRenderCommand()) {
+    if (currentRenderCommand()) {
         if (!indexBuffer.length)
             return finalizeRenderCommand();
 
@@ -853,7 +853,7 @@ RenderBundleEncoder::FinalizeRenderCommand RenderBundleEncoder::drawIndirect(Buf
 
     if (!executePreDrawCommands(needsValidationLayerWorkaround, splitPass))
         return finalizeRenderCommand();
-    if (id<MTLIndirectRenderCommand> icbCommand = currentRenderCommand()) {
+    if (currentRenderCommand()) {
         if (renderPassEncoder) {
             if (!setCommandEncoder(indirectBuffer, renderPassEncoder))
                 return finalizeRenderCommand();
@@ -1264,7 +1264,7 @@ void RenderBundleEncoder::setPipeline(const RenderPipeline& pipeline)
         return;
     }
 
-    if (id<MTLIndirectRenderCommand> icbCommand = currentRenderCommand()) {
+    if (currentRenderCommand()) {
         id<MTLRenderPipelineState> previousRenderPipelineState = m_currentPipelineState;
         id<MTLDepthStencilState> previousDepthStencilState = m_depthStencilState;
         auto previous_cullMode = m_cullMode;
@@ -1350,7 +1350,7 @@ void RenderBundleEncoder::setVertexBuffer(uint32_t slot, Buffer* optionalBuffer,
         return;
     }
 
-    if (id<MTLIndirectRenderCommand> icbCommand = currentRenderCommand()) {
+    if (currentRenderCommand()) {
         if (!optionalBuffer) {
             if (slot < m_device->limits().maxVertexBuffers)
                 m_utilizedBufferIndices.remove(slot);

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1735,7 +1735,7 @@ bool RenderPipeline::colorDepthStencilTargetsMatch(const WGPURenderPassDescripto
         return false;
     }
 
-    if (auto* depthStencil = descriptor.depthStencilAttachment) {
+    if (descriptor.depthStencilAttachment) {
         if (!depthStencilView)
             return false;
         auto& texture = *depthStencilView.get();

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -181,7 +181,7 @@ static inline bool isNat64IPAddress(const rtc::IPAddress& ip)
         return false;
 
     struct ifaddrs* interfaces;
-    if (auto error = getifaddrs(&interfaces))
+    if (getifaddrs(&interfaces))
         return true;
     std::unique_ptr<struct ifaddrs> toBeFreed(interfaces);
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -272,7 +272,7 @@ using namespace WebKit;
         [self removeInvalidResourceTypesForKey:declarativeNetRequestRuleConditionResourceTypeKey];
     }
 
-    if (NSArray<NSString *> *excludedResourceTypes = _condition[declarativeNetRequestRuleConditionExcludedResourceTypesKey])
+    if (_condition[declarativeNetRequestRuleConditionExcludedResourceTypesKey])
         [self removeInvalidResourceTypesForKey:declarativeNetRequestRuleConditionResourceTypeKey];
 
     if ([_action[declarativeNetRequestRuleActionTypeKey] isEqualToString:declarativeNetRequestRuleActionTypeAllowAllRequests]) {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -170,7 +170,7 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
     WebExtension::MatchPatternSet allowedHostPermissions = extension->allRequestedMatchPatterns();
 
     if ([callingAPIName isEqualToString:@"permissions.remove()"]) {
-        if (bool requestingToRemoveFunctionalPermissions = permissions.size() && permissions.intersectionWith(allowedPermissions).size()) {
+        if (permissions.size() && permissions.intersectionWith(allowedPermissions).size()) {
             *outExceptionString = toErrorString(nullString(), permissionsKey, @"required permissions cannot be removed");
             return false;
         }

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
@@ -104,7 +104,7 @@ TEST(BifurcatedGraphicsContextTests, Text)
         EXPECT_FALSE(displayList.isEmpty());
         bool sawDrawGlyphs = false;
         for (auto& displayListItem : displayList.items()) {
-            if (auto* item = std::get_if<DrawGlyphs>(&displayListItem))
+            if (std::holds_alternative<DrawGlyphs>(displayListItem))
                 sawDrawGlyphs = true;
         }
 


### PR DESCRIPTION
#### c6e6edd8f8ffe23a73ffa5310eae5836dc35b680
<pre>
Fix warnings found by clang-17
<a href="https://bugs.webkit.org/show_bug.cgi?id=287329">https://bugs.webkit.org/show_bug.cgi?id=287329</a>

Reviewed by Geoffrey Garen.

Fixed all the warnings newly found by clang-17. Most of them are warnings about a variable
which is set but never used.

MediaPlayerPrivateAVFoundationObjC.mm has code change to explicitly initialize each optional
member variable with std::nullopt. This shouldn&apos;t be necessary in theory but included here
to make clang-17 happy.

* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::Thread::setThreadTimeConstraints):
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
(PAL::CMBlockBufferGetDataSpan):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::attributedStringSetElement):
* Source/WebCore/page/scrolling/ScrollLatchingController.cpp:
(WebCore::ScrollLatchingController::removeLatchingStateForFrame):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastPixelBuffer):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::commonInit):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::toCMSampleBuffer):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::validateOutputDevice):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.mm:
(WebCore::CoreAudioSharedInternalUnit::setVoiceActivityDetection):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSessionDataTask initWithSession:identifier:request:targetDispatcher:]):
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::validateStructIO):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::storeInitialValue):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::analyze):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::Device::createBindGroupLayout):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::validateRenderPass const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::setPipeline):
(WebGPU::RenderBundleEncoder::setVertexBuffer):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::colorDepthStencilTargetsMatch const):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::isNat64IPAddress):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::verifyRequestedPermissions):
* Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp:
(TestWebKitAPI::TEST(BifurcatedGraphicsContextTests, Text)):

Canonical link: <a href="https://commits.webkit.org/290118@main">https://commits.webkit.org/290118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ee851fd5f95102d015abd05d1b0c6235bdf232b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68586 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48949 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6570 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38887 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81818 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95830 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87795 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16199 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11840 "Found 1 new test failure: fast/dom/crash-with-bad-url.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77465 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16455 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76755 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21146 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9282 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13950 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16213 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21524 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110288 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15954 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26472 "Found 4 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->