### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/animation-timeline-ignored.tentative.html` is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
@@ -3,5 +3,5 @@ PASS Changing animation-timeline changes the timeline (sanity check)
 PASS animation-timeline ignored after setting timeline with JS (ScrollTimeline from JS)
 PASS animation-timeline ignored after setting timeline with JS (ScrollTimeline from CSS)
 PASS animation-timeline ignored after setting timeline with JS (document timeline)
-FAIL animation-timeline ignored after setting timeline with JS (null) assert_false: expected false got true
+PASS animation-timeline ignored after setting timeline with JS (null)
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -133,10 +133,14 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
 
     // Synchronize the play state
     if (!m_overriddenProperties.contains(Property::PlayState)) {
-        if (animation.playState() == AnimationPlayState::Playing && playState() == WebAnimation::PlayState::Paused)
-            play();
-        else if (animation.playState() == AnimationPlayState::Paused && playState() == WebAnimation::PlayState::Running)
-            pause();
+        auto styleOriginatedPlayState = animation.playState();
+        if (m_lastStyleOriginatedPlayState != styleOriginatedPlayState) {
+            if (styleOriginatedPlayState == AnimationPlayState::Playing && playState() == WebAnimation::PlayState::Paused)
+                play();
+            else if (styleOriginatedPlayState == AnimationPlayState::Paused && playState() == WebAnimation::PlayState::Running)
+                pause();
+        }
+        m_lastStyleOriginatedPlayState = styleOriginatedPlayState;
     }
 
     unsuspendEffectInvalidation();

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -86,6 +86,7 @@ private:
 
     String m_animationName;
     OptionSet<Property> m_overriddenProperties;
+    std::optional<AnimationPlayState> m_lastStyleOriginatedPlayState;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 38829fba9da0e5a1389d8873d91aa9926e776202
<pre>
[scroll-animations] WPT test `scroll-animations/css/animation-timeline-ignored.tentative.html` is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=287393">https://bugs.webkit.org/show_bug.cgi?id=287393</a>

Reviewed by Tim Nguyen.

The single remaining failure in this test first sets a running animation&apos;s timeline to `null`,
runs some assertions, and then sets the `animation-timeline` property to another value. The
purpose of this test is to check that setting the `animation-timeline` property will have no
effect since the related Web Animations API was used, and uses the `pending` property to determine
that instead of looking at the `timeline` property itself.

While this isn&apos;t the most direct approach, it is perfectly valid and we would fail it because
the first call to set the null timeline would reset the playing state of the animation, and while
we didn&apos;t reset a timeline when the `animation-timeline` property was set afterwards, we would
trigger a call to `CSSAnimation::syncPropertiesWithBackingAnimation()`, correctly, which would
make sure that all non-overridden animation CSS properties were updated.

In the case of the `animation-play-state` property, we would only look at the playing state of the
animation to determine whether it matched the value held by the CSS property. In this case, the
`animation-play-state` property was set to its default `playing` value and our animation was not
in the running state due to not having a timeline. As such, we would yield a new call to `play()`
to reset this discrepancy.

To address this, we now keep track of the last `animation-play-state` value that was used to toggle
the playback state so that we only react to that value changing via style resolution.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/CSSAnimation.h:

Canonical link: <a href="https://commits.webkit.org/290148@main">https://commits.webkit.org/290148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7851d375e3155f18bfa699e92c3fc74f4bdd8cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39882 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68667 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26341 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6916 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6665 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95934 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77545 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76836 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21240 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9394 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13965 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21626 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16056 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->