### PR TITLE
[text-autospace] Default value should be normal

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1267,6 +1267,7 @@ i, cite, em, var, address, dfn {
 
 tt, code, kbd, samp {
     font-family: monospace;
+    text-autospace: no-autospace;
 }
 
 pre, xmp, plaintext, listing {
@@ -1274,6 +1275,7 @@ pre, xmp, plaintext, listing {
     font-family: monospace;
     white-space: pre;
     margin: 1__qem 0;
+    text-autospace: no-autospace;
 }
 
 mark {

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -147,7 +147,7 @@ public:
     static FontPalette initialFontPalette() { return { FontPalette::Type::Normal, nullAtom() }; }
     static FontSizeAdjust initialFontSizeAdjust() { return { FontSizeAdjust::Metric::ExHeight }; }
     static TextSpacingTrim initialTextSpacingTrim() { return { }; }
-    static TextAutospace initialTextAutospace() { return { }; }
+    static TextAutospace initialTextAutospace() { return { TextAutospace::Type::Normal }; }
     static FontFeatureSettings initialFeatureSettings() { return { }; }
     static FontVariationSettings initialVariationSettings() { return { }; }
 

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -40,6 +40,7 @@ FontDescription::FontDescription()
     : m_variantAlternates(FontCascadeDescription::initialVariantAlternates())
     , m_fontPalette({ FontPalette::Type::Normal, nullAtom() })
     , m_fontSelectionRequest { FontCascadeDescription::initialWeight(), FontCascadeDescription::initialWidth(), FontCascadeDescription::initialItalic() }
+    , m_textAutospace(FontCascadeDescription::initialTextAutospace())
     , m_orientation(enumToUnderlyingType(FontOrientation::Horizontal))
     , m_nonCJKGlyphOrientation(enumToUnderlyingType(NonCJKGlyphOrientation::Mixed))
     , m_widthVariant(enumToUnderlyingType(FontWidthVariant::RegularWidth))


### PR DESCRIPTION
#### 93b5fdd33c66b5964401ed7e35558d1b2e3c696a
<pre>
[text-autospace] Default value should be normal
<a href="https://bugs.webkit.org/show_bug.cgi?id=287355">https://bugs.webkit.org/show_bug.cgi?id=287355</a>
<a href="https://rdar.apple.com/144469006">rdar://144469006</a>

Reviewed by NOBODY (OOPS!).

See <a href="https://drafts.csswg.org/css-text-4/#text-autospace-property">https://drafts.csswg.org/css-text-4/#text-autospace-property</a>

* Source/WebCore/css/html.css:
(tt, code, kbd, samp):
(pre, xmp, plaintext, listing):
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::initialTextAutospace):
* Source/WebCore/platform/graphics/FontDescription.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93b5fdd33c66b5964401ed7e35558d1b2e3c696a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89117 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16841 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68666 "Failure limit exceed. At least found 21 new test failures: css3/font-feature-font-face-local.html fast/dynamic/text-combine.html fast/ruby/ruby-expansion-cjk-2.html fast/text/decorations-with-text-combine.html fast/text/emphasis-combined-text.html fast/text/font-fallback.html fast/text/international/synthesized-italic-vertical-latin.html fast/text/international/text-combine-image-test.html fast/text/international/wrap-CJK-001.html fast/text/justify-ideograph-leading-expansion.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26338 "Found 4 new test failures: css3/font-feature-font-face-local.html fast/text/font-fallback.html fast/text/ruby-justify-tatechuyoko.html fast/text/text-combine-placement.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92119 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6912 "Found 19 new test failures: css3/font-feature-font-face-local.html fast/css/vertical-text-overflow-ellipsis-text-align-justify.html fast/css/vertical-text-overflow-ellipsis-text-align-right.html fast/text/font-fallback.html fast/text/international/synthesized-italic-vertical-latin.html fast/text/international/text-combine-image-test.html fast/text/ruby-justify-tatechuyoko.html fast/text/text-combine-placement.html http/tests/canvas/color-fonts/ctm-sbix.html http/tests/canvas/color-fonts/fill-color-sbix.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49027 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6661 "Found 10 new test failures: imported/w3c/web-platform-tests/css/css-ruby/block-ruby-003.html imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-mixed-001.html imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-combine-001.html imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-upright-001.html imported/w3c/web-platform-tests/css/css-writing-modes/tcy-white-space-processing-002.html imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html imported/w3c/web-platform-tests/svg/import/text-align-07-t-manual.svg imported/w3c/web-platform-tests/svg/import/text-align-08-b-manual.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35248 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html css3/font-feature-font-face-local.html editing/undo/redo-reapply-edit-command-crash.html fast/css/text-overflow-ellipsis-text-align-left.html fast/css/vertical-text-overflow-ellipsis-text-align-center.html fast/css/vertical-text-overflow-ellipsis-text-align-right.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/rtl-content-selection-hairline-gap.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38985 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77024 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36232 "Found 60 new test failures: css3/color-filters/color-filter-current-color.html css3/font-feature-font-face-local.html fast/css/text-overflow-ellipsis-text-align-justify.html fast/css/textarea-resizable-preference-disabled.html fast/css/vertical-text-overflow-ellipsis-text-align-justify.html fast/css/vertical-text-overflow-ellipsis-text-align-right.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/rtl-content-selection-hairline-gap.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95930 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16297 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11947 "Found 60 new test failures: css3/font-feature-font-face-local.html editing/selection/move-by-character-brute-force.html fast/css/vertical-text-overflow-ellipsis-text-align-center.html fast/innerHTML/identical-mutations.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/rtl-content-selection-hairline-gap.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/ruby/ruby-expansion-cjk-3.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77543 "Failure limit exceed. At least found 24 new test failures: css3/font-feature-font-face-local.html fast/dynamic/text-combine.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/text/decorations-with-text-combine.html fast/text/emphasis-combined-text.html fast/text/font-fallback.html fast/text/international/synthesized-italic-vertical-latin.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76834 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21237 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19842 "Found 42 new test failures: css3/font-feature-font-face-local.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/rtl-content-selection-hairline-gap.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/ruby/ruby-expansion-cjk-3.html fast/ruby/ruby-expansion-cjk-4.html fast/ruby/ruby-expansion-cjk.html fast/ruby/ruby-justification.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9389 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21622 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16052 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->