### PR TITLE
[SwiftUI] Update WebPage.Configuration and related types to latest interface (Part 1)

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
+++ b/Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift
@@ -26,9 +26,21 @@
 import Foundation
 internal import WebKit_Internal
 
-@MainActor
-@_spi(Private)
-public struct URLScheme_v0: Hashable, Sendable {
+/// A type representing a valid URL scheme.
+///
+/// Scheme names are case sensitive, must start with an ASCII letter, and may contain only ASCII letters,
+/// numbers, the “+” character, the “-” character, and the “.” character.
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct URLScheme: Hashable, Sendable {
+    /// Creates a new `URLScheme` value from a valid scheme, which WebKit does not already handle.
+    ///
+    /// To determine whether WebKit handles a specific scheme, call the `handlesURLScheme(_:)` static method of `WebPage`.
+    ///
+    /// - Parameter rawValue: The raw value of the scheme string; if this is an invalid scheme, of if WebKit already handles
+    /// this scheme, the initializer returns `nil`.
+    @MainActor
     public init?(_ rawValue: String) {
         guard WKWebViewConfiguration._isValidCustomScheme(rawValue) else {
             return nil
@@ -37,31 +49,75 @@ public struct URLScheme_v0: Hashable, Sendable {
         self.rawValue = rawValue
     }
 
-    let rawValue: String
+    /// The raw value of the scheme string.
+    public let rawValue: String
 }
 
-@_spi(Private)
-public enum URLSchemeTaskResult_v0: Sendable {
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public enum URLSchemeTaskResult: Sendable {
+    /// The response to return to WebKit. The response value must include the MIME type of the request resource.
+    ///
+    /// This value is used to provide WebKit with the MIME type of the requested resource and its expected
+    /// size. This must be added to the task result sequence at least once, but may be added multiple times
+    /// if needed. It must be added to the sequence before any data values are.
     case response(URLResponse)
 
+    /// Data for the resource. This value may contain all of the data or only some of it.
+    ///
+    /// If you load the data incrementally, multiple of these values may be added to the result sequence to deliver
+    /// each new portion of data. Each time some new Data is added to the sequence, WebKit appends the data to any
+    /// previously received data.
+    ///
+    /// A ``URLSchemeTaskResult/response(_:)`` must have been added to the sequence prior to any data being aded to it.
     case data(Data)
 }
 
-@_spi(Private)
-public protocol URLSchemeHandler_v0 {
-    associatedtype TaskSequence: AsyncSequence<URLSchemeTaskResult_v0, any Error>
+/// A protocol for loading resources with URL schemes that WebKit doesn't handle.
+///
+/// Adopt the `URLSchemeHandler` protocol in types that handle custom URL schemes for your web content.
+/// Custom schemes let you integrate custom resource types into your web content, and you may define
+/// custom schemes for resources that your app requires. For example, you might use a custom scheme to
+/// integrate content that is available only on the user's device, such as the user's photos. These types
+/// can then be registered to a particular WebPage by using the ``WebPage/Configuration-swift.struct/urlSchemeHandlers``
+/// property of ``WebPage/Configuration-swift.struct``.
+///
+/// When a web page encounters a resource that uses a custom scheme, it passes the `URLRequest` to the
+/// scheme handler, and expects a stream of responses and data to load the result.
+///
+/// If WebKit determines that it no longer needs a resource that your handler is loading, it will cancel
+/// the Task responsible for the async sequence. Typically, this may happen when the user navigates to another
+/// page, but may happen for other reasons.
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public protocol URLSchemeHandler {
+    /// The type of sequence produced by the handler.
+    associatedtype TaskSequence: AsyncSequence<URLSchemeTaskResult, any Error>
 
+    /// Produces a sequence of intermixed responses and data to load a resource for a given request.
+    ///
+    /// Upon receiving the request, determine the size of the resource and add a ``URLSchemeTaskResult/response(_:)`` value to the async sequence. Providing a response mirrors
+    /// the behavior that a web server performs when it receives a request.
+    ///
+    /// After you load some portion of the resource data, add a ``URLSchemeTaskResult/data(_:)`` value
+    /// to the sequence. Multiple of these values may be added to the sequence to delivery data
+    /// incrementally, or a single one with all of the data.
+    ///
+    /// If an error occurs at any point during the load process, a value of type ``Failure`` can be thrown
+    /// to report it.
     func reply(for request: URLRequest) -> TaskSequence
 }
 
 // MARK: Adapters
 
 final class WKURLSchemeHandlerAdapter: NSObject, WKURLSchemeHandler {
-    init(_ wrapped: any URLSchemeHandler_v0) {
+    init(_ wrapped: any URLSchemeHandler) {
         self.wrapped = wrapped
     }
 
-    private let wrapped: any URLSchemeHandler_v0
+    private let wrapped: any URLSchemeHandler
 
     private var tasks: [ObjectIdentifier: Task<Void, Never>] = [:]
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift
@@ -28,60 +28,154 @@ internal import WebKit_Internal
 
 extension WebPage {
     @MainActor
-    @_spi(Private)
-    public struct Configuration: Sendable {
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public struct Configuration {
+        /// Creates a new configuration value.
         public init() {
         }
 
+        /// The object you use to get and set the site’s cookies and to track the cached data objects.
+        ///
+        /// To create a private web-browsing session, create a non-persistent data store using the `nonPersistent()`
+        /// method and assign it to this property. For more information, see `WKWebsiteDataStore`.
         public var websiteDataStore: WKWebsiteDataStore = .default()
 
+        /// The object that coordinates interactions between your app’s native code and the webpage’s
+        /// scripts and other content.
         public var userContentController: WKUserContentController = WKUserContentController()
 
+        @_spi(Private)
         public var webExtensionController: WKWebExtensionController? = nil
 
+        /// The default preferences to use when loading and rendering content.
+        ///
+        /// Use this property to specify the JavaScript settings and content mode for new navigations.
+        /// When the webpage navigates to a new resource, it passes the default preferences to its
+        /// navigation decider, which can modify the preferences if desired.
         public var defaultNavigationPreferences: WebPage.NavigationPreferences = WebPage.NavigationPreferences()
 
-        public var urlSchemeHandlers: [URLScheme_v0 : any URLSchemeHandler_v0] = [:]
+        /// Allows registering an object to load resources associated with a specified URL scheme.
+        public var urlSchemeHandlers: [URLScheme : any URLSchemeHandler] = [:]
 
+        /// Allows specifying how web resources may access device sensors.
+        ///
+        /// The default implementation returns `WKPermissionDecision.prompt` for all requests.
         public var deviceSensorAuthorization: WebPage.DeviceSensorAuthorization = WebPage.DeviceSensorAuthorization(decision: .prompt)
 
+        /// The app name that appears in the user agent string.
         public var applicationNameForUserAgent: String? = nil
 
+        /// Indicates whether the web view limits navigation to pages within the app’s domain.
+        ///
+        /// The default value of this property is `false`.
         public var limitsNavigationsToAppBoundDomains: Bool = false
 
+        /// Indicates whether the web view should automatically upgrade supported HTTP requests to HTTPS.
+        ///
+        /// The default value of this property is `true`.
         public var upgradeKnownHostsToHTTPS: Bool = true
 
+        /// Indicates whether the web view suppresses content rendering until the content is fully loaded into memory.
+        ///
+        /// The default value of this property is `false`.
         public var suppressesIncrementalRendering: Bool = false
 
+        /// Indicates whether the webpage allows media playback over AirPlay.
+        ///
+        /// The default value of this property is `true`.
+        public var allowsAirPlayForMediaPlayback: Bool = true
+
+        /// Indicates whether the webpage loads all of its subresources in addition to the main resource.
+        ///
+        /// The default value of this property is `true`.
+        public var loadsSubresources: Bool  = true
+
+        @_spi(Private)
         public var allowsInlinePredictions: Bool = false
 
+        @_spi(Private)
         public var supportsAdaptiveImageGlyph: Bool = false
 
 #if os(iOS)
+        /// The types of data detectors to apply to the webpage's content.
+        ///
+        /// Data detectors add interactivity to web content by creating links for specially formatted text.
+        /// For example, the `.link` type causes the apple.com portion of the text “Visit apple.com” to
+        /// become a link to the Apple website.
+        ///
+        /// The default value of this property is an empty OptionSet.
         public var dataDetectorTypes: WKDataDetectorTypes = []
 
+        /// Determines whether a webpage allows scaling of the webpage.
+        ///
+        /// When set to `true`, this property overrides the user-scalable HTML property in a webpage, and lets
+        /// the webpage scale its view's content regardless of the author’s intent.
+        ///
+        /// The default value of this property is `false`.
         public var ignoresViewportScaleLimits: Bool = false
+
+        /// Indicates whether HTML5 videos play inline or use the native full-screen controller.
+        public var mediaPlaybackBehavior: MediaPlaybackBehavior = .automatic
+#endif
+
+#if os(macOS)
+        /// The directionality of user interface elements.
+        ///
+        /// The default value of this property is `.content`.
+        public var userInterfaceDirectionPolicy: WKUserInterfaceDirectionPolicy = .content
 #endif
     }
 }
 
 extension WebPage {
-    @_spi(Private)
+    /// A type that describes the authorization permissions policy for the device's sensors a web resource may access.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public struct DeviceSensorAuthorization {
+        /// The kind of sensor permission a web resource may request to access.
         public enum Permission: Hashable, Sendable {
+            /// The orientation and motion of the device.
             case deviceOrientationAndMotion
+
+            /// A media capture device, like a microphone or camera.
             case mediaCapture(WKMediaCaptureType)
         }
 
         let decisionHandler: (Permission, WebPage.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision
 
+        /// Creates a new `DeviceSensorAuthorization` using the specified policy.
+        ///
+        /// - Parameter decisionHandler: A closure which decides the permission decision for an authorization request,
+        /// which may be based on the kind of permission, the webpage frame information, or the security origin.
         public init(decisionHandler: @escaping (Permission, WebPage.FrameInfo, WKSecurityOrigin) async -> WKPermissionDecision) {
             self.decisionHandler = decisionHandler
         }
 
+        /// A convenience initializer to create a DeviceSensorAuthorization that always uses the same permission decision.
         public init(decision: WKPermissionDecision) {
             self.init { _, _, _ in decision }
         }
+    }
+}
+
+extension WebPage.Configuration {
+    /// The behavior used when playing HTML video within a page.
+    @available(WK_IOS_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(macOS, unavailable)
+    public enum MediaPlaybackBehavior: Sendable {
+        /// Use the default system value, which is `alwaysFullscreen` for iPhone and `allowsInlinePlayback` for iPad.
+        case automatic
+
+        /// Allows videos to play inline. When adding a video element to an HTML document on iPhone, you must also include the `playsinline` attribute.
+        case allowsInlinePlayback
+
+        /// Use the native fullscreen controller.
+        case alwaysFullscreen
     }
 }
 
@@ -103,10 +197,19 @@ extension WKWebViewConfiguration {
         self.suppressesIncrementalRendering = wrapped.suppressesIncrementalRendering
         self.allowsInlinePredictions = wrapped.allowsInlinePredictions
         self.supportsAdaptiveImageGlyph = wrapped.supportsAdaptiveImageGlyph
+        self._loadsSubresources = wrapped.loadsSubresources
 
 #if os(iOS)
         self.dataDetectorTypes = wrapped.dataDetectorTypes
         self.ignoresViewportScaleLimits = wrapped.ignoresViewportScaleLimits
+
+        if wrapped.mediaPlaybackBehavior != .automatic {
+            self.allowsInlineMediaPlayback = wrapped.mediaPlaybackBehavior == .allowsInlinePlayback
+        }
+#endif
+
+#if os(macOS)
+        self.userInterfaceDirectionPolicy = wrapped.userInterfaceDirectionPolicy
 #endif
 
         for (scheme, handler) in wrapped.urlSchemeHandlers {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -27,32 +27,71 @@ import Foundation
 internal import WebKit_Internal
 
 extension WebPage {
-    @MainActor
-    @_spi(Private)
+    /// A type that specifies the behaviors to use when loading and rendering page content.
+    ///
+    /// Create a `NavigationPreferences` value when you want to change the default rendering behavior of
+    /// your web page. Typically, iOS devices render web content for a mobile experience, and Mac devices
+    /// render content for a desktop experience.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public struct NavigationPreferences: Sendable {
+        /// Options to indicate how to render web view content.
+        ///
+        /// Browsers often render webpages differently based on device type. For example, Safari provides a
+        /// desktop-class experience when displaying webpages on Mac and iPad, but it displays a mobile experience
+        /// when displaying pages on iPhone. Use content modes to specify how you want your web page to render
+        /// content within your app.
         public enum ContentMode: Sendable {
+            /// The content mode that is appropriate for the current device.
             case recommended
+
+            /// The content mode that represents a mobile experience.
             case mobile
+
+            /// The content mode that represents a desktop experience.
             case desktop
         }
 
+        /// Preference for loading a webpage with HTTPS, and how failures should be handled.
         public enum UpgradeToHTTPSPolicy: Sendable {
             case keepAsRequested
+
             case automaticFallbackToHTTP
+
             case userMediatedFallbackToHTTP
+
             case errorOnFailure
         }
 
+        /// Creates a new NavigationPreferences value.
         public init() {
         }
 
+        /// The content mode for the web view to use when it loads and renders a webpage.
+        ///
+        /// The default value of this property is `recommended`. The web page ignores this preference for subframe navigation.
         public var preferredContentMode: ContentMode = .recommended
 
+        /// Indicates whether JavaScript from web content is allowed to run.
+        ///
+        /// The default value of this property is `true`. If you change the value to `false`, the web page doesn’t
+        /// execute JavaScript code referenced by the web content. That includes JavaScript code found in inline `<script>`
+        /// elements, `javascript:` URLs, and all other referenced JavaScript content.
         public var allowsContentJavaScript: Bool = true
 
+        /// Used when performing a top-level navigation to a webpage.
+        ///
+        /// The default value is `.keepAsRequested`. The stated preference is ignored on subframe navigation, and it may be ignored based on system configuration.
+        /// The `WebPage.Configuration.upgradeKnownHostsToHTTPS` property supersedes this property for known hosts.
         public var preferredHTTPSNavigationPolicy: UpgradeToHTTPSPolicy = .keepAsRequested
 
         fileprivate var _isLockdownModeEnabled: Bool? = nil
+
+        /// A Boolean value that indicates whether to use Lockdown Mode in the web page.
+        ///
+        /// By default, this reflects whether the user has enabled Lockdown Mode on the device. Update this preference to
+        /// override the device setting when you implement a per-website or similar setting.
         public var isLockdownModeEnabled: Bool {
             get { _isLockdownModeEnabled ?? false }
             set { _isLockdownModeEnabled = newValue }
@@ -123,6 +162,7 @@ extension WebPage.NavigationPreferences.UpgradeToHTTPSPolicy {
 }
 
 extension WebPage.NavigationPreferences {
+    @MainActor
     init(_ wrapped: WKWebpagePreferences) {
         self.init()
 

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -26,7 +26,7 @@
 import Testing
 @_spi(Private) import WebKit
 
-fileprivate struct TestURLSchemeHandler: URLSchemeHandler_v0, Sendable {
+fileprivate struct TestURLSchemeHandler: URLSchemeHandler, Sendable {
     struct Failure: Error {
     }
 
@@ -43,7 +43,7 @@ fileprivate struct TestURLSchemeHandler: URLSchemeHandler_v0, Sendable {
     private let mimeType: String
     private let replyContinuation: AsyncStream<URL>.Continuation
 
-    func reply(for request: URLRequest) -> AsyncThrowingStream<URLSchemeTaskResult_v0, any Error> {
+    func reply(for request: URLRequest) -> AsyncThrowingStream<URLSchemeTaskResult, any Error> {
         AsyncThrowingStream { continuation in
             defer {
                 replyContinuation.yield(request.url!)
@@ -69,13 +69,13 @@ fileprivate struct TestURLSchemeHandler: URLSchemeHandler_v0, Sendable {
 struct URLSchemeHandlerTests {
     @Test
     func basicSchemeValidation() async throws {
-        let customScheme = URLScheme_v0("my-custom-scheme")
+        let customScheme = URLScheme("my-custom-scheme")
         #expect(customScheme != nil)
 
-        let httpsScheme = URLScheme_v0("https")
+        let httpsScheme = URLScheme("https")
         #expect(httpsScheme == nil)
 
-        let invalidScheme = URLScheme_v0("invalid scheme")
+        let invalidScheme = URLScheme("invalid scheme")
         #expect(invalidScheme == nil)
     }
 
@@ -89,7 +89,7 @@ struct URLSchemeHandlerTests {
 
         let handler = TestURLSchemeHandler(data: html, mimeType: "text/html")
         var configuration = WebPage.Configuration()
-        configuration.urlSchemeHandlers[URLScheme_v0("testing")!] = handler
+        configuration.urlSchemeHandlers[URLScheme("testing")!] = handler
 
         let page = WebPage(configuration: configuration)
 


### PR DESCRIPTION
#### 706a2b0acb16908376639ae163e731e5b15c461f
<pre>
[SwiftUI] Update WebPage.Configuration and related types to latest interface (Part 1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287352">https://bugs.webkit.org/show_bug.cgi?id=287352</a>
<a href="https://rdar.apple.com/106040941">rdar://106040941</a>

Reviewed by Tim Horton.

Update various definitions/declarations for WebPage.Configuration and related types.

* Source/WebKit/UIProcess/API/Swift/URLSchemeHandler.swift:
(URLSchemeHandler_v0.reply(for:)): Deleted.
* Source/WebKit/UIProcess/API/Swift/WebPage+Configuration.swift:
(Configuration.urlSchemeHandlers):
(Configuration.allowsAirPlayForMediaPlayback):
(Configuration.loadsSubresources):
(Configuration.mediaPlaybackBehavior):
(Configuration.userInterfaceDirectionPolicy):
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift:
(reply(for:)):
(URLSchemeHandlerTests.basicSchemeValidation):
(URLSchemeHandlerTests.basicSchemeHandling):

Canonical link: <a href="https://commits.webkit.org/290111@main">https://commits.webkit.org/290111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1ce931aad3bb4f4318dfd074dcd1eebc0bbd5db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94000 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16734 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92028 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/6828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/48956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38894 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/76939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/35994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16206 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16462 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/21154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9289 "Failed to checkout and rebase branch from PR 40306") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13947 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21531 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15961 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->