### PR TITLE
[SwiftUI] Update WebView to latest interface (Part 1)

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift
@@ -27,6 +27,9 @@ import Foundation
 
 extension WebPage {
     /// An opaque identifier which can be used to uniquely identify a load request for a web page.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public struct NavigationID: Sendable, Hashable, Equatable {
         let rawValue: ObjectIdentifier
 
@@ -36,6 +39,9 @@ extension WebPage {
     }
 
     /// A particular state that occurs during the progression of a navigation.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public struct NavigationEvent: Sendable {
         /// A set of values representing the possible types a NavigationEvent can represent.
         public enum Kind: Sendable {

--- a/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
@@ -27,16 +27,13 @@ public import SwiftUI
 
 extension EnvironmentValues {
     @Entry
-    var webViewAllowsBackForwardNavigationGestures = false
+    var webViewAllowsBackForwardNavigationGestures = WebView.BackForwardNavigationGesturesBehavior.automatic
 
     @Entry
-    var webViewAllowsLinkPreview = true
+    var webViewAllowsLinkPreview = WebView.LinkPreviewBehavior.automatic
 
     @Entry
-    var webViewAllowsTabFocusingLinks = false
-
-    @Entry
-    var webViewAllowsTextInteraction = true
+    var webViewTextSelection = true
 
     @Entry
     var webViewAllowsElementFullscreen = false
@@ -49,24 +46,25 @@ extension EnvironmentValues {
 }
 
 extension View {
-    @_spi(Private)
-    public func webViewAllowsBackForwardNavigationGestures(_ value: Bool = true) -> some View {
+    /// Determines whether horizontal swipe gestures trigger backward and forward page navigation.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public func webViewBackForwardNavigationGestures(_ value: WebView.BackForwardNavigationGesturesBehavior = .automatic) -> some View {
         environment(\.webViewAllowsBackForwardNavigationGestures, value)
     }
 
-    @_spi(Private)
-    public func webViewAllowsLinkPreview(_ value: Bool = true) -> some View {
+    /// Determines whether pressing a link displays a preview of the destination for the link.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public func webViewLinkPreviews(_ value: WebView.LinkPreviewBehavior = .automatic) -> some View {
         environment(\.webViewAllowsLinkPreview, value)
     }
 
     @_spi(Private)
-    public func webViewAllowsTabFocusingLinks(_ value: Bool = true) -> some View {
-        environment(\.webViewAllowsTabFocusingLinks, value)
-    }
-
-    @_spi(Private)
-    public func webViewAllowsTextInteraction(_ value: Bool = true) -> some View {
-        environment(\.webViewAllowsTextInteraction, value)
+    public func webViewTextSelection<S>(_ selectability: S) -> some View where S : TextSelectability {
+        environment(\.webViewTextSelection, S.allowsSelection)
     }
 
     @_spi(Private)

--- a/Source/WebKit/_WebKit_SwiftUI/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebView.swift
@@ -26,8 +26,17 @@
 public import SwiftUI
 public import WebKit
 
-@_spi(Private)
-public struct WebView_v0: View {
+/// A view that displays some web content.
+///
+/// Connect a ``WebView`` with a ``WebPage`` to fully control the browsing experience, including essential functionality such as loading a URL.
+/// Any updates to the webpage propagate the information to the view.
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct WebView: View {
+    /// Create a new WebView.
+    ///
+    /// - Parameter page: The ``WebPage`` that should be associated with this ``WebView``. It is a programming error to create multiple ``WebView``s with the same ``WebPage``.
     public init(_ page: WebPage) {
         self.page = page
     }
@@ -38,5 +47,53 @@ public struct WebView_v0: View {
         WebViewRepresentable(owner: self)
     }
 }
+
+extension WebView {
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public struct BackForwardNavigationGesturesBehavior: Sendable {
+        enum Value {
+            case automatic
+            case enabled
+            case disabled
+        }
+
+        public static let automatic: BackForwardNavigationGesturesBehavior = .init(.automatic)
+
+        public static let enabled: BackForwardNavigationGesturesBehavior = .init(.enabled)
+
+        public static let disabled: BackForwardNavigationGesturesBehavior = .init(.disabled)
+
+        init(_ value: Value) {
+            self.value = value
+        }
+
+        let value: Value
+    }
+
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public struct LinkPreviewBehavior: Sendable {
+        enum Value {
+            case automatic
+            case enabled
+            case disabled
+        }
+
+        public static let automatic: LinkPreviewBehavior = .init(.automatic)
+
+        public static let enabled: LinkPreviewBehavior = .init(.enabled)
+
+        public static let disabled: LinkPreviewBehavior = .init(.disabled)
+
+        init(_ value: Value) {
+            self.value = value
+        }
+
+        let value: Value
+    }
+ }
 
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
@@ -27,7 +27,7 @@ internal import WebKit_Internal
 
 @MainActor
 struct WebViewRepresentable {
-    let owner: WebView_v0
+    let owner: WebView
 
     func makePlatformView(context: Context) -> CocoaWebViewAdapter {
         // FIXME: Make this more robust by figuring out what happens when a WebPage moves between representables.
@@ -49,11 +49,10 @@ struct WebViewRepresentable {
 
         platformView.webView = webView
 
-        webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures
-        webView.allowsLinkPreview = environment.webViewAllowsLinkPreview
+        webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures.value != .disabled
+        webView.allowsLinkPreview = environment.webViewAllowsLinkPreview.value != .disabled
 
-        webView.configuration.preferences.isTextInteractionEnabled = environment.webViewAllowsTextInteraction
-        webView.configuration.preferences.tabFocusesLinks = environment.webViewAllowsTabFocusingLinks
+        webView.configuration.preferences.isTextInteractionEnabled = environment.webViewTextSelection
         webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewAllowsElementFullscreen
 
         context.coordinator.update(platformView, configuration: self, environment: environment)

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -226,9 +226,10 @@ struct ContentView: View {
         NavigationStack {
             @Bindable var viewModel = viewModel
 
-            WebView_v0(viewModel.page)
-                .webViewAllowsBackForwardNavigationGestures()
-                .webViewAllowsTabFocusingLinks()
+            WebView(viewModel.page)
+                .webViewBackForwardNavigationGestures(.enabled)
+                .webViewLinkPreviews(.enabled)
+                .webViewTextSelection(.enabled)
                 .webViewAllowsElementFullscreen()
                 .webViewFindNavigator(isPresented: $findNavigatorIsPresented)
                 .task {


### PR DESCRIPTION
#### 7e532a82bd700833f59a698ec81b45e15412fb0f
<pre>
[SwiftUI] Update WebView to latest interface (Part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287344">https://bugs.webkit.org/show_bug.cgi?id=287344</a>
<a href="https://rdar.apple.com/144458990">rdar://144458990</a>

Reviewed by Tim Horton.

Update various definitions/declarations for WebView.

* Source/WebKit/UIProcess/API/Swift/WebPage+Navigation.swift:
* Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift:
(View.webViewBackForwardNavigationGestures(_:)):
(View.webViewLinkPreviews(_:)):
(View.webViewAllowsBackForwardNavigationGestures(_:)): Deleted.
(View.webViewAllowsLinkPreview(_:)): Deleted.
(View.webViewAllowsTabFocusingLinks(_:)): Deleted.
(View.webViewAllowsTextInteraction(_:)): Deleted.
* Source/WebKit/_WebKit_SwiftUI/WebView.swift:
(WebView_v0.body): Deleted.
* Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):

Canonical link: <a href="https://commits.webkit.org/290110@main">https://commits.webkit.org/290110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f37f7c3250cf721df0787750b75c5226ab138634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39743 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68559 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26229 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48918 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6535 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95794 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77433 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21112 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9246 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13946 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16177 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21488 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->