### PR TITLE
Web Inspector: Worker Info not Visible In Most Timeline Profile Views like JavaScript & Events

### DIFF
--- a/LayoutTests/inspector/sampling-profiler/basic.html
+++ b/LayoutTests/inspector/sampling-profiler/basic.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="resources/calling-context-tree.js"></script>
 <script>
 
 function runFor(func, millis) {
@@ -29,12 +30,12 @@ function test()
         description: "Sample some basic code.",
         test(resolve, reject) {
             InspectorProtocol.awaitEvent({event: "ScriptProfiler.trackingComplete"}).then((messageObject) => {
-                let tree = WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject(messageObject);
+                let tree = ProtocolTest.CallingContextTree.createFromProtocolMessageObject(messageObject);
                 let trace = [
                     {name: "foo"},
                     {name: "runFor"}
                 ];
-                ProtocolTest.expectThat(tree.__test_matchesStackTrace(trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
+                ProtocolTest.expectThat(ProtocolTest.CallingContextTree.matchesStackTrace(tree, trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
                 resolve();
             });
 

--- a/LayoutTests/inspector/sampling-profiler/call-frame-with-dom-functions.html
+++ b/LayoutTests/inspector/sampling-profiler/call-frame-with-dom-functions.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="resources/calling-context-tree.js"></script>
 <script>
 
 function runFor(func, millis) {
@@ -30,21 +31,21 @@ function test()
         description: "Sample some basic code.",
         test(resolve, reject) {
             InspectorProtocol.awaitEvent({event: "ScriptProfiler.trackingComplete"}).then((messageObject) => {
-                let tree = WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject(messageObject);
+                let tree = ProtocolTest.CallingContextTree.createFromProtocolMessageObject(messageObject);
 
                 let trace = [
                     {name: "createElement"},
                     {name: "foo"},
                     {name: "runFor"}
                 ];
-                ProtocolTest.expectThat(tree.__test_matchesStackTrace(trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
+                ProtocolTest.expectThat(ProtocolTest.CallingContextTree.matchesStackTrace(tree, trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
 
                 trace = [
                     {name: "appendChild"},
                     {name: "foo"},
                     {name: "runFor"}
                 ];
-                ProtocolTest.expectThat(tree.__test_matchesStackTrace(trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
+                ProtocolTest.expectThat(ProtocolTest.CallingContextTree.matchesStackTrace(tree, trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
 
                 resolve();
             });

--- a/LayoutTests/inspector/sampling-profiler/eval-source-url.html
+++ b/LayoutTests/inspector/sampling-profiler/eval-source-url.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="resources/calling-context-tree.js"></script>
 <script>
 
 function runFor(func, millis) {
@@ -34,7 +35,7 @@ function test()
         description: "Sample some basic code.",
         test(resolve, reject) {
             InspectorProtocol.awaitEvent({event: "ScriptProfiler.trackingComplete"}).then((messageObject) => {
-                let tree = WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject(messageObject);
+                let tree = ProtocolTest.CallingContextTree.createFromProtocolMessageObject(messageObject);
 
                 let trace = [
                     {name: "foo"},
@@ -43,7 +44,7 @@ function test()
                     {name: "bar"},
                     {name: "runFor"}
                 ];
-                ProtocolTest.expectThat(tree.__test_matchesStackTrace(trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
+                ProtocolTest.expectThat(ProtocolTest.CallingContextTree.matchesStackTrace(tree, trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
                 resolve();
             });
 

--- a/LayoutTests/inspector/sampling-profiler/expression-location-info-expected.txt
+++ b/LayoutTests/inspector/sampling-profiler/expression-location-info-expected.txt
@@ -1,6 +1,6 @@
 
 == Running test suite: ScriptProfiler.Samples.ExpressionLocation
 -- Running test case: Sampling Profiler Expression Location
-PASS: Should have seen line 19, column 14.
-PASS: Should have seen line 25, column 14.
+PASS: Should have seen line 20, column 14.
+PASS: Should have seen line 26, column 14.
 

--- a/LayoutTests/inspector/sampling-profiler/expression-location-info.html
+++ b/LayoutTests/inspector/sampling-profiler/expression-location-info.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="resources/calling-context-tree.js"></script>
 <script>
 
 function runFor(func, millis) {
@@ -16,13 +17,13 @@ function foo() {
     {
         let o = {};
         for (let i = 0; i < 10000; i++) {
-            o["s" + i] = i; // line 19, column 14("[")
+            o["s" + i] = i; // line 20, column 14("[")
         }
     }
     {
         let o = {};
         for (let i = 0; i < 10000; i++) {
-            o["s" + i] = i; // line 25, column 14("[")
+            o["s" + i] = i; // line 26, column 14("[")
         }
     }
 }
@@ -37,24 +38,24 @@ function test()
         description: "Make sure we properly collect location information.",
         test(resolve, reject) {
             InspectorProtocol.awaitEvent({event: "ScriptProfiler.trackingComplete"}).then((messageObject) => {
-                let tree = WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject(messageObject);
-                let foundLine19Column14 = false;
-                let foundLine25Column14 = false;
+                let tree = ProtocolTest.CallingContextTree.createFromProtocolMessageObject(messageObject);
+                let foundLine20Column14 = false;
+                let foundLine26Column14 = false;
                 tree.forEachNode((node) => {
                     if (node.name !== "foo")
                         return;
 
                     for (let lineColumnHashedString of Object.getOwnPropertyNames(node._expressionLocations)) {
                         let [lineNumber, columnNumber] = lineColumnHashedString.split(":").map(Number);
-                        if (lineNumber === 19 && columnNumber === 14)
-                            foundLine19Column14 = true;
-                        if (lineNumber === 25 && columnNumber === 14)
-                            foundLine25Column14 = true;
+                        if (lineNumber === 20 && columnNumber === 14)
+                            foundLine20Column14 = true;
+                        if (lineNumber === 26 && columnNumber === 14)
+                            foundLine26Column14 = true;
                     }
                 });
 
-                ProtocolTest.expectThat(foundLine19Column14, "Should have seen line 19, column 14.");
-                ProtocolTest.expectThat(foundLine25Column14, "Should have seen line 25, column 14.");
+                ProtocolTest.expectThat(foundLine20Column14, "Should have seen line 20, column 14.");
+                ProtocolTest.expectThat(foundLine26Column14, "Should have seen line 26, column 14.");
                 resolve();
             });
 

--- a/LayoutTests/inspector/sampling-profiler/many-call-frames.html
+++ b/LayoutTests/inspector/sampling-profiler/many-call-frames.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="resources/calling-context-tree.js"></script>
 <script>
 
 function runFor(func, millis) {
@@ -36,7 +37,7 @@ function test()
         description: "Sample some basic code.",
         test(resolve, reject) {
             InspectorProtocol.awaitEvent({event: "ScriptProfiler.trackingComplete"}).then((messageObject) => {
-                let tree = WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject(messageObject);
+                let tree = ProtocolTest.CallingContextTree.createFromProtocolMessageObject(messageObject);
 
                 let trace = [
                     {name: "stacktraceTop"},
@@ -49,7 +50,7 @@ function test()
                     {name: "a"},
                     {name: "runFor"}
                 ];
-                ProtocolTest.expectThat(tree.__test_matchesStackTrace(trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
+                ProtocolTest.expectThat(ProtocolTest.CallingContextTree.matchesStackTrace(tree, trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
                 resolve();
             });
 

--- a/LayoutTests/inspector/sampling-profiler/named-function-expression.html
+++ b/LayoutTests/inspector/sampling-profiler/named-function-expression.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="resources/calling-context-tree.js"></script>
 <script>
 
 function runFor(func, millis) {
@@ -33,13 +34,13 @@ function test()
         description: "Sample some basic code.",
         test(resolve, reject) {
             InspectorProtocol.awaitEvent({event: "ScriptProfiler.trackingComplete"}).then((messageObject) => {
-                let tree = WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject(messageObject);
+                let tree = ProtocolTest.CallingContextTree.createFromProtocolMessageObject(messageObject);
                 let trace = [
                     {name: "bar"},
                     {name: "foo"},
                     {name: "runFor"}
                 ];
-                ProtocolTest.expectThat(tree.__test_matchesStackTrace(trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
+                ProtocolTest.expectThat(ProtocolTest.CallingContextTree.matchesStackTrace(tree, trace), "Should have seen stacktrace:\n" + JSON.stringify(trace, undefined, 2));
                 resolve();
             });
 

--- a/LayoutTests/inspector/sampling-profiler/resources/calling-context-tree.js
+++ b/LayoutTests/inspector/sampling-profiler/resources/calling-context-tree.js
@@ -1,0 +1,50 @@
+TestPage.registerInitializer(() => {
+    ProtocolTest.CallingContextTree = {};
+
+    ProtocolTest.CallingContextTree.createFromProtocolMessageObject = function(messageObject) {
+        const target = null;
+        let tree = new WI.CallingContextTree(target);
+        for (let stackTrace of messageObject.params.samples.stackTraces)
+            tree.updateTreeWithStackTrace(stackTrace);
+        return tree;
+    };
+
+    ProtocolTest.CallingContextTree.matchesStackTrace = function(tree, stackTrace) {
+        // StackTrace should have top frame first in the array and bottom frame last.
+        // We don't look for a match that traces down the tree from the root; instead,
+        // we match by looking at all the leafs, and matching while walking up the tree
+        // towards the root. If we successfully make the walk, we've got a match that
+        // suffices for a particular test. A successful match doesn't mean we actually
+        // walk all the way up to the root; it just means we didn't fail while walking
+        // in the direction of the root.
+
+        function buildLeafLinkedLists(treeNode, listParent, result) {
+            let linkedListNode = {
+                name: treeNode.name,
+                url: treeNode.url,
+                parent: listParent,
+            };
+            if (treeNode.hasChildren()) {
+                treeNode.forEachChild((childTreeNode) => {
+                    buildLeafLinkedLists(childTreeNode, linkedListNode, result);
+                });
+            } else
+                result.push(linkedListNode);
+        }
+        let leaves = [];
+        buildLeafLinkedLists(tree._root, null, leaves);
+
+        outer:
+        for (let node of leaves) {
+            for (let stackNode of stackTrace) {
+                for (let propertyName of Object.getOwnPropertyNames(stackNode)) {
+                    if (stackNode[propertyName] !== node[propertyName])
+                        continue outer;
+                }
+                node = node.parent;
+            }
+            return true;
+        }
+        return false;
+    };
+});

--- a/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h
@@ -50,8 +50,8 @@ public:
     ~InspectorHeapAgent() override;
 
     // InspectorAgentBase
-    void didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*) final;
-    void willDestroyFrontendAndBackend(DisconnectReason) final;
+    void didCreateFrontendAndBackend(FrontendRouter*, BackendDispatcher*) override;
+    void willDestroyFrontendAndBackend(DisconnectReason) override;
 
     // HeapBackendDispatcherHandler
     Protocol::ErrorStringOr<void> enable() override;

--- a/Source/JavaScriptCore/inspector/protocol/Timeline.json
+++ b/Source/JavaScriptCore/inspector/protocol/Timeline.json
@@ -2,7 +2,7 @@
     "domain": "Timeline",
     "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
     "debuggableTypes": ["page", "web-page"],
-    "targetTypes": ["page"],
+    "targetTypes": ["page", "worker"],
     "types": [
         {
             "id": "EventType",
@@ -82,6 +82,7 @@
         {
             "name": "setAutoCaptureEnabled",
             "description": "Toggle auto capture state. If <code>true</code> the backend will disable breakpoints and start capturing on navigation. The backend will fire the <code>autoCaptureStarted</code> event when an auto capture starts. The frontend should stop the auto capture when appropriate and re-enable breakpoints.",
+            "targetTypes": ["page"],
             "parameters": [
                 { "name": "enabled", "type": "boolean", "description": "New auto capture state." }
             ]
@@ -118,7 +119,8 @@
         },
         {
             "name": "autoCaptureStarted",
-            "description": "Fired when auto capture started."
+            "description": "Fired when auto capture started.",
+            "targetTypes": ["page"]
         }
     ]
 }

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -34,7 +34,7 @@ html/parser/HTMLTreeBuilder.cpp
 inspector/InspectorFrontendClientLocal.cpp
 inspector/InspectorOverlay.cpp
 inspector/agents/InspectorPageAgent.cpp
-inspector/agents/InspectorTimelineAgent.cpp
+inspector/agents/page/PageTimelineAgent.cpp
 loader/WorkerThreadableLoader.cpp
 page/DragController.cpp
 page/EventHandler.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1888,6 +1888,7 @@ inspector/agents/page/PageDebuggerAgent.cpp
 inspector/agents/page/PageHeapAgent.cpp
 inspector/agents/page/PageNetworkAgent.cpp
 inspector/agents/page/PageRuntimeAgent.cpp
+inspector/agents/page/PageTimelineAgent.cpp
 inspector/agents/page/PageWorkerAgent.cpp
 inspector/agents/worker/ServiceWorkerAgent.cpp
 inspector/agents/worker/WorkerAuditAgent.cpp
@@ -1897,6 +1898,7 @@ inspector/agents/worker/WorkerDOMDebuggerAgent.cpp
 inspector/agents/worker/WorkerDebuggerAgent.cpp
 inspector/agents/worker/WorkerNetworkAgent.cpp
 inspector/agents/worker/WorkerRuntimeAgent.cpp
+inspector/agents/worker/WorkerTimelineAgent.cpp
 inspector/agents/worker/WorkerWorkerAgent.cpp
 layout/formattingContexts/FormattingContext.cpp
 layout/formattingContexts/FormattingGeometry.cpp

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -285,7 +285,7 @@ JSC::JSValue ScriptModuleLoader::evaluate(JSC::JSGlobalObject* jsGlobalObject, J
             RELEASE_AND_RETURN(scope, frame->script().evaluateModule(sourceURL, *moduleRecord, awaitedValue, resumeMode));
     } else {
         if (auto* script = downcast<WorkerOrWorkletGlobalScope>(*m_context).script())
-            RELEASE_AND_RETURN(scope, script->evaluateModule(*moduleRecord, awaitedValue, resumeMode));
+            RELEASE_AND_RETURN(scope, script->evaluateModule(sourceURL, *moduleRecord, awaitedValue, resumeMode));
     }
     return JSC::jsUndefined();
 }

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -48,7 +48,6 @@
 #include "InspectorLayerTreeAgent.h"
 #include "InspectorMemoryAgent.h"
 #include "InspectorPageAgent.h"
-#include "InspectorTimelineAgent.h"
 #include "InstrumentingAgents.h"
 #include "JSDOMBindingSecurity.h"
 #include "JSDOMWindow.h"
@@ -65,6 +64,7 @@
 #include "PageHeapAgent.h"
 #include "PageNetworkAgent.h"
 #include "PageRuntimeAgent.h"
+#include "PageTimelineAgent.h"
 #include "PageWorkerAgent.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
@@ -191,7 +191,7 @@ void InspectorController::createLazyAgents()
     m_agents.append(makeUnique<PageHeapAgent>(pageContext));
     m_agents.append(makeUnique<PageAuditAgent>(pageContext));
     m_agents.append(makeUnique<PageCanvasAgent>(pageContext));
-    m_agents.append(makeUnique<InspectorTimelineAgent>(pageContext));
+    m_agents.append(makeUnique<PageTimelineAgent>(pageContext));
     m_agents.append(makeUnique<InspectorAnimationAgent>(pageContext));
 
     if (auto& commandLineAPIHost = m_injectedScriptManager->commandLineAPIHost())

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -505,46 +505,46 @@ void InspectorInstrumentation::didFireTimerImpl(InstrumentingAgents& instrumenti
 
 void InspectorInstrumentation::didInvalidateLayoutImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didInvalidateLayout();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didInvalidateLayout();
 }
 
 void InspectorInstrumentation::willLayoutImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willLayout();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->willLayout();
 }
 
 void InspectorInstrumentation::didLayoutImpl(InstrumentingAgents& instrumentingAgents, RenderObject& root)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didLayout(root);
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didLayout(root);
     if (auto* pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->didLayout();
 }
 
 void InspectorInstrumentation::willCompositeImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willComposite();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->willComposite();
 }
 
 void InspectorInstrumentation::didCompositeImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didComposite();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didComposite();
 }
 
 void InspectorInstrumentation::willPaintImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willPaint();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->willPaint();
 }
 
 void InspectorInstrumentation::didPaintImpl(InstrumentingAgents& instrumentingAgents, RenderObject& renderer, const LayoutRect& rect)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didPaint(renderer, rect);
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didPaint(renderer, rect);
 
     if (auto* pageAgent = instrumentingAgents.enabledPageAgent())
         pageAgent->didPaint(renderer, rect);
@@ -552,16 +552,16 @@ void InspectorInstrumentation::didPaintImpl(InstrumentingAgents& instrumentingAg
 
 void InspectorInstrumentation::willRecalculateStyleImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->willRecalculateStyle();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->willRecalculateStyle();
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->willRecalculateStyle();
 }
 
 void InspectorInstrumentation::didRecalculateStyleImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didRecalculateStyle();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didRecalculateStyle();
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->didRecalculateStyle();
     if (auto* pageAgent = instrumentingAgents.enabledPageAgent())
@@ -570,8 +570,8 @@ void InspectorInstrumentation::didRecalculateStyleImpl(InstrumentingAgents& inst
 
 void InspectorInstrumentation::didScheduleStyleRecalculationImpl(InstrumentingAgents& instrumentingAgents, Document& document)
 {
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didScheduleStyleRecalculation();
+    if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didScheduleStyleRecalculation();
     if (auto* networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->didScheduleStyleRecalculation(document);
 }
@@ -776,8 +776,8 @@ void InspectorInstrumentation::didCommitLoadImpl(InstrumentingAgents& instrument
         domAgent->didCommitLoad(frame.document());
 
     if (frame.isMainFrame()) {
-        if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-            timelineAgent->mainFrameNavigated();
+        if (auto* pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+            pageTimelineAgent->mainFrameNavigated();
     }
 }
 
@@ -801,8 +801,8 @@ void InspectorInstrumentation::frameStartedLoadingImpl(InstrumentingAgents& inst
     if (frame.isMainFrame()) {
         if (auto* pageDebuggerAgent = instrumentingAgents.enabledPageDebuggerAgent())
             pageDebuggerAgent->mainFrameStartedLoading();
-        if (auto* timelineAgent = instrumentingAgents.enabledTimelineAgent())
-            timelineAgent->mainFrameStartedLoading();
+        if (auto* pageTimelineAgent = instrumentingAgents.enabledPageTimelineAgent())
+            pageTimelineAgent->mainFrameStartedLoading();
     }
 
     if (auto* inspectorPageAgent = instrumentingAgents.enabledPageAgent())
@@ -811,8 +811,8 @@ void InspectorInstrumentation::frameStartedLoadingImpl(InstrumentingAgents& inst
 
 void InspectorInstrumentation::didCompleteRenderingFrameImpl(InstrumentingAgents& instrumentingAgents)
 {
-    if (auto* timelineAgent = instrumentingAgents.enabledTimelineAgent())
-        timelineAgent->didCompleteRenderingFrame();
+    if (auto* pageTimelineAgent = instrumentingAgents.enabledPageTimelineAgent())
+        pageTimelineAgent->didCompleteRenderingFrame();
 }
 
 void InspectorInstrumentation::frameStoppedLoadingImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -177,7 +177,9 @@ public:
     static void didDispatchEventOnWindow(LocalFrame*, const Event&);
     static void eventDidResetAfterDispatch(const Event&);
     static void willEvaluateScript(LocalFrame&, const String& url, int lineNumber, int columnNumber);
+    static void willEvaluateScript(WorkerOrWorkletGlobalScope&, const String& url, int lineNumber, int columnNumber);
     static void didEvaluateScript(LocalFrame&);
+    static void didEvaluateScript(WorkerOrWorkletGlobalScope&);
     static void willFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
     static void didFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
     static void didInvalidateLayout(LocalFrame&);
@@ -953,11 +955,23 @@ inline void InspectorInstrumentation::willEvaluateScript(LocalFrame& frame, cons
         willEvaluateScriptImpl(*agents, url, lineNumber, columnNumber);
 }
 
+inline void InspectorInstrumentation::willEvaluateScript(WorkerOrWorkletGlobalScope& globalScope, const String& url, int lineNumber, int columnNumber)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    willEvaluateScriptImpl(instrumentingAgents(globalScope), url, lineNumber, columnNumber);
+}
+
 inline void InspectorInstrumentation::didEvaluateScript(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
         didEvaluateScriptImpl(*agents);
+}
+
+inline void InspectorInstrumentation::didEvaluateScript(WorkerOrWorkletGlobalScope& globalScope)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    didEvaluateScriptImpl(instrumentingAgents(globalScope));
 }
 
 inline void InspectorInstrumentation::willFireTimer(ScriptExecutionContext& context, int timerId, bool oneShot)

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -62,8 +62,10 @@ class PageDOMDebuggerAgent;
 class PageDebuggerAgent;
 class PageHeapAgent;
 class PageRuntimeAgent;
+class PageTimelineAgent;
 class WebConsoleAgent;
 class WebDebuggerAgent;
+class WebHeapAgent;
 
 #define DEFINE_INSPECTOR_AGENT(macro, Class, Name, Getter, Setter) macro(Class, Name, Getter, Setter)
 
@@ -78,6 +80,7 @@ class WebDebuggerAgent;
 #define DEFINE_INSPECTOR_AGENT_DOMStorage(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorDOMStorageAgent, DOMStorageAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Debugger_Web(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, WebDebuggerAgent, WebDebuggerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Debugger_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageDebuggerAgent, PageDebuggerAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_Heap_Web(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, WebHeapAgent, WebHeapAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Heap_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageHeapAgent, PageHeapAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Inspector(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, Inspector::InspectorAgent, InspectorAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_LayerTree(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorLayerTreeAgent, LayerTreeAgent, Getter, Setter)
@@ -86,6 +89,7 @@ class WebDebuggerAgent;
 #define DEFINE_INSPECTOR_AGENT_Runtime_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageRuntimeAgent, PageRuntimeAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_ScriptProfiler(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, Inspector::InspectorScriptProfilerAgent, ScriptProfilerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Timeline(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorTimelineAgent, TimelineAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_Timeline_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageTimelineAgent, PageTimelineAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Worker(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorWorkerAgent, WorkerAgent, Getter, Setter)
 
 #if ENABLE(RESOURCE_USAGE)
@@ -110,6 +114,7 @@ class WebDebuggerAgent;
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Animation) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, CPUProfiler) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, DOM) \
+    DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Heap_Web) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Inspector) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, Memory) \
     DEFINE_PERSISTENT_INSPECTOR_AGENT(macro, ScriptProfiler) \
@@ -131,8 +136,10 @@ class WebDebuggerAgent;
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Runtime_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Timeline) \
+    DEFINE_ENABLED_INSPECTOR_AGENT(macro, Timeline_Page) \
     DEFINE_TRACKING_INSPECTOR_AGENT(macro, Animation) \
     DEFINE_TRACKING_INSPECTOR_AGENT(macro, Timeline) \
+    DEFINE_TRACKING_INSPECTOR_AGENT(macro, Timeline_Page) \
 
 class InstrumentingAgents : public RefCounted<InstrumentingAgents> {
     WTF_MAKE_NONCOPYABLE(InstrumentingAgents);

--- a/Source/WebCore/inspector/WorkerInspectorController.cpp
+++ b/Source/WebCore/inspector/WorkerInspectorController.cpp
@@ -47,6 +47,7 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerRuntimeAgent.h"
 #include "WorkerThread.h"
+#include "WorkerTimelineAgent.h"
 #include "WorkerToPageFrontendChannel.h"
 #include "WorkerWorkerAgent.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
@@ -215,6 +216,7 @@ void WorkerInspectorController::createLazyAgents()
     m_agents.append(makeUnique<WorkerDOMDebuggerAgent>(workerContext, debuggerAgentPtr));
     m_agents.append(makeUnique<WorkerAuditAgent>(workerContext));
     m_agents.append(makeUnique<WorkerCanvasAgent>(workerContext));
+    m_agents.append(makeUnique<WorkerTimelineAgent>(workerContext));
     m_agents.append(makeUnique<WorkerWorkerAgent>(workerContext));
 
     auto scriptProfilerAgentPtr = makeUnique<InspectorScriptProfilerAgent>(workerContext);

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -48,7 +48,6 @@ namespace WebCore {
 class Event;
 class FloatQuad;
 class RenderObject;
-class RunLoopObserver;
 
 enum class TimelineRecordType {
     EventDispatch,
@@ -83,11 +82,11 @@ enum class TimelineRecordType {
     Screenshot,
 };
 
-class InspectorTimelineAgent final : public InspectorAgentBase , public Inspector::TimelineBackendDispatcherHandler , public JSC::Debugger::Observer {
+class InspectorTimelineAgent : public InspectorAgentBase, public Inspector::TimelineBackendDispatcherHandler, public JSC::Debugger::Observer {
     WTF_MAKE_NONCOPYABLE(InspectorTimelineAgent);
     WTF_MAKE_TZONE_ALLOCATED(InspectorTimelineAgent);
 public:
-    InspectorTimelineAgent(PageAgentContext&);
+    InspectorTimelineAgent(WebAgentContext&);
     ~InspectorTimelineAgent();
 
     // InspectorAgentBase
@@ -99,7 +98,6 @@ public:
     Inspector::Protocol::ErrorStringOr<void> disable();
     Inspector::Protocol::ErrorStringOr<void> start(std::optional<int>&& maxCallStackDepth);
     Inspector::Protocol::ErrorStringOr<void> stop();
-    Inspector::Protocol::ErrorStringOr<void> setAutoCaptureEnabled(bool);
     Inspector::Protocol::ErrorStringOr<void> setInstruments(Ref<JSON::Array>&&);
 
     // JSC::Debugger::Observer
@@ -114,52 +112,41 @@ public:
     void didCallFunction();
     void willDispatchEvent(const Event&);
     void didDispatchEvent(bool defaultPrevented);
-    void willEvaluateScript(const String&, int lineNumber, int columnNumber);
+    void willEvaluateScript(const String& url, int lineNumber, int columnNumber);
     void didEvaluateScript();
-    void didInvalidateLayout();
-    void willLayout();
-    void didLayout(RenderObject&);
-    void willComposite();
-    void didComposite();
-    void willPaint();
-    void didPaint(RenderObject&, const LayoutRect&);
-    void willRecalculateStyle();
-    void didRecalculateStyle();
-    void didScheduleStyleRecalculation();
-    void didTimeStamp(const String&);
-    void didPerformanceMark(const String&, std::optional<MonotonicTime>);
+    void didTimeStamp(const String& message);
+    void didPerformanceMark(const String& label, std::optional<MonotonicTime>);
     void didRequestAnimationFrame(int callbackId);
     void didCancelAnimationFrame(int callbackId);
     void willFireAnimationFrame(int callbackId);
     void didFireAnimationFrame();
     void willFireObserverCallback(const String& callbackType);
     void didFireObserverCallback();
-    void time(const String&);
-    void timeEnd(const String&);
-    void mainFrameStartedLoading();
-    void mainFrameNavigated();
-    void didCompleteRenderingFrame();
+    void time(const String& label);
+    void timeEnd(const String& label);
 
     // Console
     void startFromConsole(const String& title);
     void stopFromConsole(const String& title);
 
-private:
-    void startProgrammaticCapture();
-    void stopProgrammaticCapture();
+protected:
+    virtual bool enabled() const;
+    virtual void internalEnable();
+    virtual void internalDisable();
+
+    virtual bool tracking() const;
+    virtual void internalStart(std::optional<int>&& maxCallStackDepth);
+    virtual void internalStop();
+
+    virtual bool shouldStartHeapInstrument() const { return true; }
+    void autoCaptureStarted() const;
+
+    const Vector<Inspector::Protocol::Timeline::Instrument>& instruments() const { return m_instruments; }
 
     enum class InstrumentState { Start, Stop };
     void toggleInstruments(InstrumentState);
-    void toggleScriptProfilerInstrument(InstrumentState);
-    void toggleHeapInstrument(InstrumentState);
-    void toggleCPUInstrument(InstrumentState);
-    void toggleMemoryInstrument(InstrumentState);
-    void toggleTimelineInstrument(InstrumentState);
-    void toggleAnimationInstrument(InstrumentState);
-    void disableBreakpoints();
-    void enableBreakpoints();
 
-    void captureScreenshot();
+    double timestamp();
 
     struct TimelineRecordEntry {
         TimelineRecordEntry(Ref<JSON::Object>&& record, Ref<JSON::Object>&& data, RefPtr<JSON::Array>&& children, TimelineRecordType type)
@@ -175,51 +162,48 @@ private:
         RefPtr<JSON::Array> children;
         TimelineRecordType type;
     };
+    TimelineRecordEntry* lastRecordEntry();
 
-    void internalStart(std::optional<int>&& maxCallStackDepth);
-    void internalStop();
-    double timestamp();
+    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
+    void pushCurrentRecord(Ref<JSON::Object>&&, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
+    void didCompleteCurrentRecord(TimelineRecordType);
+
+private:
+    void startProgrammaticCapture();
+    void stopProgrammaticCapture();
+
+    void toggleScriptProfilerInstrument(InstrumentState);
+    void toggleHeapInstrument(InstrumentState);
+    void toggleCPUInstrument(InstrumentState);
+    void toggleMemoryInstrument(InstrumentState);
+    void toggleTimelineInstrument(InstrumentState);
+    void toggleAnimationInstrument(InstrumentState);
+    void disableBreakpoints();
+    void enableBreakpoints();
+
     std::optional<double> timestampFromMonotonicTime(MonotonicTime);
 
     void sendEvent(Ref<JSON::Object>&&);
-    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
-    void pushCurrentRecord(Ref<JSON::Object>&&, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
     void pushCurrentRecord(const TimelineRecordEntry& record) { m_recordStack.append(record); }
 
     TimelineRecordEntry createRecordEntry(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, std::optional<double> startTime = std::nullopt);
 
     void didCompleteRecordEntry(const TimelineRecordEntry&);
-    void didCompleteCurrentRecord(TimelineRecordType);
 
     void addRecordToTimeline(Ref<JSON::Object>&&, TimelineRecordType);
 
     std::unique_ptr<Inspector::TimelineFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::TimelineBackendDispatcher> m_backendDispatcher;
-    WeakRef<Page> m_inspectedPage;
 
     Vector<TimelineRecordEntry> m_recordStack;
     Vector<TimelineRecordEntry> m_pendingConsoleProfileRecords;
 
     int m_maxCallStackDepth { 5 };
 
-    bool m_tracking { false };
     bool m_trackingFromFrontend { false };
     bool m_programmaticCaptureRestoreBreakpointActiveValue { false };
 
-    bool m_autoCaptureEnabled { false };
-    enum class AutoCapturePhase { None, BeforeLoad, FirstNavigation, AfterFirstNavigation };
-    AutoCapturePhase m_autoCapturePhase { AutoCapturePhase::None };
     Vector<Inspector::Protocol::Timeline::Instrument> m_instruments;
-
-#if PLATFORM(COCOA)
-    std::unique_ptr<WebCore::RunLoopObserver> m_frameStartObserver;
-    std::unique_ptr<WebCore::RunLoopObserver> m_frameStopObserver;
-    int m_runLoopNestingLevel { 0 };
-#elif USE(GLIB_EVENT_LOOP)
-    std::unique_ptr<RunLoop::Observer> m_runLoopObserver;
-#endif
-    bool m_startedComposite { false };
-    bool m_isCapturingScreenshot { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/WebHeapAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.cpp
@@ -111,6 +111,22 @@ WebHeapAgent::WebHeapAgent(WebAgentContext& context)
 
 WebHeapAgent::~WebHeapAgent() = default;
 
+void WebHeapAgent::didCreateFrontendAndBackend(FrontendRouter* frontendRouter, BackendDispatcher* backendDispatcher)
+{
+    InspectorHeapAgent::didCreateFrontendAndBackend(frontendRouter, backendDispatcher);
+
+    ASSERT(m_instrumentingAgents.persistentWebHeapAgent() != this);
+    m_instrumentingAgents.setPersistentWebHeapAgent(this);
+}
+
+void WebHeapAgent::willDestroyFrontendAndBackend(DisconnectReason reason)
+{
+    InspectorHeapAgent::willDestroyFrontendAndBackend(reason);
+
+    ASSERT(m_instrumentingAgents.persistentWebHeapAgent() == this);
+    m_instrumentingAgents.setPersistentWebHeapAgent(nullptr);
+}
+
 Inspector::Protocol::ErrorStringOr<void> WebHeapAgent::enable()
 {
     auto result = InspectorHeapAgent::enable();

--- a/Source/WebCore/inspector/agents/WebHeapAgent.h
+++ b/Source/WebCore/inspector/agents/WebHeapAgent.h
@@ -43,6 +43,10 @@ public:
     WebHeapAgent(WebAgentContext&);
     ~WebHeapAgent() override;
 
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*) override;
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
+
     // HeapBackendDispatcherHandler
     Inspector::Protocol::ErrorStringOr<void> enable() override;
     Inspector::Protocol::ErrorStringOr<void> disable() override;

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -1,0 +1,340 @@
+/*
+ * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2014 University of Washington.
+ * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PageTimelineAgent.h"
+
+#include "FrameSnapshotting.h"
+#include "ImageBuffer.h"
+#include "InspectorClient.h"
+#include "InspectorController.h"
+#include "InstrumentingAgents.h"
+#include "Page.h"
+#include "RenderView.h"
+#include "TimelineRecordFactory.h"
+#include "WebDebuggerAgent.h"
+
+#if PLATFORM(IOS_FAMILY)
+#include "WebCoreThreadInternal.h"
+#include <wtf/RuntimeApplicationChecks.h>
+#endif
+
+#if PLATFORM(COCOA)
+#include "RunLoopObserver.h"
+#endif
+
+namespace WebCore {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PageTimelineAgent);
+
+#if PLATFORM(COCOA)
+static CFRunLoopRef currentRunLoop()
+{
+#if PLATFORM(IOS_FAMILY)
+    // A race condition during WebView deallocation can lead to a crash if the layer sync run loop
+    // observer is added to the main run loop <rdar://problem/9798550>. However, for responsiveness,
+    // we still allow this, see <rdar://problem/7403328>. Since the race condition and subsequent
+    // crash are especially troublesome for iBooks, we never allow the observer to be added to the
+    // main run loop in iBooks.
+    if (WTF::CocoaApplication::isIBooks())
+        return WebThreadRunLoop();
+#endif
+    return CFRunLoopGetCurrent();
+}
+#endif
+
+PageTimelineAgent::PageTimelineAgent(PageAgentContext& context)
+    : InspectorTimelineAgent(context)
+    , m_inspectedPage(context.inspectedPage)
+{
+}
+
+PageTimelineAgent::~PageTimelineAgent() = default;
+
+bool PageTimelineAgent::enabled() const
+{
+    return m_instrumentingAgents.enabledPageTimelineAgent() == this && InspectorTimelineAgent::enabled();
+}
+
+void PageTimelineAgent::internalEnable()
+{
+    m_instrumentingAgents.setEnabledPageTimelineAgent(this);
+
+    InspectorTimelineAgent::internalEnable();
+}
+
+void PageTimelineAgent::internalDisable()
+{
+    m_instrumentingAgents.setEnabledPageTimelineAgent(nullptr);
+
+    m_autoCaptureEnabled = false;
+
+    InspectorTimelineAgent::internalDisable();
+}
+
+bool PageTimelineAgent::tracking() const
+{
+    return m_instrumentingAgents.trackingPageTimelineAgent() == this && InspectorTimelineAgent::tracking();
+}
+
+void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
+{
+    m_instrumentingAgents.setTrackingPageTimelineAgent(this);
+
+    // FIXME: Abstract away platform-specific code once https://bugs.webkit.org/show_bug.cgi?id=142748 is fixed.
+
+#if PLATFORM(COCOA)
+    m_frameStartObserver = makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::InspectorFrameBegin, [this] {
+        if (!tracking() || m_environment.debugger()->isPaused())
+            return;
+        if (!m_runLoopNestingLevel) {
+            pushCurrentRecord(JSON::Object::create(), TimelineRecordType::RenderingFrame, false);
+            m_runLoopNestingLevel++;
+        }
+    });
+
+    m_frameStartObserver->schedule(currentRunLoop(), { RunLoopObserver::Activity::Entry, RunLoopObserver::Activity::AfterWaiting });
+
+    // Create a runloop record and increment the runloop nesting level, to capture the current turn of the main runloop
+    // (which is the outer runloop if recording started while paused in the debugger).
+    pushCurrentRecord(JSON::Object::create(), TimelineRecordType::RenderingFrame, false);
+
+    m_runLoopNestingLevel = 1;
+#elif USE(GLIB_EVENT_LOOP)
+    m_runLoopObserver = makeUnique<RunLoop::Observer>([this](RunLoop::Event event, const String& name) {
+        if (!tracking() || m_environment.debugger()->isPaused())
+            return;
+
+        switch (event) {
+        case RunLoop::Event::WillDispatch:
+            pushCurrentRecord(TimelineRecordFactory::createRenderingFrameData(name), TimelineRecordType::RenderingFrame, false);
+            break;
+        case RunLoop::Event::DidDispatch:
+            if (m_startedComposite)
+                didComposite();
+            didCompleteCurrentRecord(TimelineRecordType::RenderingFrame);
+            break;
+        }
+    });
+    RunLoop::current().observe(*m_runLoopObserver);
+#endif
+
+    InspectorTimelineAgent::internalStart(WTFMove(maxCallStackDepth));
+
+    if (auto* client = m_inspectedPage->inspectorController().inspectorClient())
+        client->timelineRecordingChanged(true);
+}
+
+void PageTimelineAgent::internalStop()
+{
+    m_instrumentingAgents.setTrackingPageTimelineAgent(nullptr);
+
+    m_autoCapturePhase = AutoCapturePhase::None;
+
+#if PLATFORM(COCOA)
+    m_frameStartObserver = nullptr;
+    m_runLoopNestingLevel = 0;
+#elif USE(GLIB_EVENT_LOOP)
+    m_runLoopObserver = nullptr;
+#endif
+    m_startedComposite = false;
+
+    InspectorTimelineAgent::internalStop();
+
+    if (auto* client = m_inspectedPage->inspectorController().inspectorClient())
+        client->timelineRecordingChanged(false);
+}
+
+Inspector::Protocol::ErrorStringOr<void> PageTimelineAgent::setAutoCaptureEnabled(bool enabled)
+{
+    m_autoCaptureEnabled = enabled;
+
+    return { };
+}
+
+void PageTimelineAgent::didInvalidateLayout()
+{
+    appendRecord(JSON::Object::create(), TimelineRecordType::InvalidateLayout, true);
+}
+
+void PageTimelineAgent::willLayout()
+{
+    pushCurrentRecord(JSON::Object::create(), TimelineRecordType::Layout, true);
+}
+
+void PageTimelineAgent::didLayout(RenderObject& root)
+{
+    auto* entry = lastRecordEntry();
+    if (!entry)
+        return;
+
+    ASSERT(entry->type == TimelineRecordType::Layout);
+
+    Vector<FloatQuad> quads;
+    root.absoluteQuads(quads);
+    ASSERT(quads.size() >= 1);
+    if (quads.size() >= 1)
+        TimelineRecordFactory::appendLayoutRoot(entry->data.get(), quads[0]);
+
+    didCompleteCurrentRecord(TimelineRecordType::Layout);
+}
+
+void PageTimelineAgent::didScheduleStyleRecalculation()
+{
+    appendRecord(JSON::Object::create(), TimelineRecordType::ScheduleStyleRecalculation, true);
+}
+
+void PageTimelineAgent::willRecalculateStyle()
+{
+    pushCurrentRecord(JSON::Object::create(), TimelineRecordType::RecalculateStyles, true);
+}
+
+void PageTimelineAgent::didRecalculateStyle()
+{
+    didCompleteCurrentRecord(TimelineRecordType::RecalculateStyles);
+}
+
+void PageTimelineAgent::willComposite()
+{
+    ASSERT(!m_startedComposite);
+    pushCurrentRecord(JSON::Object::create(), TimelineRecordType::Composite, true);
+    m_startedComposite = true;
+}
+
+void PageTimelineAgent::didComposite()
+{
+    if (m_startedComposite)
+        didCompleteCurrentRecord(TimelineRecordType::Composite);
+    m_startedComposite = false;
+
+    if (instruments().contains(Inspector::Protocol::Timeline::Instrument::Screenshot))
+        captureScreenshot();
+}
+
+void PageTimelineAgent::willPaint()
+{
+    if (m_isCapturingScreenshot)
+        return;
+
+    pushCurrentRecord(JSON::Object::create(), TimelineRecordType::Paint, true);
+}
+
+void PageTimelineAgent::didPaint(RenderObject& renderer, const LayoutRect& clipRect)
+{
+    if (m_isCapturingScreenshot)
+        return;
+
+    auto* entry = lastRecordEntry();
+    if (!entry)
+        return;
+
+    ASSERT(entry->type == TimelineRecordType::Paint);
+
+    auto clipQuadInRootView = renderer.view().frameView().contentsToRootView(renderer.localToAbsoluteQuad({ clipRect }));
+    entry->data = TimelineRecordFactory::createPaintData(clipQuadInRootView);
+
+    didCompleteCurrentRecord(TimelineRecordType::Paint);
+}
+
+void PageTimelineAgent::mainFrameStartedLoading()
+{
+    if (!m_autoCaptureEnabled)
+        return;
+
+    if (instruments().isEmpty())
+        return;
+
+    m_autoCapturePhase = AutoCapturePhase::BeforeLoad;
+
+    // Pre-emptively disable breakpoints. The frontend must re-enable them.
+    if (auto* webDebuggerAgent = m_instrumentingAgents.enabledWebDebuggerAgent())
+        webDebuggerAgent->setBreakpointsActive(false);
+
+    // Inform the frontend we started an auto capture. The frontend must stop capture.
+    autoCaptureStarted();
+
+    toggleInstruments(InstrumentState::Start);
+}
+
+void PageTimelineAgent::mainFrameNavigated()
+{
+    if (m_autoCapturePhase == AutoCapturePhase::BeforeLoad) {
+        m_autoCapturePhase = AutoCapturePhase::FirstNavigation;
+        toggleInstruments(InstrumentState::Start);
+        m_autoCapturePhase = AutoCapturePhase::AfterFirstNavigation;
+    }
+}
+
+void PageTimelineAgent::didCompleteRenderingFrame()
+{
+#if PLATFORM(COCOA)
+    if (!tracking() || m_environment.debugger()->isPaused())
+        return;
+
+    ASSERT(m_runLoopNestingLevel > 0);
+    m_runLoopNestingLevel--;
+    if (m_runLoopNestingLevel)
+        return;
+
+    if (m_startedComposite)
+        didComposite();
+
+    didCompleteCurrentRecord(TimelineRecordType::RenderingFrame);
+#endif
+}
+
+bool PageTimelineAgent::shouldStartHeapInstrument() const
+{
+    if (m_autoCapturePhase == AutoCapturePhase::BeforeLoad || m_autoCapturePhase == AutoCapturePhase::AfterFirstNavigation)
+        return false;
+    return InspectorTimelineAgent::shouldStartHeapInstrument();
+}
+
+void PageTimelineAgent::captureScreenshot()
+{
+    SetForScope isTakingScreenshot(m_isCapturingScreenshot, true);
+
+    auto snapshotStartTime = timestamp();
+
+    RefPtr localMainFrame = m_inspectedPage->localMainFrame();
+    if (!localMainFrame)
+        return;
+
+    RefPtr localMainFrameView = localMainFrame->view();
+    if (!localMainFrameView)
+        return;
+
+    if (auto snapshot = snapshotFrameRect(*localMainFrame, localMainFrameView->unobscuredContentRect(), { { }, ImageBufferPixelFormat::BGRA8, DestinationColorSpace::SRGB() })) {
+        auto snapshotRecord = TimelineRecordFactory::createScreenshotData(snapshot->toDataURL("image/png"_s));
+        pushCurrentRecord(WTFMove(snapshotRecord), TimelineRecordType::Screenshot, false, snapshotStartTime);
+        didCompleteCurrentRecord(TimelineRecordType::Screenshot);
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2014 University of Washington.
+ * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorTimelineAgent.h"
+
+namespace WebCore {
+
+class Page;
+class RunLoopObserver;
+
+class PageTimelineAgent final : public InspectorTimelineAgent {
+    WTF_MAKE_NONCOPYABLE(PageTimelineAgent);
+    WTF_MAKE_TZONE_ALLOCATED(PageTimelineAgent);
+public:
+    PageTimelineAgent(PageAgentContext&);
+    ~PageTimelineAgent();
+
+    // TimelineBackendDispatcherHandler
+    Inspector::Protocol::ErrorStringOr<void> setAutoCaptureEnabled(bool) override;
+
+    // InspectorInstrumentation
+    void didInvalidateLayout();
+    void willLayout();
+    void didLayout(RenderObject&);
+    void willComposite();
+    void didComposite();
+    void willPaint();
+    void didPaint(RenderObject&, const LayoutRect&);
+    void willRecalculateStyle();
+    void didRecalculateStyle();
+    void didScheduleStyleRecalculation();
+    void mainFrameStartedLoading();
+    void mainFrameNavigated();
+    void didCompleteRenderingFrame();
+
+private:
+    bool enabled() const override;
+    void internalEnable() override;
+    void internalDisable() override;
+
+    bool tracking() const override;
+    void internalStart(std::optional<int>&& maxCallStackDepth) override;
+    void internalStop() override;
+
+    bool shouldStartHeapInstrument() const override;
+
+    void captureScreenshot();
+
+    WeakRef<Page> m_inspectedPage;
+
+    bool m_autoCaptureEnabled { false };
+    enum class AutoCapturePhase { None, BeforeLoad, FirstNavigation, AfterFirstNavigation };
+    AutoCapturePhase m_autoCapturePhase { AutoCapturePhase::None };
+
+#if PLATFORM(COCOA)
+    std::unique_ptr<WebCore::RunLoopObserver> m_frameStartObserver;
+    std::unique_ptr<WebCore::RunLoopObserver> m_frameStopObserver;
+    int m_runLoopNestingLevel { 0 };
+#elif USE(GLIB_EVENT_LOOP)
+    std::unique_ptr<RunLoop::Observer> m_runLoopObserver;
+#endif
+    bool m_startedComposite { false };
+    bool m_isCapturingScreenshot { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerTimelineAgent.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2014 University of Washington.
+ * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WorkerTimelineAgent.h"
+
+#include "WorkerOrWorkletGlobalScope.h"
+
+namespace WebCore {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerTimelineAgent);
+
+WorkerTimelineAgent::WorkerTimelineAgent(WorkerAgentContext& context)
+    : InspectorTimelineAgent(context)
+{
+    ASSERT(context.globalScope->isContextThread());
+}
+
+WorkerTimelineAgent::~WorkerTimelineAgent() = default;
+
+Inspector::Protocol::ErrorStringOr<void> WorkerTimelineAgent::setAutoCaptureEnabled(bool)
+{
+    return makeUnexpected("Not supported"_s);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/worker/WorkerTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerTimelineAgent.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2014 University of Washington.
+ * Copyright (C) 2015-2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorTimelineAgent.h"
+
+namespace WebCore {
+
+class WorkerTimelineAgent final : public InspectorTimelineAgent {
+    WTF_MAKE_NONCOPYABLE(WorkerTimelineAgent);
+    WTF_MAKE_TZONE_ALLOCATED(WorkerTimelineAgent);
+public:
+    WorkerTimelineAgent(WorkerAgentContext&);
+    ~WorkerTimelineAgent();
+
+    // TimelineBackendDispatcherHandler
+    Inspector::Protocol::ErrorStringOr<void> setAutoCaptureEnabled(bool) override;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -104,7 +104,6 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
     if (markOptions && markOptions->startTime)
         timestamp = m_performance->monotonicTimeFromRelativeTime(*markOptions->startTime);
 
-    RefPtr document = dynamicDowncast<Document>(context);
     InspectorInstrumentation::performanceMark(context.get(), markName, timestamp);
 
     auto mark = PerformanceMark::create(globalObject, context, markName, WTFMove(markOptions));

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -103,7 +103,7 @@ public:
     void evaluate(const ScriptSourceCode&, String* returnedExceptionMessage = nullptr);
     void evaluate(const ScriptSourceCode&, NakedPtr<JSC::Exception>& returnedException, String* returnedExceptionMessage = nullptr);
 
-    JSC::JSValue evaluateModule(JSC::AbstractModuleRecord&, JSC::JSValue awaitedValue, JSC::JSValue resumeMode);
+    JSC::JSValue evaluateModule(const URL&, JSC::AbstractModuleRecord&, JSC::JSValue awaitedValue, JSC::JSValue resumeMode);
 
     void linkAndEvaluateModule(WorkerScriptFetcher&, const ScriptSourceCode&, String* returnedExceptionMessage = nullptr);
     bool loadModuleSynchronously(WorkerScriptFetcher&, const ScriptSourceCode&);

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -446,6 +446,7 @@ localizedStrings["Console prompt"] = "Console prompt";
 localizedStrings["Console:"] = "Console:";
 localizedStrings["Containing"] = "Containing";
 localizedStrings["Content Security Policy violation of directive: %s"] = "Content Security Policy violation of directive: %s";
+localizedStrings["Context"] = "Context";
 /* Property value for `font-variant-ligatures: contextual`. */
 localizedStrings["Contextual Alternates @ Font Details Sidebar Property Value"] = "Contextual Alternates";
 localizedStrings["Continuation Frame"] = "Continuation Frame";
@@ -1985,6 +1986,7 @@ localizedStrings["With Object Properties"] = "With Object Properties";
 localizedStrings["Worker"] = "Worker";
 localizedStrings["Worker Thread"] = "Worker Thread";
 localizedStrings["Worker Threads"] = "Worker Threads";
+localizedStrings["Worker \u201C%s\u201D"] = "Worker \u201C%s\u201D";
 localizedStrings["Worker \u201C%s\u201D Snapshot %s"] = "Worker \u201C%s\u201D Snapshot %s";
 localizedStrings["Worker: %s"] = "Worker: %s";
 /* Title for list of JavaScript web worker execution contexts */

--- a/Source/WebInspectorUI/UserInterface/Controllers/HeapManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/HeapManager.js
@@ -128,7 +128,7 @@ WI.HeapManager = class HeapManager extends WI.Object
             return;
 
         let collection = WI.GarbageCollection.fromPayload(payload);
-        this.dispatchEventToListeners(WI.HeapManager.Event.GarbageCollected, {collection});
+        this.dispatchEventToListeners(WI.HeapManager.Event.GarbageCollected, {target, collection});
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -216,6 +216,7 @@
     <link rel="stylesheet" href="Views/ScreenshotsTimelineView.css">
     <link rel="stylesheet" href="Views/ScriptContentView.css">
     <link rel="stylesheet" href="Views/ScriptDetailsTimelineView.css">
+    <link rel="stylesheet" href="Views/ScriptProfileTimelineView.css">
     <link rel="stylesheet" href="Views/ScriptTimelineOverviewGraph.css">
     <link rel="stylesheet" href="Views/ScrubberNavigationItem.css">
     <link rel="stylesheet" href="Views/SearchIcons.css">

--- a/Source/WebInspectorUI/UserInterface/Models/CallingContextTreeNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CallingContextTreeNode.js
@@ -218,25 +218,6 @@ WI.CallingContextTreeNode = class CallingContextTreeNode
 
         return cpuProfileNode;
     }
-
-    // Testing.
-
-    __test_buildLeafLinkedLists(parent, result)
-    {
-        let linkedListNode = {
-            name: this._name,
-            url: this._url,
-            parent: parent
-        };
-        if (this.hasChildren()) {
-            this.forEachChild((child) => {
-                child.__test_buildLeafLinkedLists(linkedListNode, result);
-            });
-        } else {
-            // We're a leaf.
-            result.push(linkedListNode);
-        }
-    }
 };
 
 WI.CallingContextTreeNode.__uid = 0;

--- a/Source/WebInspectorUI/UserInterface/Models/Instrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Instrument.js
@@ -66,8 +66,12 @@ WI.Instrument = class Instrument
         if (initiatedByBackend)
             return;
 
-        let target = WI.assumingMainTarget();
-        target.TimelineAgent.start();
+        for (let target of WI.targets) {
+            if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
+                continue;
+            if (target.hasDomain("Timeline"))
+                target.TimelineAgent.start();
+        }
     }
 
     static stopLegacyTimelineAgent(initiatedByBackend)
@@ -82,8 +86,12 @@ WI.Instrument = class Instrument
         if (initiatedByBackend)
             return;
 
-        let target = WI.assumingMainTarget();
-        target.TimelineAgent.stop();
+        for (let target of WI.targets) {
+            if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)
+                continue;
+            if (target.hasDomain("Timeline"))
+                target.TimelineAgent.stop();
+        }
     }
 
     // Protected

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js
@@ -49,8 +49,6 @@ WI.ScriptInstrument = class ScriptInstrument extends WI.Instrument
 
     stopInstrumentation(initiatedByBackend)
     {
-        let target = WI.assumingMainTarget();
-
         if (!initiatedByBackend) {
             for (let target of WI.targets) {
                 if (target.type === WI.TargetType.Worker && !WI.settings.experimentalEnableWorkerTimelineRecording.value)

--- a/Source/WebInspectorUI/UserInterface/Protocol/TimelineObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/TimelineObserver.js
@@ -29,7 +29,7 @@ WI.TimelineObserver = class TimelineObserver extends InspectorBackend.Dispatcher
 
     eventRecorded(record)
     {
-        WI.timelineManager.eventRecorded(record);
+        WI.timelineManager.eventRecorded(this._target, record);
     }
 
     recordingStarted(startTime)

--- a/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js
@@ -92,6 +92,8 @@ WI.CPUTimelineView = class CPUTimelineView extends WI.TimelineView
     closed()
     {
         this.representedObject.removeEventListener(WI.Timeline.Event.RecordAdded, this._cpuTimelineRecordAdded, this);
+
+        super.closed();
     }
 
     reset()

--- a/Source/WebInspectorUI/UserInterface/Views/ClusterContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ClusterContentView.js
@@ -35,6 +35,7 @@ WI.ClusterContentView = class ClusterContentView extends WI.ContentView
         this._contentViewContainer.addEventListener(WI.ContentViewContainer.Event.CurrentContentViewDidChange, this._currentContentViewDidChange, this);
         this.addSubview(this._contentViewContainer);
 
+        WI.ContentView.addEventListener(WI.ContentView.Event.NavigationItemsDidChange, this._contentViewNavigationItemsDidChange, this);
         WI.ContentView.addEventListener(WI.ContentView.Event.SelectionPathComponentsDidChange, this._contentViewSelectionPathComponentDidChange, this);
         WI.ContentView.addEventListener(WI.ContentView.Event.SupplementalRepresentedObjectsDidChange, this._contentViewSupplementalRepresentedObjectsDidChange, this);
         WI.ContentView.addEventListener(WI.ContentView.Event.NumberOfSearchResultsDidChange, this._contentViewNumberOfSearchResultsDidChange, this);
@@ -72,6 +73,7 @@ WI.ClusterContentView = class ClusterContentView extends WI.ContentView
 
         this._contentViewContainer.closeAllContentViews();
 
+        WI.ContentView.removeEventListener(WI.ContentView.Event.NavigationItemsDidChange, this._contentViewNavigationItemsDidChange, this);
         WI.ContentView.removeEventListener(WI.ContentView.Event.SelectionPathComponentsDidChange, this._contentViewSelectionPathComponentDidChange, this);
         WI.ContentView.removeEventListener(WI.ContentView.Event.SupplementalRepresentedObjectsDidChange, this._contentViewSupplementalRepresentedObjectsDidChange, this);
         WI.ContentView.removeEventListener(WI.ContentView.Event.NumberOfSearchResultsDidChange, this._contentViewNumberOfSearchResultsDidChange, this);
@@ -229,6 +231,13 @@ WI.ClusterContentView = class ClusterContentView extends WI.ContentView
 
         this.dispatchEventToListeners(WI.ContentView.Event.SelectionPathComponentsDidChange);
         this.dispatchEventToListeners(WI.ContentView.Event.NumberOfSearchResultsDidChange);
+        this.dispatchEventToListeners(WI.ContentView.Event.NavigationItemsDidChange);
+    }
+
+    _contentViewNavigationItemsDidChange(event)
+    {
+        if (event.target !== this._contentViewContainer.currentContentView)
+            return;
         this.dispatchEventToListeners(WI.ContentView.Event.NavigationItemsDidChange);
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
@@ -852,6 +852,9 @@ WI.DataGrid = class DataGrid extends WI.View
         this._fillerRowElement.insertBefore(fillerCellElement, referenceElement);
 
         this.setColumnVisible(columnIdentifier, !column.hidden);
+
+        for (let child of this.children)
+            child.refresh();
     }
 
     removeColumn(columnIdentifier)
@@ -972,7 +975,7 @@ WI.DataGrid = class DataGrid extends WI.View
         console.assert(column, "Missing column info for identifier: " + columnIdentifier);
         console.assert(typeof visible === "boolean", "New visible state should be explicit boolean", typeof visible);
 
-        if (!column || visible === !column.hidden)
+        if (!column || ("hidden" in column && visible === !column.hidden))
             return;
 
         column.element.style.width = visible ? column.width : 0;
@@ -1698,7 +1701,9 @@ WI.DataGrid = class DataGrid extends WI.View
         if (this._columnChooserEnabled) {
             let didAddSeparator = false;
 
-            for (let [identifier, columnInfo] of this.columns) {
+            for (let identifier of this.orderedColumns) {
+                let columnInfo = this.columns.get(identifier);
+
                 if (columnInfo.locked)
                     continue;
 

--- a/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
@@ -247,6 +247,8 @@ WI.HeapAllocationsTimelineView = class HeapAllocationsTimelineView extends WI.Ti
         WI.ContentView.removeEventListener(WI.ContentView.Event.SelectionPathComponentsDidChange, this._contentViewSelectionPathComponentDidChange, this);
         WI.HeapSnapshotProxy.removeEventListener(WI.HeapSnapshotProxy.Event.Invalidated, this._heapSnapshotInvalidated, this);
         WI.HeapSnapshotWorkerProxy.singleton().removeEventListener(WI.HeapSnapshotWorkerProxy.Event.Collection, this._heapSnapshotCollectionEvent, this);
+
+        super.closed();
     }
 
     layout()

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js
@@ -146,6 +146,8 @@ WI.LayoutTimelineView = class LayoutTimelineView extends WI.TimelineView
         this.representedObject.removeEventListener(WI.Timeline.Event.RecordAdded, this._layoutTimelineRecordAdded, this);
 
         this._dataGrid.closed();
+
+        super.closed();
     }
 
     reset()

--- a/Source/WebInspectorUI/UserInterface/Views/MemoryTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MemoryTimelineView.js
@@ -131,6 +131,8 @@ WI.MemoryTimelineView = class MemoryTimelineView extends WI.TimelineView
     closed()
     {
         this.representedObject.removeEventListener(WI.Timeline.Event.RecordAdded, this._memoryTimelineRecordAdded, this);
+
+        super.closed();
     }
 
     reset()

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTimelineView.js
@@ -158,6 +158,8 @@ WI.NetworkTimelineView = class NetworkTimelineView extends WI.TimelineView
         this.representedObject.removeEventListener(WI.Timeline.Event.RecordAdded, this._networkTimelineRecordAdded, this);
 
         this._dataGrid.closed();
+
+        super.closed();
     }
 
     reset()

--- a/Source/WebInspectorUI/UserInterface/Views/OverviewTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OverviewTimelineView.js
@@ -112,6 +112,8 @@ WI.OverviewTimelineView = class OverviewTimelineView extends WI.TimelineView
         this._recording.removeEventListener(WI.TimelineRecording.Event.SourceCodeTimelineAdded, this._sourceCodeTimelineAdded, this);
         this._recording.removeEventListener(WI.TimelineRecording.Event.MarkerAdded, this._markerAdded, this);
         this._recording.removeEventListener(WI.TimelineRecording.Event.Reset, this._recordingReset, this);
+
+        super.closed();
     }
 
     get navigationItems()

--- a/Source/WebInspectorUI/UserInterface/Views/ProfileDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ProfileDataGridNode.js
@@ -58,7 +58,7 @@ WI.ProfileDataGridNode = class ProfileDataGridNode extends WI.DataGridNode
 
     iconClassName()
     {
-        let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, WI.assumingMainTarget());
+        let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, this._tree.target);
         if (!script || !script.url)
             return "native-icon";
         if (this._node.name === "(program)")
@@ -128,7 +128,7 @@ WI.ProfileDataGridNode = class ProfileDataGridNode extends WI.DataGridNode
     {
         if (columnIdentifier === "function") {
             let filterableData = [this.displayName()];
-            let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, WI.assumingMainTarget());
+            let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, this._tree.target);
             if (script && script.url && this._node.line >= 0 && this._node.column >= 0)
                 filterableData.push(script.url);
             return filterableData;
@@ -230,7 +230,7 @@ WI.ProfileDataGridNode = class ProfileDataGridNode extends WI.DataGridNode
         let titleElement = fragment.appendChild(document.createElement("span"));
         titleElement.textContent = title;
 
-        let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, WI.assumingMainTarget());
+        let script = WI.debuggerManager.scriptForIdentifier(this._node.sourceID, this._tree.target);
         if (script && script.url && this._node.line >= 0 && this._node.column >= 0) {
             // Convert from 1-based line and column to 0-based.
             let sourceCodeLocation = script.createSourceCodeLocation(this._node.line - 1, this._node.column - 1);

--- a/Source/WebInspectorUI/UserInterface/Views/ProfileDataGridTree.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ProfileDataGridTree.js
@@ -59,6 +59,8 @@ WI.ProfileDataGridTree = class ProfileDataGridTree extends WI.Object
 
     // Public
 
+    get target() { return this._callingContextTree.target; }
+
     get callingContextTree() { return this._callingContextTree; }
 
     get focusNodes()

--- a/Source/WebInspectorUI/UserInterface/Views/RenderingFrameTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/RenderingFrameTimelineView.js
@@ -120,6 +120,8 @@ WI.RenderingFrameTimelineView = class RenderingFrameTimelineView extends WI.Time
         this.representedObject.removeEventListener(WI.Timeline.Event.RecordAdded, this._renderingFrameTimelineRecordAdded, this);
 
         this._dataGrid.closed();
+
+        super.closed();
     }
 
     get selectionPathComponents()

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptDetailsTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptDetailsTimelineView.js
@@ -39,6 +39,8 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
         columns.name.disclosure = true;
         columns.name.locked = true;
 
+        // The "Target" column is only added once there's more than one `WI.Target`.
+
         columns.location.title = WI.UIString("Location");
         columns.location.icon = true;
         columns.location.width = "15%";
@@ -80,6 +82,8 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
         timeline.addEventListener(WI.Timeline.Event.RecordAdded, this._scriptTimelineRecordAdded, this);
         timeline.addEventListener(WI.Timeline.Event.Refreshed, this._scriptTimelineRecordRefreshed, this);
 
+        this._targets = new Set;
+
         this._pendingRecords = [];
 
         for (let record of timeline.records)
@@ -96,6 +100,8 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
         this.representedObject.removeEventListener(WI.Timeline.Event.Refreshed, this._scriptTimelineRecordRefreshed, this);
 
         this._dataGrid.closed();
+
+        super.closed();
     }
 
     get selectionPathComponents()
@@ -184,7 +190,11 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
         if (!this._pendingRecords.length)
             return;
 
+        let previousTargetCount = this._targets.size;
+
         for (let scriptTimelineRecord of this._pendingRecords) {
+            this._targets.add(scriptTimelineRecord.target);
+
             let rootNodes = [];
             if (scriptTimelineRecord.profile) {
                 // FIXME: Support using the bottom-up tree once it is implemented.
@@ -205,6 +215,14 @@ WI.ScriptDetailsTimelineView = class ScriptDetailsTimelineView extends WI.Timeli
         }
 
         this._pendingRecords = [];
+
+        if (previousTargetCount <= 1 && this._targets.size > 1) {
+            this._dataGrid.insertColumn("target", {
+                title: WI.UIString("Context"),
+                width: "10%",
+                sortable: true,
+            }, 1);
+        }
     }
 
     _scriptTimelineRecordAdded(event)

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptProfileTimelineView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptProfileTimelineView.css
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.content-view.timeline-recording .navigation-bar > .script-profile-target > .selector-arrows {
+    width: 6px;
+    height: 16px;
+    padding-inline-start: 1px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    margin-inline: 3px 3px;
+    opacity: 0.6;
+}

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptTimelineDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptTimelineDataGridNode.js
@@ -54,6 +54,7 @@ WI.ScriptTimelineDataGridNode = class ScriptTimelineDataGridNode extends WI.Time
         this._cachedData = super.data;
         this._cachedData.type = this.record.eventType;
         this._cachedData.name = this.displayName();
+        this._cachedData.target = this.record.target.type === WI.TargetType.Worker ? WI.UIString("Worker \u201C%s\u201D").format(this.record.target.displayName) : WI.UIString("Page");
         this._cachedData.startTime = startTime - baseStartTime;
         this._cachedData.selfTime = duration;
         this._cachedData.totalTime = duration;

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -444,6 +444,8 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
             timelinesGroup.addSetting(WI.settings.experimentalEnableWorkerTimelineRecording, WI.UIString("Enable recording in Workers", "Label for checkbox that controls whether timeline recordings can capture activity in Worker contexts."));
         }
 
+        experimentalSettingsView.addSeparator();
+
         let diagnosticsGroup = experimentalSettingsView.addGroup(WI.UIString("Diagnostics:", "Diagnostics: @ Experimental Settings", "Category label for experimental settings related to Web Inspector diagnostics."));
         diagnosticsGroup.addSetting(WI.settings.experimentalAllowInspectingInspector, WI.UIString("Allow Inspecting Web Inspector", "Allow Inspecting Web Inspector @ Experimental Settings", "Label for setting that allows the user to inspect the Web Inspector user interface."));
         experimentalSettingsView.addSeparator();


### PR DESCRIPTION
#### 783a08ad6950cdf316d3f4ab3807797f09f84dc0
<pre>
Web Inspector: Worker Info not Visible In Most Timeline Profile Views like JavaScript &amp; Events
<a href="https://bugs.webkit.org/show_bug.cgi?id=263334">https://bugs.webkit.org/show_bug.cgi?id=263334</a>
<a href="https://rdar.apple.com/117491838">rdar://117491838</a>

Reviewed by BJ Burg.

This will allow developers to investigate performance issues in `Worker` using the Timelines Tab just like they can already do for other page content (i.e. main thread).

* Source/JavaScriptCore/inspector/protocol/Timeline.json:
* Source/WebCore/inspector/WorkerInspectorController.cpp:
(WebCore::WorkerInspectorController::createLazyAgents):
Expose `Timeline` in `Worker`.

* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:
(WebCore::InspectorTimelineAgent::shouldStartHeapInstrument const):
(WebCore::InspectorTimelineAgent::instruments const):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::InspectorTimelineAgent):
(WebCore::InspectorTimelineAgent::enable):
(WebCore::InspectorTimelineAgent::disable):
(WebCore::InspectorTimelineAgent::start):
(WebCore::InspectorTimelineAgent::stop):
(WebCore::InspectorTimelineAgent::enabled const):
(WebCore::InspectorTimelineAgent::internalEnable):
(WebCore::InspectorTimelineAgent::internalDisable):
(WebCore::InspectorTimelineAgent::tracking const):
(WebCore::InspectorTimelineAgent::internalStart):
(WebCore::InspectorTimelineAgent::internalStop):
(WebCore::InspectorTimelineAgent::autoCaptureStarted const):
(WebCore::InspectorTimelineAgent::startFromConsole):
(WebCore::InspectorTimelineAgent::startProgrammaticCapture):
(WebCore::InspectorTimelineAgent::stopProgrammaticCapture):
(WebCore::InspectorTimelineAgent::toggleHeapInstrument):
(WebCore::InspectorTimelineAgent::toggleTimelineInstrument):
(WebCore::InspectorTimelineAgent::lastRecordEntry):
(WebCore::currentRunLoop): Deleted.
(WebCore::InspectorTimelineAgent::setAutoCaptureEnabled): Deleted.
(WebCore::InspectorTimelineAgent::didInvalidateLayout): Deleted.
(WebCore::InspectorTimelineAgent::willLayout): Deleted.
(WebCore::InspectorTimelineAgent::didLayout): Deleted.
(WebCore::InspectorTimelineAgent::didScheduleStyleRecalculation): Deleted.
(WebCore::InspectorTimelineAgent::willRecalculateStyle): Deleted.
(WebCore::InspectorTimelineAgent::didRecalculateStyle): Deleted.
(WebCore::InspectorTimelineAgent::willComposite): Deleted.
(WebCore::InspectorTimelineAgent::didComposite): Deleted.
(WebCore::InspectorTimelineAgent::willPaint): Deleted.
(WebCore::InspectorTimelineAgent::didPaint): Deleted.
(WebCore::InspectorTimelineAgent::mainFrameStartedLoading): Deleted.
(WebCore::InspectorTimelineAgent::mainFrameNavigated): Deleted.
(WebCore::InspectorTimelineAgent::captureScreenshot): Deleted.
(WebCore::InspectorTimelineAgent::didCompleteRenderingFrame): Deleted.
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h: Added.
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp: Added.
(WebCore::currentRunLoop):
(WebCore::PageTimelineAgent::PageTimelineAgent):
(WebCore::PageTimelineAgent::enabled const):
(WebCore::PageTimelineAgent::internalEnable):
(WebCore::PageTimelineAgent::internalDisable):
(WebCore::PageTimelineAgent::tracking const):
(WebCore::PageTimelineAgent::internalStart):
(WebCore::PageTimelineAgent::internalStop):
(WebCore::PageTimelineAgent::setAutoCaptureEnabled):
(WebCore::PageTimelineAgent::didInvalidateLayout):
(WebCore::PageTimelineAgent::willLayout):
(WebCore::PageTimelineAgent::didLayout):
(WebCore::PageTimelineAgent::didScheduleStyleRecalculation):
(WebCore::PageTimelineAgent::willRecalculateStyle):
(WebCore::PageTimelineAgent::didRecalculateStyle):
(WebCore::PageTimelineAgent::willComposite):
(WebCore::PageTimelineAgent::didComposite):
(WebCore::PageTimelineAgent::willPaint):
(WebCore::PageTimelineAgent::didPaint):
(WebCore::PageTimelineAgent::mainFrameStartedLoading):
(WebCore::PageTimelineAgent::mainFrameNavigated):
(WebCore::PageTimelineAgent::didCompleteRenderingFrame):
(WebCore::PageTimelineAgent::shouldStartHeapInstrument const):
(WebCore::PageTimelineAgent::captureScreenshot):
* Source/WebCore/inspector/agents/worker/WorkerTimelineAgent.h: Added.
* Source/WebCore/inspector/agents/worker/WorkerTimelineAgent.cpp: Added.
(WebCore::WorkerTimelineAgent::WorkerTimelineAgent):
(WebCore::WorkerTimelineAgent::setAutoCaptureEnabled):
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::createLazyAgents):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didInvalidateLayoutImpl):
(WebCore::InspectorInstrumentation::willLayoutImpl):
(WebCore::InspectorInstrumentation::didLayoutImpl):
(WebCore::InspectorInstrumentation::willCompositeImpl):
(WebCore::InspectorInstrumentation::didCompositeImpl):
(WebCore::InspectorInstrumentation::willPaintImpl):
(WebCore::InspectorInstrumentation::didPaintImpl):
(WebCore::InspectorInstrumentation::willRecalculateStyleImpl):
(WebCore::InspectorInstrumentation::didRecalculateStyleImpl):
(WebCore::InspectorInstrumentation::didScheduleStyleRecalculationImpl):
(WebCore::InspectorInstrumentation::didCommitLoadImpl):
(WebCore::InspectorInstrumentation::frameStartedLoadingImpl):
(WebCore::InspectorInstrumentation::didCompleteRenderingFrameImpl):
Split the existing `InspectorTimelineAgent` into a `PageTimelineAgent` and `WorkerTimelineAgent`.
This is mainly done for clarity as certain concepts (e.g. compositing, navigation, screenshots, etc.) don&apos;t make sense in a `Worker`.

* Source/WebCore/workers/WorkerOrWorkletScriptController.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::evaluate):
(WebCore::WorkerOrWorkletScriptController::evaluateModule):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::evaluate):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::willEvaluateScript):
(WebCore::InspectorInstrumentation::didEvaluateScript):
Add `InspectorInstrumentation` hooks before and after evaluating JS in `Worker`.

* Source/JavaScriptCore/inspector/agents/InspectorHeapAgent.h:
* Source/WebCore/inspector/agents/WebHeapAgent.h:
* Source/WebCore/inspector/agents/WebHeapAgent.cpp:
(WebCore::WebHeapAgent::didCreateFrontendAndBackend):
(WebCore::WebHeapAgent::willDestroyFrontendAndBackend):
Also expose `WebHeapAgent` via `InstrumentingAgents` instead of only just `PageHeapAgent`.
This is needed by `InspectorTimelineAgent` to start capturing heap snapshots during a timeline recording.

* Source/WebInspectorUI/UserInterface/Models/Instrument.js:
(WI.Instrument.startLegacyTimelineAgent):
(WI.Instrument.stopLegacyTimelineAgent):
Iterate over all `WI.Target` when starting a timeline recording now that `Timeline` also exists in `Worker`.

* Source/WebInspectorUI/UserInterface/Protocol/TimelineObserver.js:
(WI.TimelineObserver.prototype.eventRecorded):
* Source/WebInspectorUI/UserInterface/Controllers/HeapManager.js:
(WI.HeapManager.prototype.garbageCollected):
Pass along the `WI.Target`.

* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager):
(WI.TimelineManager.prototype.initializeTarget):
(WI.TimelineManager.prototype.capturingStarted):
(WI.TimelineManager.prototype.eventRecorded):
(WI.TimelineManager.prototype.scriptProfilerTrackingUpdated):
(WI.TimelineManager.prototype.scriptProfilerTrackingCompleted):
(WI.TimelineManager.prototype._processRecord):
(WI.TimelineManager.prototype._processEvent):
(WI.TimelineManager.prototype._stackTraceFromPayload):
(WI.TimelineManager.prototype._garbageCollected):
Have a separate array of `WI.ScriptTimelineRecord` for each `WI.Target`.

* Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js:
(WI.TimelineRecording):
(WI.TimelineRecording.async import):
(WI.TimelineRecording.prototype.get targets): Added.
(WI.TimelineRecording.prototype.callingContextTree): Added.
(WI.TimelineRecording.prototype.reset):
(WI.TimelineRecording.prototype.updateCallingContextTrees): Renamed from `initializeCallingContextTrees`.
(WI.TimelineRecording.prototype.get topDownCallingContextTree): Deleted.
(WI.TimelineRecording.prototype.get bottomUpCallingContextTree): Deleted.
(WI.TimelineRecording.prototype.get topFunctionsTopDownCallingContextTree): Deleted.
(WI.TimelineRecording.prototype.get topFunctionsBottomUpCallingContextTree): Deleted.
Have separate `WI.CallingContextTree` for each `WI.Target` (and for each `WI.CallingContextTree.Type`).
Callers must `updateCallingContextTrees` with a valid `WI.Target` before attempting to fetch a `WI.CallingContextTree` for that `WI.Target` (and `WI.CallingContextTree.Type`).

* Source/WebInspectorUI/UserInterface/Models/ScriptTimelineRecord.js:
(WI.ScriptTimelineRecord.async fromJSON):
(WI.ScriptTimelineRecord.prototype.toJSON):
(WI.ScriptTimelineRecord.prototype.get target): Added.
(WI.ScriptTimelineRecord.prototype._initializeProfileFromPayload.profileNodeFromPayload):
* Source/WebInspectorUI/UserInterface/Models/CallingContextTree.js:
(WI.CallingContextTree):
(WI.CallingContextTree.prototype.get target): Added.
(WI.CallingContextTree.prototype.reset): Deleted.
(WI.CallingContextTree.__test_makeTreeFromProtocolMessageObject): Deleted.
(WI.CallingContextTree.prototype.__test_matchesStackTrace): Deleted.
(WI.CallingContextTree.prototype.__test_buildLeafLinkedLists): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ProfileDataGridTree.js:
(WI.ProfileDataGridTree.prototype.get target): Added.
* Source/WebInspectorUI/UserInterface/Views/ProfileDataGridNode.js:
(WI.ProfileDataGridNode.prototype.iconClassName):
(WI.ProfileDataGridNode.prototype.filterableDataForColumn):
(WI.ProfileDataGridNode.prototype._displayContent):
Save and use the relevant `WI.Target`.

* Source/WebInspectorUI/UserInterface/Views/ScriptDetailsTimelineView.js:
(WI.ScriptDetailsTimelineView):
(WI.ScriptDetailsTimelineView.prototype.closed):
(WI.ScriptDetailsTimelineView.prototype._processPendingRecords):
* Source/WebInspectorUI/UserInterface/Views/ScriptTimelineDataGridNode.js:
(WI.ScriptTimelineDataGridNode.prototype.get data):
Show the name of the `WI.Target` (a.k.a. &quot;Context&quot;) when there&apos;s more than one.

* Source/WebInspectorUI/UserInterface/Views/ScriptProfileTimelineView.js:
(WI.ScriptProfileTimelineView):
(WI.ScriptProfileTimelineView.prototype.closed):
(WI.ScriptProfileTimelineView.prototype.get navigationItems):
(WI.ScriptProfileTimelineView.prototype._callingContextTreeForOrientation):
(WI.ScriptProfileTimelineView.prototype._updateTargetNavigationItemDisplay):
(WI.ScriptProfileTimelineView.prototype._displayNameForTarget):
(WI.ScriptProfileTimelineView.prototype._profileOrientationButtonClicked):
(WI.ScriptProfileTimelineView.prototype._topFunctionsButtonClicked):
(WI.ScriptProfileTimelineView.prototype._createProfileView):
(WI.ScriptProfileTimelineView.prototype._showProfileView):
(WI.ScriptProfileTimelineView.prototype._handleRecordingTargetAdded):
(WI.ScriptProfileTimelineView.prototype._populateTargetNavigationItemContextMenu):
(WI.ScriptProfileTimelineView.prototype._showProfileViewForOrientation): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ScriptProfileTimelineView.css: Added.
(.content-view.timeline-recording .navigation-bar &gt; .script-profile-target &gt; .selector-arrows):
Create a dropdown for all `WI.Target` when there&apos;s more than one to control which `WI.CallingContextTree` is shown.
We probably don&apos;t want to merge stack trace data from different `WI.Target` as it could be misleading if a function (or at least it&apos;s name and source code location) is used in multiple `WI.Target`.

* Source/WebInspectorUI/UserInterface/Views/ClusterContentView.js:
(WI.ClusterContentView):
(WI.ClusterContentView.prototype.closed):
(WI.ClusterContentView.prototype._contentViewNavigationItemsDidChange):
This appears to be the first time that a `WI.ContentView` inside a `WI.ClusterContentView` ever dynamically changes the result of `get navigationItems`, so dispatch a `WI.ContentView.Event.NavigationItemsDidChange` to the parent `WI.ContentBrowser` so that it&apos;s updated accordingly.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.js:
(WI.DataGrid.prototype.insertColumn): All cells need to be refreshed when a new column is inserted.
(WI.DataGrid.prototype.setColumnVisible): When a new column is first inserted it doesn&apos;t have a previous `hidden` state, so always make sure to set one.
(WI.DataGrid.prototype._contextMenuInHeader): Columns should be listed by ordinal instead of insertion order.

* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::mark):
* Source/WebInspectorUI/UserInterface/Models/ScriptInstrument.js:
(WI.ScriptInstrument.prototype.stopInstrumentation):
Drive-by: remove unused variable.

* Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js:
(WI.CPUTimelineView.prototype.closed):
* Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js:
(WI.HeapAllocationsTimelineView.prototype.closed):
* Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js:
(WI.LayoutTimelineView.prototype.closed):
* Source/WebInspectorUI/UserInterface/Views/MemoryTimelineView.js:
(WI.MemoryTimelineView.prototype.closed):
* Source/WebInspectorUI/UserInterface/Views/NetworkTimelineView.js:
(WI.NetworkTimelineView.prototype.closed):
* Source/WebInspectorUI/UserInterface/Views/OverviewTimelineView.js:
(WI.OverviewTimelineView.prototype.closed):
* Source/WebInspectorUI/UserInterface/Views/RenderingFrameTimelineView.js:
(WI.RenderingFrameTimelineView.prototype.closed):
Drive-by: add missing `super` call.

* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createExperimentalSettingsView):
Drive-by: add missing separator.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* Source/WebInspectorUI/UserInterface/Models/CallingContextTreeNode.js:
(WI.CallingContextTreeNode.prototype.__test_buildLeafLinkedLists): Deleted.
* LayoutTests/inspector/sampling-profiler/basic.html:
* LayoutTests/inspector/sampling-profiler/call-frame-with-dom-functions.html:
* LayoutTests/inspector/sampling-profiler/eval-source-url.html:
* LayoutTests/inspector/sampling-profiler/expression-location-info.html:
* LayoutTests/inspector/sampling-profiler/expression-location-info-expected.txt:
* LayoutTests/inspector/sampling-profiler/many-call-frames.html:
* LayoutTests/inspector/sampling-profiler/named-function-expression.html:
* LayoutTests/inspector/sampling-profiler/resources/calling-context-tree.js: Added.
Move test functions to test files so they&apos;re not shipped in production builds.

Canonical link: <a href="https://commits.webkit.org/290430@main">https://commits.webkit.org/290430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bac739300fb881cc502bec577561e20e1faa3ce9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40783 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17825 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26896 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93011 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7322 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39917 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82813 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96836 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88788 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77497 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21946 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10392 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17208 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111279 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16949 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26640 "Found 9 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->