### PR TITLE
Clamp contents ink overflow for LegacyRenderSVGRoot

### DIFF
--- a/LayoutTests/svg/overflow/large-overflow-expected.html
+++ b/LayoutTests/svg/overflow/large-overflow-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/overflow/large-overflow.html
+++ b/LayoutTests/svg/overflow/large-overflow.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<div style="overflow: hidden; position: relative">
+  <svg style="overflow: visible">
+    <rect width="100" height="100" fill="green"/>
+    <g transform="translate(0, -9000000000)">
+      <path d="M 3.5 0.5 L 28.5 0.5" stroke="red"/>
+    </g>
+  </svg>
+</div>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -4,6 +4,7 @@
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2009-2023 Google, Inc.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -206,11 +207,8 @@ void LegacyRenderSVGRoot::layout()
     }
 
     clearOverflow();
-    if (!shouldApplyViewportClip()) {
-        FloatRect contentRepaintRect = repaintRectInLocalCoordinates();
-        contentRepaintRect = m_localToBorderBoxTransform.mapRect(contentRepaintRect);
-        addVisualOverflow(enclosingLayoutRect(contentRepaintRect));
-    }
+    if (!shouldApplyViewportClip())
+        addVisualOverflow(computeContentsInkOverflow());
 
     updateLayerTransform();
     m_hasBoxDecorations = isDocumentElementRenderer() ? hasVisibleBoxDecorationStyle() : hasVisibleBoxDecorations();
@@ -219,6 +217,18 @@ void LegacyRenderSVGRoot::layout()
     repainter.repaintAfterLayout();
 
     clearNeedsLayout();
+}
+
+LayoutRect LegacyRenderSVGRoot::computeContentsInkOverflow() const
+{
+    FloatRect contentRepaintRect = repaintRectInLocalCoordinates();
+    contentRepaintRect = m_localToBorderBoxTransform.mapRect(contentRepaintRect);
+    // Condition the visual overflow rect to avoid being clipped/culled
+    // out if it is huge. This may sacrifice overflow, but usually only
+    // overflow that would never be seen anyway.
+    // To condition, we intersect with something that we oftentimes
+    // consider to be "infinity".
+    return intersection(enclosingLayoutRect(contentRepaintRect), LayoutRect::infiniteRect());
 }
 
 bool LegacyRenderSVGRoot::shouldApplyViewportClip() const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2009-2016 Google, Inc.  All rights reserved.
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2018 Google, Inc.  All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -96,6 +96,8 @@ private:
     RepaintRects rectsForRepaintingAfterLayout(const RenderLayerModelObject* repaintContainer, RepaintOutlineBounds) const override;
 
     LayoutRect localClippedOverflowRect(RepaintRectCalculation) const;
+
+    LayoutRect computeContentsInkOverflow() const;
 
     std::optional<FloatRect> computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject* container, VisibleRectContext) const override;
 


### PR DESCRIPTION
#### b3e802df574fb29c7954371d82a10afce0399025
<pre>
Clamp contents ink overflow for LegacyRenderSVGRoot

<a href="https://bugs.webkit.org/show_bug.cgi?id=287016">https://bugs.webkit.org/show_bug.cgi?id=287016</a>
<a href="https://rdar.apple.com/144443670">rdar://144443670</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/acc79f1cd39645d800757d7cfb09e4740a89ceab">https://chromium.googlesource.com/chromium/src.git/+/acc79f1cd39645d800757d7cfb09e4740a89ceab</a>

If the contents overflow rect for the SVG root is too large, it could
end up shifting the overflow rect such that it is culled and thus never
painted.

To avoid this, clip the content overflow rect with LayoutRect::infiniteRect().
This gives reasonable enough leeway, and also matches the rect that is
commonly used to represent infinity for culling and clipping etc.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::layout):
(WebCore::LegacyRenderSVGRoot::computeContentsInkOverflow const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* LayoutTests/svg/overflow/large-overflow.html:
* LayoutTests/svg/overflow/large-overflow-expected.html:

Canonical link: <a href="https://commits.webkit.org/290116@main">https://commits.webkit.org/290116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af4135c7c7c0ee72c57fea3e87b62c1b569677ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68534 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6515 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95771 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77414 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18917 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21091 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9221 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21465 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15895 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->