### PR TITLE
Use smart pointers to store reference to Element in IdChangeInvalidation.

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -100,7 +100,6 @@ style/AttributeChangeInvalidation.h
 style/ChildChangeInvalidation.h
 style/ClassChangeInvalidation.cpp
 style/ElementRuleCollector.cpp
-style/IdChangeInvalidation.h
 style/PseudoClassChangeInvalidation.h
 style/RuleSetBuilder.h
 style/StyleRelations.h

--- a/Source/WebCore/style/IdChangeInvalidation.cpp
+++ b/Source/WebCore/style/IdChangeInvalidation.cpp
@@ -53,20 +53,20 @@ void IdChangeInvalidation::invalidateStyle(const AtomString& changedId)
         return;
 
     if (mayAffectStyleInShadowTree) {
-        m_element.invalidateStyleForSubtree();
+        m_element->invalidateStyleForSubtree();
         return;
     }
 
-    m_element.invalidateStyle();
+    m_element->invalidateStyle();
 
     auto collect = [&](auto& ruleSets, std::optional<MatchElement> onlyMatchElement = { }) {
         // This could be easily optimized for fine-grained descendant invalidation similar to ClassChangeInvalidation.
         // However using ids for dynamic styling is rare and this is probably not worth the memory cost of the required data structures.
         bool mayAffectDescendantStyle = ruleSets.features().idsMatchingAncestorsInRules.contains(changedId);
         if (mayAffectDescendantStyle)
-            m_element.invalidateStyleForSubtree();
+            m_element->invalidateStyleForSubtree();
         else
-            m_element.invalidateStyle();
+            m_element->invalidateStyle();
 
         // Invalidation rulesets exist for :has() / :nth-child() / :nth-last-child.
         if (auto* invalidationRuleSets = ruleSets.idInvalidationRuleSets(changedId)) {
@@ -79,9 +79,9 @@ void IdChangeInvalidation::invalidateStyle(const AtomString& changedId)
         }
     };
 
-    collect(m_element.styleResolver().ruleSets());
+    collect(m_element->styleResolver().ruleSets());
 
-    if (auto* shadowRoot = m_element.shadowRoot())
+    if (auto* shadowRoot = m_element->shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 
 }

--- a/Source/WebCore/style/IdChangeInvalidation.h
+++ b/Source/WebCore/style/IdChangeInvalidation.h
@@ -34,7 +34,7 @@ namespace Style {
 
 class IdChangeInvalidation {
 public:
-    IdChangeInvalidation(Element&, const AtomString& oldId, const AtomString& newId);
+    IdChangeInvalidation(Ref<Element>&&, const AtomString& oldId, const AtomString& newId);
     ~IdChangeInvalidation();
 
 private:
@@ -42,16 +42,16 @@ private:
     void invalidateStyleWithRuleSets();
 
     const bool m_isEnabled;
-    Element& m_element;
+    Ref<Element> m_element;
 
     AtomString m_newId;
 
     Invalidator::MatchElementRuleSets m_matchElementRuleSets;
 };
 
-inline IdChangeInvalidation::IdChangeInvalidation(Element& element, const AtomString& oldId, const AtomString& newId)
-    : m_isEnabled(element.needsStyleInvalidation())
-    , m_element(element)
+inline IdChangeInvalidation::IdChangeInvalidation(Ref<Element>&& element, const AtomString& oldId, const AtomString& newId)
+    : m_isEnabled(element->needsStyleInvalidation())
+    , m_element(WTFMove(element))
 {
     if (!m_isEnabled)
         return;


### PR DESCRIPTION
#### 754f4bc24546b87e9e8c0cfb8bae07fa90a41cd8
<pre>
Use smart pointers to store reference to Element in IdChangeInvalidation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287349">https://bugs.webkit.org/show_bug.cgi?id=287349</a>
<a href="https://rdar.apple.com/problem/144463136">rdar://problem/144463136</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning caused by using a raw reference to
store element in IdChangeInvalidation.

* Source/WebCore/style/IdChangeInvalidation.cpp:
(WebCore::Style::IdChangeInvalidation::invalidateStyle):
* Source/WebCore/style/IdChangeInvalidation.h:
(WebCore::Style::IdChangeInvalidation::IdChangeInvalidation):

Canonical link: <a href="https://commits.webkit.org/290128@main">https://commits.webkit.org/290128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/641ab78864c053f657954da9f3492424b92a8bf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68587 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26261 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6824 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6573 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38889 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95832 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16201 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11841 "Found 5 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77463 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16457 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76753 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21147 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9284 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13954 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21526 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->