### PR TITLE
Import a copy of the proposed std::indirect to make writing value semantics easier

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		BC05ACA62CEA70E500750CB1 /* VariantListOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2C0C212D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2C0C202D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC5267672C2726D600E422DD /* MakeString.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5267662C2726D600E422DD /* MakeString.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC9C64CB2D5947CD002B8E80 /* Indirect.h in Headers */ = {isa = PBXBuildFile; fileRef = BC9C64CA2D5946A9002B8E80 /* Indirect.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFA72D1865B9003F0349 /* CompactVariant.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA62D1865B9003F0349 /* CompactVariant.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFA92D1865C4003F0349 /* CompactVariantOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCE0DFAB2D18670B003F0349 /* VariantExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFAA2D18670B003F0349 /* VariantExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1583,6 +1584,7 @@
 		BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantListOperations.h; sourceTree = "<group>"; };
 		BC2C0C202D2C54A900FCFBA0 /* FlatteningVariantAdaptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FlatteningVariantAdaptor.h; sourceTree = "<group>"; };
 		BC5267662C2726D600E422DD /* MakeString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MakeString.h; sourceTree = "<group>"; };
+		BC9C64CA2D5946A9002B8E80 /* Indirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Indirect.h; sourceTree = "<group>"; };
 		BCE0DFA62D1865B9003F0349 /* CompactVariant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariant.h; sourceTree = "<group>"; };
 		BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariantOperations.h; sourceTree = "<group>"; };
 		BCE0DFAA2D18670B003F0349 /* VariantExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantExtras.h; sourceTree = "<group>"; };
@@ -2315,6 +2317,7 @@
 				5B43383A5D0B463C9433D933 /* IndexMap.h */,
 				3137E1D7DBD84AC38FAE4D34 /* IndexSet.h */,
 				2684D4351C000D400081D663 /* IndexSparseSet.h */,
+				BC9C64CA2D5946A9002B8E80 /* Indirect.h */,
 				A8A472BC151A825A004123FF /* InlineASM.h */,
 				A70DA0821799F04D00529A9B /* Insertion.h */,
 				5182C22C1F2BC7E60059BA7C /* InstanceCounted.h */,
@@ -3420,6 +3423,7 @@
 				DD3DC94327A4BF8E007E5B61 /* IndexMap.h in Headers */,
 				DD3DC93F27A4BF8E007E5B61 /* IndexSet.h in Headers */,
 				DD3DC96627A4BF8E007E5B61 /* IndexSparseSet.h in Headers */,
+				BC9C64CB2D5947CD002B8E80 /* Indirect.h in Headers */,
 				DD3DC97227A4BF8E007E5B61 /* InlineASM.h in Headers */,
 				DD3DC91327A4BF8E007E5B61 /* Insertion.h in Headers */,
 				DD3DC98B27A4BF8E007E5B61 /* InstanceCounted.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -126,6 +126,7 @@ set(WTF_PUBLIC_HEADERS
     IndexSet.h
     IndexSparseSet.h
     IndexedContainerIterator.h
+    Indirect.h
     InlineASM.h
     Insertion.h
     InstanceCounted.h

--- a/Source/WTF/wtf/Indirect.h
+++ b/Source/WTF/wtf/Indirect.h
@@ -1,0 +1,476 @@
+/* Copyright (c) 2016 The Value Types Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+
+// Imported from https://github.com/jbcoe/value_types (57e3aa5adf930a5a6e93115f9ebd9923e9f83b8c)
+//
+// Minor changes made to use WTF macros and default allocator.
+
+#pragma once
+
+#include <compare>
+#include <concepts>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/GetPtr.h>
+
+namespace WTF {
+
+[[noreturn]] inline void unreachable() {
+    WTF_UNREACHABLE();
+}
+
+template <class T, class A>
+class indirect;
+
+template <class>
+inline constexpr bool is_indirect_v = false;
+
+template <class T, class A>
+inline constexpr bool is_indirect_v<indirect<T, A>> = true;
+
+template <class T, class A = FastAllocator<T>>
+class indirect {
+  using allocator_traits = std::allocator_traits<A>;
+
+ public:
+  using value_type = T;
+  using allocator_type = A;
+  using pointer = typename allocator_traits::pointer;
+  using const_pointer = typename allocator_traits::const_pointer;
+
+  //
+  // Constructors.
+  //
+
+  explicit constexpr indirect()
+    requires std::default_initializable<A>
+      : alloc_() {
+    static_assert(std::default_initializable<T>);
+    p_ = construct_from(alloc_);
+  }
+
+  template <class U = T>
+  explicit constexpr indirect(U&& u)
+    requires(!std::same_as<std::remove_cvref_t<U>, indirect> &&
+             !std::same_as<std::remove_cvref_t<U>, std::in_place_t> &&
+             std::constructible_from<T, U> && std::default_initializable<A>)
+      : alloc_() {
+    p_ = construct_from(alloc_, std::forward<U>(u));
+  }
+
+  template <class... Us>
+  explicit constexpr indirect(std::in_place_t, Us&&... us)
+    requires std::constructible_from<T, Us&&...> &&
+             std::default_initializable<A>
+      : alloc_() {
+    p_ = construct_from(alloc_, std::forward<Us>(us)...);
+  }
+
+  template <class U = T, class... Us>
+  explicit constexpr indirect(std::in_place_t, std::initializer_list<U> ilist,
+                              Us&&... us)
+    requires std::constructible_from<T, std::initializer_list<U>&, Us...> &&
+             std::default_initializable<A>
+      : alloc_() {
+    p_ = construct_from(alloc_, ilist, std::forward<Us>(us)...);
+  }
+
+  constexpr indirect(const indirect& other)
+      : indirect(std::allocator_arg,
+                 allocator_traits::select_on_container_copy_construction(
+                     other.alloc_),
+                 other) {
+    // static_assert(std::copy_constructible<T>);
+  }
+
+  constexpr indirect(indirect&& other) noexcept(
+      allocator_traits::is_always_equal::value)
+      : indirect(std::allocator_arg, other.alloc_, std::move(other)) {}
+
+  //
+  // Allocator-extended constructors.
+  //
+
+  explicit constexpr indirect(std::allocator_arg_t, const A& alloc)
+      : alloc_(alloc) {
+    p_ = construct_from(alloc_);
+  }
+
+  template <class U = T>
+  explicit constexpr indirect(std::allocator_arg_t, const A& alloc, U&& u)
+    requires(!std::same_as<std::remove_cvref_t<U>, indirect> &&
+             !std::same_as<std::remove_cvref_t<U>, std::in_place_t> &&
+             std::constructible_from<T, U>)
+      : alloc_(alloc) {
+    p_ = construct_from(alloc_, std::forward<U>(u));
+  }
+
+  template <class U = T>
+  explicit constexpr indirect(std::allocator_arg_t, const A& alloc,
+                              std::in_place_t, U&& u)
+    requires(!std::same_as<std::remove_cvref_t<U>, indirect> &&
+             std::constructible_from<T, U>)
+      : alloc_(alloc) {
+    p_ = construct_from(alloc_, std::forward<U>(u));
+  }
+
+  template <class... Us>
+  explicit constexpr indirect(std::allocator_arg_t, const A& alloc,
+                              std::in_place_t, Us&&... us)
+    requires std::constructible_from<T, Us&&...>
+      : alloc_(alloc) {
+    p_ = construct_from(alloc_, std::forward<Us>(us)...);
+  }
+
+  template <class U = T, class... Us>
+  explicit constexpr indirect(std::allocator_arg_t, const A& alloc,
+                              std::in_place_t, std::initializer_list<U> ilist,
+                              Us&&... us)
+    requires std::constructible_from<T, std::initializer_list<U>&, Us...>
+      : alloc_(alloc) {
+    p_ = construct_from(alloc_, ilist, std::forward<Us>(us)...);
+  }
+
+  constexpr indirect(std::allocator_arg_t, const A& alloc,
+                     const indirect& other)
+      : alloc_(alloc) {
+    // static_assert(std::copy_constructible<T>);
+
+    if (other.valueless_after_move()) {
+      p_ = nullptr;
+      return;
+    }
+    p_ = construct_from(alloc_, *other);
+  }
+
+  constexpr indirect(
+      std::allocator_arg_t, const A& alloc,
+      indirect&& other) noexcept(allocator_traits::is_always_equal::value)
+      : p_(nullptr), alloc_(alloc) {
+    // static_assert(std::move_constructible<T>);
+
+    if constexpr (allocator_traits::is_always_equal::value) {
+      std::swap(p_, other.p_);
+    } else {
+      if (alloc_ == other.alloc_) {
+        std::swap(p_, other.p_);
+      } else {
+        if (!other.valueless_after_move()) {
+          p_ = construct_from(alloc_, std::move(*other));
+        } else {
+          p_ = nullptr;
+        }
+      }
+    }
+  }
+
+  //
+  // Destructor.
+  //
+
+  constexpr ~indirect() { reset(); }
+
+  //
+  // Assignment.
+  //
+
+  constexpr indirect& operator=(const indirect& other) {
+    // static_assert(std::copy_constructible<T>);
+
+    if (this == &other) return *this;
+
+    // Check to see if the allocators need to be updated.
+    // We defer actually updating the allocator until later because it may be
+    // needed to delete the current control block.
+    bool update_alloc =
+        allocator_traits::propagate_on_container_copy_assignment::value;
+
+    if (other.valueless_after_move()) {
+      reset();
+    } else {
+      if (std::assignable_from<T&, T> && !valueless_after_move() &&
+          alloc_ == other.alloc_) {
+        *p_ = *other;
+      } else {
+        // Constructing a new object could throw so we need to defer resetting
+        // or updating allocators until this is done.
+        auto tmp =
+            construct_from(update_alloc ? other.alloc_ : alloc_, *other.p_);
+        reset();
+        p_ = tmp;
+      }
+    }
+    if (update_alloc) {
+      alloc_ = other.alloc_;
+    }
+    return *this;
+  }
+
+  constexpr indirect& operator=(indirect&& other) noexcept(
+      allocator_traits::propagate_on_container_move_assignment::value ||
+      allocator_traits::is_always_equal::value) {
+    // static_assert(std::move_constructible<T>);
+
+    if (this == &other) return *this;
+
+    // Check to see if the allocators need to be updated.
+    // We defer actually updating the allocator until later because it may be
+    // needed to delete the current control block.
+    bool update_alloc =
+        allocator_traits::propagate_on_container_move_assignment::value;
+
+    if (other.valueless_after_move()) {
+      reset();
+    } else {
+      if (alloc_ == other.alloc_) {
+        std::swap(p_, other.p_);
+        other.reset();
+      } else {
+        // Constructing a new object could throw so we need to defer resetting
+        // or updating allocators until this is done.
+        auto tmp = construct_from(update_alloc ? other.alloc_ : alloc_,
+                                  std::move(*other.p_));
+        reset();
+        p_ = tmp;
+      }
+    }
+    if (update_alloc) {
+      alloc_ = other.alloc_;
+    }
+    return *this;
+  }
+
+  template <class U>
+  constexpr indirect& operator=(U&& u)
+    requires(!std::same_as<std::remove_cvref_t<U>, indirect> &&
+             std::constructible_from<T, U> && std::assignable_from<T&, U>)
+  {
+    if (valueless_after_move()) {
+      p_ = construct_from(alloc_, std::forward<U>(u));
+    } else {
+      *p_ = std::forward<U>(u);
+    }
+    return *this;
+  }
+
+  //
+  // Accessors.
+  //
+
+  [[nodiscard]] constexpr const T& operator*() const& noexcept {
+    ASSERT(!valueless_after_move());  // LCOV_EXCL_LINE
+    return *p_;
+  }
+
+  [[nodiscard]] constexpr T& operator*() & noexcept {
+    ASSERT(!valueless_after_move());  // LCOV_EXCL_LINE
+    return *p_;
+  }
+
+  [[nodiscard]] constexpr T&& operator*() && noexcept {
+    ASSERT(!valueless_after_move());  // LCOV_EXCL_LINE
+    return std::move(*p_);
+  }
+
+  [[nodiscard]] constexpr const T&& operator*() const&& noexcept {
+    ASSERT(!valueless_after_move());  // LCOV_EXCL_LINE
+    return std::move(*p_);
+  }
+
+  [[nodiscard]] constexpr const_pointer operator->() const noexcept {
+    ASSERT(!valueless_after_move());  // LCOV_EXCL_LINE
+    return p_;
+  }
+
+  [[nodiscard]] constexpr pointer operator->() noexcept {
+    ASSERT(!valueless_after_move());  // LCOV_EXCL_LINE
+    return p_;
+  }
+
+  [[nodiscard]] constexpr bool valueless_after_move() const noexcept {
+    return p_ == nullptr;
+  }
+
+  constexpr allocator_type get_allocator() const noexcept { return alloc_; }
+
+  //
+  // Modifiers.
+  //
+
+  constexpr void swap(indirect& other) noexcept(
+      std::allocator_traits<A>::propagate_on_container_swap::value ||
+      std::allocator_traits<A>::is_always_equal::value) {
+    if constexpr (allocator_traits::propagate_on_container_swap::value) {
+      // If allocators move with their allocated objects, we can swap both.
+      std::swap(alloc_, other.alloc_);
+      std::swap(p_, other.p_);
+      return;
+    } else /* constexpr */ {
+      if (alloc_ == other.alloc_) {
+        std::swap(p_, other.p_);
+      } else {
+        unreachable();  // LCOV_EXCL_LINE
+      }
+    }
+  }
+
+  friend constexpr void swap(indirect& lhs,
+                             indirect& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+    lhs.swap(rhs);
+  }
+
+  //
+  // Comparison operators.
+  //
+
+  template <class U, class AA>
+  [[nodiscard]] friend constexpr bool operator==(
+      const indirect<T, A>& lhs,
+      const indirect<U, AA>& rhs) noexcept(noexcept(*lhs == *rhs)) {
+    if (lhs.valueless_after_move()) {
+      return rhs.valueless_after_move();
+    }
+    if (rhs.valueless_after_move()) {
+      return false;
+    }
+    return *lhs == *rhs;
+  }
+
+  template <class U, class AA>
+  [[nodiscard]] friend constexpr auto operator<=>(
+      const indirect<T, A>& lhs,
+      const indirect<U, AA>& rhs) noexcept(noexcept(*lhs <=> *rhs))
+      -> std::compare_three_way_result_t<T, U> {
+    if (lhs.valueless_after_move() || rhs.valueless_after_move()) {
+      return !lhs.valueless_after_move() <=> !rhs.valueless_after_move();
+    }
+    return *lhs <=> *rhs;
+  }
+
+  template <class U>
+  [[nodiscard]] friend constexpr bool operator==(
+      const indirect<T, A>& lhs, const U& rhs) noexcept(noexcept(*lhs == rhs))
+    requires(!is_indirect_v<U>)
+  {
+    if (lhs.valueless_after_move()) {
+      return false;
+    }
+    return *lhs == rhs;
+  }
+
+  template <class U>
+  [[nodiscard]] friend constexpr auto operator<=>(
+      const indirect<T, A>& lhs, const U& rhs) noexcept(noexcept(*lhs <=> rhs))
+      -> std::compare_three_way_result_t<T, U>
+    requires(!is_indirect_v<U>)
+  {
+    if (lhs.valueless_after_move()) {
+      return false <=> true;
+    }
+    return *lhs <=> rhs;
+  }
+
+ private:
+  pointer p_;
+
+#if defined(_MSC_VER)
+  // https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/#msvc-extensions-and-abi
+  [[msvc::no_unique_address]] A alloc_;
+#else
+  [[no_unique_address]] A alloc_;
+#endif
+
+  constexpr void reset() noexcept {
+    if (p_ == nullptr) return;
+    destroy_with(alloc_, p_);
+    p_ = nullptr;
+  }
+
+  template <typename... Ts>
+  [[nodiscard]] constexpr static pointer construct_from(A alloc, Ts&&... ts) {
+    pointer mem = allocator_traits::allocate(alloc, 1);
+
+    allocator_traits::construct(alloc, std::to_address(mem),
+                                std::forward<Ts>(ts)...);
+    return mem;
+
+#if 0
+    // Disabling exceptions code path for WTF.
+
+    try {
+      allocator_traits::construct(alloc, std::to_address(mem),
+                                  std::forward<Ts>(ts)...);
+      return mem;
+    } catch (...) {
+      allocator_traits::deallocate(alloc, mem, 1);
+      throw;
+    }
+#endif
+  }
+
+  constexpr static void destroy_with(A alloc, pointer p) {
+    allocator_traits::destroy(alloc, std::to_address(p));
+    allocator_traits::deallocate(alloc, p, 1);
+  }
+};
+
+template <class T>
+concept is_hashable = requires(T t) { std::hash<T>{}(t); };
+
+template <typename Value>
+indirect(Value) -> indirect<Value>;
+
+template <typename Alloc, typename Value>
+indirect(std::allocator_arg_t, Alloc, Value) -> indirect<
+    Value, typename std::allocator_traits<Alloc>::template rebind_alloc<Value>>;
+
+// MARK: WTF Specific specializations
+
+template <typename T, typename Allocator> struct IsSmartPtr<indirect<T, Allocator>> {
+    static constexpr bool value = true;
+    static constexpr bool isNullable = false;
+};
+
+template <typename T, typename Allocator>
+struct GetPtrHelper<indirect<T, Allocator>> {
+    using PtrType = T*;
+    using UnderlyingType = T;
+    static T* getPtr(const indirect<T, Allocator>& p) { return std::addressof(*p); }
+};
+
+}  // namespace WTF
+
+template <class T, class Alloc>
+  requires WTF::is_hashable<T>
+struct std::hash<WTF::indirect<T, Alloc>> {
+  constexpr std::size_t operator()(const WTF::indirect<T, Alloc>& key) const {
+    if (key.valueless_after_move()) {
+      return static_cast<std::size_t>(-1);  // Implementation defined value.
+    }
+    return std::hash<typename WTF::indirect<T, Alloc>::value_type>{}(*key);
+  }
+};
+
+using WTF::indirect;

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -225,7 +225,7 @@ std::optional<double> evaluate(const IndirectNode<MediaProgress>& root, const Ev
         return { };
 
     Ref document = options.conversionData->styleBuilderState()->document();
-    auto value = evaluateMediaProgress(root, document, *options.conversionData);
+    auto value = evaluateMediaProgress(*root, document, *options.conversionData);
     return Calculation::executeOperation<ToCalculationTreeOp<Progress>>(value, *start, *end);
 }
 
@@ -243,7 +243,7 @@ std::optional<double> evaluate(const IndirectNode<ContainerProgress>& root, cons
         return { };
 
     Ref element = *options.conversionData->styleBuilderState()->element();
-    auto value = evaluateContainerProgress(root, element, *options.conversionData);
+    auto value = evaluateContainerProgress(*root, element, *options.conversionData);
     if (!value)
         return { };
 

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -30,6 +30,7 @@
 #include "CSSUnits.h"
 #include "CSSValueKeywords.h"
 #include <variant>
+#include <wtf/Indirect.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -163,17 +164,15 @@ struct Symbol {
 
 template<typename Op> struct IndirectNode {
     Type type;
-    UniqueRef<Op> op;
+    indirect<Op> op;
 
     // Forward * and -> to the operation for convenience.
     const Op& operator*() const { return *op; }
     Op& operator*() { return *op; }
-    const Op* operator->() const { return op.ptr(); }
-    Op* operator->() { return op.ptr(); }
-    operator const Op&() const { return *op; }
-    operator Op&() { return *op; }
+    const Op* operator->() const { return op.operator->(); }
+    Op* operator->() { return op.operator->(); }
 
-    bool operator==(const IndirectNode<Op>& other) const { return type == other.type && op.get() == other.op.get(); }
+    bool operator==(const IndirectNode<Op>& other) const { return type == other.type && op == other.op; }
 };
 
 using Node = std::variant<
@@ -870,34 +869,34 @@ TextStream& operator<<(TextStream&, Tree);
 
 // Default implementation of ChildConstruction used for all indirect nodes.
 template<typename Op> struct ChildConstruction {
-    static Child make(Op&& op, Type type) { return Child { IndirectNode<Op> { type, makeUniqueRef<Op>(WTFMove(op)) } }; }
+    static Child make(Op&& op, Type type) { return Child { IndirectNode<Op> { type, indirect(WTFMove(op)) } }; }
 };
 
-// Specialized implementation of ChildConstruction for Number, needed to avoid `makeUniqueRef`.
+// Specialized implementation of ChildConstruction for Number.
 template<> struct ChildConstruction<Number> {
     static Child make(Number&& op, Type) { return Child { WTFMove(op) }; }
     static Child make(Number&& op) { return Child { WTFMove(op) }; }
 };
 
-// Specialized implementation of ChildConstruction for Percentage, needed to avoid `makeUniqueRef`.
+// Specialized implementation of ChildConstruction for Percentage.
 template<> struct ChildConstruction<Percentage> {
     static Child make(Percentage&& op, Type) { return Child { WTFMove(op) }; }
     static Child make(Percentage&& op) { return Child { WTFMove(op) }; }
 };
 
-// Specialized implementation of ChildConstruction for CanonicalDimension, needed to avoid `makeUniqueRef`.
+// Specialized implementation of ChildConstruction for CanonicalDimension.
 template<> struct ChildConstruction<CanonicalDimension> {
     static Child make(CanonicalDimension&& op, Type) { return Child { WTFMove(op) }; }
     static Child make(CanonicalDimension&& op) { return Child { WTFMove(op) }; }
 };
 
-// Specialized implementation of ChildConstruction for NonCanonicalDimension, needed to avoid `makeUniqueRef`.
+// Specialized implementation of ChildConstruction for NonCanonicalDimension.
 template<> struct ChildConstruction<NonCanonicalDimension> {
     static Child make(NonCanonicalDimension&& op, Type) { return Child { WTFMove(op) }; }
     static Child make(NonCanonicalDimension&& op) { return Child { WTFMove(op) }; }
 };
 
-// Specialized implementation of ChildConstruction for Symbol, needed to avoid `makeUniqueRef`.
+// Specialized implementation of ChildConstruction for Symbol.
 template<> struct ChildConstruction<Symbol> {
     static Child make(Symbol&& op, Type) { return Child { WTFMove(op) }; }
     static Child make(Symbol&& op) { return Child { WTFMove(op) }; }

--- a/Source/WebCore/css/values/color/CSSDynamicRangeLimit.cpp
+++ b/Source/WebCore/css/values/color/CSSDynamicRangeLimit.cpp
@@ -50,7 +50,7 @@ DynamicRangeLimit::DynamicRangeLimit(CSS::Keyword::High keyword)
 }
 
 DynamicRangeLimit::DynamicRangeLimit(DynamicRangeLimitMixFunction&& mix)
-    : value { WTF::makeUniqueRef<DynamicRangeLimitMixFunction>(WTFMove(mix)) }
+    : value { indirect(WTFMove(mix)) }
 {
 }
 

--- a/Source/WebCore/css/values/color/CSSDynamicRangeLimit.h
+++ b/Source/WebCore/css/values/color/CSSDynamicRangeLimit.h
@@ -27,6 +27,7 @@
 
 #include "CSSValueTypes.h"
 #include <wtf/CompactVariant.h>
+#include <wtf/Indirect.h>
 
 namespace WebCore {
 namespace CSS {
@@ -44,7 +45,7 @@ struct DynamicRangeLimit {
     DynamicRangeLimit(DynamicRangeLimit&&);
     DynamicRangeLimit& operator=(DynamicRangeLimit&&);
 
-    // Delete to avoid unnecessary unnecessary allocations on accidental copy.
+    // Deleted to avoid unnecessary unnecessary allocations on accidental copy.
     DynamicRangeLimit(const DynamicRangeLimit&) = delete;
     DynamicRangeLimit& operator=(const DynamicRangeLimit&) = delete;
 
@@ -59,7 +60,7 @@ private:
        CSS::Keyword::Standard,
        CSS::Keyword::ConstrainedHigh,
        CSS::Keyword::High,
-       UniqueRef<DynamicRangeLimitMixFunction>
+       indirect<DynamicRangeLimitMixFunction>
     >;
 
     Kind value;
@@ -74,8 +75,8 @@ template<typename... F> decltype(auto) DynamicRangeLimit::switchOn(F&&... f) con
         [&]<CSSValueID Id>(const Constant<Id>& keyword) -> ResultType {
             return visitor(keyword);
         },
-        [&](const UniqueRef<DynamicRangeLimitMixFunction>& mix) -> ResultType {
-            return visitor(mix.get());
+        [&](const indirect<DynamicRangeLimitMixFunction>& mix) -> ResultType {
+            return visitor(*mix);
         }
     );
 }

--- a/Source/WebCore/css/values/color/CSSDynamicRangeLimitMix.h
+++ b/Source/WebCore/css/values/color/CSSDynamicRangeLimitMix.h
@@ -41,13 +41,6 @@ using DynamicRangeLimitMixParameters = CommaSeparatedVector<DynamicRangeLimitMix
 using DynamicRangeLimitMixFunctionValue = FunctionNotation<CSSValueDynamicRangeLimitMix, DynamicRangeLimitMixParameters>;
 DEFINE_TYPE_WRAPPER(DynamicRangeLimitMixFunction, DynamicRangeLimitMixFunctionValue);
 
-// Overload of operator== for UniqueRef<DynamicRangeLimitMixFunction> to make DynamicRangeLimit::Kind's operator== work.
-// FIXME: Replace use of direct UniqueRef with something like std::indirect from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3019r12.pdf to get this for free.
-inline bool operator==(const UniqueRef<DynamicRangeLimitMixFunction>& a, const UniqueRef<DynamicRangeLimitMixFunction>& b)
-{
-    return a.get() == b.get();
-}
-
 } // namespace CSS
 } // namespace WebCore
 

--- a/Source/WebCore/platform/calc/CalculationTree.h
+++ b/Source/WebCore/platform/calc/CalculationTree.h
@@ -29,6 +29,7 @@
 #include <optional>
 #include <tuple>
 #include <variant>
+#include <wtf/Indirect.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -121,19 +122,7 @@ struct None {
     constexpr bool operator==(const None&) const = default;
 };
 
-template<typename Op> struct IndirectNode {
-    UniqueRef<Op> op;
-
-    // Forward * and -> to the operation for convenience.
-    const Op& operator*() const { return *op; }
-    Op& operator*() { return *op; }
-    const Op* operator->() const { return op.ptr(); }
-    Op* operator->() { return op.ptr(); }
-    operator const Op&() const { return *op; }
-    operator Op&() { return *op; }
-
-    bool operator==(const IndirectNode<Op>& other) const { return op.get() == other.op.get(); }
-};
+template<typename Op> using IndirectNode = indirect<Op>;
 
 using Node = std::variant<
     Number,
@@ -547,7 +536,7 @@ static_assert(sizeof(Child) <= 16, "Child should stay small");
 
 // Default implementation of ChildConstruction used for all indirect nodes.
 template<typename Op> struct ChildConstruction {
-    static Child make(Op&& op) { return Child { IndirectNode<Op> { makeUniqueRef<Op>(WTFMove(op)) } }; }
+    static Child make(Op&& op) { return Child { IndirectNode<Op> { WTFMove(op) } }; }
 };
 
 // Specialized implementation of ChildConstruction for Number, needed to avoid `makeUniqueRef`.

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
@@ -38,7 +38,7 @@ namespace Style {
 using namespace CSS::Literals;
 
 // Resolves a `dynamic-range-limit-mix` function value for the `dynamic-range-limit` property.
-static DynamicRangeLimit resolve(DynamicRangeLimitMixFunction&& mix)
+static DynamicRangeLimit resolveLimit(DynamicRangeLimitMixFunction&& mix)
 {
     // https://drafts.csswg.org/css-color-hdr/#computing-dynamic-range-limit
 
@@ -54,27 +54,23 @@ static DynamicRangeLimit resolve(DynamicRangeLimitMixFunction&& mix)
     return DynamicRangeLimit(WTFMove(mix));
 }
 
+// Resolves a supported keyword values for the `dynamic-range-limit` property.
+template<CSSValueID Id>
+static DynamicRangeLimit resolveLimit(Constant<Id> keyword)
+{
+    return DynamicRangeLimit(keyword);
+}
+
 // MARK: - Conversion
 
 auto ToCSS<DynamicRangeLimit>::operator()(const DynamicRangeLimit& limit, const RenderStyle& style) -> CSS::DynamicRangeLimit
 {
-    return WTF::switchOn(limit,
-        [&](const auto& value) -> CSS::DynamicRangeLimit {
-            return CSS::DynamicRangeLimit(toCSS(value, style));
-        }
-    );
+    return WTF::switchOn(limit, [&](const auto& value) -> CSS::DynamicRangeLimit { return toCSS(value, style); });
 }
 
 auto ToStyle<CSS::DynamicRangeLimit>::operator()(const CSS::DynamicRangeLimit& limit, const BuilderState& state) -> DynamicRangeLimit
 {
-    return WTF::switchOn(limit,
-        [&]<CSSValueID Id>(const Constant<Id>& keyword) -> DynamicRangeLimit {
-            return DynamicRangeLimit(keyword);
-        },
-        [&](const CSS::DynamicRangeLimitMixFunction& mix) -> DynamicRangeLimit {
-            return resolve(toStyle(mix, state));
-        }
-    );
+    return WTF::switchOn(limit, [&](const auto& value) -> DynamicRangeLimit { return resolveLimit(toStyle(value, state)); });
 }
 
 // MARK: - Blending
@@ -97,7 +93,7 @@ auto Blending<DynamicRangeLimit>::blend(const DynamicRangeLimit& from, const Dyn
     addWeightedLimitTo(function, from, fromMixPercentage);
     addWeightedLimitTo(function, to, toMixPercentage);
 
-    return resolve(WTFMove(function));
+    return resolveLimit(WTFMove(function));
 }
 
 // MARK: - Logging

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -28,7 +28,7 @@
 #include "StyleDynamicRangeLimitMix.h"
 #include "StyleValueTypes.h"
 #include <wtf/CompactVariant.h>
-#include <wtf/UniqueRef.h>
+#include <wtf/Indirect.h>
 
 namespace WebCore {
 
@@ -44,12 +44,6 @@ struct DynamicRangeLimit {
     DynamicRangeLimit(CSS::Keyword::High);
     DynamicRangeLimit(DynamicRangeLimitMixFunction&&);
 
-    DynamicRangeLimit(DynamicRangeLimit&&) = default;
-    DynamicRangeLimit& operator=(DynamicRangeLimit&&) = default;
-
-    DynamicRangeLimit(const DynamicRangeLimit&);
-    DynamicRangeLimit& operator=(const DynamicRangeLimit&);
-
     template<typename... F> decltype(auto) switchOn(F&&...) const;
 
     bool operator==(const DynamicRangeLimit&) const = default;
@@ -59,10 +53,8 @@ private:
        CSS::Keyword::Standard,
        CSS::Keyword::ConstrainedHigh,
        CSS::Keyword::High,
-       UniqueRef<DynamicRangeLimitMixFunction>
+       indirect<DynamicRangeLimitMixFunction>
     >;
-
-    static Kind copyKind(const Kind&);
 
     Kind value;
 };
@@ -83,21 +75,8 @@ inline DynamicRangeLimit::DynamicRangeLimit(CSS::Keyword::High keyword)
 }
 
 inline DynamicRangeLimit::DynamicRangeLimit(DynamicRangeLimitMixFunction&& mix)
-    : value { WTF::makeUniqueRef<DynamicRangeLimitMixFunction>(WTFMove(mix)) }
+    : value { indirect(WTFMove(mix)) }
 {
-}
-
-inline DynamicRangeLimit::DynamicRangeLimit(const DynamicRangeLimit& other)
-    : value { copyKind(other.value) }
-{
-}
-
-inline DynamicRangeLimit& DynamicRangeLimit::operator=(const DynamicRangeLimit& other)
-{
-    if (this == &other)
-        return *this;
-    value = copyKind(other.value);
-    return *this;
 }
 
 template<typename... F> decltype(auto) DynamicRangeLimit::switchOn(F&&... f) const
@@ -109,20 +88,8 @@ template<typename... F> decltype(auto) DynamicRangeLimit::switchOn(F&&... f) con
         [&]<CSSValueID Id>(const Constant<Id>& keyword) -> ResultType {
             return visitor(keyword);
         },
-        [&](const UniqueRef<DynamicRangeLimitMixFunction>& mix) -> ResultType {
-            return visitor(mix.get());
-        }
-    );
-}
-
-inline DynamicRangeLimit::Kind DynamicRangeLimit::copyKind(const Kind& other)
-{
-    return WTF::switchOn(other,
-        []<CSSValueID Id>(const Constant<Id>& keyword) {
-            return Kind { keyword };
-        },
-        [](const UniqueRef<DynamicRangeLimitMixFunction>& mix) {
-            return Kind { WTF::makeUniqueRef<DynamicRangeLimitMixFunction>(*mix) };
+        [&](const indirect<DynamicRangeLimitMixFunction>& mix) -> ResultType {
+            return visitor(*mix);
         }
     );
 }

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimitMix.cpp
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimitMix.cpp
@@ -49,11 +49,11 @@ void addWeightedLimitTo(DynamicRangeLimitMixFunction& addingTo, const DynamicRan
             addingTo->high.value                += mixPercentage.value; /* implicit multiplication by (100 / 100) elided */
         },
         [&](const DynamicRangeLimitMixFunction& innerMix) {
-            if (!Style::isZero(innerMix->standard))
+            if (!isZero(innerMix->standard))
                 addingTo->standard.value        += mixPercentage.value * (innerMix->standard.value        / 100.0);
-            if (!Style::isZero(innerMix->constrainedHigh))
+            if (!isZero(innerMix->constrainedHigh))
                 addingTo->constrainedHigh.value += mixPercentage.value * (innerMix->constrainedHigh.value / 100.0);
-            if (!Style::isZero(innerMix->high))
+            if (!isZero(innerMix->high))
                 addingTo->high.value            += mixPercentage.value * (innerMix->high.value            / 100.0);
         }
     );
@@ -65,11 +65,11 @@ auto ToCSS<DynamicRangeLimitMixFunction>::operator()(const DynamicRangeLimitMixF
 {
     CSS::DynamicRangeLimitMixFunction result;
 
-    if (!Style::isZero(mix.parameters.standard))
+    if (!isZero(mix.parameters.standard))
         result->parameters.value.append({ { CSS::Keyword::Standard { } },        toCSS(mix.parameters.standard, style) });
-    if (!Style::isZero(mix.parameters.constrainedHigh))
+    if (!isZero(mix.parameters.constrainedHigh))
         result->parameters.value.append({ { CSS::Keyword::ConstrainedHigh { } }, toCSS(mix.parameters.constrainedHigh, style) });
-    if (!Style::isZero(mix.parameters.high))
+    if (!isZero(mix.parameters.high))
         result->parameters.value.append({ { CSS::Keyword::High { } },            toCSS(mix.parameters.high, style) });
 
     return result;
@@ -132,17 +132,17 @@ auto ToStyle<CSS::DynamicRangeLimitMixFunction>::operator()(const CSS::DynamicRa
 TextStream& operator<<(TextStream& ts, const DynamicRangeLimitMixParameters& mix)
 {
     bool needsComma = false;
-    if (!Style::isZero(mix.standard)) {
+    if (!isZero(mix.standard)) {
         ts << "standard " << mix.standard;
         needsComma = true;
     }
-    if (!Style::isZero(mix.constrainedHigh)) {
+    if (!isZero(mix.constrainedHigh)) {
         if (needsComma)
             ts << ", ";
         ts << "constrained-high " << mix.constrainedHigh;
         needsComma = true;
     }
-    if (!Style::isZero(mix.high)) {
+    if (!isZero(mix.high)) {
         if (needsComma)
             ts << ", ";
         ts << "high " << mix.high;


### PR DESCRIPTION
#### 40920f76aa63693636b500a8fecc440d8f033d5c
<pre>
Import a copy of the proposed std::indirect to make writing value semantics easier
<a href="https://bugs.webkit.org/show_bug.cgi?id=287366">https://bugs.webkit.org/show_bug.cgi?id=287366</a>

Reviewed by NOBODY (OOPS!).

Imports a copy of the proposed type std::indirect&lt;T&gt;
from <a href="https://github.com/jbcoe/value_types.">https://github.com/jbcoe/value_types.</a>

Adopts it in a few places to remove some boiler plate.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Indirect.h: Added.
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
    - Utilize indirect to store the op in IndirectNode. If we remove Type
      from IndirectNode at some point, we can entirely replace IndirectNode
      here like we do in CalculationTree.
* Source/WebCore/platform/calc/CalculationTree.cpp:
* Source/WebCore/platform/calc/CalculationTree.h:
    - Replace implementation of IndirectNode with a type alias to indirect&lt;Op&gt;.

* Source/WebCore/css/values/color/CSSDynamicRangeLimit.cpp:
* Source/WebCore/css/values/color/CSSDynamicRangeLimit.h:
* Source/WebCore/css/values/color/CSSDynamicRangeLimitMix.h:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.h:
* Source/WebCore/style/values/color/StyleDynamicRangeLimitMix.cpp:
    - Replace use of UniqueRef with indirect, allowing the removal
      of custom operator== overloads and copy construction/assignment.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40920f76aa63693636b500a8fecc440d8f033d5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89085 "282 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8609 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43863 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94063 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39846 "Hash 40920f76 for PR 40325 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68637 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/39846 "Hash 40920f76 for PR 40325 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6882 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/43863 "Failed to compile WebKit") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6631 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/43863 "Failed to compile WebKit") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38953 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81884 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76994 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/43863 "Failed to compile WebKit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95898 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87861 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11904 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77515 "Failure limit exceed. At least found 1 new test failure: svg/custom/image-with-transform-clip-filter.svg (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16521 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/43863 "Failed to compile WebKit") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76803 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21207 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/43863 "Failed to compile WebKit") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9357 "Hash 40920f76 for PR 40325 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21590 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110354 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16020 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26491 "Found 9 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->