### PR TITLE
AX: Serve NSAccessibilityBoundsForRangeParameterizedAttribute and NSAccessibilityBoundsForTextMarkerRangeAttribute off the main-thread

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -317,7 +317,7 @@ public:
     AXTextMarkerRange paragraphRange() const;
     // Returns a range pointing to the start and end positions that have the same text styles as `this`.
     AXTextMarkerRange rangeWithSameStyle() const;
-    // Given a character offset relative to this marker, find the next marker the offset points to.
+    // Starting from this marker, return a text marker that is `offset` characters away.
     AXTextMarker nextMarkerFromOffset(unsigned) const;
     // Returns the number of intermediate text markers between this and the root.
     unsigned offsetFromRoot() const;
@@ -407,6 +407,9 @@ public:
 #if ENABLE(AX_THREAD_TEXT_APIS)
     // Traverses from m_start to m_end, collecting all text along the way.
     String toString() const;
+    // Returns the bounds (frame) of the text in this range relative to the viewport.
+    // Analagous to AXCoreObject::relativeFrame().
+    FloatRect viewportRelativeFrame() const;
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> toAttributedString(AXCoreObject::SpellCheck) const;
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXTextRun.h
+++ b/Source/WebCore/accessibility/AXTextRun.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
 
+#include "FloatRect.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
@@ -83,11 +84,19 @@ struct AXTextRuns {
     void* containingBlock { nullptr };
     Vector<AXTextRun> runs;
     bool containsOnlyASCII { true };
+    // A rough estimate of the size of the characters in these runs. This is per-AXTextRuns because
+    // AXTextRuns are associated with a single RenderText, which has the same style for all its runs.
+    // This is still an estimate, as characters can have vastly different sizes. We use this to serve
+    // APIs like AXBoundsForTextMarkerRangeAttribute quickly off the main-thread, and get more accurate
+    // sizes on-demand for runs that assistive technologies are actually requesting these APIs from.
+    static constexpr uint8_t defaultEstimatedCharacterWidth = 12;
+    uint8_t estimatedCharacterWidth { defaultEstimatedCharacterWidth };
 
     AXTextRuns() = default;
-    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns)
+    AXTextRuns(RenderBlock* containingBlock, Vector<AXTextRun>&& textRuns, uint8_t estimatedCharacterWidth)
         : containingBlock(containingBlock)
         , runs(WTFMove(textRuns))
+        , estimatedCharacterWidth(estimatedCharacterWidth)
     {
         for (const auto& run : runs) {
             if (!run.text.containsOnlyASCII()) {
@@ -138,6 +147,15 @@ struct AXTextRuns {
     }
     String substring(unsigned start, unsigned length = StringImpl::MaxLength) const;
     String toString() const { return substring(0); }
+
+    // Returns a "local" rect representing the range specified by |start| and |end|.
+    // "Local" means the rect is relative only to the top-left of this AXTextRuns instance.
+    // For example, consider these runs where "|" represents |start| and |end|:
+    //   aaaa
+    //   b|bb|b
+    // The local rect would be:
+    //   {x: width_of_single_b, y: |lineHeight| * 1, width: width_of_two_b, height: |lineHeight * 1|}
+    FloatRect localRect(unsigned start, unsigned end, float lineHeight) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -63,6 +63,7 @@ public:
     bool isTable() const final { return boolAttributeValue(AXProperty::IsTable); }
     bool isExposable() const final { return boolAttributeValue(AXProperty::IsExposable); }
     bool hasClickHandler() const final { return boolAttributeValue(AXProperty::HasClickHandler); }
+    FloatRect relativeFrame() const final;
 
     bool hasAttachmentTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::attachment; }
     bool hasBodyTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::body; }
@@ -234,7 +235,6 @@ private:
     bool isFileUploadButton() const final { return boolAttributeValue(AXProperty::IsFileUploadButton); }
     FloatPoint screenRelativePosition() const final;
     IntPoint remoteFrameOffset() const final;
-    FloatRect relativeFrame() const final;
     std::optional<IntRect> cachedRelativeFrame() const { return optionalAttributeValue<IntRect>(AXProperty::RelativeFrame); }
 #if PLATFORM(MAC)
     FloatRect primaryScreenRect() const final;

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -148,6 +148,9 @@ FloatRect AXIsolatedObject::primaryScreenRect() const
 
 FloatRect AXIsolatedObject::convertRectToPlatformSpace(const FloatRect& rect, AccessibilityConversionSpace space) const
 {
+    if (space == AccessibilityConversionSpace::Screen)
+        return convertFrameToSpace(rect, space);
+
     return Accessibility::retrieveValueFromMainThread<FloatRect>([&rect, &space, this] () -> FloatRect {
         if (auto* axObject = associatedAXObject())
             return axObject->convertRectToPlatformSpace(rect, space);

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -523,7 +523,7 @@ static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, con
 
 - (CGRect)convertRectToSpace:(const WebCore::FloatRect&)rect space:(AccessibilityConversionSpace)space
 {
-    RefPtr backingObject = dynamicDowncast<AccessibilityObject>(self.baseUpdateBackingStore);
+    RefPtr<AXCoreObject> backingObject = self.baseUpdateBackingStore;
     if (!backingObject)
         return CGRectZero;
 


### PR DESCRIPTION
#### c6bfb1759dd575c0178e46bd2f710f213dae2524
<pre>
AX: Serve NSAccessibilityBoundsForRangeParameterizedAttribute and NSAccessibilityBoundsForTextMarkerRangeAttribute off the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=287369">https://bugs.webkit.org/show_bug.cgi?id=287369</a>
<a href="https://rdar.apple.com/106041510">rdar://106041510</a>

Reviewed by Chris Fleizach.

This commits implements the ability to serve NSAccessibilityBoundsForRangeParameterizedAttribute and
NSAccessibilityBoundsForTextMarkerRangeAttribute off the main-thread. We do this by measuring the size of each character
in the text run and dividing the result by the number of characters. This means we can compute a resonable frame for
any arbirtrary range of characters using this average character size.

This patch also implements conversion of rects to screen-relative space by generalizing the existing logic for doing
so in AXIsolatedObject::screenRelativePosition(). Both bounds-for-range APIs expect the returned rects to be in
screen-relative space.

In a future patch, we should implement a system that computes 100% accurate character sizes on-demand for text ranges
that ATs are actually interacting with via these APIs. So if an AT requests NSAccessibilityBoundsForTextMarkerRangeAttribute
for one range, we serve an estimate, and then compute the true per-character widths for that text and also nearby text
under the assumption that an AT is likely going to move there next. An example usecase might be line-by-line navigation,
where if one of these APIs is requested for one line, it&apos;s likely the user will continue moving down to the next lines.

This commit leaves other problems unresolved, too — specifically:
  - AXTextRuns::rect() likely does not do the right thing for vertical writing modes.
  - We probably need to special-case certain types of text-run-producing objects, like those from br elements.

We&apos;ll need to address these in later commits.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::viewportRelativeFrameFromRuns):
(WebCore::AXTextMarkerRange::viewportRelativeFrame const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::rect const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRuns::AXTextRuns):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/290242@main">https://commits.webkit.org/290242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fac87ae02fd766c36394ffeac71ee940553529cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68772 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7035 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81012 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIMenus.MacAudioContextMenuItems (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39133 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12128 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77650 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76946 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19010 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21360 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19967 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9565 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16459 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21770 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16200 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->