### PR TITLE
[GStreamer][MediaStream] Reduce memory copies in MediaStreamAudioDestinationNode implementation

### DIFF
--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -29,25 +29,6 @@
 
 namespace WebCore {
 
-static void copyBusData(AudioBus& bus, GstBuffer* buffer, bool isMuted)
-{
-    GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
-    if (isMuted) {
-        memset(mappedBuffer.data(), 0, mappedBuffer.size());
-        return;
-    }
-
-    size_t offset = 0;
-    for (size_t channelIndex = 0; channelIndex < bus.numberOfChannels(); ++channelIndex) {
-        const auto& channel = *bus.channel(channelIndex);
-        auto dataSize = sizeof(float) * channel.length();
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        memcpy(mappedBuffer.data() + offset, channel.data(), dataSize);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-        offset += dataSize;
-    }
-}
-
 void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
 {
     if (!bus.numberOfChannels() || bus.numberOfChannels() > 2) {
@@ -65,14 +46,25 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
         m_caps = adoptGRef(gst_audio_info_to_caps(&m_info));
     }
 
-    size_t size = GST_AUDIO_INFO_BPS(&m_info) * bus.numberOfChannels() * numberOfFrames;
-    auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, size, nullptr));
-
+    auto buffer = adoptGRef(gst_buffer_new());
     GST_BUFFER_PTS(buffer.get()) = toGstClockTime(mediaTime);
     GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_LIVE);
 
-    copyBusData(bus, buffer.get(), muted());
+    for (size_t channelIndex = 0; channelIndex < bus.numberOfChannels(); ++channelIndex) {
+        auto& channel = *bus.channel(channelIndex);
+        auto dataSize = sizeof(float) * channel.length();
+
+        bus.ref();
+        gst_buffer_append_memory(buffer.get(), gst_memory_new_wrapped(GST_MEMORY_FLAG_READONLY, channel.mutableData(), dataSize, 0, dataSize, &bus, reinterpret_cast<GDestroyNotify>(+[](gpointer data) {
+            auto bus = reinterpret_cast<AudioBus*>(data);
+            bus->deref();
+        })));
+    }
+
     gst_buffer_add_audio_meta(buffer.get(), &m_info, numberOfFrames, nullptr);
+    if (bus.isSilent())
+        gst_buffer_add_audio_level_meta(buffer.get(), 127, FALSE);
+
     auto sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
     GStreamerAudioData audioBuffer(WTFMove(sample), m_info);
     GStreamerAudioStreamDescription description(&m_info);


### PR DESCRIPTION
#### 8bbe3af182ad0f135f95d36385501ed0279c565d
<pre>
[GStreamer][MediaStream] Reduce memory copies in MediaStreamAudioDestinationNode implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=287330">https://bugs.webkit.org/show_bug.cgi?id=287330</a>

Reviewed by Xabier Rodriguez-Calvar.

The memory copies are avoided by wrapping each audio channel data in a GstMemory, keeping the
AudioBus alive until the GstMemory is disposed.

* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp:
(WebCore::MediaStreamAudioSource::consumeAudio):
(WebCore::copyBusData): Deleted.

Canonical link: <a href="https://commits.webkit.org/290153@main">https://commits.webkit.org/290153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1646d7da2cbabe98d515e2e3f823bf6a95723a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68523 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91948 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6756 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48887 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6505 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38814 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76867 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95757 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77402 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16382 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76690 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21078 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9198 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16140 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21451 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->