### PR TITLE
Invalidate table borders with writing mode changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/border-writing-mode-dynamic-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/border-writing-mode-dynamic-001-expected.txt
@@ -3,5 +3,5 @@ TBODY
 TR
 TD
 
-FAIL Table borders track writing mode changes assert_equals: expected 132 but got 152
+PASS Table borders track writing mode changes
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -1093,6 +1093,9 @@ inline bool RenderStyle::columnSpanEqual(const RenderStyle& other) const
 
 inline bool RenderStyle::borderIsEquivalentForPainting(const RenderStyle& other) const
 {
+    if (writingMode() != other.writingMode())
+        return false;
+
     bool colorDiffers = color() != other.color();
 
     if (!colorDiffers


### PR DESCRIPTION
#### 80f5cfefbfe9c625416a0007849ab8fa9c6294b5
<pre>
Invalidate table borders with writing mode changes

<a href="https://bugs.webkit.org/show_bug.cgi?id=287361">https://bugs.webkit.org/show_bug.cgi?id=287361</a>
<a href="https://rdar.apple.com/144479912">rdar://144479912</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

In this patch, we ensure that we invalidate collapsed table borders whenever
writing mode changes by updating &apos;borderIsEquivalentForPainting&apos;.

Credits to Tim Nguyen for help in coming up with proper fix.

* Source/WebCore/rendering/style/RenderStyleInlines.h:
(borderIsEquivalentForPainting):
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/border-writing-mode-dynamic-001-expected.txt:

Canonical link: <a href="https://commits.webkit.org/290160@main">https://commits.webkit.org/290160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38ee6bf10ec59e1dfdbdde0fdc47e7c90ff6b10f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68638 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26311 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49000 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35240 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38951 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95896 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16263 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11903 "Found 3 new test failures: imported/w3c/web-platform-tests/css/selectors/invalidation/fullscreen-pseudo-class-in-has.html imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77516 "Failure limit exceed. At least found 1 new test failure: css3/filters/filter-repaint-child-layers.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76822 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18947 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9355 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21588 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->