### PR TITLE
[JSC] Remove sensitive to NaN in B3

### DIFF
--- a/Source/JavaScriptCore/b3/B3Kind.cpp
+++ b/Source/JavaScriptCore/b3/B3Kind.cpp
@@ -41,8 +41,6 @@ void Kind::dump(PrintStream& out) const
         out.print(comma, "Chill"_s);
     if (traps())
         out.print(comma, "Traps"_s);
-    if (isSensitiveToNaN())
-        out.print(comma, "SensitiveToNaN"_s);
     if (isCloningForbidden())
         out.print(comma, "CloningForbidden"_s);
     if (comma.didPrint())

--- a/Source/JavaScriptCore/b3/B3Kind.h
+++ b/Source/JavaScriptCore/b3/B3Kind.h
@@ -147,35 +147,6 @@ public:
         m_traps = traps;
     }
 
-    static constexpr bool hasIsSensitiveToNaN(Opcode opcode)
-    {
-        switch (opcode) {
-        case Add:
-        case Sub:
-        case Mul:
-        case Div:
-        case Mod:
-        case DoubleToFloat:
-        case FloatToDouble:
-            return true;
-        default:
-            return false;
-        }
-    }
-    bool hasIsSensitiveToNaN() const
-    {
-        return hasIsSensitiveToNaN(m_opcode);
-    }
-    bool isSensitiveToNaN() const
-    {
-        return m_isSensitiveToNaN;
-    }
-    void setIsSensitiveToNaN(bool isSensitiveToNaN)
-    {
-        ASSERT(hasIsSensitiveToNaN());
-        m_isSensitiveToNaN = isSensitiveToNaN;
-    }
-
     static constexpr bool hasCloningForbidden(Opcode opcode)
     {
         switch (opcode) {
@@ -215,7 +186,7 @@ public:
     {
         // It's almost certainly more important that this hash function is cheap to compute than
         // anything else. We can live with some kind hash collisions.
-        return m_opcode + (static_cast<unsigned>(m_isChill) << 16) + (static_cast<unsigned>(m_traps) << 7) + (static_cast<unsigned>(m_isSensitiveToNaN) << 24) + (static_cast<unsigned>(m_cloningForbidden) << 13);
+        return m_opcode + (static_cast<unsigned>(m_isChill) << 16) + (static_cast<unsigned>(m_traps) << 7) + (static_cast<unsigned>(m_cloningForbidden) << 8);
     }
     
     Kind(WTF::HashTableDeletedValueType)
@@ -233,7 +204,6 @@ private:
     Opcode m_opcode;
     bool m_isChill : 1 { false };
     bool m_traps : 1 { false };
-    bool m_isSensitiveToNaN : 1 { false };
     bool m_cloningForbidden : 1 { false };
 };
 
@@ -254,12 +224,6 @@ inline Kind chill(Kind kind)
 inline Kind trapping(Kind kind)
 {
     kind.setTraps(true);
-    return kind;
-}
-
-inline Kind sensitiveToNaN(Kind kind)
-{
-    kind.setIsSensitiveToNaN(true);
     return kind;
 }
 

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -2146,14 +2146,10 @@ private:
             break;
 
         case DoubleToFloat:
-            // Turn this: DoubleToFloat(FloatToDouble(value))
-            // Into this: value
-            if (!m_value->isSensitiveToNaN()) {
-                if (m_value->child(0)->opcode() == FloatToDouble) {
-                    replaceWithIdentity(m_value->child(0)->child(0));
-                    break;
-                }
-            }
+            // We do not have the following pattern.
+            //     Turn this: DoubleToFloat(FloatToDouble(value))
+            //     Into this: value
+            // because this breaks NaN bit patterns, which is tested via wasm spec tests.
 
             // Turn this: DoubleToFloat(constant)
             // Into this: ConstFloat(constant)

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -79,7 +79,6 @@ public:
     // instead of value->kind().isBlah().
     bool isChill() const { return kind().isChill(); }
     bool traps() const { return kind().traps(); }
-    bool isSensitiveToNaN() const { return kind().isSensitiveToNaN(); }
 
     Origin origin() const { return m_origin; }
     void setOrigin(Origin origin) { m_origin = origin; }

--- a/Source/JavaScriptCore/wasm/generateWasmOMGIRGeneratorInlinesHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOMGIRGeneratorInlinesHeader.py
@@ -133,8 +133,6 @@ class CodeGenerator:
 
     def generateB3OpCode(self, index, op, params):
         self.code.append("Value* " + temp(index) + " = m_currentBlock->appendNew<Value>(m_proc, B3::" + op + ", origin(), " + ", ".join(params) + ");")
-        self.code.append("if (B3::Kind::hasIsSensitiveToNaN(" + op + ") && " + temp(index) + "->type().isFloat())")
-        self.code.append("    " + temp(index) + "->setKindUnsafely(sensitiveToNaN(B3::" + op + "));")
 
     def generateConstCode(self, index, value, type):
         self.code.append("Value* " + temp(index) + " = constant(" + type + ", " + value + ");")


### PR DESCRIPTION
#### c25f2c42bb37335f1afbff09f42afbd076bd3629
<pre>
[JSC] Remove sensitive to NaN in B3
<a href="https://bugs.webkit.org/show_bug.cgi?id=287341">https://bugs.webkit.org/show_bug.cgi?id=287341</a>
<a href="https://rdar.apple.com/144457462">rdar://144457462</a>

Reviewed by Yijia Huang.

The optimization with this flag is not used in various benchmarks.
Plus, we can do these optimization in FTL layer etc. by using PurifyNaN
node, thus we no longer need this weird flag.

* Source/JavaScriptCore/b3/B3Kind.cpp:
(JSC::B3::Kind::dump const):
* Source/JavaScriptCore/b3/B3Kind.h:
(JSC::B3::Kind::hash const):
(JSC::B3::Kind::hasIsSensitiveToNaN): Deleted.
(JSC::B3::Kind::hasIsSensitiveToNaN const): Deleted.
(JSC::B3::Kind::isSensitiveToNaN const): Deleted.
(JSC::B3::Kind::setIsSensitiveToNaN): Deleted.
(JSC::B3::sensitiveToNaN): Deleted.
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/wasm/generateWasmOMGIRGeneratorInlinesHeader.py:
(CodeGenerator.generateB3OpCode):

Canonical link: <a href="https://commits.webkit.org/290098@main">https://commits.webkit.org/290098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39af65b185c9eafd7423a5b076decf89edf0d8b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39737 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16685 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26226 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6781 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48916 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6530 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38845 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81776 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95788 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87753 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16157 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16413 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76718 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21106 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9240 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13940 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21482 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110246 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15912 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26459 "Found 4 new JSC stress test failures: microbenchmarks/memcpy-wasm.js.mini-mode, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->