### PR TITLE
Address safer C++ static analysis warnings in MediaPlayer

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1105,7 +1105,6 @@ platform/graphics/ImageBackingStore.h
 platform/graphics/ImageBufferContextSwitcher.cpp
 platform/graphics/ImageFrame.cpp
 platform/graphics/ImageFrameWorkQueue.cpp
-platform/graphics/MediaPlayer.cpp
 platform/graphics/Path.cpp
 platform/graphics/ShadowBlur.cpp
 platform/graphics/SourceBufferPrivate.cpp
@@ -1206,7 +1205,6 @@ platform/mock/MockRealtimeMediaSourceCenter.cpp
 platform/mock/MockRealtimeVideoSource.cpp
 platform/mock/RTCNotifiersMock.cpp
 platform/mock/TimerEventBasedMock.h
-platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
 platform/mock/mediasource/MockMediaSourcePrivate.cpp
 platform/network/BlobData.cpp
 platform/network/BlobRegistryImpl.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -177,7 +177,6 @@ platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/CoreAudioSharedUnit.cpp
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
-platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
 platform/network/CacheValidation.cpp
 rendering/BackgroundPainter.cpp
 rendering/BorderPainter.cpp

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -643,46 +643,47 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
     } else if (m_currentMediaEngine != engine) {
         m_currentMediaEngine = engine;
         m_attemptedEngines.add(*engine);
-        m_private = engine->createMediaEnginePlayer(this);
-        if (m_private) {
+        RefPtr playerPrivate = engine->createMediaEnginePlayer(this);
+        m_private = playerPrivate;
+        if (playerPrivate) {
             client().mediaPlayerEngineUpdated();
 #if USE(AVFOUNDATION)
-            m_private->setDecompressionSessionPreferences(m_preferDecompressionSession, m_canFallbackToDecompressionSession);
+            playerPrivate->setDecompressionSessionPreferences(m_preferDecompressionSession, m_canFallbackToDecompressionSession);
 #endif
             if (m_pageIsVisible)
-                m_private->setPageIsVisible(m_pageIsVisible);
+                playerPrivate->setPageIsVisible(m_pageIsVisible);
             if (m_visibleInViewport)
-                m_private->setVisibleInViewport(m_visibleInViewport);
+                playerPrivate->setVisibleInViewport(m_visibleInViewport);
             if (m_isGatheringVideoFrameMetadata)
-                m_private->startVideoFrameMetadataGathering();
+                playerPrivate->startVideoFrameMetadataGathering();
             if (m_processIdentity)
-                m_private->setResourceOwner(m_processIdentity);
+                playerPrivate->setResourceOwner(m_processIdentity);
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)
             if (m_shouldContinueAfterKeyNeeded)
-                m_private->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
+                playerPrivate->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
 #endif
-            m_private->prepareForPlayback(m_inPrivateBrowsingMode, m_preload, m_preservesPitch, m_shouldPrepareToPlay, m_shouldPrepareToRender);
+            playerPrivate->prepareForPlayback(m_inPrivateBrowsingMode, m_preload, m_preservesPitch, m_shouldPrepareToPlay, m_shouldPrepareToRender);
 #if HAVE(SPATIAL_TRACKING_LABEL)
-            m_private->setDefaultSpatialTrackingLabel(m_defaultSpatialTrackingLabel);
-            m_private->setSpatialTrackingLabel(m_spatialTrackingLabel);
+            playerPrivate->setDefaultSpatialTrackingLabel(m_defaultSpatialTrackingLabel);
+            playerPrivate->setSpatialTrackingLabel(m_spatialTrackingLabel);
 #endif
         }
     }
 
-    if (m_private) {
-        m_private->setShouldCheckHardwareSupport(client().mediaPlayerShouldCheckHardwareSupport());
+    if (RefPtr playerPrivate = m_private) {
+        playerPrivate->setShouldCheckHardwareSupport(client().mediaPlayerShouldCheckHardwareSupport());
 
 #if ENABLE(MEDIA_SOURCE)
         if (RefPtr mediaSource = m_mediaSource.get())
-            m_private->load(m_url, m_loadOptions, *mediaSource);
+            playerPrivate->load(m_url, m_loadOptions, *mediaSource);
         else
 #endif
 #if ENABLE(MEDIA_STREAM)
-        if (m_mediaStream)
-            m_private->load(*m_mediaStream);
+        if (RefPtr mediaStream = m_mediaStream)
+            playerPrivate->load(*mediaStream);
         else
 #endif
-        m_private->load(m_url, m_loadOptions);
+        playerPrivate->load(m_url, m_loadOptions);
     } else {
         m_private = NullMediaPlayerPrivate::create(*this);
         if (!m_activeEngineIdentifier
@@ -707,7 +708,7 @@ void MediaPlayer::queueTaskOnEventLoop(Function<void()>&& task)
 
 bool MediaPlayer::hasAvailableVideoFrame() const
 {
-    return m_private->hasAvailableVideoFrame();
+    return protectedPrivate()->hasAvailableVideoFrame();
 }
 
 void MediaPlayer::prepareForRendering()
@@ -718,7 +719,7 @@ void MediaPlayer::prepareForRendering()
 
 void MediaPlayer::cancelLoad()
 {
-    m_private->cancelLoad();
+    protectedPrivate()->cancelLoad();
 }    
 
 void MediaPlayer::prepareToPlay()
@@ -731,12 +732,12 @@ void MediaPlayer::prepareToPlay()
 
 void MediaPlayer::play()
 {
-    m_private->play();
+    protectedPrivate()->play();
 }
 
 void MediaPlayer::pause()
 {
-    m_private->pause();
+    protectedPrivate()->pause();
 }
 
 void MediaPlayer::setBufferingPolicy(BufferingPolicy policy)
@@ -797,27 +798,27 @@ void MediaPlayer::setShouldContinueAfterKeyNeeded(bool should)
 
 MediaTime MediaPlayer::duration() const
 {
-    return m_private->duration();
+    return protectedPrivate()->duration();
 }
 
 MediaTime MediaPlayer::startTime() const
 {
-    return m_private->startTime();
+    return protectedPrivate()->startTime();
 }
 
 MediaTime MediaPlayer::initialTime() const
 {
-    return m_private->initialTime();
+    return protectedPrivate()->initialTime();
 }
 
 MediaTime MediaPlayer::currentTime() const
 {
-    return m_private->currentTime();
+    return protectedPrivate()->currentTime();
 }
 
 bool MediaPlayer::timeIsProgressing() const
 {
-    return m_private->timeIsProgressing();
+    return protectedPrivate()->timeIsProgressing();
 }
 
 bool MediaPlayer::setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&& callback)
@@ -827,7 +828,7 @@ bool MediaPlayer::setCurrentTimeDidChangeCallback(CurrentTimeDidChangeCallback&&
 
 MediaTime MediaPlayer::getStartDate() const
 {
-    return m_private->getStartDate();
+    return protectedPrivate()->getStartDate();
 }
 
 void MediaPlayer::willSeekToTarget(const MediaTime& time)
@@ -837,8 +838,9 @@ void MediaPlayer::willSeekToTarget(const MediaTime& time)
 
 void MediaPlayer::seekToTarget(const SeekTarget& target)
 {
-    m_private->willSeekToTarget(MediaTime::invalidTime());
-    m_private->seekToTarget(target);
+    RefPtr playerPrivate = m_private;
+    playerPrivate->willSeekToTarget(MediaTime::invalidTime());
+    playerPrivate->seekToTarget(target);
 }
 
 void MediaPlayer::seekToTime(const MediaTime& time)
@@ -848,7 +850,7 @@ void MediaPlayer::seekToTime(const MediaTime& time)
 
 void MediaPlayer::seekWhenPossible(const MediaTime& time)
 {
-    if (m_private->readyState() < MediaPlayer::ReadyState::HaveMetadata)
+    if (protectedPrivate()->readyState() < MediaPlayer::ReadyState::HaveMetadata)
         m_pendingSeekRequest = time;
     else
         seekToTime(time);
@@ -861,12 +863,12 @@ void MediaPlayer::seeked(const MediaTime& time)
 
 bool MediaPlayer::paused() const
 {
-    return m_private->paused();
+    return protectedPrivate()->paused();
 }
 
 bool MediaPlayer::seeking() const
 {
-    return m_private->seeking();
+    return protectedPrivate()->seeking();
 }
 
 bool MediaPlayer::supportsFullscreen() const
@@ -896,17 +898,17 @@ bool MediaPlayer::requiresImmediateCompositing() const
 
 FloatSize MediaPlayer::naturalSize()
 {
-    return m_private->naturalSize();
+    return protectedPrivate()->naturalSize();
 }
 
 bool MediaPlayer::hasVideo() const
 {
-    return m_private->hasVideo();
+    return protectedPrivate()->hasVideo();
 }
 
 bool MediaPlayer::hasAudio() const
 {
-    return m_private->hasAudio();
+    return protectedPrivate()->hasAudio();
 }
 
 PlatformLayer* MediaPlayer::platformLayer() const
@@ -918,12 +920,12 @@ PlatformLayer* MediaPlayer::platformLayer() const
 
 RetainPtr<PlatformLayer> MediaPlayer::createVideoFullscreenLayer()
 {
-    return m_private->createVideoFullscreenLayer();
+    return protectedPrivate()->createVideoFullscreenLayer();
 }
 
 void MediaPlayer::setVideoFullscreenLayer(PlatformLayer* layer, Function<void()>&& completionHandler)
 {
-    m_private->setVideoFullscreenLayer(layer, WTFMove(completionHandler));
+    protectedPrivate()->setVideoFullscreenLayer(layer, WTFMove(completionHandler));
 }
 
 void MediaPlayer::updateVideoFullscreenInlineImage()
@@ -1006,12 +1008,12 @@ String MediaPlayer::errorLog() const
 
 MediaPlayer::NetworkState MediaPlayer::networkState()
 {
-    return m_private->networkState();
+    return protectedPrivate()->networkState();
 }
 
 MediaPlayer::ReadyState MediaPlayer::readyState() const
 {
-    return m_private->readyState();
+    return protectedPrivate()->readyState();
 }
 
 void MediaPlayer::setVolumeLocked(bool volumeLocked)
@@ -1092,24 +1094,29 @@ void MediaPlayer::setPitchCorrectionAlgorithm(PitchCorrectionAlgorithm pitchCorr
     m_private->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
 }
 
+RefPtr<MediaPlayerPrivateInterface> MediaPlayer::protectedPrivate() const
+{
+    return m_private;
+}
+
 const PlatformTimeRanges& MediaPlayer::buffered() const
 {
-    return m_private->buffered();
+    return protectedPrivate()->buffered();
 }
 
 const PlatformTimeRanges& MediaPlayer::seekable() const
 {
-    return m_private->seekable();
+    return protectedPrivate()->seekable();
 }
 
 MediaTime MediaPlayer::maxTimeSeekable() const
 {
-    return m_private->maxTimeSeekable();
+    return protectedPrivate()->maxTimeSeekable();
 }
 
 MediaTime MediaPlayer::minTimeSeekable() const
 {
-    return m_private->minTimeSeekable();
+    return protectedPrivate()->minTimeSeekable();
 }
 
 double MediaPlayer::seekableTimeRangesLastModifiedTime()
@@ -1134,7 +1141,7 @@ double MediaPlayer::liveUpdateInterval()
 
 void MediaPlayer::didLoadingProgress(DidLoadingProgressCompletionHandler&& callback) const
 {
-    m_private->didLoadingProgressAsync(WTFMove(callback));
+    protectedPrivate()->didLoadingProgressAsync(WTFMove(callback));
 }
 
 void MediaPlayer::setPresentationSize(const IntSize& size)
@@ -1149,7 +1156,7 @@ void MediaPlayer::setPresentationSize(const IntSize& size)
 void MediaPlayer::setPageIsVisible(bool visible)
 {
     m_pageIsVisible = visible;
-    m_private->setPageIsVisible(visible);
+    protectedPrivate()->setPageIsVisible(visible);
 }
 
 void MediaPlayer::setVisibleForCanvas(bool visible)
@@ -1158,7 +1165,7 @@ void MediaPlayer::setVisibleForCanvas(bool visible)
         return;
 
     m_visibleForCanvas = visible;
-    m_private->setVisibleForCanvas(visible);
+    protectedPrivate()->setVisibleForCanvas(visible);
 }
 
 void MediaPlayer::setVisibleInViewport(bool visible)
@@ -1189,12 +1196,12 @@ void MediaPlayer::setPreload(MediaPlayer::Preload preload)
 
 void MediaPlayer::paint(GraphicsContext& context, const FloatRect& destination)
 {
-    m_private->paint(context, destination);
+    protectedPrivate()->paint(context, destination);
 }
 
 void MediaPlayer::paintCurrentFrameInContext(GraphicsContext& context, const FloatRect& destination)
 {
-    m_private->paintCurrentFrameInContext(context, destination);
+    protectedPrivate()->paintCurrentFrameInContext(context, destination);
 }
 
 RefPtr<VideoFrame> MediaPlayer::videoFrameForCurrentTime()
@@ -1210,7 +1217,7 @@ RefPtr<NativeImage> MediaPlayer::nativeImageForCurrentTime()
 
 DestinationColorSpace MediaPlayer::colorSpace()
 {
-    return m_private->colorSpace();
+    return protectedPrivate()->colorSpace();
 }
 
 bool MediaPlayer::shouldGetNativeImageForCanvasDrawing() const
@@ -1268,7 +1275,7 @@ bool MediaPlayer::isCurrentPlaybackTargetWireless() const
 
 String MediaPlayer::wirelessPlaybackTargetName() const
 {
-    return m_private->wirelessPlaybackTargetName();
+    return protectedPrivate()->wirelessPlaybackTargetName();
 }
 
 MediaPlayer::WirelessPlaybackTargetType MediaPlayer::wirelessPlaybackTargetType() const
@@ -1335,7 +1342,7 @@ void MediaPlayer::setShouldMaintainAspectRatio(bool maintainAspectRatio)
 
 void MediaPlayer::requestHostingContextID(LayerHostingContextIDCallback&& callback)
 {
-    return m_private->requestHostingContextID(WTFMove(callback));
+    return protectedPrivate()->requestHostingContextID(WTFMove(callback));
 }
 
 LayerHostingContextID MediaPlayer::hostingContextID() const
@@ -1350,7 +1357,7 @@ bool MediaPlayer::didPassCORSAccessCheck() const
 
 bool MediaPlayer::isCrossOrigin(const SecurityOrigin& origin) const
 {
-    if (auto crossOrigin = m_private->isCrossOrigin(origin))
+    if (auto crossOrigin = protectedPrivate()->isCrossOrigin(origin))
         return *crossOrigin;
 
     if (m_url.protocolIsData())
@@ -1391,7 +1398,7 @@ unsigned MediaPlayer::videoDecodedByteCount() const
 
 void MediaPlayer::reloadTimerFired()
 {
-    m_private->cancelLoad();
+    protectedPrivate()->cancelLoad();
     loadWithNextMediaEngine(m_currentMediaEngine);
 }
 
@@ -1444,11 +1451,12 @@ void MediaPlayer::setPrivateBrowsingMode(bool privateBrowsingMode)
 // Client callbacks.
 void MediaPlayer::networkStateChanged()
 {
-    if (m_private->networkState() >= MediaPlayer::NetworkState::FormatError)
-        m_lastErrorMessage = m_private->errorMessage();
+    RefPtr playerPrivate = m_private;
+    if (playerPrivate->networkState() >= MediaPlayer::NetworkState::FormatError)
+        m_lastErrorMessage = playerPrivate->errorMessage();
     // If more than one media engine is installed and this one failed before finding metadata,
     // let the next engine try.
-    if (m_private->networkState() >= MediaPlayer::NetworkState::FormatError && m_private->readyState() < MediaPlayer::ReadyState::HaveMetadata) {
+    if (playerPrivate->networkState() >= MediaPlayer::NetworkState::FormatError && playerPrivate->readyState() < MediaPlayer::ReadyState::HaveMetadata) {
         client().mediaPlayerEngineFailedToLoad();
         if (!m_activeEngineIdentifier
             && installedMediaEngines().size() > 1
@@ -1463,7 +1471,7 @@ void MediaPlayer::networkStateChanged()
 void MediaPlayer::readyStateChanged()
 {
     client().mediaPlayerReadyStateChanged();
-    if (m_pendingSeekRequest && m_private->readyState() == MediaPlayer::ReadyState::HaveMetadata)
+    if (m_pendingSeekRequest && protectedPrivate()->readyState() == MediaPlayer::ReadyState::HaveMetadata)
         seekToTime(*std::exchange(m_pendingSeekRequest, std::nullopt));
 }
 
@@ -1587,10 +1595,8 @@ String MediaPlayer::userAgent() const
 
 String MediaPlayer::engineDescription() const
 {
-    if (!m_private)
-        return String();
-
-    return m_private->engineDescription();
+    RefPtr playerPrivate = m_private;
+    return playerPrivate ? playerPrivate->engineDescription() : String();
 }
 
 long MediaPlayer::platformErrorCode() const
@@ -1712,18 +1718,14 @@ void MediaPlayer::endSimulatedHDCPError()
 
 String MediaPlayer::languageOfPrimaryAudioTrack() const
 {
-    if (!m_private)
-        return emptyString();
-    
-    return m_private->languageOfPrimaryAudioTrack();
+    RefPtr playerPrivate = m_private;
+    return playerPrivate ? playerPrivate->languageOfPrimaryAudioTrack() : emptyString();
 }
 
 size_t MediaPlayer::extraMemoryCost() const
 {
-    if (!m_private)
-        return 0;
-
-    return m_private->extraMemoryCost();
+    RefPtr playerPrivate = m_private;
+    return playerPrivate ? playerPrivate->extraMemoryCost() : 0;
 }
 
 unsigned long long MediaPlayer::fileSize() const
@@ -1741,18 +1743,20 @@ bool MediaPlayer::ended() const
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayer::videoPlaybackQualityMetrics()
 {
-    if (!m_private)
+    RefPtr playerPrivate = m_private;
+    if (!playerPrivate)
         return std::nullopt;
 
-    return m_private->videoPlaybackQualityMetrics();
+    return playerPrivate->videoPlaybackQualityMetrics();
 }
 
 Ref<MediaPlayer::VideoPlaybackQualityMetricsPromise> MediaPlayer::asyncVideoPlaybackQualityMetrics()
 {
-    if (!m_private)
+    RefPtr playerPrivate = m_private;
+    if (!playerPrivate)
         return VideoPlaybackQualityMetricsPromise::createAndReject(PlatformMediaError::Cancelled);
 
-    return m_private->asyncVideoPlaybackQualityMetrics();
+    return playerPrivate->asyncVideoPlaybackQualityMetrics();
 }
 
 String MediaPlayer::sourceApplicationIdentifier() const
@@ -1900,12 +1904,12 @@ void MediaPlayer::audioOutputDeviceChanged()
 
 std::optional<MediaPlayerIdentifier> MediaPlayer::identifier() const
 {
-    return m_private->identifier();
+    return protectedPrivate()->identifier();
 }
 
 std::optional<VideoFrameMetadata> MediaPlayer::videoFrameMetadata()
 {
-    return m_private->videoFrameMetadata();
+    return protectedPrivate()->videoFrameMetadata();
 }
 
 void MediaPlayer::startVideoFrameMetadataGathering()

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -801,6 +801,8 @@ private:
 
     MediaPlayerClient& client() const { return *m_client; }
 
+    RefPtr<MediaPlayerPrivateInterface> protectedPrivate() const;
+
     const MediaPlayerFactory* nextBestMediaEngine(const MediaPlayerFactory*);
     void loadWithNextMediaEngine(const MediaPlayerFactory*);
     const MediaPlayerFactory* nextMediaEngine(const MediaPlayerFactory*);

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -145,12 +145,14 @@ FloatSize MockMediaPlayerMediaSource::naturalSize() const
 
 bool MockMediaPlayerMediaSource::hasVideo() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->hasVideo() : false;
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate ? mediaSourcePrivate->hasVideo() : false;
 }
 
 bool MockMediaPlayerMediaSource::hasAudio() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->hasAudio() : false;
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate ? mediaSourcePrivate->hasAudio() : false;
 }
 
 void MockMediaPlayerMediaSource::setPageIsVisible(bool)
@@ -208,7 +210,10 @@ MediaTime MockMediaPlayerMediaSource::currentTime() const
 
 bool MockMediaPlayerMediaSource::timeIsProgressing() const
 {
-    return m_playing && m_mediaSourcePrivate && m_mediaSourcePrivate->hasFutureTime(currentTime());
+    if (!m_playing)
+        return false;
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate && mediaSourcePrivate->hasFutureTime(currentTime());
 }
 
 void MockMediaPlayerMediaSource::notifyActiveSourceBuffersChanged()
@@ -219,31 +224,38 @@ void MockMediaPlayerMediaSource::notifyActiveSourceBuffersChanged()
 
 MediaTime MockMediaPlayerMediaSource::duration() const
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->duration() : MediaTime::zeroTime();
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate ? mediaSourcePrivate->duration() : MediaTime::zeroTime();
+}
+
+RefPtr<MockMediaSourcePrivate> MockMediaPlayerMediaSource::protectedMediaSourcePrivate()
+{
+    return m_mediaSourcePrivate;
 }
 
 void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
 {
     m_lastSeekTarget = target;
-    m_mediaSourcePrivate->waitForTarget(target)->whenSettled(RunLoop::current(), [this, weakThis = WeakPtr { this }](auto&& result) {
-        if (!weakThis || !result)
+    protectedMediaSourcePrivate()->waitForTarget(target)->whenSettled(RunLoop::protectedCurrent(), [weakThis = WeakPtr { this }](auto&& result) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !result)
             return;
 
-        m_mediaSourcePrivate->seekToTime(*result)->whenSettled(RunLoop::current(), [this, weakThis, seekTime = *result] {
+        protectedThis->protectedMediaSourcePrivate()->seekToTime(*result)->whenSettled(RunLoop::protectedCurrent(), [weakThis, seekTime = *result] {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
-            m_lastSeekTarget.reset();
-            m_currentTime = seekTime;
+            protectedThis->m_lastSeekTarget.reset();
+            protectedThis->m_currentTime = seekTime;
 
-            if (auto player = m_player.get()) {
+            if (RefPtr player = protectedThis->m_player.get()) {
                 player->seeked(seekTime);
                 player->timeChanged();
             }
 
-            if (m_playing) {
-                callOnMainThread([this, protectedThis = WTFMove(protectedThis)] {
-                    advanceCurrentTime();
+            if (protectedThis->m_playing) {
+                callOnMainThread([protectedThis = WTFMove(protectedThis)] {
+                    protectedThis->advanceCurrentTime();
                 });
             }
         });
@@ -252,10 +264,11 @@ void MockMediaPlayerMediaSource::seekToTarget(const SeekTarget& target)
 
 void MockMediaPlayerMediaSource::advanceCurrentTime()
 {
-    if (!m_mediaSourcePrivate)
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    if (!mediaSourcePrivate)
         return;
 
-    auto buffered = m_mediaSourcePrivate->buffered();
+    auto buffered = mediaSourcePrivate->buffered();
     size_t pos = buffered.find(m_currentTime);
     if (pos == notFound)
         return;
@@ -298,7 +311,8 @@ void MockMediaPlayerMediaSource::setNetworkState(MediaPlayer::NetworkState netwo
 
 std::optional<VideoPlaybackQualityMetrics> MockMediaPlayerMediaSource::videoPlaybackQualityMetrics()
 {
-    return m_mediaSourcePrivate ? m_mediaSourcePrivate->videoPlaybackQualityMetrics() : std::nullopt;
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    return mediaSourcePrivate ? mediaSourcePrivate->videoPlaybackQualityMetrics() : std::nullopt;
 }
 
 DestinationColorSpace MockMediaPlayerMediaSource::colorSpace()

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -99,6 +99,7 @@ private:
     MediaTime duration() const override;
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() override;
     DestinationColorSpace colorSpace() override;
+    RefPtr<MockMediaSourcePrivate> protectedMediaSourcePrivate();
 
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     RefPtr<MockMediaSourcePrivate> m_mediaSourcePrivate;


### PR DESCRIPTION
#### 2862dca2d113384625da5d7e1d828f0e6e0af1f6
<pre>
Address safer C++ static analysis warnings in MediaPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=287343">https://bugs.webkit.org/show_bug.cgi?id=287343</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::hasAvailableVideoFrame const):
(WebCore::MediaPlayer::cancelLoad):
(WebCore::MediaPlayer::play):
(WebCore::MediaPlayer::pause):
(WebCore::MediaPlayer::duration const):
(WebCore::MediaPlayer::startTime const):
(WebCore::MediaPlayer::initialTime const):
(WebCore::MediaPlayer::currentTime const):
(WebCore::MediaPlayer::timeIsProgressing const):
(WebCore::MediaPlayer::getStartDate const):
(WebCore::MediaPlayer::seekToTarget):
(WebCore::MediaPlayer::seekWhenPossible):
(WebCore::MediaPlayer::paused const):
(WebCore::MediaPlayer::seeking const):
(WebCore::MediaPlayer::naturalSize):
(WebCore::MediaPlayer::hasVideo const):
(WebCore::MediaPlayer::hasAudio const):
(WebCore::MediaPlayer::createVideoFullscreenLayer):
(WebCore::MediaPlayer::setVideoFullscreenLayer):
(WebCore::MediaPlayer::networkState):
(WebCore::MediaPlayer::readyState const):
(WebCore::MediaPlayer::protectedPrivate const):
(WebCore::MediaPlayer::buffered const):
(WebCore::MediaPlayer::seekable const):
(WebCore::MediaPlayer::maxTimeSeekable const):
(WebCore::MediaPlayer::minTimeSeekable const):
(WebCore::MediaPlayer::didLoadingProgress const):
(WebCore::MediaPlayer::setPageIsVisible):
(WebCore::MediaPlayer::setVisibleForCanvas):
(WebCore::MediaPlayer::paint):
(WebCore::MediaPlayer::paintCurrentFrameInContext):
(WebCore::MediaPlayer::colorSpace):
(WebCore::MediaPlayer::wirelessPlaybackTargetName const):
(WebCore::MediaPlayer::requestHostingContextID):
(WebCore::MediaPlayer::isCrossOrigin const):
(WebCore::MediaPlayer::reloadTimerFired):
(WebCore::MediaPlayer::networkStateChanged):
(WebCore::MediaPlayer::readyStateChanged):
(WebCore::MediaPlayer::engineDescription const):
(WebCore::MediaPlayer::languageOfPrimaryAudioTrack const):
(WebCore::MediaPlayer::extraMemoryCost const):
(WebCore::MediaPlayer::videoPlaybackQualityMetrics):
(WebCore::MediaPlayer::asyncVideoPlaybackQualityMetrics):
(WebCore::MediaPlayer::identifier const):
(WebCore::MediaPlayer::videoFrameMetadata):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::hasVideo const):
(WebCore::MockMediaPlayerMediaSource::hasAudio const):
(WebCore::MockMediaPlayerMediaSource::timeIsProgressing const):
(WebCore::MockMediaPlayerMediaSource::duration const):
(WebCore::MockMediaPlayerMediaSource::protectedMediaSourcePrivate):
(WebCore::MockMediaPlayerMediaSource::seekToTarget):
(WebCore::MockMediaPlayerMediaSource::advanceCurrentTime):
(WebCore::MockMediaPlayerMediaSource::videoPlaybackQualityMetrics):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:

Canonical link: <a href="https://commits.webkit.org/290107@main">https://commits.webkit.org/290107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8503f95327baef1f3221b461547a2f40a36c1a65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39769 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26251 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6812 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6561 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95820 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16189 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21133 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9272 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16203 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21514 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->