### PR TITLE
[JSC] create_hash_table: Remove the MSVC workaround

### DIFF
--- a/Source/JavaScriptCore/create_hash_table
+++ b/Source/JavaScriptCore/create_hash_table
@@ -446,31 +446,20 @@ sub output() {
 
         my $hashTableString = "";
 
-        if ($compactSize != 0) {
-            $hashTableString .= "static constinit const struct CompactHashIndex ${nameIndex}\[$compactSize\] = {\n";
-            for (my $i = 0; $i < $compactSize; $i++) {
-                my $T = -1;
-                if (defined($table[$i])) { $T = $table[$i]; }
-                my $L = -1;
-                if (defined($links[$i])) { $L = $links[$i]; }
-                $hashTableString .= "    { $T, $L },\n";
-            }
-        } else {
-            # MSVC dislikes empty arrays.
-            $hashTableString .= "static constinit const struct CompactHashIndex ${nameIndex}\[1\] = {\n";
-            $hashTableString .= "    { 0, 0 }\n";
+        $hashTableString .= "static constinit const struct CompactHashIndex ${nameIndex}\[$compactSize\] = {\n";
+        for (my $i = 0; $i < $compactSize; $i++) {
+            my $T = -1;
+            if (defined($table[$i])) { $T = $table[$i]; }
+            my $L = -1;
+            if (defined($links[$i])) { $L = $links[$i]; }
+            $hashTableString .= "    { $T, $L },\n";
         }
+
         $hashTableString .= "};\n";
         $hashTableString .= "\n";
 
         my $packedSize = scalar @keys;
-        if ($packedSize != 0) {
-            $hashTableString .= "static constinit const struct HashTableValue ${nameEntries}\[$packedSize\] = {\n";
-        } else {
-            # MSVC dislikes empty arrays.
-            $hashTableString .= "static constinit const struct HashTableValue ${nameEntries}\[1\] = {\n";
-            $hashTableString .= "    { { }, 0, NoIntrinsic, { HashTableValue::End } }\n";
-        }
+	$hashTableString .= "static constinit const struct HashTableValue ${nameEntries}\[$packedSize\] = {\n";
 
         my $i = 0;
         foreach my $key (@keys) {


### PR DESCRIPTION
#### b07c8e6ae9b583a3688d2f905fe1ce0aebfe5434
<pre>
[JSC] create_hash_table: Remove the MSVC workaround
<a href="https://bugs.webkit.org/show_bug.cgi?id=287377">https://bugs.webkit.org/show_bug.cgi?id=287377</a>

Reviewed by Yusuke Suzuki.

&lt;<a href="https://commits.webkit.org/181484@main">https://commits.webkit.org/181484@main</a>&gt; added an MSVC workaround to
create_hash_table. WebKit no longer supports MSVC.

* Source/JavaScriptCore/create_hash_table:

Canonical link: <a href="https://commits.webkit.org/290139@main">https://commits.webkit.org/290139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25386c6d332fa868c7027a05ebe988a272d815f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39842 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68636 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26308 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48998 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6625 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38949 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/81880 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95894 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/87857 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16261 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11899 "Found 2 new test failures: http/tests/pdf/page-in-window-update-with-linearized-pdf-in-display-none-iframe.html imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77513 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76801 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21201 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9353 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13960 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21586 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110350 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16016 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26489 "Found 1 new JSC binary failure: testb3, Found 193 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager, microbenchmarks/memcpy-wasm-large.js.dfg-eager-no-cjit-validate, microbenchmarks/memcpy-wasm-large.js.eager-jettison-no-cjit, microbenchmarks/memcpy-wasm-large.js.mini-mode, microbenchmarks/memcpy-wasm-large.js.no-cjit-collect-continuously, microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->