### PR TITLE
[css-overflow] Implement `overflow-block` and `overflow-inline` CSS properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -247,6 +247,8 @@ PASS outline-offset
 PASS outline-style
 PASS outline-width
 PASS overflow-anchor
+PASS overflow-block
+PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -230,6 +230,8 @@ PASS outline-offset
 PASS outline-style
 PASS outline-width
 PASS overflow-anchor
+PASS overflow-block
+PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt
@@ -5,10 +5,10 @@ PASS Property continue has initial value auto
 PASS Property continue does not inherit
 PASS Property max-lines has initial value none
 PASS Property max-lines does not inherit
-FAIL Property overflow-block has initial value visible assert_true: overflow-block doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-block does not inherit assert_true: expected true got false
-FAIL Property overflow-inline has initial value visible assert_true: overflow-inline doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-inline does not inherit assert_true: expected true got false
+PASS Property overflow-block has initial value visible
+PASS Property overflow-block does not inherit
+PASS Property overflow-inline has initial value visible
+PASS Property overflow-inline does not inherit
 PASS Property overflow-x has initial value visible
 PASS Property overflow-x does not inherit
 PASS Property overflow-y has initial value visible

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/logical-overflow-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/logical-overflow-001-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL overflow-x matches overflow-inline, and overflow-y matches overflow-block when the element has a horizontal writing mode assert_equals: expected "scroll" but got "visible"
-FAIL overflow-y matches overflow-inline, and overflow-x matches overflow-block when the element has a vertical writing mode assert_equals: expected "hidden" but got "visible"
+PASS overflow-x matches overflow-inline, and overflow-y matches overflow-block when the element has a horizontal writing mode
+PASS overflow-y matches overflow-inline, and overflow-x matches overflow-block when the element has a vertical writing mode
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-shorthand-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-shorthand-002-expected.txt
@@ -1,0 +1,4 @@
+
+PASS overflow - horizontal writing mode
+PASS overflow - vertical writing mode
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-shorthand-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-shorthand-002.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Overflow Test: Overflow shorthand logical mapping</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#propdef-overflow">
+<style>
+  #horizontal {
+    writing-mode: horizontal-tb;
+  }
+  #vertical {
+    writing-mode: vertical-lr;
+  }
+  .overflow {
+    overflow: visible clip;
+  }
+</style>
+<div id="horizontal" class="overflow"></div>
+<div id="vertical" class="overflow"></div>
+<script>
+  test(() => {
+    const style = getComputedStyle(horizontal);
+    assert_equals(style.overflowX, "visible");
+    assert_equals(style.overflowY, "clip");
+    assert_equals(style.overflowInline, "visible");
+    assert_equals(style.overflowBlock, "clip");
+  }, "overflow - horizontal writing mode");
+
+  test(() => {
+    const style = getComputedStyle(vertical);
+    assert_equals(style.overflowX, "visible");
+    assert_equals(style.overflowY, "clip");
+    assert_equals(style.overflowInline, "clip");
+    assert_equals(style.overflowBlock, "visible");
+  }, "overflow - vertical writing mode");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-computed-expected.txt
@@ -28,9 +28,9 @@ PASS Property overflow-x value 'visible'
 PASS Property overflow-y value 'clip'
 PASS Property overflow-y value 'auto'
 PASS Property overflow-y value 'visible'
-FAIL Property overflow-block value 'hidden' assert_true: overflow-block doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-block value 'clip' assert_true: overflow-block doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-block value 'visible' assert_true: overflow-block doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-inline value 'scroll' assert_true: overflow-inline doesn't seem to be supported in the computed style expected true got false
-FAIL Property overflow-inline value 'visible' assert_true: overflow-inline doesn't seem to be supported in the computed style expected true got false
+PASS Property overflow-block value 'hidden'
+PASS Property overflow-block value 'clip'
+PASS Property overflow-block value 'visible'
+PASS Property overflow-inline value 'scroll'
+PASS Property overflow-inline value 'visible'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-valid-expected.txt
@@ -13,8 +13,8 @@ PASS e.style['overflow-x'] = "visible" should set the property value
 PASS e.style['overflow-x'] = "scroll" should set the property value
 PASS e.style['overflow-y'] = "clip" should set the property value
 PASS e.style['overflow-y'] = "auto" should set the property value
-FAIL e.style['overflow-block'] = "hidden" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['overflow-block'] = "clip" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['overflow-inline'] = "scroll" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['overflow-inline'] = "visible" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['overflow-block'] = "hidden" should set the property value
+PASS e.style['overflow-block'] = "clip" should set the property value
+PASS e.style['overflow-inline'] = "scroll" should set the property value
+PASS e.style['overflow-inline'] = "visible" should set the property value
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -247,6 +247,8 @@ PASS outline-offset
 PASS outline-style
 PASS outline-width
 PASS overflow-anchor
+PASS overflow-block
+PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -145,7 +145,6 @@ PASS font-optical-sizing
 PASS font-palette
 PASS font-size
 PASS font-size-adjust
-PASS font-stretch
 PASS font-style
 PASS font-synthesis-small-caps
 PASS font-synthesis-style
@@ -159,6 +158,7 @@ PASS font-variant-numeric
 PASS font-variant-position
 PASS font-variation-settings
 PASS font-weight
+PASS font-width
 PASS glyph-orientation-horizontal
 PASS glyph-orientation-vertical
 PASS grid-auto-columns
@@ -247,6 +247,8 @@ PASS outline-offset
 PASS outline-style
 PASS outline-width
 PASS overflow-anchor
+PASS overflow-block
+PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y
@@ -268,6 +270,7 @@ PASS perspective-origin
 PASS pointer-events
 PASS position
 PASS position-anchor
+PASS position-try-fallbacks
 PASS position-try-order
 PASS print-color-adjust
 PASS quotes
@@ -417,7 +420,6 @@ PASS -webkit-locale
 PASS -webkit-mask-position-x
 PASS -webkit-mask-position-y
 PASS -webkit-nbsp-mode
-PASS -webkit-overflow-scrolling
 PASS -webkit-rtl-ordering
 PASS -webkit-text-fill-color
 PASS -webkit-text-security

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -245,6 +245,8 @@ PASS outline-offset
 PASS outline-style
 PASS outline-width
 PASS overflow-anchor
+PASS overflow-block
+PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -246,6 +246,8 @@ PASS outline-offset
 PASS outline-style
 PASS outline-width
 PASS overflow-anchor
+PASS overflow-block
+PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -229,6 +229,8 @@ PASS outline-offset
 PASS outline-style
 PASS outline-width
 PASS overflow-anchor
+PASS overflow-block
+PASS overflow-inline
 PASS overflow-wrap
 PASS overflow-x
 PASS overflow-y

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5176,7 +5176,11 @@
                 }
             ],
             "codegen-properties": {
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "logical-property-group": {
+                    "name": "overflow",
+                    "resolver": "horizontal"
+                }
             },
             "specification": {
                 "category": "css-overflow",
@@ -5204,11 +5208,57 @@
                 }
             ],
             "codegen-properties": {
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "logical-property-group": {
+                    "name": "overflow",
+                    "resolver": "vertical"
+                }
             },
             "specification": {
                 "category": "css-overflow",
                 "url": "https://www.w3.org/TR/css-overflow-3/#propdef-overflow-y"
+            }
+        },
+        "overflow-inline": {
+            "values": [
+                "visible",
+                "hidden",
+                "clip",
+                "scroll",
+                "auto"
+            ],
+            "codegen-properties": {
+                "skip-builder": true,
+                "logical-property-group": {
+                    "name": "overflow",
+                    "resolver": "inline"
+                },
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-overflow",
+                "url": "https://www.w3.org/TR/css-overflow-3/#propdef-overflow-inline"
+            }
+        },
+        "overflow-block": {
+            "values": [
+                "visible",
+                "hidden",
+                "clip",
+                "scroll",
+                "auto"
+            ],
+            "codegen-properties": {
+                "skip-builder": true,
+                "logical-property-group": {
+                    "name": "overflow",
+                    "resolver": "block"
+                },
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-overflow",
+                "url": "https://www.w3.org/TR/css-overflow-3/#propdef-overflow-block"
             }
         },
         "overscroll-behavior": {

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -98,6 +98,7 @@ public:
     static bool isMarginProperty(CSSPropertyID);
     static bool isMaxSizeProperty(CSSPropertyID);
     static bool isMinSizeProperty(CSSPropertyID);
+    static bool isOverflowProperty(CSSPropertyID);
     static bool isOverscrollBehaviorProperty(CSSPropertyID);
     static bool isPaddingProperty(CSSPropertyID);
     static bool isScrollMarginProperty(CSSPropertyID);

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4904,6 +4904,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertyMaxInlineSize:
     case CSSPropertyMinBlockSize:
     case CSSPropertyMinInlineSize:
+    case CSSPropertyOverflowBlock:
+    case CSSPropertyOverflowInline:
     case CSSPropertyScrollMarginBlockEnd:
     case CSSPropertyScrollMarginBlockStart:
     case CSSPropertyScrollMarginInlineEnd:


### PR DESCRIPTION
#### f0ee52bc70e74487b6f33e6285884f0a8789a33f
<pre>
[css-overflow] Implement `overflow-block` and `overflow-inline` CSS properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=218091">https://bugs.webkit.org/show_bug.cgi?id=218091</a>
<a href="https://rdar.apple.com/70579028">rdar://70579028</a>

Reviewed by Sam Weinig.

Implement logical versions of overflow-x &amp; overflow-y.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/logical-overflow-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-shorthand-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-shorthand-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/overflow-valid-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):

Canonical link: <a href="https://commits.webkit.org/290109@main">https://commits.webkit.org/290109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/478fe64d9c359e74f408970c6aec0297833355bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16723 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26258 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80621 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6567 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38883 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77458 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76748 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21142 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9278 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16209 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21520 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->