### PR TITLE
Sync `svg/linking` from WPT upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2166,6 +2166,7 @@ imported/w3c/web-platform-tests/svg/painting/parsing/color-interpolation-valid.s
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-001.svg [ ImageOnlyFailure ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-002.svg [ ImageOnlyFailure ]
 webkit.org/b/269522 imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-003.svg [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/linking/reftests/view-viewbox-override.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/render/reftests/render-sync-with-font-size.html [ Skip ]
 imported/w3c/web-platform-tests/svg/render/order/z-index.svg [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>URL processing: Fetching the document</title>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint"/>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint"/>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL-fetch"/>
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+
+  <rect width="100" height="100" fill="url('http://{{hosts[][www]}}:{{ports[http][0]}}/svg/painting/reftests/support/resources.svg?pipe=header(Access-Control-Allow-Origin,*)#greenGradient') red"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>URL processing: Fetching the document</title>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint"/>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint"/>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#URLReference"/>
+  <h:link rel="help" href="https://svgwg.org/svg2-draft/linking.html#processingURL-fetch"/>
+  <h:link rel="match" href="reference/green-100x100.svg"/>
+
+  <rect width="100" height="100" fill="url('http://{{hosts[][www]}}:{{ports[http][0]}}/svg/painting/reftests/support/resources.svg#redGradient') green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/w3c-import.log
@@ -40,6 +40,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-use-element.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/svgview-viewbox-override-multiple-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/svgview-viewbox-override-multiple.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-001-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-001.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-whitespace-002-expected.svg


### PR DESCRIPTION
#### 2fbd37b23b10b46f8a302706f86a1ab0a3b0ea12
<pre>
Sync `svg/linking` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=287363">https://bugs.webkit.org/show_bug.cgi?id=287363</a>
<a href="https://rdar.apple.com/problem/144482293">rdar://problem/144482293</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/9a30cb29d0a0117e67ccac1bb5528ed6a2605464">https://github.com/web-platform-tests/wpt/commit/9a30cb29d0a0117e67ccac1bb5528ed6a2605464</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-001.sub.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/url-processing-fetch-properties-002.sub.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/w3c-import.log:
* LayoutTests/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/290122@main">https://commits.webkit.org/290122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b746b4974263cd6c45ad04677e1a9ef346623bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39804 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68608 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26283 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6592 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95854 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16223 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11865 "Found 3 new test failures: fast/dom/crash-with-bad-url.html media/media-vp8-webm-with-poster.html pdf/pdf-in-styled-embed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77487 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16479 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76776 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21167 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9312 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16237 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->