### PR TITLE
Dynamic Content Scaling is needlessly enabled for some canvas elements

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -139,7 +139,9 @@ public:
 
     virtual TransformationMatrix transformMatrixForProperty(AnimatedProperty) const { return { }; }
 
-    virtual bool layerContainsBitmapOnly(const GraphicsLayer*) const { return false; }
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    virtual bool layerAllowsDynamicContentScaling(const GraphicsLayer*) const { return true; }
+#endif
 
     virtual bool layerNeedsPlatformContext(const GraphicsLayer*) const { return false; }
 

--- a/Source/WebCore/platform/graphics/RenderingMode.cpp
+++ b/Source/WebCore/platform/graphics/RenderingMode.cpp
@@ -37,7 +37,6 @@ TextStream& operator<<(TextStream& ts, RenderingPurpose purpose)
     case RenderingPurpose::Canvas: ts << "Canvas"; break;
     case RenderingPurpose::DOM: ts << "DOM"; break;
     case RenderingPurpose::LayerBacking: ts << "LayerBacking"; break;
-    case RenderingPurpose::BitmapOnlyLayerBacking: ts << "BitmapOnlyLayerBacking"; break;
     case RenderingPurpose::Snapshot: ts << "Snapshot"; break;
     case RenderingPurpose::ShareableSnapshot: ts << "ShareableSnapshot"; break;
     case RenderingPurpose::ShareableLocalSnapshot: ts << "ShareableLocalSnapshot"; break;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -264,8 +264,11 @@ private:
     WEBCORE_EXPORT bool platformCALayerCSSUnprefixedBackdropFilterEnabled() const override;
     WEBCORE_EXPORT void platformCALayerLogFilledVisibleFreshTile(unsigned) override;
     WEBCORE_EXPORT bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
-    bool platformCALayerContainsBitmapOnly(const PlatformCALayer*) const override { return client().layerContainsBitmapOnly(this); }
     bool platformCALayerShouldPaintUsingCompositeCopy() const override { return shouldPaintUsingCompositeCopy(); }
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    bool platformCALayerAllowsDynamicContentScaling(const PlatformCALayer*) const override { return client().layerAllowsDynamicContentScaling(this); }
+#endif
 
     bool isCommittingChanges() const override { return m_isCommittingChanges; }
     bool isUsingDisplayListDrawing(PlatformCALayer*) const override { return m_usesDisplayListDrawing; }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -79,7 +79,9 @@ public:
 
     virtual void platformCALayerLogFilledVisibleFreshTile(unsigned /* blankPixelCount */) { }
 
-    virtual bool platformCALayerContainsBitmapOnly(const PlatformCALayer*) const { return false; }
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    virtual bool platformCALayerAllowsDynamicContentScaling(const PlatformCALayer*) const { return true; }
+#endif
 
     virtual bool platformCALayerShouldPaintUsingCompositeCopy() const { return false; }
 

--- a/Source/WebCore/platform/graphics/cocoa/DynamicContentScalingDisplayList.h
+++ b/Source/WebCore/platform/graphics/cocoa/DynamicContentScalingDisplayList.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+enum class IncludeDynamicContentScalingDisplayList : bool { No, Yes };
+
 class DynamicContentScalingDisplayList {
 public:
     DynamicContentScalingDisplayList(Ref<WebCore::SharedBuffer> displayList, Vector<MachSendRight>&& surfaces)

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -60,7 +60,6 @@ public:
         ImageBuffer,
         ImageBufferShareableMapped,
         LayerBacking,
-        BitmapOnlyLayerBacking,
         MediaPainting,
         Snapshot,
         ShareableSnapshot,

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -69,8 +69,6 @@ static auto surfaceNameToNSString(IOSurface::Name name)
         return @"WebKit ImageBufferShareableMapped";
     case IOSurface::Name::LayerBacking:
         return @"WebKit LayerBacking";
-    case IOSurface::Name::BitmapOnlyLayerBacking:
-        return @"WebKit LayerBacking (bitmap only)";
     case IOSurface::Name::MediaPainting:
         return @"WebKit MediaPainting";
     case IOSurface::Name::Snapshot:
@@ -714,9 +712,6 @@ IOSurface::Name IOSurface::nameForRenderingPurpose(RenderingPurpose purpose)
 
     case RenderingPurpose::LayerBacking:
         return Name::LayerBacking;
-
-    case RenderingPurpose::BitmapOnlyLayerBacking:
-        return Name::BitmapOnlyLayerBacking;
 
     case RenderingPurpose::Snapshot:
         return Name::Snapshot;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6169,6 +6169,19 @@ bool RenderLayer::isTransparentRespectingParentFrames() const
     return false;
 }
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+bool RenderLayer::allowsDynamicContentScaling() const
+{
+    if (is<RenderHTMLCanvas>(renderer()))
+        return false;
+
+    if (isBitmapOnly())
+        return false;
+
+    return true;
+}
+#endif
+
 bool RenderLayer::isBitmapOnly() const
 {
     if (hasVisibleBoxDecorationsOrBackground())

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -884,6 +884,10 @@ public:
 
     bool isBitmapOnly() const;
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    bool allowsDynamicContentScaling() const;
+#endif
+
     enum ViewportConstrainedNotCompositedReason {
         NoNotCompositedReason,
         NotCompositedForBoundsOutOfView,

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3228,6 +3228,12 @@ bool RenderLayerBacking::isBitmapOnly() const
     return m_owningLayer.isBitmapOnly();
 }
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+bool RenderLayerBacking::layerAllowsDynamicContentScaling(const GraphicsLayer*) const
+{
+    return m_owningLayer.allowsDynamicContentScaling();
+}
+#endif
 
 bool RenderLayerBacking::isUnscaledBitmapOnly() const
 {

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -233,7 +233,9 @@ public:
     float deviceScaleFactor() const override;
     float contentsScaleMultiplierForNewTiles(const GraphicsLayer*) const override;
 
-    bool layerContainsBitmapOnly(const GraphicsLayer*) const override { return isBitmapOnly(); }
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    bool layerAllowsDynamicContentScaling(const GraphicsLayer*) const override;
+#endif
 
     bool paintsOpaquelyAtNonIntegralScales(const GraphicsLayer*) const override;
 

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -584,6 +584,8 @@ set(WebKit_SERIALIZATION_IN_FILES
 
     Shared/Gamepad/GamepadData.serialization.in
 
+    Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
+
     Shared/WebGPU/WebGPUBindGroupDescriptor.serialization.in
     Shared/WebGPU/WebGPUBindGroupEntry.serialization.in
     Shared/WebGPU/WebGPUBindGroupLayoutDescriptor.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -488,6 +488,7 @@ $(PROJECT_DIR)/Shared/cf/CoreIPCSecAccessControl.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecCertificate.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecKeychainItem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecTrust.serialization.in
+$(PROJECT_DIR)/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
 $(PROJECT_DIR)/Shared/ios/CursorContext.serialization.in
 $(PROJECT_DIR)/Shared/ios/DynamicViewportSizeUpdate.serialization.in
 $(PROJECT_DIR)/Shared/ios/GestureTypes.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -766,6 +766,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/cf/CoreIPCSecCertificate.serialization.in \
 	Shared/cf/CoreIPCSecKeychainItem.serialization.in \
 	Shared/cf/CoreIPCSecTrust.serialization.in \
+	Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in \
 	Shared/mac/PDFContextMenuItem.serialization.in \
 	Shared/mac/SecItemRequestData.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -86,14 +86,9 @@ IPC::StreamConnectionWorkQueue& RemoteImageBufferSet::workQueue() const
     return m_backend->workQueue();
 }
 
-void RemoteImageBufferSet::updateConfiguration(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::ImageBufferPixelFormat pixelFormat)
+void RemoteImageBufferSet::updateConfiguration(const RemoteImageBufferSetConfiguration& configuration)
 {
-    m_logicalSize = logicalSize;
-    m_renderingMode = renderingMode;
-    m_renderingPurpose = renderingPurpose;
-    m_resolutionScale = resolutionScale;
-    m_colorSpace = colorSpace;
-    m_pixelFormat = pixelFormat;
+    m_configuration = configuration;
     clearBuffers();
 }
 
@@ -136,9 +131,9 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
         << m_backBuffer << " (in-use " << (m_backBuffer && protectedBackBuffer()->isInUse()) << ") "
         << m_secondaryBackBuffer << " (in-use " << (m_secondaryBackBuffer && protectedSecondaryBackBuffer()->isInUse()) << ") ");
 
-    displayRequirement = swapBuffersForDisplay(inputData.hasEmptyDirtyRegion, inputData.supportsPartialRepaint && !isSmallLayerBacking({ m_logicalSize, m_resolutionScale, m_colorSpace, m_pixelFormat, WebCore::RenderingPurpose::LayerBacking }));
+    displayRequirement = swapBuffersForDisplay(inputData.hasEmptyDirtyRegion, inputData.supportsPartialRepaint && !isSmallLayerBacking({ m_configuration.logicalSize, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.pixelFormat, m_configuration.renderingPurpose }));
     if (displayRequirement == SwapBuffersDisplayRequirement::NeedsFullDisplay) {
-        auto layerBounds = WebCore::IntRect { { }, expandedIntSize(m_logicalSize) };
+        auto layerBounds = WebCore::IntRect { { }, expandedIntSize(m_configuration.logicalSize) };
         MESSAGE_CHECK(isSync || inputData.dirtyRegion.contains(layerBounds), "Can't asynchronously require full display for a buffer set");
         inputData.dirtyRegion = layerBounds;
     }
@@ -148,10 +143,10 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
     if (!m_frontBuffer) {
         WebCore::ImageBufferCreationContext creationContext;
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-        if (m_renderingPurpose == RenderingPurpose::LayerBacking || m_renderingPurpose == RenderingPurpose::DOM)
+        if (m_configuration.includeDisplayList == WebCore::IncludeDynamicContentScalingDisplayList::Yes)
             creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
 #endif
-        m_frontBuffer = backend->allocateImageBuffer(m_logicalSize, m_renderingMode, m_renderingPurpose, m_resolutionScale, m_colorSpace, m_pixelFormat, WTFMove(creationContext), WebCore::RenderingResourceIdentifier::generate());
+        m_frontBuffer = backend->allocateImageBuffer(m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.pixelFormat, WTFMove(creationContext), WebCore::RenderingResourceIdentifier::generate());
         m_frontBufferIsCleared = true;
     }
 
@@ -166,8 +161,8 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
 
 void RemoteImageBufferSet::prepareBufferForDisplay(const WebCore::Region& dirtyRegion, bool requiresClearedPixels)
 {
-    PaintRectList paintingRects = computePaintingRects(dirtyRegion, m_resolutionScale);
-    WebCore::FloatRect layerBounds { { }, m_logicalSize };
+    PaintRectList paintingRects = computePaintingRects(dirtyRegion, m_configuration.resolutionScale);
+    WebCore::FloatRect layerBounds { { }, m_configuration.logicalSize };
 
     ImageBufferSet::prepareBufferForDisplay(layerBounds, dirtyRegion, paintingRects, requiresClearedPixels);
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -30,6 +30,7 @@
 #include "IPCEvent.h"
 #include "ImageBufferSet.h"
 #include "PrepareBackingStoreBuffersData.h"
+#include "RemoteImageBufferSetConfiguration.h"
 #include "RemoteImageBufferSetIdentifier.h"
 #include "RenderingUpdateID.h"
 #include "StreamConnectionWorkQueue.h"
@@ -70,7 +71,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     // Messages
-    void updateConfiguration(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat);
+    void updateConfiguration(const RemoteImageBufferSetConfiguration&);
     void endPrepareForDisplay(RenderingUpdateID);
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
@@ -81,22 +82,17 @@ private:
     bool isOpaque() const
     {
 #if ENABLE(PIXEL_FORMAT_RGB10)
-        if (m_pixelFormat == WebCore::ImageBufferPixelFormat::RGB10)
+        if (m_configuration.pixelFormat == WebCore::ImageBufferPixelFormat::RGB10)
             return true;
 #endif
-        return m_pixelFormat == WebCore::ImageBufferPixelFormat::BGRX8;
+        return m_configuration.pixelFormat == WebCore::ImageBufferPixelFormat::BGRX8;
     }
 
     const RemoteImageBufferSetIdentifier m_identifier;
     const WebCore::RenderingResourceIdentifier m_displayListIdentifier;
     RefPtr<RemoteRenderingBackend> m_backend;
 
-    WebCore::FloatSize m_logicalSize;
-    WebCore::RenderingMode m_renderingMode;
-    WebCore::RenderingPurpose m_renderingPurpose;
-    float m_resolutionScale { 1.0f };
-    WebCore::DestinationColorSpace m_colorSpace { WebCore::DestinationColorSpace::SRGB() };
-    WebCore::ImageBufferPixelFormat m_pixelFormat;
+    RemoteImageBufferSetConfiguration m_configuration;
     bool m_displayListCreated { false };
 
     std::optional<WebCore::IntRect> m_previouslyPaintedRect;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -97,7 +97,7 @@ bool isSmallLayerBacking(const ImageBufferParameters& parameters)
 {
     const unsigned maxSmallLayerBackingArea = 64u * 64u; // 4096 == 16kb backing store which equals 1 page on AS.
     auto checkedArea = ImageBuffer::calculateBackendSize(parameters.logicalSize, parameters.resolutionScale).area<RecordOverflow>();
-    return (parameters.purpose == RenderingPurpose::LayerBacking || parameters.purpose == RenderingPurpose::BitmapOnlyLayerBacking)
+    return (parameters.purpose == RenderingPurpose::LayerBacking)
         && !checkedArea.hasOverflowed() && checkedArea <= maxSmallLayerBackingArea
         && (parameters.pixelFormat == ImageBufferPixelFormat::BGRA8 || parameters.pixelFormat == ImageBufferPixelFormat::BGRX8);
 }
@@ -327,7 +327,7 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
     RefPtr<ImageBuffer> imageBuffer;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    if (m_gpuConnectionToWebProcess->isDynamicContentScalingEnabled() && (purpose == RenderingPurpose::LayerBacking || purpose == RenderingPurpose::DOM))
+    if (m_gpuConnectionToWebProcess->isDynamicContentScalingEnabled() && creationContext.dynamicContentScalingResourceCache)
         imageBuffer = allocateImageBufferInternal<DynamicContentScalingBifurcatedImageBuffer>(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, creationContext, imageBufferIdentifier);
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -90,10 +90,6 @@ public:
         Bitmap
     };
 
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    enum class IncludeDisplayList : bool { No, Yes };
-#endif
-
     virtual bool isRemoteLayerWithRemoteRenderingBackingStore() const { return false; }
     virtual bool isRemoteLayerWithInProcessRenderingBackingStore() const { return false; }
 
@@ -110,7 +106,7 @@ public:
         bool isOpaque { false };
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-        IncludeDisplayList includeDisplayList { IncludeDisplayList::No };
+        WebCore::IncludeDynamicContentScalingDisplayList includeDisplayList { WebCore::IncludeDynamicContentScalingDisplayList::No };
 #endif
 
         friend bool operator==(const Parameters&, const Parameters&) = default;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -302,7 +302,7 @@ bool RemoteLayerBackingStore::supportsPartialRepaint() const
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     // FIXME: Find a way to support partial repaint for backing store that
     // includes a display list without allowing unbounded memory growth.
-    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes)
+    if (m_parameters.includeDisplayList == WebCore::IncludeDynamicContentScalingDisplayList::Yes)
         return false;
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -201,18 +201,17 @@ static RefPtr<ImageBuffer> allocateBufferInternal(RemoteLayerBackingStore::Type 
 
 RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer()
 {
-    auto purpose = m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
     ImageBufferCreationContext creationContext;
     creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPoolSingleton();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes) {
+    if (m_parameters.includeDisplayList == WebCore::IncludeDynamicContentScalingDisplayList::Yes) {
         creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
-        return allocateBufferInternal<DynamicContentScalingBifurcatedImageBuffer>(type(), size(), purpose, scale(), colorSpace(), pixelFormat(), creationContext);
+        return allocateBufferInternal<DynamicContentScalingBifurcatedImageBuffer>(type(), size(), RenderingPurpose::LayerBacking, scale(), colorSpace(), pixelFormat(), creationContext);
     }
 #endif
 
-    return allocateBufferInternal<ImageBuffer>(type(), size(), purpose, scale(), colorSpace(), pixelFormat(), creationContext);
+    return allocateBufferInternal<ImageBuffer>(type(), size(), RenderingPurpose::LayerBacking, scale(), colorSpace(), pixelFormat(), creationContext);
 }
 
 void RemoteLayerWithInProcessRenderingBackingStore::ensureFrontBuffer()

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -112,9 +112,18 @@ void RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore(const Parame
     m_parameters = parameters;
     m_cleared = true;
     if (m_bufferSet) {
-        auto renderingMode = type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
-        auto renderingPurpose = m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
-        m_bufferSet->setConfiguration(size(), scale(), colorSpace(), pixelFormat(), renderingMode, renderingPurpose);
+        RemoteImageBufferSetConfiguration configuration {
+            .logicalSize = size(),
+            .resolutionScale = scale(),
+            .colorSpace = colorSpace(),
+            .pixelFormat = pixelFormat(),
+            .renderingMode = type() == RemoteLayerBackingStore::Type::IOSurface ? RenderingMode::Accelerated : RenderingMode::Unaccelerated,
+            .renderingPurpose = WebCore::RenderingPurpose::LayerBacking,
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+            .includeDisplayList = m_parameters.includeDisplayList,
+#endif
+        };
+        m_bufferSet->setConfiguration(WTFMove(configuration));
     }
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1813,7 +1813,6 @@ enum class WebCore::RenderingPurpose : uint8_t {
     Canvas,
     DOM,
     LayerBacking,
-    BitmapOnlyLayerBacking,
     Snapshot,
     ShareableSnapshot,
     ShareableLocalSnapshot,
@@ -8191,6 +8190,8 @@ header: <WebCore/ShareableResource.h>
     Ref<WebCore::SharedBuffer> displayList();
     Vector<MachSendRight> takeSurfaces();
 }
+
+enum class WebCore::IncludeDynamicContentScalingDisplayList : bool;
 #endif
 
 enum class WebCore::PlatformCursorType : uint8_t {

--- a/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h
+++ b/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,34 +25,32 @@
 
 #pragma once
 
-namespace WTF {
-class TextStream;
-}
+#include <WebCore/DestinationColorSpace.h>
+#include <WebCore/FloatSize.h>
+#include <WebCore/ImageBufferPixelFormat.h>
+#include <WebCore/RenderingMode.h>
 
-namespace WebCore {
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+#include <WebCore/DynamicContentScalingDisplayList.h>
+#endif
 
-enum class RenderingPurpose : uint8_t {
-    Unspecified,
-    Canvas,
-    DOM,
-    LayerBacking,
-    Snapshot,
-    ShareableSnapshot,
-    ShareableLocalSnapshot,
-    MediaPainting,
+#if ENABLE(GPU_PROCESS)
+
+namespace WebKit {
+
+struct RemoteImageBufferSetConfiguration {
+    WebCore::FloatSize logicalSize;
+    float resolutionScale { 1.0f };
+    WebCore::DestinationColorSpace colorSpace { WebCore::DestinationColorSpace::SRGB() };
+    WebCore::ImageBufferPixelFormat pixelFormat { WebCore::ImageBufferPixelFormat::BGRA8 };
+    WebCore::RenderingMode renderingMode { WebCore::RenderingMode::Unaccelerated };
+    WebCore::RenderingPurpose renderingPurpose { WebCore::RenderingPurpose::Unspecified };
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    WebCore::IncludeDynamicContentScalingDisplayList includeDisplayList { WebCore::IncludeDynamicContentScalingDisplayList::No };
+#endif
 };
 
-enum class RenderingMode : uint8_t {
-    Unaccelerated,
-    Accelerated,
-    PDFDocument,
-    DisplayList,
-};
+} // namespace WebKit
 
-enum class RenderingMethod : bool { Local };
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RenderingPurpose);
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RenderingMode);
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RenderingMethod);
-
-} // namespace WebCore
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
+++ b/Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,18 +22,19 @@
 
 #if ENABLE(GPU_PROCESS)
 
-[
-    ExceptionForEnabledBy,
-    DispatchedFrom=WebContent,
-    DispatchedTo=GPU
-]
-messages -> RemoteImageBufferSet Stream {
-    UpdateConfiguration(struct WebKit::RemoteImageBufferSetConfiguration configuration)
-    EndPrepareForDisplay(WebKit::RenderingUpdateID renderingUpdateID)
+header: "RemoteImageBufferSetConfiguration.h"
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebKit::RemoteImageBufferSetConfiguration {
+    WebCore::FloatSize logicalSize;
+    float resolutionScale;
+    WebCore::DestinationColorSpace colorSpace;
+    WebCore::ImageBufferPixelFormat pixelFormat;
+    WebCore::RenderingMode renderingMode;
+    WebCore::RenderingPurpose renderingPurpose;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    DynamicContentScalingDisplayList() -> (std::optional<WebCore::DynamicContentScalingDisplayList> displayList) Synchronous NotStreamEncodableReply
+    WebCore::IncludeDynamicContentScalingDisplayList includeDisplayList;
 #endif
-}
+};
 
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4473,6 +4473,8 @@
 		29D04E2821F7C73D0076741D /* ApplicationServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApplicationServicesSPI.h; sourceTree = "<group>"; };
 		2D0035221BC7414800DA8716 /* PDFPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PDFPlugin.h; path = PDF/PDFPlugin.h; sourceTree = "<group>"; };
 		2D0035231BC7414800DA8716 /* PDFPlugin.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PDFPlugin.mm; path = PDF/PDFPlugin.mm; sourceTree = "<group>"; };
+		2D0440922D58810D00E98A2E /* RemoteImageBufferSetConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteImageBufferSetConfiguration.h; sourceTree = "<group>"; };
+		2D0440932D58810D00E98A2E /* RemoteImageBufferSetConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteImageBufferSetConfiguration.serialization.in; sourceTree = "<group>"; };
 		2D0C56FB229F1DEA00BD33E7 /* DeviceManagementSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceManagementSoftLink.h; sourceTree = "<group>"; };
 		2D0C56FC229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DeviceManagementSoftLink.mm; sourceTree = "<group>"; };
 		2D0CF64B21F2A80300787566 /* TextCheckingController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextCheckingController.mm; sourceTree = "<group>"; };
@@ -13866,6 +13868,8 @@
 			children = (
 				A7D5005A2B266DF200D3497E /* ImageBufferSet.cpp */,
 				A7D5005C2B266E0600D3497E /* ImageBufferSet.h */,
+				2D0440922D58810D00E98A2E /* RemoteImageBufferSetConfiguration.h */,
+				2D0440932D58810D00E98A2E /* RemoteImageBufferSetConfiguration.serialization.in */,
 			);
 			path = graphics;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -206,7 +206,7 @@ void RemoteImageBufferSetProxy::didPrepareForDisplay(ImageBufferSetPrepareBuffer
 
         auto createBufferAndBackendInfo = [&](const std::optional<WebCore::RenderingResourceIdentifier>& bufferIdentifier) {
             if (bufferIdentifier)
-                return std::optional { BufferAndBackendInfo { *bufferIdentifier, m_generation }    };
+                return std::optional { BufferAndBackendInfo { *bufferIdentifier, m_generation } };
             return std::optional<BufferAndBackendInfo>();
         };
 
@@ -239,14 +239,9 @@ void RemoteImageBufferSetProxy::close()
         remoteRenderingBackendProxy->releaseRemoteImageBufferSet(*this);
 }
 
-void RemoteImageBufferSetProxy::setConfiguration(WebCore::FloatSize size, float scale, const WebCore::DestinationColorSpace& colorSpace, WebCore::ImageBufferPixelFormat pixelFormat, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose)
+void RemoteImageBufferSetProxy::setConfiguration(RemoteImageBufferSetConfiguration&& configuration)
 {
-    m_size = size;
-    m_scale = scale;
-    m_colorSpace = colorSpace;
-    m_pixelFormat = pixelFormat;
-    m_renderingMode = renderingMode;
-    m_renderingPurpose = renderingPurpose;
+    m_configuration = WTFMove(configuration);
     m_remoteNeedsConfigurationUpdate = true;
 }
 
@@ -273,9 +268,9 @@ void RemoteImageBufferSetProxy::willPrepareForDisplay()
         return;
 
     if (m_remoteNeedsConfigurationUpdate) {
-        send(Messages::RemoteImageBufferSet::UpdateConfiguration(m_size, m_renderingMode, m_renderingPurpose, m_scale, m_colorSpace, m_pixelFormat));
+        send(Messages::RemoteImageBufferSet::UpdateConfiguration(m_configuration));
 
-        m_displayListRecorder = Ref { *m_remoteRenderingBackendProxy }->createDisplayListRecorder(m_displayListIdentifier, m_size, m_renderingMode, m_renderingPurpose, m_scale, m_colorSpace, m_pixelFormat);
+        m_displayListRecorder = Ref { *m_remoteRenderingBackendProxy }->createDisplayListRecorder(m_displayListIdentifier, m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.pixelFormat);
     }
     m_remoteNeedsConfigurationUpdate = false;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -29,6 +29,7 @@
 #include "MarkSurfacesAsVolatileRequestIdentifier.h"
 #include "PrepareBackingStoreBuffersData.h"
 #include "RemoteDisplayListRecorderProxy.h"
+#include "RemoteImageBufferSetConfiguration.h"
 #include "RemoteImageBufferSetIdentifier.h"
 #include "RenderingUpdateID.h"
 #include "WorkQueueMessageReceiver.h"
@@ -100,7 +101,7 @@ public:
 
     std::unique_ptr<ThreadSafeImageBufferSetFlusher> flushFrontBufferAsync(ThreadSafeImageBufferSetFlusher::FlushType);
 
-    void setConfiguration(WebCore::FloatSize, float, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat, WebCore::RenderingMode, WebCore::RenderingPurpose);
+    void setConfiguration(RemoteImageBufferSetConfiguration&&);
     void willPrepareForDisplay();
     void remoteBufferSetWasDestroyed();
 
@@ -128,12 +129,8 @@ private:
     OptionSet<BufferInSetType> m_requestedVolatility;
     OptionSet<BufferInSetType> m_confirmedVolatility;
 
-    WebCore::FloatSize m_size;
-    float m_scale { 1.0f };
-    WebCore::DestinationColorSpace m_colorSpace { WebCore::DestinationColorSpace::SRGB() };
-    WebCore::ImageBufferPixelFormat m_pixelFormat;
-    WebCore::RenderingMode m_renderingMode { WebCore::RenderingMode::Unaccelerated };
-    WebCore::RenderingPurpose m_renderingPurpose { WebCore::RenderingPurpose::Unspecified };
+    RemoteImageBufferSetConfiguration m_configuration;
+
     unsigned m_generation { 0 };
     bool m_remoteNeedsConfigurationUpdate { false };
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -47,7 +47,6 @@ class ModelContext;
 
 namespace WebKit {
 
-
 using LayerHostingContextID = uint32_t;
 
 struct PlatformCALayerRemoteDelegatedContents {
@@ -266,7 +265,9 @@ public:
     void markFrontBufferVolatileForTesting() override;
     virtual void populateCreationProperties(RemoteLayerTreeTransaction::LayerCreationProperties&, const RemoteLayerTreeContext&, WebCore::PlatformCALayer::LayerType);
 
-    bool containsBitmapOnly() const;
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    bool allowsDynamicContentScaling() const;
+#endif
 
     void purgeFrontBufferForTesting() override;
     void purgeBackBufferForTesting() override;
@@ -286,7 +287,7 @@ private:
     WebCore::DestinationColorSpace displayColorSpace() const;
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    RemoteLayerBackingStore::IncludeDisplayList shouldIncludeDisplayListInBackingStore() const;
+    WebCore::IncludeDynamicContentScalingDisplayList shouldIncludeDisplayListInBackingStore() const;
 #endif
 
     bool requiresCustomAppearanceUpdateOnBoundsChange() const;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -292,11 +292,6 @@ void PlatformCALayerRemote::ensureBackingStore()
     updateBackingStore();
 }
 
-bool PlatformCALayerRemote::containsBitmapOnly() const
-{
-    return owner() && owner()->platformCALayerContainsBitmapOnly(this);
-}
-
 DestinationColorSpace PlatformCALayerRemote::displayColorSpace() const
 {
     if (auto displayColorSpace = contentsFormatExtendedColorSpace(contentsFormat()))
@@ -311,13 +306,18 @@ DestinationColorSpace PlatformCALayerRemote::displayColorSpace() const
 }
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-RemoteLayerBackingStore::IncludeDisplayList PlatformCALayerRemote::shouldIncludeDisplayListInBackingStore() const
+bool PlatformCALayerRemote::allowsDynamicContentScaling() const
+{
+    return owner() && owner()->platformCALayerAllowsDynamicContentScaling(this);
+}
+
+IncludeDynamicContentScalingDisplayList PlatformCALayerRemote::shouldIncludeDisplayListInBackingStore() const
 {
     if (m_context && !m_context->useDynamicContentScalingDisplayListsForDOMRendering())
-        return RemoteLayerBackingStore::IncludeDisplayList::No;
-    if (containsBitmapOnly())
-        return RemoteLayerBackingStore::IncludeDisplayList::No;
-    return RemoteLayerBackingStore::IncludeDisplayList::Yes;
+        return IncludeDynamicContentScalingDisplayList::No;
+    if (!allowsDynamicContentScaling())
+        return IncludeDynamicContentScalingDisplayList::No;
+    return IncludeDynamicContentScalingDisplayList::Yes;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2382,7 +2382,6 @@ bool WebProcess::shouldUseRemoteRenderingFor(RenderingPurpose purpose)
         return m_useGPUProcessForCanvasRendering;
     case RenderingPurpose::DOM:
     case RenderingPurpose::LayerBacking:
-    case RenderingPurpose::BitmapOnlyLayerBacking:
     case RenderingPurpose::Snapshot:
     case RenderingPurpose::ShareableSnapshot:
         return m_useGPUProcessForDOMRendering;


### PR DESCRIPTION
#### 89b7e1f4bfb2a61da2b79fc4d06de621187d1e67
<pre>
Dynamic Content Scaling is needlessly enabled for some canvas elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=287372">https://bugs.webkit.org/show_bug.cgi?id=287372</a>
<a href="https://rdar.apple.com/144489486">rdar://144489486</a>

Reviewed by Wenson Hsieh.

Dynamic Content Scaling doesn&apos;t work for canvas right now, because we don&apos;t
record and replay canvas commands. Because of this, we disable it for layers
that back canvases, to avoid pointless overhead.

However, to identify canvas layers, we were using isBitmapOnly(), which does not
include e.g. canvases that have backgrounds.

Instead, centralize the Dynamic Content Scaling policy in its own method, which
applies to all canvases regardless of decorations, *and* bitmap-only layers.

Also, the way that Dynamic Content Scaling enablement was plumbed to GPUP-hosted
layer backing was very duplicative (instead of conferring with includeDisplayList,
we would check isBitmapOnly() again!). Repair this so we can have the logic
in only one place. This also obviates the need for RenderingPurpose::BitmapOnlyLayerBacking,
which was a bit of a conflation of two separate dimensions.

* Source/WebCore/platform/graphics/RenderingMode.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/RenderingMode.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::surfaceNameToNSString):
(WebCore::IOSurface::nameForRenderingPurpose):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::shouldUseRemoteRenderingFor):
Get rid of BitmapOnlyLayerBacking.

* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::layerAllowsDynamicContentScaling const):
(WebCore::GraphicsLayerClient::layerContainsBitmapOnly const): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::platformCALayerAllowsDynamicContentScaling const):
(WebCore::PlatformCALayerClient::platformCALayerContainsBitmapOnly const): Deleted.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::layerAllowsDynamicContentScaling const):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::allowsDynamicContentScaling const):
(WebKit::PlatformCALayerRemote::shouldIncludeDisplayListInBackingStore const):
(WebKit::PlatformCALayerRemote::containsBitmapOnly const): Deleted.
Replace &quot;contains bitmap only&quot; layer-level plumbing with &quot;allows dynamic content scaling&quot; one.
Let RenderLayer maintain the single implementation of the policy.

* Source/WebCore/platform/graphics/cocoa/DynamicContentScalingDisplayList.h:
Hoist IncludeDynamicContentScalingDisplayList down here to fix some circular header
dependencies in WebKit.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::updateConfiguration):
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
(WebKit::RemoteImageBufferSet::prepareBufferForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
(WebKit::RemoteImageBufferSet::isOpaque const):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::isSmallLayerBacking):
(WebKit::RemoteRenderingBackend::allocateImageBuffer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::supportsPartialRepaint const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::ensureBackingStore):
* Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.h: Added.
* Source/WebKit/Shared/graphics/RemoteImageBufferSetConfiguration.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::didPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::setConfiguration):
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
Encapsulate RemoteImageBufferSet configuration in a struct, so we can
easily have an optional bit for whether Dynamic Content Scaling is enabled or not.

Canonical link: <a href="https://commits.webkit.org/290181@main">https://commits.webkit.org/290181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e9e510e6ea2047bdde7712c0a102a6a6a1de1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39940 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16892 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26388 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80943 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49081 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35321 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76887 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18962 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21296 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9474 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21684 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16114 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->