### PR TITLE
[macOS] Make it possible for clients to set a left obscured content inset

### DIFF
--- a/LayoutTests/fast/scrolling/latching/scroll-select-bottom-test.html
+++ b/LayoutTests/fast/scrolling/latching/scroll-select-bottom-test.html
@@ -66,7 +66,7 @@
         description("Tests that a select doesn't pass wheel events to main frame when scrolling at bottom");
 
         if (window.testRunner)
-            await testRunner.setTopContentInset(clientInset);
+            await testRunner.setObscuredContentInsets(clientInset, 0, 0, 0);
 
         if (window.eventSender) {
             setTimeout(scrollTest, 0);

--- a/LayoutTests/fast/scrolling/mac/async-scroll-overflow-top-inset.html
+++ b/LayoutTests/fast/scrolling/mac/async-scroll-overflow-top-inset.html
@@ -102,7 +102,7 @@
         window.addEventListener('load', async () => {
             
             if (window.testRunner)
-                await testRunner.setTopContentInset(topContentInset);
+                await testRunner.setObscuredContentInsets(topContentInset, 0, 0, 0);
         
             scroller = document.querySelector('.scroller');
             scroller.addEventListener('scroll', () => {

--- a/LayoutTests/platform/mac-wk1/fast/backgrounds/top-content-inset-fixed-attachment.html
+++ b/LayoutTests/platform/mac-wk1/fast/backgrounds/top-content-inset-fixed-attachment.html
@@ -20,7 +20,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
     window.scrollTo(0, 100);
 }
 

--- a/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame.html
+++ b/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame.html
@@ -30,7 +30,7 @@ if (window.accessibilityController) {
     var newScrollViewHeight, newScrollViewY;
     setTimeout(async function() {
         if (window.testRunner)
-            await testRunner.setTopContentInset(100);
+            await testRunner.setObscuredContentInsets(100, 0, 0, 0);
         await waitFor(() => {
             newScrollViewY =  scrollView.y - scrollView.height;
             return newScrollViewY - scrollViewY === 100;

--- a/LayoutTests/platform/mac/fast/events/content-inset-hit-testing-in-frame.html
+++ b/LayoutTests/platform/mac/fast/events/content-inset-hit-testing-in-frame.html
@@ -6,7 +6,7 @@
             return;
         if (window.testRunner) {
             testRunner.waitUntilDone();
-            await testRunner.setTopContentInset(100);
+            await testRunner.setObscuredContentInsets(100, 0, 0, 0);
             testRunner.dumpAsText();
         }
 

--- a/LayoutTests/platform/mac/fast/events/content-inset-hit-testing.html
+++ b/LayoutTests/platform/mac/fast/events/content-inset-hit-testing.html
@@ -15,7 +15,7 @@
             return;
         if (window.testRunner) {
             testRunner.waitUntilDone();
-            await testRunner.setTopContentInset(100);
+            await testRunner.setObscuredContentInsets(100, 0, 0, 0);
             testRunner.dumpAsText();
         }
 

--- a/LayoutTests/scrollingcoordinator/mac/top-content-inset-to-zero.html
+++ b/LayoutTests/scrollingcoordinator/mac/top-content-inset-to-zero.html
@@ -9,11 +9,11 @@
         {
             requestAnimationFrame(async () => {
                 if (window.testRunner)
-                    await testRunner.setTopContentInset(50);
+                    await testRunner.setObscuredContentInsets(50, 0, 0, 0);
 
                 requestAnimationFrame(async () => {
                     if (window.testRunner)
-                        await testRunner.setTopContentInset(0);
+                        await testRunner.setObscuredContentInsets(0, 0, 0, 0);
 
                     if (window.testRunner)
                         testRunner.notifyDone();

--- a/LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-header.html
+++ b/LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-header.html
@@ -22,7 +22,7 @@
         {
             window.setTimeout(async () => {
                 if (window.testRunner)
-                    await testRunner.setTopContentInset(60);
+                    await testRunner.setObscuredContentInsets(60, 0, 0, 0);
                 // Scroll to test the mapping from document to view coords.
                 document.scrollingElement.scrollTop = 195;
                 dumpRegionAndNotifyDone();

--- a/LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset.html
+++ b/LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset.html
@@ -19,7 +19,7 @@
         {
             window.setTimeout(async () => {
                 if (window.testRunner)
-                    await testRunner.setTopContentInset(60);
+                    await testRunner.setObscuredContentInsets(60, 0, 0, 0);
                 // Scroll to test the mapping from document to view coords.
                 document.scrollingElement.scrollTop = 195;
                 dumpRegionAndNotifyDone();

--- a/LayoutTests/tiled-drawing/scrolling/scroll-with-top-left-content-inset-expected.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-with-top-left-content-inset-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.wide, .tall {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.wide {
+    width: 800px;
+    height: 50px;
+    background: orange;
+}
+
+.tall {
+    width: 50px;
+    height: 600px;
+    background: plum;
+}
+</style>
+<script>
+window.internals?.setUsesOverlayScrollbars(true);
+</script>
+</head>
+<body>
+    <div class="wide"></div>
+    <div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/tiled-drawing/scrolling/scroll-with-top-left-content-inset.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-with-top-left-content-inset.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.wide, .tall {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.wide {
+    width: 800px;
+    height: 50px;
+    background: orange;
+}
+
+.tall {
+    width: 50px;
+    height: 600px;
+    background: plum;
+}
+
+body::-webkit-scrollbar {
+    display: none;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+window.internals?.setUsesOverlayScrollbars(true);
+
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await window.testRunner?.setObscuredContentInsets(50, 0, 0, 150);
+
+    eventSender.mouseMoveTo(300, 300);
+
+    async function scrollWithDeltas(x, y) {
+        await UIHelper.startMonitoringWheelEvents();
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "began", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "changed", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "changed", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "none", "begin", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "none", "continue", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end", true);
+        await UIHelper.waitForScrollCompletion();
+    }
+
+    await scrollWithDeltas(-10, 0);
+    await scrollWithDeltas(0, -10);
+
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="wide"></div>
+    <div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-body.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-body.html
@@ -15,7 +15,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(50);
+        await testRunner.setObscuredContentInsets(50, 0, 0, 0);
 }
 
 window.addEventListener('load', runTest, false);

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-expected.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-expected.html
@@ -16,7 +16,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 }
 window.addEventListener('load', runTest, false);
 </script>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-local-expected.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-local-expected.html
@@ -17,7 +17,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 }
 window.addEventListener('load', runTest, false);
 </script>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-local.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-local.html
@@ -20,7 +20,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
     window.scrollTo(0, 100);
 }
 window.addEventListener('load', runTest, false);

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover.html
@@ -16,7 +16,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 }
 window.addEventListener('load', runTest, false);
 </script>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-expected.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-expected.html
@@ -22,7 +22,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 }
 window.addEventListener('load', runTest, false);
 </script>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local-expected.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local-expected.html
@@ -19,7 +19,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 }
 window.addEventListener('load', runTest, false);
 </script>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local.html
@@ -24,7 +24,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
     window.scrollTo(0, 100);
 }
 window.addEventListener('load', runTest, false);

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-positioned-expected.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-positioned-expected.html
@@ -19,7 +19,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 }
 window.addEventListener('load', runTest, false);
 </script>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-positioned.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-positioned.html
@@ -18,7 +18,7 @@ html {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 }
 window.addEventListener('load', runTest, false);
 </script>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment.html
@@ -21,7 +21,7 @@ body {
 <script>
 async function runTest() {
     if (window.testRunner)
-        await testRunner.setTopContentInset(100);
+        await testRunner.setObscuredContentInsets(100, 0, 0, 0);
     window.scrollTo(0, 100);
 }
 window.addEventListener('load', runTest, false);

--- a/LayoutTests/tiled-drawing/top-left-content-insets-expected.html
+++ b/LayoutTests/tiled-drawing/top-left-content-insets-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.wide, .tall {
+    position: absolute;
+    top: 50px;
+    left: 150px;
+}
+
+.wide {
+    width: 800px;
+    height: 50px;
+    background: orange;
+}
+
+.tall {
+    width: 50px;
+    height: 600px;
+    background: plum;
+}
+
+body::-webkit-scrollbar {
+    display: none;
+}
+</style>
+<script>
+window.internals?.setUsesOverlayScrollbars(true);
+</script>
+</head>
+<body>
+    <div class="wide"></div>
+    <div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/tiled-drawing/top-left-content-insets.html
+++ b/LayoutTests/tiled-drawing/top-left-content-insets.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.wide, .tall {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.wide {
+    width: 800px;
+    height: 50px;
+    background: orange;
+}
+
+.tall {
+    width: 50px;
+    height: 600px;
+    background: plum;
+}
+
+body::-webkit-scrollbar {
+    display: none;
+}
+</style>
+<script>
+window.internals?.setUsesOverlayScrollbars(true);
+
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await window.testRunner?.setObscuredContentInsets(50, 0, 0, 150);
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="wide"></div>
+    <div class="tall"></div>
+</body>
+</html>

--- a/LayoutTests/tiled-drawing/visible-rect-content-inset.html
+++ b/LayoutTests/tiled-drawing/visible-rect-content-inset.html
@@ -11,7 +11,7 @@
             testRunner.waitUntilDone();
             testRunner.dumpAsText();
             internals.disableTileSizeUpdateDelay();
-            await testRunner.setTopContentInset(100);
+            await testRunner.setObscuredContentInsets(100, 0, 0, 0);
 
             document.getElementById('layers').innerText = internals.layerTreeAsText(document,
                 internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS | internals.LAYER_TREE_INCLUDES_TILE_CACHES);

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -367,10 +367,10 @@ public:
     
     WEBCORE_EXPORT static LayoutPoint computeLayoutViewportOrigin(const LayoutRect& visualViewport, const LayoutPoint& stableLayoutViewportOriginMin, const LayoutPoint& stableLayoutViewportOriginMax, const LayoutRect& layoutViewport, ScrollBehaviorForFixedElements);
 
-    // These layers are positioned differently when there is a top inset, a header, or a footer. These value need to be computed
-    // on both the main thread and the scrolling thread.
-    static float yPositionForInsetClipLayer(const FloatPoint& scrollPosition, float topInset);
-    WEBCORE_EXPORT static FloatPoint positionForRootContentLayer(const FloatPoint& scrollPosition, const FloatPoint& scrollOrigin, float topInset, float headerHeight);
+    // These layers are positioned differently when there are obscured content insets, a header, or a footer.
+    // These value need to be computed on both the main thread and the scrolling thread.
+    static FloatPoint positionForInsetClipLayer(const FloatPoint& scrollPosition, const FloatBoxExtent& obscuredContentInsets);
+    WEBCORE_EXPORT static FloatPoint positionForRootContentLayer(const FloatPoint& scrollPosition, const FloatPoint& scrollOrigin, const FloatBoxExtent& obscuredContentInsets, float headerHeight);
     WEBCORE_EXPORT FloatPoint positionForRootContentLayer() const;
 
     WEBCORE_EXPORT static float yPositionForHeaderLayer(const FloatPoint& scrollPosition, float topInset);

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -795,7 +795,7 @@ void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameVie
 
     FloatPoint positionForInsetClipLayer;
     if (insetClipLayer)
-        positionForInsetClipLayer = FloatPoint(insetClipLayer->position().x(), LocalFrameView::yPositionForInsetClipLayer(scrollPosition, obscuredContentInsets.top()));
+        positionForInsetClipLayer = LocalFrameView::positionForInsetClipLayer(scrollPosition, obscuredContentInsets);
     FloatPoint positionForContentsLayer = frameView.positionForRootContentLayer();
     
     FloatPoint positionForHeaderLayer = FloatPoint(scrollPositionForFixed.x(), LocalFrameView::yPositionForHeaderLayer(scrollPosition, obscuredContentInsets.top()));

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
@@ -127,15 +127,15 @@ void ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers()
     if (m_counterScrollingLayer)
         m_counterScrollingLayer->setPositionForScrolling(layoutViewport.location());
 
-    float topContentInset = obscuredContentInsets().top();
+    auto contentInsets = obscuredContentInsets();
     if (m_insetClipLayer && m_rootContentsLayer) {
         FloatPoint insetClipPosition;
         {
             Locker locker { m_insetClipLayer->lock() };
-            insetClipPosition = FloatPoint(m_insetClipLayer->position().x(), LocalFrameView::yPositionForInsetClipLayer(scrollPosition, topContentInset));
+            insetClipPosition = LocalFrameView::positionForInsetClipLayer(scrollPosition, contentInsets);
         }
         m_insetClipLayer->setPositionForScrolling(insetClipPosition);
-        auto rootContentsPosition = LocalFrameView::positionForRootContentLayer(scrollPosition, scrollOrigin(), topContentInset, headerHeight());
+        auto rootContentsPosition = LocalFrameView::positionForRootContentLayer(scrollPosition, scrollOrigin(), contentInsets, headerHeight());
         m_rootContentsLayer->setPositionForScrolling(rootContentsPosition);
         if (m_contentShadowLayer)
             m_contentShadowLayer->setPositionForScrolling(rootContentsPosition);
@@ -147,9 +147,9 @@ void ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers()
         // then we should recompute layoutViewport.x() for the banner with a scale factor of 1.
         float horizontalScrollOffsetForBanner = layoutViewport.x();
         if (m_headerLayer)
-            m_headerLayer->setPositionForScrolling(FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForHeaderLayer(scrollPosition, topContentInset)));
+            m_headerLayer->setPositionForScrolling(FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForHeaderLayer(scrollPosition, contentInsets.top())));
         if (m_footerLayer)
-            m_footerLayer->setPositionForScrolling(FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForFooterLayer(scrollPosition, topContentInset, totalContentsSize().height(), footerHeight())));
+            m_footerLayer->setPositionForScrolling(FloatPoint(horizontalScrollOffsetForBanner, LocalFrameView::yPositionForFooterLayer(scrollPosition, contentInsets.top(), totalContentsSize().height(), footerHeight())));
     }
 
     delegate().updateVisibleLengths();

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -198,8 +198,13 @@ void ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers()
 
     auto obscuredContentInsets = this->obscuredContentInsets();
     if (m_insetClipLayer && m_rootContentsLayer) {
-        m_insetClipLayer.get().position = FloatPoint(m_insetClipLayer.get().position.x, LocalFrameView::yPositionForInsetClipLayer(scrollPosition, obscuredContentInsets.top()));
-        m_rootContentsLayer.get().position = LocalFrameView::positionForRootContentLayer(scrollPosition, scrollOrigin(), obscuredContentInsets.top(), headerHeight());
+        [m_insetClipLayer setPosition:[&] {
+            auto position = LocalFrameView::positionForInsetClipLayer(scrollPosition, obscuredContentInsets);
+            if (!obscuredContentInsets.left())
+                position.setX([m_insetClipLayer position].x);
+            return position;
+        }()];
+        [m_rootContentsLayer setPosition:LocalFrameView::positionForRootContentLayer(scrollPosition, scrollOrigin(), obscuredContentInsets, headerHeight())];
         if (m_contentShadowLayer)
             m_contentShadowLayer.get().position = m_rootContentsLayer.get().position;
     }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -614,7 +614,7 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
             if (renderer.fixedBackgroundPaintsInLocalCoordinates()) {
                 if (!useFixedLayout) {
                     // Shifting location by the content insets is needed for layout tests which expect
-                    // layout to be shifted down when calling window.internals.setTopContentInset().
+                    // layout to be shifted when calling window.internals.setObscuredContentInsets().
                     obscuredContentInsets = frameView.obscuredContentInsets(ScrollView::InsetType::WebCoreOrPlatformInset);
                     viewportRect.setLocation({ -obscuredContentInsets.left(), -obscuredContentInsets.top() });
                 }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2839,8 +2839,8 @@ FloatPoint RenderLayerCompositor::positionForClipLayer() const
 {
     auto& frameView = m_renderView.frameView();
 
-    return FloatPoint(frameView.insetForLeftScrollbarSpace(),
-        LocalFrameView::yPositionForInsetClipLayer(frameView.scrollPosition(), frameView.obscuredContentInsets().top()));
+    auto clipLayerPosition = LocalFrameView::positionForInsetClipLayer(frameView.scrollPosition(), frameView.obscuredContentInsets());
+    return FloatPoint(frameView.insetForLeftScrollbarSpace() + clipLayerPosition.x(), clipLayerPosition.y());
 }
 
 void RenderLayerCompositor::frameViewDidScroll()
@@ -5000,7 +5000,7 @@ void RenderLayerCompositor::ensureRootLayer()
             }
 #endif
             // FIXME: m_scrollContainerLayer and m_clipLayer have similar roles here, but m_clipLayer has some special positioning to
-            // account for clipping and top content inset (see LocalFrameView::yPositionForInsetClipLayer()).
+            // account for clipping and top content inset (see LocalFrameView::positionForInsetClipLayer()).
             if (!m_scrollContainerLayer) {
                 m_clipLayer = GraphicsLayer::create(graphicsLayerFactory(), *this);
                 m_clipLayer->setName(MAKE_STATIC_STRING_IMPL("frame clipping"));

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3468,13 +3468,13 @@ void WKPageSetPermissionLevelForTesting(WKPageRef pageRef, WKStringRef origin, b
         pageForTesting->setPermissionLevel(toImpl(origin)->string(), allowed);
 }
 
-void WKPageSetTopContentInsetForTesting(WKPageRef pageRef, float contentInset, void* context, WKPageSetTopContentInsetForTestingFunction callback)
+void WKPageSetObscuredContentInsetsForTesting(WKPageRef pageRef, float top, float right, float bottom, float left, void* context, WKPageSetObscuredContentInsetsForTestingFunction callback)
 {
     RefPtr pageForTesting = toImpl(pageRef)->pageForTesting();
     if (!pageForTesting)
         return callback(context);
 
-    pageForTesting->setTopContentInset(contentInset, [context, callback] {
+    pageForTesting->setObscuredContentInsets(top, right, bottom, left, [context, callback] {
         callback(context);
     });
 }

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -225,8 +225,8 @@ WK_EXPORT bool WKPageIsEditingCommandEnabledForTesting(WKPageRef page, WKStringR
 WK_EXPORT void WKPageSetPermissionLevelForTesting(WKPageRef page, WKStringRef origin, bool allowed);
 WK_EXPORT void WKPageResetStateBetweenTests(WKPageRef pageRef);
 
-typedef void (*WKPageSetTopContentInsetForTestingFunction)(void* functionContext);
-WK_EXPORT void WKPageSetTopContentInsetForTesting(WKPageRef page, float contentInset, void* context, WKPageSetTopContentInsetForTestingFunction callback);
+typedef void (*WKPageSetObscuredContentInsetsForTestingFunction)(void* functionContext);
+WK_EXPORT void WKPageSetObscuredContentInsetsForTesting(WKPageRef page, float top, float right, float bottom, float left, void* context, WKPageSetObscuredContentInsetsForTestingFunction callback);
 typedef void (*WKPageSetPageScaleFactorForTestingFunction)(void* functionContext);
 WK_EXPORT void WKPageSetPageScaleFactorForTesting(WKPageRef page, float scaleFactor, WKPoint point, void* context, WKPageSetPageScaleFactorForTestingFunction completionHandler);
 typedef void (*WKPageClearBackForwardListForTestingFunction)(void* functionContext);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -866,6 +866,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (void)_setFont:(NSFont *)font sender:(id)sender WK_API_AVAILABLE(macos(13.3));
 
 - (void)_setTopContentInset:(CGFloat)topContentInset immediate:(BOOL)immediate WK_API_AVAILABLE(macos(WK_MAC_TBA));
+- (void)_setObscuredContentInsets:(NSEdgeInsets)insets immediate:(BOOL)immediate WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 - (void)_showWritingTools WK_API_AVAILABLE(macos(15.2));
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1492,6 +1492,24 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _impl->flushPendingObscuredContentInsetChanges();
 }
 
+- (void)_setObscuredContentInsets:(NSEdgeInsets)insets immediate:(BOOL)immediate
+{
+    if (insets.top < 0 || insets.left < 0 || insets.bottom < 0 || insets.right < 0) {
+        [NSException raise:NSInvalidArgumentException format:@"Obscured insets cannot be negative: {%f, %f, %f, %f}", insets.top, insets.left, insets.bottom, insets.right];
+        return;
+    }
+
+    _impl->setObscuredContentInsets({
+        static_cast<float>(insets.top),
+        static_cast<float>(insets.right),
+        static_cast<float>(insets.bottom),
+        static_cast<float>(insets.left)
+    });
+
+    if (immediate)
+        _impl->flushPendingObscuredContentInsetChanges();
+}
+
 - (void)_setAutomaticallyAdjustsContentInsets:(BOOL)automaticallyAdjustsContentInsets
 {
     _impl->setAutomaticallyAdjustsContentInsets(automaticallyAdjustsContentInsets);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -484,7 +484,7 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
 
     RetainPtr scrolledContentsLayer { static_cast<CALayer*>(rootScrollingNode->scrolledContentsLayer()) };
 
-    auto rootContentsLayerPosition = LocalFrameView::positionForRootContentLayer(rootScrollingNode->currentScrollPosition(), FloatPoint { 0, 0 }, rootScrollingNode->obscuredContentInsets().top(), rootScrollingNode->headerHeight());
+    auto rootContentsLayerPosition = LocalFrameView::positionForRootContentLayer(rootScrollingNode->currentScrollPosition(), { }, rootScrollingNode->obscuredContentInsets(), rootScrollingNode->headerHeight());
     auto pointInContentsLayer = point;
     pointInContentsLayer.moveBy(rootContentsLayerPosition);
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -196,9 +196,9 @@ void WebPageProxyTesting::setSystemCanPromptForGetDisplayMediaForTesting(bool ca
 }
 #endif
 
-void WebPageProxyTesting::setTopContentInset(float contentInset, CompletionHandler<void()>&& completionHandler)
+void WebPageProxyTesting::setObscuredContentInsets(float top, float right, float bottom, float left, CompletionHandler<void()>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebPageTesting::SetTopContentInset(contentInset), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebPageTesting::SetObscuredContentInsets(top, right, bottom, left), WTFMove(completionHandler));
 }
 
 Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -76,7 +76,7 @@ public:
     void setSystemCanPromptForGetDisplayMediaForTesting(bool);
 #endif
 
-    void setTopContentInset(float, CompletionHandler<void()>&&);
+    void setObscuredContentInsets(float top, float right, float bottom, float left, CompletionHandler<void()>&&);
 
     void clearBackForwardList(CompletionHandler<void()>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4065,11 +4065,6 @@ void WebPage::setObscuredContentInsetsFenced(const FloatBoxExtent& obscuredConte
 }
 #endif
 
-FloatBoxExtent WebPage::obscuredContentInsets() const
-{
-    return m_page->obscuredContentInsets();
-}
-
 void WebPage::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInsets)
 {
     if (obscuredContentInsets == m_page->obscuredContentInsets())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1930,7 +1930,6 @@ public:
 #endif
     void loadRequest(LoadParameters&&);
 
-    WebCore::FloatBoxExtent obscuredContentInsets() const;
     void setObscuredContentInsets(const WebCore::FloatBoxExtent&);
 
     void updateOpener(WebCore::FrameIdentifier, WebCore::FrameIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -119,13 +119,10 @@ void WebPageTesting::clearWheelEventTestMonitor()
     page->clearWheelEventTestMonitor();
 }
 
-void WebPageTesting::setTopContentInset(float topInset, CompletionHandler<void()>&& completionHandler)
+void WebPageTesting::setObscuredContentInsets(float top, float right, float bottom, float left, CompletionHandler<void()>&& completionHandler)
 {
-    if (RefPtr page = m_page.get()) {
-        auto obscuredContentInsets = page->obscuredContentInsets();
-        obscuredContentInsets.setTop(topInset);
-        page->setObscuredContentInsets(obscuredContentInsets);
-    }
+    if (RefPtr page = m_page.get())
+        page->setObscuredContentInsets({ top, right, bottom, left });
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -67,7 +67,7 @@ private:
     void clearNotificationPermissionState();
 #endif
 
-    void setTopContentInset(float, CompletionHandler<void()>&&);
+    void setObscuredContentInsets(float top, float right, float bottom, float left, CompletionHandler<void()>&&);
 
     void clearWheelEventTestMonitor();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -35,7 +35,7 @@ messages -> WebPageTesting {
 
     ClearWheelEventTestMonitor()
     ResetStateBetweenTests()
-    SetTopContentInset(float contentInset) -> ()
+    SetObscuredContentInsets(float top, float right, float bottom, float left) -> ()
     ClearCachedBackForwardListCounts() -> ()
     SetTracksRepaints(bool trackRepaints) -> ()
     DisplayAndTrackRepaints() -> ()

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -4174,13 +4174,10 @@ IGNORE_WARNINGS_END
     return nil;
 }
 
-- (void)_setTopContentInsetForTesting:(float)inset
+- (void)_setObscuredTopContentInsetForTesting:(float)top right:(float)right bottom:(float)bottom left:(float)left
 {
-    if (_private && _private->page) {
-        auto obscuredContentInsets = _private->page->obscuredContentInsets();
-        obscuredContentInsets.setTop(inset);
-        _private->page->setObscuredContentInsets(obscuredContentInsets);
-    }
+    if (_private && _private->page)
+        _private->page->setObscuredContentInsets({ top, right, bottom, left });
 }
 
 - (BOOL)_isSoftwareRenderable

--- a/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
@@ -727,7 +727,7 @@ Could be worth adding to the API.
 - (int)validationMessageTimerMagnification;
 - (void)setValidationMessageTimerMagnification:(int)newValue;
 - (NSDictionary *)_contentsOfUserInterfaceItem:(NSString *)userInterfaceItem;
-- (void)_setTopContentInsetForTesting:(float)contentInset;
+- (void)_setObscuredTopContentInsetForTesting:(float)top right:(float)right bottom:(float)bottom left:(float)left;
 
 // Returns YES if NSView -displayRectIgnoringOpacity:inContext: will produce a faithful representation of the content.
 - (BOOL)_isSoftwareRenderable;

--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -1783,13 +1783,16 @@ static JSValueRef forceImmediateCompletionCallback(JSContextRef context, JSObjec
     return JSValueMakeUndefined(context);
 }
 
-static JSValueRef setTopContentInsetCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+static JSValueRef setObscuredContentInsetsCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    if (argumentCount != 1)
+    if (argumentCount != 4)
         return JSValueMakeUndefined(context);
     TestRunner* controller = static_cast<TestRunner*>(JSObjectGetPrivate(thisObject));
-    double contentInset = JSValueToNumber(context, arguments[0], exception);
-    controller->setTopContentInset(contentInset);
+    double top = JSValueToNumber(context, arguments[0], exception);
+    double right = JSValueToNumber(context, arguments[1], exception);
+    double bottom = JSValueToNumber(context, arguments[2], exception);
+    double left = JSValueToNumber(context, arguments[3], exception);
+    controller->setObscuredContentInsets(top, right, bottom, left);
     return TestRunner::alwaysResolvePromise(context);
 }
 
@@ -2113,7 +2116,7 @@ const JSStaticFunction* TestRunner::staticFunctions()
         { "setOpenPanelFilesMediaIcon", SetOpenPanelFilesMediaIconCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "stopLoading", stopLoadingCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "forceImmediateCompletion", forceImmediateCompletionCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
-        { "setTopContentInset", setTopContentInsetCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "setObscuredContentInsets", setObscuredContentInsetsCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setPageScaleFactor", setPageScaleFactorCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
 #if PLATFORM(IOS_FAMILY)
         { "setPagePaused", setPagePausedCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },

--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -396,7 +396,7 @@ public:
 
     void generateTestReport(JSStringRef message, JSStringRef group);
 
-    void setTopContentInset(double);
+    void setObscuredContentInsets(double top, double right, double bottom, double left);
 
     void setPageScaleFactor(double scaleFactor, long x, long y);
     static JSValueRef alwaysResolvePromise(JSContextRef);

--- a/Tools/DumpRenderTree/mac/TestRunnerMac.mm
+++ b/Tools/DumpRenderTree/mac/TestRunnerMac.mm
@@ -1209,7 +1209,7 @@ bool TestRunner::isSecureEventInputEnabled() const
 
 #endif // PLATFORM(MAC)
 
-void TestRunner::setTopContentInset(double contentInset)
+void TestRunner::setObscuredContentInsets(double top, double right, double bottom, double left)
 {
-    [[mainFrame webView] _setTopContentInsetForTesting:contentInset];
+    [[mainFrame webView] _setObscuredTopContentInsetForTesting:top right:right bottom:bottom left:left];
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -463,7 +463,7 @@ interface TestRunner {
     undefined finishFullscreenExit();
     undefined requestExitFullscreenFromUIProcess();
 
-    Promise<undefined> setTopContentInset(double contentInset);
+    Promise<undefined> setObscuredContentInsets(double top, double right, double bottom, double left);
     Promise<undefined> setPageScaleFactor(unrestricted double scaleFactor, long x, long y);
 
     // ResourceMonitor

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2140,9 +2140,14 @@ bool TestRunner::shouldDumpBackForwardListsForAllWindows() const
     return postSynchronousPageMessageReturningBoolean("ShouldDumpBackForwardListsForAllWindows");
 }
 
-void TestRunner::setTopContentInset(JSContextRef context, double contentInset, JSValueRef callback)
+void TestRunner::setObscuredContentInsets(JSContextRef context, double top, double right, double bottom, double left, JSValueRef callback)
 {
-    postMessageWithAsyncReply(context, "SetTopContentInset", adoptWK(WKDoubleCreate(contentInset)), callback);
+    auto insetValues = adoptWK(WKMutableArrayCreate());
+    WKArrayAppendItem(insetValues.get(), adoptWK(WKDoubleCreate(top)).get());
+    WKArrayAppendItem(insetValues.get(), adoptWK(WKDoubleCreate(right)).get());
+    WKArrayAppendItem(insetValues.get(), adoptWK(WKDoubleCreate(bottom)).get());
+    WKArrayAppendItem(insetValues.get(), adoptWK(WKDoubleCreate(left)).get());
+    postMessageWithAsyncReply(context, "SetObscuredContentInsets", insetValues, callback);
 }
 
 void TestRunner::setResourceMonitorList(JSContextRef context, JSStringRef rulesText, JSValueRef callback)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -555,7 +555,7 @@ public:
 
     void getAndClearReportedWindowProxyAccessDomains(JSContextRef, JSValueRef);
 
-    void setTopContentInset(JSContextRef, double, JSValueRef);
+    void setObscuredContentInsets(JSContextRef, double top, double right, double bottom, double left, JSValueRef);
 
     void setPageScaleFactor(JSContextRef, double scaleFactor, long x, long y, JSValueRef callback);
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2301,8 +2301,14 @@ void TestController::didReceiveAsyncMessageFromInjectedBundle(WKStringRef messag
     if (WKStringIsEqualToUTF8CString(messageName, "RemoveAllSessionCredentials"))
         return TestController::singleton().removeAllSessionCredentials(WTFMove(completionHandler));
 
-    if (WKStringIsEqualToUTF8CString(messageName, "SetTopContentInset"))
-        return WKPageSetTopContentInsetForTesting(TestController::singleton().mainWebView()->page(), static_cast<float>(doubleValue(messageBody)), completionHandler.leak(), adoptAndCallCompletionHandler);
+    if (WKStringIsEqualToUTF8CString(messageName, "SetObscuredContentInsets")) {
+        auto insetValues = arrayValue(messageBody);
+        auto top = static_cast<float>(doubleValue(WKArrayGetItemAtIndex(insetValues, 0)));
+        auto right = static_cast<float>(doubleValue(WKArrayGetItemAtIndex(insetValues, 1)));
+        auto bottom = static_cast<float>(doubleValue(WKArrayGetItemAtIndex(insetValues, 2)));
+        auto left = static_cast<float>(doubleValue(WKArrayGetItemAtIndex(insetValues, 3)));
+        return WKPageSetObscuredContentInsetsForTesting(TestController::singleton().mainWebView()->page(), top, right, bottom, left, completionHandler.leak(), adoptAndCallCompletionHandler);
+    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "ClearBackForwardList"))
         return WKPageClearBackForwardListForTesting(TestController::singleton().mainWebView()->page(), completionHandler.leak(), adoptAndCallCompletionHandler);


### PR DESCRIPTION
#### 1fbfb97625d62916adbd8b7b30b01735694346e1
<pre>
[macOS] Make it possible for clients to set a left obscured content inset
<a href="https://bugs.webkit.org/show_bug.cgi?id=287340">https://bugs.webkit.org/show_bug.cgi?id=287340</a>
<a href="https://rdar.apple.com/144115092">rdar://144115092</a>

Reviewed by Tim Horton.

Add (partial) support for a new SPI on macOS:

```
- (void)_setObscuredContentInsets:(NSEdgeInsets)insets immediate:(BOOL)immediate;
```

...which allows WebKit clients to set content insets on all edges, which represents regions of the
page that are obscured by the app. This patch also adjusts related testing-only helpers that
currently set top content inset via `testRunner`, such that they can now be used to specify content
insets on all sides.

* LayoutTests/fast/scrolling/latching/scroll-select-bottom-test.html:
* LayoutTests/fast/scrolling/mac/async-scroll-overflow-top-inset.html:
* LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame.html:
* LayoutTests/platform/mac-wk1/fast/backgrounds/top-content-inset-fixed-attachment.html:
* LayoutTests/platform/mac/fast/events/content-inset-hit-testing-in-frame.html:
* LayoutTests/platform/mac/fast/events/content-inset-hit-testing.html:
* LayoutTests/scrollingcoordinator/mac/top-content-inset-to-zero.html:
* LayoutTests/tiled-drawing/scrolling/scroll-with-top-left-content-inset-expected.html: Added.
* LayoutTests/tiled-drawing/scrolling/scroll-with-top-left-content-inset.html: Added.

Add a new layout test to exercise both vertical and horizontal scrolling in a web view with both top
and left content insets.

* LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset-header.html:
* LayoutTests/tiled-drawing/scrolling/non-fast-region/top-content-inset.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-body.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-expected.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-local-expected.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover-local.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-cover.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-expected.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local-expected.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-positioned-expected.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-positioned.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment.html:
* LayoutTests/tiled-drawing/top-left-content-insets-expected.html: Added.
* LayoutTests/tiled-drawing/top-left-content-insets.html: Added.

Add a new layout test to verify that setting top/left content insets results in visual margins
around the top left corner of the page.

* LayoutTests/tiled-drawing/visible-rect-content-inset.html:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::positionForInsetClipLayer):

Rename `yPositionForInsetClipLayer` → `positionForInsetClipLayer`, pass in the full set of insets,
and make it return a `FloatPoint` instead. This allows us to apply the same treatment for the top
content inset, to the left content inset as well.

(WebCore::LocalFrameView::positionForRootContentLayer):

Adjust `positionForRootContentLayer` to take all inset edges instead of just the top content inset;
account for this inset by clamping the root content layer position to the left inset (or the scroll
position, if the scroll position is less than the left inset).

(WebCore::LocalFrameView::positionForRootContentLayer const):
(WebCore::LocalFrameView::yPositionForInsetClipLayer): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp:
(WebCore::ScrollingTreeFrameScrollingNodeCoordinated::repositionRelatedLayers):
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::repositionRelatedLayers):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::calculateBackgroundImageGeometry):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::positionForClipLayer const):
(WebCore::RenderLayerCompositor::ensureRootLayer):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetObscuredContentInsetsForTesting):
(WKPageSetTopContentInsetForTesting): Deleted.

Update this test helper to include all 4 content inset values.

* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _setObscuredContentInsets:immediate:]):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingNodeForPoint):
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::setObscuredContentInsets):
(WebKit::WebPageProxyTesting::setTopContentInset): Deleted.
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::obscuredContentInsets const): Deleted.

Remove this getter, now that it&apos;s no longer used by `WebPageTesting`.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::setObscuredContentInsets):
(WebKit::WebPageTesting::setTopContentInset): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _setObscuredTopContentInsetForTesting:right:bottom:left:]):
(-[WebView _setTopContentInsetForTesting:]): Deleted.

Update this test helper to include all 4 content inset values.

* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:
* Tools/DumpRenderTree/TestRunner.cpp:
(setObscuredContentInsetsCallback):
(TestRunner::staticFunctions):
(setTopContentInsetCallback): Deleted.
* Tools/DumpRenderTree/TestRunner.h:
* Tools/DumpRenderTree/mac/TestRunnerMac.mm:
(TestRunner::setObscuredContentInsets):
(TestRunner::setTopContentInset): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setObscuredContentInsets):
(WTR::TestRunner::setTopContentInset): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/290178@main">https://commits.webkit.org/290178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/604aa4b5d79682a629f8d42fb6918b9962469aff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94045 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68627 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26297 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48989 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35252 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11883 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77505 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76793 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18961 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16258 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21569 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15999 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->