### PR TITLE
[scroll-animations] address WPT failures related to `timeline-scope` and `animation-timeline`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6956,9 +6956,6 @@ webkit.org/b/283701 imported/w3c/web-platform-tests/scroll-animations/css/deferr
 webkit.org/b/283702 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/constructor-no-document.html [ Skip ]
 webkit.org/b/283107 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/updating-the-finished-state.html [ Skip ]
 
-# webkit.org/b/263871 [scroll-animations] some WPT tests are failures or flaky failures
-imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none.html [ Pass Failure ]
-
 webkit.org/b/284299 imported/w3c/web-platform-tests/scroll-animations/view-timelines/animation-events.html [ Pass Failure ]
 
 # webkit.org/b/263872 [scroll-animations] some WPT tests are ImageOnlyFailure

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Animation.timeline returns attached timeline
-FAIL Animation.timeline returns a timeline with no source for inactive deferred timeline promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'animating.getAnimations()[0].timeline')"
+PASS Animation.timeline returns a timeline with no source for inactive deferred timeline
 PASS Animation.timeline returns a timeline with no source for inactive (overattached) deferred timeline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -3,8 +3,8 @@ PASS scroll-timeline-name is referenceable in animation-timeline on the declarin
 PASS scroll-timeline-name is referenceable in animation-timeline on that element's descendants
 PASS scroll-timeline-name is not referenceable in animation-timeline on that element's siblings
 PASS scroll-timeline-name on an element which is not a scroll-container
-FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected null but got object "[object DocumentTimeline]"
-FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: Failed to remove timeline expected null but got object "[object ScrollTimeline]"
+PASS Change in scroll-timeline-name to match animation timeline updates animation.
+PASS Change in scroll-timeline-name to no longer match animation timeline updates animation.
 PASS Timeline lookup updates candidate when closer match available.
 PASS Timeline lookup updates candidate when match becomes available.
 PASS scroll-timeline-axis is block

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Animation with animation-timeline:none holds current time at zero assert_equals: expected "100px" but got "0px"
-FAIL Animation with unknown timeline name holds current time at zero assert_equals: expected "100px" but got "100.8125px"
+PASS Animation with animation-timeline:none holds current time at zero
+PASS Animation with unknown timeline name holds current time at zero
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
@@ -5,12 +5,12 @@ PASS Switching pending animation from document to scroll timelines [immediate]
 PASS Switching pending animation from document to scroll timelines [scroll]
 PASS Changing computed value of animation-timeline changes effective timeline [immediate]
 PASS Changing computed value of animation-timeline changes effective timeline [scroll]
-FAIL Changing to/from animation-timeline:none [immediate] assert_equals: expected "0px" but got "100px"
-FAIL Changing to/from animation-timeline:none [scroll] assert_equals: expected "0px" but got "100px"
-FAIL Reverse animation direction [immediate] assert_equals: expected "0px" but got "190px"
-FAIL Reverse animation direction [scroll] assert_equals: expected "0px" but got "190px"
-FAIL Change to timeline attachment while paused [immediate] assert_equals: expected "0px" but got "100px"
-FAIL Change to timeline attachment while paused [scroll] assert_equals: expected "0px" but got "100px"
+PASS Changing to/from animation-timeline:none [immediate]
+PASS Changing to/from animation-timeline:none [scroll]
+PASS Reverse animation direction [immediate]
+PASS Reverse animation direction [scroll]
+PASS Change to timeline attachment while paused [immediate]
+PASS Change to timeline attachment while paused [scroll]
 FAIL Switching timelines and pausing at the same time [immediate] assert_equals: expected "100px" but got "120px"
 FAIL Switching timelines and pausing at the same time [scroll] assert_equals: expected "100px" but got "120px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -4,9 +4,9 @@ PASS Deferred timeline with no attachments
 PASS Inner timeline does not interfere with outer timeline
 PASS Deferred timeline with two attachments
 PASS Dynamically re-attaching
-FAIL Dynamically detaching assert_equals: expected "100px" but got "0px"
+PASS Dynamically detaching
 FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
 PASS Ancestor attached element becoming display:none/block
-FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "0px" but got "100px"
+FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
 PASS Animations prefer non-deferred timelines
 

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -86,6 +86,7 @@ public:
     void updateNamedTimelineMapForTimelineScope(const TimelineScope&, const Styleable&);
     void updateTimelineForTimelineScope(const Ref<ScrollTimeline>&, const AtomString&);
     void unregisterNamedTimelinesAssociatedWithElement(const Styleable&);
+    void removePendingOperationsForCSSAnimation(const CSSAnimation&);
     void documentDidResolveStyle();
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
@@ -104,6 +105,8 @@ private:
     bool isPendingTimelineAttachment(const WebAnimation&) const;
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
 
+    enum class AllowsDeferral : bool { No, Yes };
+    void setTimelineForName(const AtomString&, const Styleable&, CSSAnimation&, AllowsDeferral);
     ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
     ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
     ScrollTimeline& inactiveNamedTimeline(const AtomString&);


### PR DESCRIPTION
#### dd9fc65cb4bc5cd6455330e6ae0cca0d9cfe328d
<pre>
[scroll-animations] address WPT failures related to `timeline-scope` and `animation-timeline`
<a href="https://bugs.webkit.org/show_bug.cgi?id=287337">https://bugs.webkit.org/show_bug.cgi?id=287337</a>

Reviewed by Anne van Kesteren.

In 290046@main we put together a sounder approach to attaching timelines to style-originated
animations by waiting until the style resolution process completed. But the attachment logic
as well as when to attempt attachment immediately or defer it was lacking and resulted in many
WPT failures related to the `timeline-scope` and `animation-timeline` properties.

We now add a parameter to `AnimationTimelinesController::setTimelineForName()` that determines
whether attachment deferral until style resolution has completed is allowed (ie. when we&apos;re
processing the `animation-timeline` property during style resolution) or to attempt attachment
immediately (ie. when style resolution has completed).

Then when we enter `setTimelineForName()`, we have three options:

1. If deferral is allowed and we don&apos;t have an active named timeline, wait until style resolution
has completed to see if a timeline exists then.

2. If deferral is not allowed and we still don&apos;t have an active named timeline, assign either a
placeholder inactive scroll timeline if the name is in scope, or a null timeline otherwise.

3. If we have an active named timeline, determine which one to use per `determineTimelineForElement()`.

Finally, when the `animation-timeline` property changes to a value that is not a timeline name – such
as `auto`, `none`, `scroll()` or `view()` – we remove all pending attachment operations for this CSS
Animation.

There remain a few WPT failures but these will be handled by future individual patches.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-deferred-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::removePendingOperationsForCSSAnimation):
(WebCore::AnimationTimelinesController::documentDidResolveStyle):
(WebCore::AnimationTimelinesController::unregisterNamedTimeline):
(WebCore::AnimationTimelinesController::setTimelineForName):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):

Canonical link: <a href="https://commits.webkit.org/290145@main">https://commits.webkit.org/290145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39e3cb5f25bbbc36d967ed9a91a205ab8d05db09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68549 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26224 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6779 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6528 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38843 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76890 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95786 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77427 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16411 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76715 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21102 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9238 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13964 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21480 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->