### PR TITLE
Remove non-standard encodings (e.g., 'x-mac-turkish', 'x-mac-greek' etc.)

### DIFF
--- a/LayoutTests/fast/encoding/char-decoding-mac-expected.txt
+++ b/LayoutTests/fast/encoding/char-decoding-mac-expected.txt
@@ -6,13 +6,13 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS decode('mac', '%C3') is 'U+221A'
 PASS decode('macintosh', '%C3') is 'U+221A'
 PASS decode('MacRoman', '%C3') is 'U+221A'
-PASS decode('x-mac-greek', '%B0') is 'U+0391'
+PASS decode('x-mac-greek', '%B0') is 'U+FFFD'
 PASS decode('x-mac-ukrainian', '%80') is 'U+0410'
 PASS decode('x-mac-cyrillic', '%80') is 'U+0410'
 PASS decode('mac-cyrillic', '%80') is 'U+0410'
-PASS decode('x-mac-centraleurroman', '%81') is 'U+0100'
-PASS decode('x-mac-ce', '%81') is 'U+0100'
-PASS decode('x-mac-turkish', '%81') is 'U+00C5'
+PASS decode('x-mac-centraleurroman', '%81') is 'U+FFFD'
+PASS decode('x-mac-ce', '%81') is 'U+FFFD'
+PASS decode('x-mac-turkish', '%81') is 'U+FFFD'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/encoding/char-decoding-mac.html
+++ b/LayoutTests/fast/encoding/char-decoding-mac.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="resources/char-decoding-utils.js"></script>
 </head>
 <body>
@@ -12,15 +12,14 @@ description("This tests decoding characters in various character sets.");
 testDecode('mac', '%C3', 'U+221A');
 testDecode('macintosh', '%C3', 'U+221A');
 testDecode('MacRoman', '%C3', 'U+221A');
-testDecode('x-mac-greek', '%B0', 'U+0391');
+testDecode('x-mac-greek', '%B0', 'U+FFFD');
 testDecode('x-mac-ukrainian', '%80', 'U+0410');
 testDecode('x-mac-cyrillic', '%80', 'U+0410');
 testDecode('mac-cyrillic', '%80', 'U+0410');
-testDecode('x-mac-centraleurroman', '%81', 'U+0100');
-testDecode('x-mac-ce', '%81', 'U+0100');
-testDecode('x-mac-turkish', '%81', 'U+00C5');
+testDecode('x-mac-centraleurroman', '%81', 'U+FFFD');
+testDecode('x-mac-ce', '%81', 'U+FFFD');
+testDecode('x-mac-turkish', '%81', 'U+FFFD');
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/encoding/char-encoding-mac-expected.txt
+++ b/LayoutTests/fast/encoding/char-encoding-mac-expected.txt
@@ -3,14 +3,17 @@ This tests encoding characters in various character sets.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
 PASS encode('mac', 'U+221A') is '%C3'
 PASS encode('macintosh', 'U+221A') is '%C3'
 PASS encode('MacRoman', 'U+221A') is '%C3'
-PASS encode('x-mac-greek', 'U+0391') is '%B0'
+PASS encode('x-mac-greek', 'U+0391') is '%26%23913%3B'
 PASS encode('x-mac-cyrillic', 'U+0410') is '%80'
 PASS encode('mac-cyrillic', 'U+0410') is '%80'
-PASS encode('x-mac-centraleurroman', 'U+0100') is '%81'
-PASS encode('x-mac-turkish', 'U+00C5') is '%81'
+PASS encode('x-mac-centraleurroman', 'U+0100') is '%26%23256%3B'
+PASS encode('x-mac-turkish', 'U+00C5') is '%C5'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/encoding/char-encoding-mac.html
+++ b/LayoutTests/fast/encoding/char-encoding-mac.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="resources/char-encoding-utils.js"></script>
 </head>
 <body>
@@ -21,11 +21,11 @@ var i = 0;
 testEncode('mac', 'U+221A', '%C3');
 testEncode('macintosh', 'U+221A', '%C3');
 testEncode('MacRoman', 'U+221A', '%C3');
-testEncode('x-mac-greek', 'U+0391', '%B0');
+testEncode('x-mac-greek', 'U+0391', '%26%23913%3B');
 testEncode('x-mac-cyrillic', 'U+0410', '%80');
 testEncode('mac-cyrillic', 'U+0410', '%80');
-testEncode('x-mac-centraleurroman', 'U+0100', '%81');
-testEncode('x-mac-turkish', 'U+00C5', '%81');
+testEncode('x-mac-centraleurroman', 'U+0100', '%26%23256%3B');
+testEncode('x-mac-turkish', 'U+00C5', '%C5');
 
 if (window.testRunner)
     testRunner.waitUntilDone();

--- a/LayoutTests/fast/encoding/legacy-ios-encodings-expected.txt
+++ b/LayoutTests/fast/encoding/legacy-ios-encodings-expected.txt
@@ -10,21 +10,21 @@ PASS new TextDecoder("macos-35-10.2").encoding threw exception RangeError: Bad v
 PASS new TextDecoder("macos-29-10.2").encoding threw exception RangeError: Bad value.
 PASS new TextDecoder("macos-7_3-10.2").encoding threw exception RangeError: Bad value.
 PASS new TextDecoder("softbank-sjis").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("x-mac-greek").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("x-mac-turkish").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("x-mac-centraleurroman").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("windows-10006").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("macgr").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("x-macgreek").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("windows-10081").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("mactr").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("x-macturkish").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("windows-10029").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("x-mac-ce").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("macce").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("maccentraleurope").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("x-maccentraleurope").encoding threw exception RangeError: Bad value.
 The following encoding names are supported by WebKit cross-platform, but some may be removed at a later time.
-PASS new TextDecoder("x-mac-greek").encoding is "x-mac-greek"
-PASS new TextDecoder("windows-10006").encoding is "x-mac-greek"
-PASS new TextDecoder("macgr").encoding is "x-mac-greek"
-PASS new TextDecoder("x-macgreek").encoding is "x-mac-greek"
-PASS new TextDecoder("x-mac-turkish").encoding is "x-mac-turkish"
-PASS new TextDecoder("windows-10081").encoding is "x-mac-turkish"
-PASS new TextDecoder("mactr").encoding is "x-mac-turkish"
-PASS new TextDecoder("x-macturkish").encoding is "x-mac-turkish"
-PASS new TextDecoder("x-mac-centraleurroman").encoding is "x-mac-centraleurroman"
-PASS new TextDecoder("windows-10029").encoding is "x-mac-centraleurroman"
-PASS new TextDecoder("x-mac-ce").encoding is "x-mac-centraleurroman"
-PASS new TextDecoder("macce").encoding is "x-mac-centraleurroman"
-PASS new TextDecoder("maccentraleurope").encoding is "x-mac-centraleurroman"
-PASS new TextDecoder("x-maccentraleurope").encoding is "x-mac-centraleurroman"
 PASS new TextDecoder("x-mac-cyrillic").encoding is "x-mac-cyrillic"
 PASS new TextDecoder("windows-10007").encoding is "x-mac-cyrillic"
 PASS new TextDecoder("mac-cyrillic").encoding is "x-mac-cyrillic"

--- a/LayoutTests/fast/encoding/legacy-ios-encodings.html
+++ b/LayoutTests/fast/encoding/legacy-ios-encodings.html
@@ -9,20 +9,17 @@
 description("This test verifies that certain legacy iOS text encodings are not supported.");
 
 debug("The following encodings should not be supported");
-let iosLegacyEncodings = ['macos-6-10.2','macos-6_2-10.4', 'macos-35-10.2', 'macos-29-10.2', 'macos-7_3-10.2', 'softbank-sjis'];
+let iosLegacyEncodings = ['macos-6-10.2','macos-6_2-10.4', 'macos-35-10.2', 'macos-29-10.2', 'macos-7_3-10.2', 'softbank-sjis', 'x-mac-greek',
+    'x-mac-turkish', 'x-mac-centraleurroman', 'windows-10006', 'macgr', 'x-macgreek', 'windows-10081', 'mactr', 'x-macturkish',
+    'windows-10029', 'x-mac-ce', 'macce', 'maccentraleurope', 'x-maccentraleurope'];
 
 for (let encoding of iosLegacyEncodings) {
     let canonical_name_expr = 'new TextDecoder("' + encoding + '").encoding';
     shouldThrow(canonical_name_expr);
 }
 
-
-
 debug("The following encoding names are supported by WebKit cross-platform, but some may be removed at a later time.");
 let validForNow = [
-    {encoding: 'x-mac-greek', aliases: ['x-mac-greek', 'windows-10006', 'macgr', 'x-macgreek']},
-    {encoding: 'x-mac-turkish', aliases: ['x-mac-turkish', 'windows-10081', 'mactr', 'x-macturkish']},
-    {encoding: 'x-mac-centraleurroman', aliases: ['x-mac-centraleurroman', 'windows-10029', 'x-mac-ce', 'macce', 'maccentraleurope', 'x-maccentraleurope']},
     {encoding: 'x-mac-cyrillic', aliases: ['x-mac-cyrillic', 'windows-10007', 'mac-cyrillic', 'maccy', 'x-maccyrillic', 'x-macukraine']}
 ];
 

--- a/LayoutTests/fast/encoding/legacy-tec-encodings-expected.txt
+++ b/LayoutTests/fast/encoding/legacy-tec-encodings-expected.txt
@@ -56,8 +56,8 @@ PASS new TextDecoder("x-mac-devanagari").encoding threw exception RangeError: Ba
 PASS new TextDecoder("x-mac-gujarati").encoding threw exception RangeError: Bad value.
 PASS new TextDecoder("x-mac-gurmukhi").encoding threw exception RangeError: Bad value.
 PASS new TextDecoder("x-mac-tibetan").encoding threw exception RangeError: Bad value.
-The following encoding names are supported by WebKit cross-platform, but some may be removed at a later time.
-PASS new TextDecoder("EUC-TW").encoding is "euc-tw"
+PASS new TextDecoder("euc-tw").encoding threw exception RangeError: Bad value.
+PASS new TextDecoder("EUC-TW").encoding threw exception RangeError: Bad value.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/encoding/legacy-tec-encodings.html
+++ b/LayoutTests/fast/encoding/legacy-tec-encodings.html
@@ -13,27 +13,13 @@ let tecLegacyEncodings = ['cp950', 'cp737', 'ibm737',
 'ISO-2022-JP-3', 'JIS_C6226-1978', 'Shift_JIS_X0213-2000', 'ibm-942_P12A-1999', 'ibm-1399_P110-2003',
 'JIS_X0212-1990', 'x-mac-arabic', 'x-mac-croatian', 'x-mac-hebrew', 'x-mac-icelandic', 'x-mac-romanian', 'x-mac-thai', 'johab', 'x-mac-dingbats', 'x-mac-symbol', 'JIS_X0208-1990', 'JIS_X0208-1983', 'csiso159jisx02121990', 'isoir159', 'x0212', 'jis_x0208-1983', 'csiso87jisx0208', 'isoir87',
 'ibm-953_P100-2000', 'macos-518-10.2', 'macos-36_2-10.2', 'macos-1285-10.2', 'macos-37_5-10.2', 'macos-38_2-10.2', 'macos-21-10.5', 'windows-1361-2000', 'macos-34-10.2', 'macos-33-10.5', 'ibm-952_P110-1997', 'ibm-955_P110-1997',
-'x-mac-chinesesimp', 'xmacsimpchinese', 'x-mac-chinesetrad', 'xmactradchinese', 'x-mac-japanese', 'x-mac-korean', 'x-mac-vt100', 'x-nextstep', 'x-mac-farsi', 'x-mac-roman-latin1', 'x-mac-devanagari', 'x-mac-gujarati', 'x-mac-gurmukhi', 'x-mac-tibetan',
+'x-mac-chinesesimp', 'xmacsimpchinese', 'x-mac-chinesetrad', 'xmactradchinese', 'x-mac-japanese', 'x-mac-korean', 'x-mac-vt100', 'x-nextstep', 'x-mac-farsi', 'x-mac-roman-latin1', 'x-mac-devanagari', 'x-mac-gujarati', 'x-mac-gurmukhi', 'x-mac-tibetan', 'euc-tw', 'EUC-TW'
 ]; 
 
 for (let encoding of tecLegacyEncodings) {
     let canonical_name_expr = 'new TextDecoder("' + encoding + '").encoding';
     shouldThrow(canonical_name_expr);
 }
-
-debug("The following encoding names are supported by WebKit cross-platform, but some may be removed at a later time.");
-let validForNow = [
-    {encoding: 'euc-tw', aliases: ['EUC-TW']},
-];
-
-for (let encoding of validForNow) {
-    for (let alias of encoding.aliases) {
-         let canonical_name_expr = 'new TextDecoder("' + alias + '").encoding';
-         shouldBe(canonical_name_expr, '"' + encoding.encoding + '"');
-    }
-}
-
-
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/unsupported-labels.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/unsupported-labels.window-expected.txt
@@ -21,7 +21,7 @@ PASS csviscii is not supported by the Encoding Standard
 PASS dos-720 is not supported by the Encoding Standard
 PASS dos-862 is not supported by the Encoding Standard
 PASS ecma-cyrillic is not supported by the Encoding Standard
-FAIL euc-tw is not supported by the Encoding Standard assert_equals: expected "UTF-8" but got "EUC-TW"
+PASS euc-tw is not supported by the Encoding Standard
 PASS german is not supported by the Encoding Standard
 PASS geostd8 is not supported by the Encoding Standard
 PASS hp-roman8 is not supported by the Encoding Standard
@@ -96,7 +96,7 @@ PASS tis-620-2533 is not supported by the Encoding Standard
 PASS utf-7 is not supported by the Encoding Standard
 PASS utf-32 is not supported by the Encoding Standard
 PASS viscii is not supported by the Encoding Standard
-FAIL windows-936-2000 is not supported by the Encoding Standard assert_equals: expected "UTF-8" but got "GBK"
+PASS windows-936-2000 is not supported by the Encoding Standard
 PASS windows-sami-2 is not supported by the Encoding Standard
 PASS ws2 is not supported by the Encoding Standard
 PASS x-chinese-cns is not supported by the Encoding Standard
@@ -130,15 +130,15 @@ PASS x-iscii-t is not supported by the Encoding Standard
 PASS x-iscii-ta is not supported by the Encoding Standard
 PASS x-iscii-te is not supported by the Encoding Standard
 PASS x-mac-arabic is not supported by the Encoding Standard
-FAIL x-mac-ce is not supported by the Encoding Standard assert_equals: expected "UTF-8" but got "x-mac-centraleurroman"
-FAIL x-mac-centraleurroman is not supported by the Encoding Standard assert_equals: expected "UTF-8" but got "x-mac-centraleurroman"
+PASS x-mac-ce is not supported by the Encoding Standard
+PASS x-mac-centraleurroman is not supported by the Encoding Standard
 PASS x-mac-chinesesimp is not supported by the Encoding Standard
 PASS x-mac-chinesetrad is not supported by the Encoding Standard
 PASS x-mac-croatian is not supported by the Encoding Standard
 PASS x-mac-devanagari is not supported by the Encoding Standard
 PASS x-mac-dingbats is not supported by the Encoding Standard
 PASS x-mac-farsi is not supported by the Encoding Standard
-FAIL x-mac-greek is not supported by the Encoding Standard assert_equals: expected "UTF-8" but got "x-mac-greek"
+PASS x-mac-greek is not supported by the Encoding Standard
 PASS x-mac-gujarati is not supported by the Encoding Standard
 PASS x-mac-gurmukhi is not supported by the Encoding Standard
 PASS x-mac-hebrew is not supported by the Encoding Standard
@@ -150,7 +150,7 @@ PASS x-mac-romanian is not supported by the Encoding Standard
 PASS x-mac-symbol is not supported by the Encoding Standard
 PASS x-mac-thai is not supported by the Encoding Standard
 PASS x-mac-tibetan is not supported by the Encoding Standard
-FAIL x-mac-turkish is not supported by the Encoding Standard assert_equals: expected "UTF-8" but got "x-mac-turkish"
+PASS x-mac-turkish is not supported by the Encoding Standard
 PASS x-mac-vt100 is not supported by the Encoding Standard
 PASS x-nextstep is not supported by the Encoding Standard
 PASS x-vps is not supported by the Encoding Standard

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encoding/unsupported-labels-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/encoding/unsupported-labels-expected.txt
@@ -21,7 +21,7 @@ PASS csviscii is not supported by the Encoding Standard
 PASS dos-720 is not supported by the Encoding Standard
 PASS dos-862 is not supported by the Encoding Standard
 PASS ecma-cyrillic is not supported by the Encoding Standard
-FAIL euc-tw is not supported by the Encoding Standard assert_equals: expected "windows-1252" but got "EUC-TW"
+PASS euc-tw is not supported by the Encoding Standard
 PASS german is not supported by the Encoding Standard
 PASS geostd8 is not supported by the Encoding Standard
 PASS hp-roman8 is not supported by the Encoding Standard
@@ -96,7 +96,7 @@ PASS tis-620-2533 is not supported by the Encoding Standard
 PASS utf-7 is not supported by the Encoding Standard
 PASS utf-32 is not supported by the Encoding Standard
 PASS viscii is not supported by the Encoding Standard
-FAIL windows-936-2000 is not supported by the Encoding Standard assert_equals: expected "windows-1252" but got "GBK"
+PASS windows-936-2000 is not supported by the Encoding Standard
 PASS windows-sami-2 is not supported by the Encoding Standard
 PASS ws2 is not supported by the Encoding Standard
 PASS x-chinese-cns is not supported by the Encoding Standard
@@ -130,15 +130,15 @@ PASS x-iscii-t is not supported by the Encoding Standard
 PASS x-iscii-ta is not supported by the Encoding Standard
 PASS x-iscii-te is not supported by the Encoding Standard
 PASS x-mac-arabic is not supported by the Encoding Standard
-FAIL x-mac-ce is not supported by the Encoding Standard assert_equals: expected "windows-1252" but got "x-mac-centraleurroman"
-FAIL x-mac-centraleurroman is not supported by the Encoding Standard assert_equals: expected "windows-1252" but got "x-mac-centraleurroman"
+PASS x-mac-ce is not supported by the Encoding Standard
+PASS x-mac-centraleurroman is not supported by the Encoding Standard
 PASS x-mac-chinesesimp is not supported by the Encoding Standard
 PASS x-mac-chinesetrad is not supported by the Encoding Standard
 PASS x-mac-croatian is not supported by the Encoding Standard
 PASS x-mac-devanagari is not supported by the Encoding Standard
 PASS x-mac-dingbats is not supported by the Encoding Standard
 PASS x-mac-farsi is not supported by the Encoding Standard
-FAIL x-mac-greek is not supported by the Encoding Standard assert_equals: expected "windows-1252" but got "x-mac-greek"
+PASS x-mac-greek is not supported by the Encoding Standard
 PASS x-mac-gujarati is not supported by the Encoding Standard
 PASS x-mac-gurmukhi is not supported by the Encoding Standard
 PASS x-mac-hebrew is not supported by the Encoding Standard
@@ -150,7 +150,7 @@ PASS x-mac-romanian is not supported by the Encoding Standard
 PASS x-mac-symbol is not supported by the Encoding Standard
 PASS x-mac-thai is not supported by the Encoding Standard
 PASS x-mac-tibetan is not supported by the Encoding Standard
-FAIL x-mac-turkish is not supported by the Encoding Standard assert_equals: expected "windows-1252" but got "x-mac-turkish"
+PASS x-mac-turkish is not supported by the Encoding Standard
 PASS x-mac-vt100 is not supported by the Encoding Standard
 PASS x-nextstep is not supported by the Encoding Standard
 PASS x-vps is not supported by the Encoding Standard

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,8 +128,7 @@ void TextCodecCJK::registerEncodingNames(EncodingNameRegistrar registrar)
         "cp936"_s,
         "ms936"_s,
         "gb2312-1980"_s,
-        "windows-936"_s,
-        "windows-936-2000"_s
+        "windows-936"_s
     });
 
     registerAliases({

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov <ap@nypop.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -66,10 +66,6 @@ DECLARE_ALIASES(windows_1254, "winturkish"_s, "cp1254"_s, "csisolatin5"_s, "iso-
 DECLARE_ALIASES(windows_1256, "winarabic"_s, "cp1256"_s, "x-cp1256"_s);
 DECLARE_ALIASES(windows_1258, "winvietnamese"_s, "cp1258"_s, "x-cp1258"_s);
 DECLARE_ALIASES(x_mac_cyrillic, "maccyrillic"_s, "x-mac-ukrainian"_s, "windows-10007"_s, "mac-cyrillic"_s, "maccy"_s, "x-MacCyrillic"_s, "x-MacUkraine"_s);
-// Encodings below are not in the standard.
-DECLARE_ALIASES(x_mac_greek, "windows-10006"_s, "macgr"_s, "x-MacGreek"_s);
-DECLARE_ALIASES(x_mac_centraleurroman, "windows-10029"_s, "x-mac-ce"_s, "macce"_s, "maccentraleurope"_s, "x-MacCentralEurope"_s);
-DECLARE_ALIASES(x_mac_turkish, "windows-10081"_s, "mactr"_s, "x-MacTurkish"_s);
 
 #define DECLARE_ENCODING_NAME(encoding, alias_array) \
     { encoding, std::span { alias_array##_aliases } }
@@ -96,12 +92,7 @@ static const struct EncodingName {
     DECLARE_ENCODING_NAME("windows-1254"_s, windows_1254),
     DECLARE_ENCODING_NAME("windows-1256"_s, windows_1256),
     DECLARE_ENCODING_NAME("windows-1258"_s, windows_1258),
-    DECLARE_ENCODING_NAME("x-mac-cyrillic"_s, x_mac_cyrillic),
-    // Encodings below are not in the standard.
-    DECLARE_ENCODING_NAME("x-mac-greek"_s, x_mac_greek),
-    DECLARE_ENCODING_NAME("x-mac-centraleurroman"_s, x_mac_centraleurroman),
-    DECLARE_ENCODING_NAME("x-mac-turkish"_s, x_mac_turkish),
-    DECLARE_ENCODING_NAME_NO_ALIASES("EUC-TW"_s),
+    DECLARE_ENCODING_NAME("x-mac-cyrillic"_s, x_mac_cyrillic)
 };
 
 void TextCodecICU::registerEncodingNames(EncodingNameRegistrar registrar)


### PR DESCRIPTION
#### 24abef6de5646a7df69ba3a8c06462f4d9e26e78
<pre>
Remove non-standard encodings (e.g., &apos;x-mac-turkish&apos;, &apos;x-mac-greek&apos; etc.)
<a href="https://bugs.webkit.org/show_bug.cgi?id=265261">https://bugs.webkit.org/show_bug.cgi?id=265261</a>
<a href="https://rdar.apple.com/118944539">rdar://118944539</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium by removing following
non-standard encodings:

- x-mac-ce
- x-mac-centraleurroman
- x-mac-turkish
- x-mac-greek
- euc-tw
- windows-936-2000

* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::TextCodecCJK::registerEncodingNames):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(DECLARE_ALIASES):
(EncodingName):
* LayoutTests/fast/encoding/char-decoding-mac-expected.txt:
* LayoutTests/fast/encoding/char-decoding-mac.html:
* LayoutTests/fast/encoding/char-encoding-mac-expected.txt:
* LayoutTests/fast/encoding/char-encoding-mac.html:
* LayoutTests/fast/encoding/legacy-ios-encodings-expected.txt:
* LayoutTests/fast/encoding/legacy-ios-encodings.html:
* LayoutTests/fast/encoding/legacy-tec-encodings-expected.txt:
* LayoutTests/fast/encoding/legacy-tec-encodings.html:
* LayoutTests/imported/w3c/web-platform-tests/encoding/unsupported-labels.window-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/encoding/unsupported-labels-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24abef6de5646a7df69ba3a8c06462f4d9e26e78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39903 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68689 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26359 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95956 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76859 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9428 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21647 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->