### PR TITLE
[GStreamer][WebRTC] Add stats rate limiting support

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
@@ -22,8 +22,11 @@
 #if ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)
 
 #include "GRefPtrGStreamer.h"
+#include "RTCStatsReport.h"
 
 #include <wtf/CompletionHandler.h>
+#include <wtf/HashMap.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/glib/GRefPtr.h>
@@ -42,8 +45,17 @@ public:
     using PreprocessCallback = Function<GUniquePtr<GstStructure>(const GRefPtr<GstPad>&, const GstStructure*)>;
     void getStats(CollectorCallback&&, const GRefPtr<GstPad>&, PreprocessCallback&&);
 
+    void invalidateCache();
+
 private:
     GRefPtr<GstElement> m_webrtcBin;
+
+    struct CachedReport {
+        MonotonicTime generationTime;
+        RefPtr<RTCStatsReport> report;
+    };
+    HashMap<GRefPtr<GstPad>, CachedReport> m_cachedReportsPerPad;
+    std::optional<CachedReport> m_cachedGlobalReport;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f478a060beab25af39e8e8c03a77d946cc939678
<pre>
[GStreamer][WebRTC] Add stats rate limiting support
<a href="https://bugs.webkit.org/show_bug.cgi?id=287408">https://bugs.webkit.org/show_bug.cgi?id=287408</a>

Reviewed by Xabier Rodriguez-Calvar.

Keep each stats report cached for at most 300 ms, otherwise some apps can call getStats() at any rate
and without caching this involves a significant amount of allocations.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::getStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::GStreamerStatsCollector::getStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h:

Canonical link: <a href="https://commits.webkit.org/290209@main">https://commits.webkit.org/290209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6150863b208d53ab9a34e94fee0f1af9d984d414

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/43981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94135 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68700 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26369 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6701 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35298 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html editing/undo/redo-reapply-edit-command-crash.html http/tests/eventsource/eventsource-page-cache-connected.html http/tests/eventsource/eventsource-page-cache-connecting.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/websocket/tests/hybi/client-close-2.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html imported/w3c/web-platform-tests/css/css-grid/animation/grid-template-columns-composition.html imported/w3c/web-platform-tests/css/css-grid/animation/grid-template-columns-interpolation.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95968 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77577 "Failure limit exceed. At least found 2 new test failures: svg/custom/stale-resource-data-crash.svg svg/dynamic-updates/SVGFEColorMatrixElement-dom-in-attr.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21273 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9444 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21659 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->