### PR TITLE
text-spacing: text-autospace: Fast path for some ASCII characters in characterClass

### DIFF
--- a/Source/WebCore/platform/text/TextSpacing.cpp
+++ b/Source/WebCore/platform/text/TextSpacing.cpp
@@ -27,6 +27,7 @@
 #include "TextSpacing.h"
 
 #include "Font.h"
+#include <wtf/ASCIICType.h>
 
 namespace WebCore {
 
@@ -103,6 +104,12 @@ static bool isNonIdeographicNumeral(char32_t character, uint32_t generalCategory
 // Classes are defined at https://www.w3.org/TR/css-text-4/#text-spacing-classes
 CharacterClass characterClass(char32_t character)
 {
+    // fast path
+    if (isASCIIAlpha(character))
+        return CharacterClass::NonIdeographLetter;
+    if (isASCIIDigit(character))
+        return CharacterClass::NonIdeographNumeral;
+
     auto generalCategoryMask = U_GET_GC_MASK(character);
     if (isIdeograph(character))
         return CharacterClass::Ideograph;


### PR DESCRIPTION
#### 8adb7f552d00f1d4cd617cd0077c52caab773dc0
<pre>
text-spacing: text-autospace: Fast path for some ASCII characters in characterClass
<a href="https://bugs.webkit.org/show_bug.cgi?id=287357">https://bugs.webkit.org/show_bug.cgi?id=287357</a>
<a href="https://rdar.apple.com/144471199">rdar://144471199</a>

Reviewed by Tim Nguyen.

This should cause no changes on behavior.

* Source/WebCore/platform/text/TextSpacing.cpp:
(WebCore::TextSpacing::characterClass):

Canonical link: <a href="https://commits.webkit.org/292324@main">https://commits.webkit.org/292324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b529518cd8aef40d14bf9e5de6f95574e448e9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68625 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26299 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36261 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95879 "Failed to compile WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16248 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76789 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20377 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19864 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9340 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21573 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16003 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->