### PR TITLE
[JSC] `AsyncFromSyncIterator` should close its sync-iterator when `next`/`throw` yields rejected promise

### DIFF
--- a/JSTests/stress/async-from-sync-iterator-prototype-next-rejected-close-sync-iter.js
+++ b/JSTests/stress/async-from-sync-iterator-prototype-next-rejected-close-sync-iter.js
@@ -1,0 +1,123 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+
+function shouldThrowAsync(run, errorType, message) {
+    let actual;
+    var hadError = false;
+    run().then(function(value) { actual = value; },
+               function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    if (message !== void 0 && actual.message !== message)
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+}
+
+{
+    let finallyCount = 0;
+
+    function OurError() {}
+
+    function* iterator() {
+      try {
+        yield Promise.reject(new OurError());
+      } finally {
+        finallyCount += 1;
+      }
+    }
+
+    shouldThrowAsync(async () => {
+        for await (const _ of iterator());
+    }, OurError);
+    drainMicrotasks();
+
+    shouldBe(finallyCount, 1);
+}
+
+{
+    let returnCount = 0;
+
+    function OurError() {}
+
+    const syncIterator = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            return { value: Promise.reject(new OurError()), done: false };
+          },
+          return() {
+            returnCount += 1;
+          }
+        };
+      }
+    };
+
+    shouldThrowAsync(async () => {
+        for await (const _ of syncIterator);
+    }, OurError);
+    drainMicrotasks();
+
+    shouldBe(returnCount, 1);
+}
+
+{
+    let finallyCount = 0;
+
+    function OurError() {}
+
+    function* iterator() {
+      try {
+        yield Promise.reject(new OurError());
+      } finally {
+        finallyCount += 1;
+      }
+    }
+
+    async function* asyncIterator() {
+      yield* iterator()
+    }
+
+    shouldThrowAsync(async () => {
+        await asyncIterator().next();
+    }, OurError);
+    drainMicrotasks();
+
+    shouldBe(finallyCount, 1);
+
+}
+
+{
+    let returnCount = 0;
+
+    function OurError() {}
+
+    const syncIterator = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            return { value: Promise.reject(new OurError()), done: false };
+          },
+          return() {
+            returnCount += 1;
+          }
+        };
+      }
+    };
+
+    async function* asyncIterator() {
+      yield* syncIterator;
+    }
+
+    shouldThrowAsync(async () => {
+        await asyncIterator().next();
+    }, OurError);
+    drainMicrotasks();
+
+    shouldBe(returnCount, 1);
+}
+

--- a/JSTests/stress/async-from-sync-iterator-prototype-throw-rejected-close-sync-iter.js
+++ b/JSTests/stress/async-from-sync-iterator-prototype-throw-rejected-close-sync-iter.js
@@ -1,0 +1,59 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+
+function shouldThrowAsync(run, errorType, message) {
+    let actual;
+    var hadError = false;
+    run().then(function(value) { actual = value; },
+               function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but threw '" + actual + "'");
+    if (message !== void 0 && actual.message !== message)
+        throw new Error("Expected " + run + "() to throw '" + message + "', but threw '" + actual.message + "'");
+}
+
+{
+    let returnCount = 0;
+
+    function OurError() {}
+
+    var iterator = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            return { value: 1, done: false };
+          },
+          throw() {
+            return {
+              value: Promise.reject(new OurError()),
+              done: false
+            };
+          },
+          return() {
+            returnCount += 1;
+          }
+        };
+      }
+    };
+
+    async function* asyncIterator() {
+      return yield* iterator;
+    }
+
+    let iter = asyncIterator();
+
+    shouldThrowAsync(async () => {
+        await iter.next();
+        await iter.throw();
+    }, OurError);
+    drainMicrotasks();
+
+    shouldBe(returnCount, 1);
+}
+

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1,30 +1,6 @@
 ---
 test/annexB/language/function-code/block-decl-func-skip-arguments.js:
   default: 'Test262Error: Expected SameValue(«"function arguments() {}"», «"[object Arguments]"») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/next/for-await-iterator-next-rejected-promise-close.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/next/for-await-next-rejected-promise-close.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-poisoned-wrapper.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/next/next-result-poisoned-wrapper.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/next/yield-iterator-next-rejected-promise-close.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/next/yield-next-rejected-promise-close.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-rejected-promise-close.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected SameValue(«0», «1») to be true'
-test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-result-poisoned-wrapper.js:
-  default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
-  strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: iterator closed properly Expected SameValue(«0», «1») to be true'
 test/built-ins/Date/prototype/setHours/date-value-read-before-tonumber-when-date-is-invalid.js:
   default: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'
   strict mode: 'Test262Error: time updated in valueOf Expected SameValue(«NaN», «0») to be true'

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -218,6 +218,7 @@ namespace JSC {
     macro(asyncFromSyncIteratorCreate) \
     macro(regExpStringIteratorCreate) \
     macro(iteratorHelperCreate) \
+    macro(syncIterator) \
 
 
 namespace Symbols {


### PR DESCRIPTION
#### 1962d559593056e23a400faada02e62c7222c79e
<pre>
[JSC] `AsyncFromSyncIterator` should close its sync-iterator when `next`/`throw` yields rejected promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=273768">https://bugs.webkit.org/show_bug.cgi?id=273768</a>

Reviewed by Yusuke Suzuki.

The normative change for `AsyncFromSyncIterator`[1] includes the following two changes:

1. AsyncFromSyncIterator now closes the sync iterator when `throw` is called on the
wrapper but is not implemented on the sync iterator. In that case, it updates the
rejection value to a `TypeError` to reflect the contract violation.
2. AsyncFromSyncIterator closes its sync iterator when the sync iterator yields a
rejected promise as its value.

This normative change has already been implemented in V8[2]. This patch changes to
implement only the second change.

[1]: tc39/ecma262#2600
[2]: v8/v8@6c3f7aa#diff-c18e5d5743326f6ba544801f6ce25154b785f759885651f98924d5b56dc1c2e6

* JSTests/stress/async-from-sync-iterator-prototype-next-rejected-close-sync-iter.js: Added.
(shouldBe):
(shouldThrowAsync):
(throw.new.Error.OurError):
(throw.new.Error.iterator):
(OurError):
(throw.new.Error.async drainMicrotasks):
(iterator):
(async asyncIterator):
(async drainMicrotasks):
* JSTests/stress/async-from-sync-iterator-prototype-throw-rejected-close-sync-iter.js: Added.
(shouldBe):
(shouldThrowAsync):
(throw.new.Error.OurError):
(throw.new.Error.async asyncIterator):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/AsyncFromSyncIteratorPrototype.js:
(linkTimeConstant.asyncFromSyncIteratorOnRejected):
(linkTimeConstant.asyncFromSyncIteratorOnFulfilledContinue):
(linkTimeConstant.asyncFromSyncIteratorOnFulfilledDone):
(return):
(throw):
* Source/JavaScriptCore/builtins/BuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/290137@main">https://commits.webkit.org/290137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/749aea53431bfe299f156f5bef434fbf426f6fb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39802 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26281 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6842 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48969 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6591 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38909 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81840 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95852 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87817 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77485 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76774 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18931 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21166 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9309 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21546 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110310 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15976 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26484 "Found 5 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->