### PR TITLE
[WebGPU] GPUBindGroupEntry::equal does not check binding for equality

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287392-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287392-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287392.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287392.html
@@ -1,0 +1,191 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+// START
+a = await navigator.gpu.requestAdapter()
+b = await a.requestDevice()
+c = b.createBindGroupLayout({entries : []})
+d = b.createTexture({
+  size : {width : 10, depthOrArrayLayers : 9},
+  format : 'rgba16uint',
+  usage : GPUTextureUsage.STORAGE_BINDING
+})
+e = b.createBindGroupLayout({
+  entries : [
+    {
+      binding : 32,
+      visibility : GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'rg32uint', viewDimension : '3d'}
+    },
+    {binding : 111, visibility : GPUShaderStage.FRAGMENT, externalTexture : {}},
+    {
+      binding : 216,
+      visibility : GPUShaderStage.FRAGMENT,
+      storageTexture : {
+        format : 'rgba16uint',
+        access : 'read-only',
+        viewDimension : '2d-array'
+      }
+    }
+  ]
+})
+f = b.createTexture({
+  size : [],
+  dimension : '3d',
+  format : 'rg32uint',
+  usage : GPUTextureUsage.STORAGE_BINDING
+})
+k = d.createView()
+g = b.createBindGroupLayout({
+  entries : [
+    {
+      binding : 32,
+      visibility : GPUShaderStage.FRAGMENT,
+      storageTexture : {format : 'rg32uint', viewDimension : '3d'}
+    },
+    {binding : 111, visibility : GPUShaderStage.FRAGMENT, externalTexture : {}},
+    {
+      binding : 216,
+      visibility : GPUShaderStage.FRAGMENT,
+      storageTexture : {
+        format : 'rgba16uint',
+        access : 'read-only',
+        viewDimension : '2d-array'
+      }
+    }
+  ]
+})
+m = b.createPipelineLayout({bindGroupLayouts : [ e ]})
+h = f.createView()
+i = b.createTexture({
+  size : [ 6, 5, 65 ],
+  dimension : '3d',
+  format : 'r32sint',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT
+})
+j = i.createView()
+p = b.createShaderModule({
+  code : ` 
+                     override l: f32;
+                     struct n {
+                    @builtin(position) o: vec4f}
+                     @vertex fn t() -> n {
+                    var aa: n;
+                    return aa;
+                    _ = l;
+                  }
+                    `
+})
+q = new VideoFrame(
+    new ArrayBuffer(16),
+    {codedWidth : 2, codedHeight : 2, format : 'BGRA', timestamp : 0})
+r = b.createShaderModule({
+  code : ` 
+                     @group(0) @binding(32) var ab: texture_storage_3d<rg32uint, write>;
+                     struct s {
+                    @location(0) o: i32}
+                     @fragment fn a() -> s {
+                    var aa: s;
+                    textureStore(ab, vec3i(), vec4u());
+                    return aa;
+                  }
+                    `
+})
+u = b.importExternalTexture({source : q})
+b.createBindGroup({
+  layout : g,
+  entries : [
+    {binding : 32, resource : h}, {binding : 216, resource : k},
+    {binding : 111, resource : u}
+  ]
+})
+v = b.createBindGroup({
+  layout : c,
+  entries : [
+    {binding : 2, resource : h}, {binding : 6, resource : k},
+    {binding : 1, resource : u}
+  ]
+})
+w = await b.createRenderPipelineAsync({
+  layout : m,
+  fragment : {module : r, targets : [ {format : 'r32sint'} ]},
+  vertex : {module : p, constants : {l : 1}},
+  primitive : {topology : 'point-list'}
+})
+ad = b.createCommandEncoder()
+ae = ad.beginRenderPass({
+  colorAttachments :
+      [ {view : j, depthSlice : 8, loadOp : 'load', storeOp : 'store'} ]
+})
+try {
+  ae.setPipeline(w)
+  ae.setBindGroup(0, v)
+  ae.draw(6)
+  ae.end()
+} catch {
+}
+ag = ad.finish()
+try {
+  b.queue.submit([ ag ])
+} catch {
+}
+// END
+await b.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
@@ -117,6 +117,9 @@ struct GPUBindGroupEntry {
     }
     static bool equal(const GPUBindGroupEntry& entry, const GPUBindGroupEntry& otherEntry)
     {
+        if (entry.binding != otherEntry.binding)
+            return false;
+
         return WTF::switchOn(entry.resource, [&](const RefPtr<GPUSampler>& sampler) -> bool {
             return sampler.get() && equal(*sampler, otherEntry.resource);
         }, [&](const RefPtr<GPUTextureView>& textureView) -> bool {


### PR DESCRIPTION
#### 49d7170cec44bb427db511acea67b55c92e62221
<pre>
[WebGPU] GPUBindGroupEntry::equal does not check binding for equality
<a href="https://bugs.webkit.org/show_bug.cgi?id=287392">https://bugs.webkit.org/show_bug.cgi?id=287392</a>
<a href="https://rdar.apple.com/144315413">rdar://144315413</a>

Reviewed by Tadeu Zagallo.

For two GPUBindGroupEntry instances to be equal, their binding and resource
must be equal. Previously, the check for binding equality was missing.

* LayoutTests/fast/webgpu/nocrash/fuzz-287392-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-287392.html: Added.
Add regression test.

* Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h:
(WebCore::GPUBindGroupEntry::equal):

Canonical link: <a href="https://commits.webkit.org/290171@main">https://commits.webkit.org/290171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18790d864a01a365024ef940ea3ea77d19c911ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68662 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26334 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35246 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95928 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16295 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76831 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18955 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9387 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21620 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16050 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->