### PR TITLE
Non-unified source build fix of February 2025 (part 5)

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "ExecutableAllocator.h"
+#include "JSCellInlines.h"
 #include "JSWebAssemblyInstance.h"
 #include "LLIntData.h"
 #include "MachineContext.h"

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimitMix.cpp
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimitMix.cpp
@@ -27,6 +27,7 @@
 #include "StyleDynamicRangeLimitMix.h"
 
 #include "CSSDynamicRangeLimitMix.h"
+#include "StyleDynamicRangeLimit.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 


### PR DESCRIPTION
#### 8d697f6000589749ad396935b8611d4ff7dd3b9f
<pre>
Non-unified source build fix of February 2025 (part 5)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286904">https://bugs.webkit.org/show_bug.cgi?id=286904</a>

Unreviewed non-unified build fix.

* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
* Source/WebCore/style/values/color/StyleDynamicRangeLimitMix.cpp:

Canonical link: <a href="https://commits.webkit.org/290129@main">https://commits.webkit.org/290129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26b0938d84bf3c2dcde0fec7c7f5597492e860d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39824 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68622 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6609 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38931 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81862 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95874 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87839 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76788 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21184 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9335 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13955 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21568 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110332 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15998 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26483 "Found 5 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->