### PR TITLE
webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode.html fails

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -490,9 +490,6 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediastreamaudiosourc
 # This test is timing out due to lack of support for SharedArrayBuffer.
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-sharedarraybuffer.https.html [ Skip ]
 
-# This webaudio test has been timing out since its import from Blink.
-webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode.html [ Skip ]
-
 # Webaudio tests that are flaky.
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-stereo-panner.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/cors-check.https.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -83,6 +83,7 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interfac
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-setsinkid.https.html [ Skip ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-state-change.https.html [ Skip ]
 media/now-playing-status-for-video-conference-web-page.html [ Skip ]
+webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode.html [ Skip ]
 
 # Payment request &  Merchant Validation APIs are not supported on WK1.
 imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html [ Skip ]

--- a/LayoutTests/webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode-expected.txt
+++ b/LayoutTests/webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode-expected.txt
@@ -1,5 +1,17 @@
-#PID UNRESPONSIVE - WebKitTestRunner (pid 5731)
-FAIL: Timed out waiting for notifyDone to be called
 
-#EOF
-#EOF
+PASS # AUDIT TASK RUNNER STARTED.
+PASS Executing "test"
+PASS Audit report
+PASS > [test] Basic tests for MediaStreamAudioSourceNode API
+PASS   {audio:true} generated stream correctly
+PASS   mediaStreamSource.numberOfInputs is equal to 0.
+PASS   mediaStreamSource.numberOfOutputs is equal to 1.
+PASS   mediaStreamSource.mediaStream instanceof MediaStream is true.
+PASS   mediaStreamSource.mediaStream is same object is true.
+PASS   mediaStreamSource.connect(0, 0, 0) threw TypeError: "Argument 1 ('destination') to AudioNode.connect must be an instance of AudioNode".
+PASS   mediaStreamSource.connect(context.destination, 5, 0) threw IndexSizeError: "Output index exceeds number of outputs".
+PASS   mediaStreamSource.connect(context.destination, 0, 5) threw IndexSizeError: "Input index exceeds number of inputs".
+PASS   mediaStreamSource.connect(context.destination, 0, 0) did not throw an exception.
+PASS < [test] All assertions passed. (total 9 assertions)
+PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+

--- a/LayoutTests/webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode.html
+++ b/LayoutTests/webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode.html
@@ -11,6 +11,9 @@
   </head>
   <body>
     <script id="layout-test-code">
+     if (window.testRunner)
+         testRunner.setUserMediaPermission(true);
+
       let audit = Audit.createTaskRunner();
 
       audit.define(
@@ -18,21 +21,10 @@
             label: 'test',
             description: 'Basic tests for MediaStreamAudioSourceNode API'
           },
-          (task, should) => {
-            should(
-                () => {navigator.webkitGetUserMedia(
-                    {audio: true},
-                    (stream) => {
-                      gotStream(stream, should);
-                      task.done();
-                    },
-                    () => {
-                      should(false, 'Stream generation')
-                          .message('succeeded', 'failed');
-                      task.done();
-                    })},
-                'getUserMedia()')
-                .notThrow();
+          async (task, should) => {
+            const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+            gotStream(stream, should);
+            task.done();
           });
 
       audit.run();


### PR DESCRIPTION
#### 4d4159108c57517eac17f075c57965a4a42c97b3
<pre>
webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=287331">https://bugs.webkit.org/show_bug.cgi?id=287331</a>

Reviewed by Xabier Rodriguez-Calvar.

The test was failing because it was using navigator.webkitGetUserMedia which is no longer exposed.
The convoluted JS logic was simplified as well by making the test callback an async function.

* LayoutTests/TestExpectations:
* LayoutTests/webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode-expected.txt:
* LayoutTests/webaudio/MediaStreamAudioSource/mediastreamaudiosourcenode.html:

Canonical link: <a href="https://commits.webkit.org/290155@main">https://commits.webkit.org/290155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f541e3ee8fa24b2a0a2da293b6d43c5373b57c9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16845 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26350 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92134 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6677 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95946 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16312 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16568 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76848 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21252 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9414 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16326 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->