### PR TITLE
[HDR] Scan the layer backing for HDR contents

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -118,6 +118,10 @@ public:
     virtual bool willReadFrequently() const;
     virtual std::optional<RenderingMode> renderingModeForTesting() const { return std::nullopt; }
 
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    bool drawsHDRContent() const { return pixelFormat() == ImageBufferPixelFormat::RGBA16F; }
+#endif
+
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3023,7 +3023,16 @@ FloatPoint CanvasRenderingContext2DBase::textOffset(float width, TextDirection d
 ImageBufferPixelFormat CanvasRenderingContext2DBase::pixelFormat() const
 {
     // FIXME: Take m_settings.alpha into account here and add PixelFormat::BGRX8.
-    return ImageBufferPixelFormat::BGRA8;
+    switch (m_settings.pixelFormat) {
+    case CanvasRenderingContext2DSettings::PixelFormat::Uint8:
+        return ImageBufferPixelFormat::BGRA8;
+    case CanvasRenderingContext2DSettings::PixelFormat::Float16:
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+        return ImageBufferPixelFormat::RGBA16F;
+#else
+        return ImageBufferPixelFormat::BGRA8;
+#endif
+    }
 }
 
 DestinationColorSpace CanvasRenderingContext2DBase::colorSpace() const

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -363,6 +363,13 @@ void CachedImage::computeIntrinsicDimensions(Length& intrinsicWidth, Length& int
         image->computeIntrinsicDimensions(intrinsicWidth, intrinsicHeight, intrinsicRatio);
 }
 
+Headroom CachedImage::headroom() const
+{
+    if (RefPtr image = m_image)
+        return image->headroom();
+    return Headroom::None;
+}
+
 void CachedImage::notifyObservers(const IntRect* changeRect)
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -97,6 +97,11 @@ public:
     LayoutSize unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType = UsedSize) const;
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio);
 
+    Headroom headroom() const;
+#if ENABLE(HDR_FOR_IMAGES)
+    bool drawsHDRContent() const { return headroom() > Headroom::None; }
+#endif
+
     bool isManuallyCached() const { return m_isManuallyCached; }
     RevalidationDecision makeRevalidationDecision(CachePolicy) const override;
     void load(CachedResourceLoader&) override;

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -72,6 +72,7 @@ public:
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_source->size(orientation); }
     FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return m_source->sourceSize(orientation); }
     DestinationColorSpace colorSpace() final { return m_source->colorSpace(); }
+    Headroom headroom() const final { return m_source->headroom(); }
     ImageOrientation orientation() const final { return m_source->orientation(); }
     unsigned frameCount() const final { return m_source->frameCount(); }
 #if ASSERT_ENABLED

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
@@ -163,6 +163,12 @@ std::optional<Color> BitmapImageDescriptor::singlePixelSolidColor() const
     return primaryNativeImageMetadata(m_singlePixelSolidColor, std::optional<Color>(), CachedFlag::SinglePixelSolidColor, &NativeImage::singlePixelSolidColor);
 }
 
+Headroom BitmapImageDescriptor::headroom() const
+{
+    // FIXME: Headroom should be a metadata of the image. We should not have to decode the primary frame to get it.
+    return primaryNativeImageMetadata(m_headroom, Headroom::None, CachedFlag::Headroom, &NativeImage::headroom);
+}
+
 String BitmapImageDescriptor::uti() const
 {
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
@@ -56,6 +56,7 @@ public:
     RepetitionCount repetitionCount() const;
     DestinationColorSpace colorSpace() const;
     std::optional<Color> singlePixelSolidColor() const;
+    Headroom headroom() const;
 
     String uti() const;
     String filenameExtension() const;
@@ -85,12 +86,13 @@ private:
         RepetitionCount             = 1 << 6,
         ColorSpace                  = 1 << 7,
         SinglePixelSolidColor       = 1 << 8,
+        Headroom                    = 1 << 9,
 
-        UTI                         = 1 << 9,
-        FilenameExtension           = 1 << 10,
-        AccessibilityDescription    = 1 << 11,
-        HotSpot                     = 1 << 12,
-        MaximumSubsamplingLevel     = 1 << 13,
+        UTI                         = 1 << 10,
+        FilenameExtension           = 1 << 11,
+        AccessibilityDescription    = 1 << 12,
+        HotSpot                     = 1 << 13,
+        MaximumSubsamplingLevel     = 1 << 14,
     };
 
     template<typename MetadataType>
@@ -113,6 +115,7 @@ private:
     mutable RepetitionCount m_repetitionCount { RepetitionCountNone };
     mutable DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
     mutable std::optional<Color> m_singlePixelSolidColor;
+    mutable Headroom m_headroom { Headroom::None };
 
     mutable String m_uti;
     mutable String m_filenameExtension;

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -667,11 +667,6 @@ ImageOrientation BitmapImageSource::frameOrientationAtIndex(unsigned index) cons
     return const_cast<BitmapImageSource&>(*this).frameAtIndexCacheIfNeeded(index).orientation();
 }
 
-Headroom BitmapImageSource::frameHeadroomAtIndex(unsigned index) const
-{
-    return const_cast<BitmapImageSource&>(*this).frameAtIndexCacheIfNeeded(index).headroom();
-}
-
 DecodingStatus BitmapImageSource::frameDecodingStatusAtIndex(unsigned index) const
 {
     return const_cast<BitmapImageSource&>(*this).frameAtIndexCacheIfNeeded(index).decodingStatus();

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -157,6 +157,7 @@ private:
     ImageOrientation orientation() const final { return m_descriptor.orientation(); }
     DestinationColorSpace colorSpace() const final { return m_descriptor.colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_descriptor.singlePixelSolidColor(); }
+    Headroom headroom() const final { return m_descriptor.headroom(); }
 
     String uti() const final { return m_descriptor.uti(); }
     String filenameExtension() const final { return m_descriptor.filenameExtension(); }
@@ -175,7 +176,6 @@ private:
 
     // ImageFrame metadata
     ImageOrientation frameOrientationAtIndex(unsigned index) const final;
-    Headroom frameHeadroomAtIndex(unsigned index) const final;
 
     // BitmapImage metadata
     RefPtr<ImageObserver> imageObserver() const;

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -120,6 +120,7 @@ public:
     const FragmentedSharedBuffer* data() const { return m_encodedImageData.get(); }
 
     virtual DestinationColorSpace colorSpace();
+    virtual Headroom headroom() const { return Headroom::None; }
 
     // Animation begins whenever someone draws the image, so startAnimation() is not normally called.
     // It will automatically pause once all observers no longer want to render the image anywhere.

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -80,6 +80,7 @@ public:
     virtual unsigned frameCount() const { return 1; }
     virtual DestinationColorSpace colorSpace() const = 0;
     virtual std::optional<Color> singlePixelSolidColor() const = 0;
+    virtual Headroom headroom() const = 0;
 
     bool hasSolidColor() const;
 
@@ -101,7 +102,6 @@ public:
     // ImageFrame Metadata
     virtual Seconds frameDurationAtIndex(unsigned) const { RELEASE_ASSERT_NOT_REACHED(); return 0_s; }
     virtual ImageOrientation frameOrientationAtIndex(unsigned) const { RELEASE_ASSERT_NOT_REACHED(); return ImageOrientation::Orientation::None; }
-    virtual Headroom frameHeadroomAtIndex(unsigned) const { RELEASE_ASSERT_NOT_REACHED(); return Headroom::None; }
     virtual DecodingStatus frameDecodingStatusAtIndex(unsigned) const { RELEASE_ASSERT_NOT_REACHED(); return DecodingStatus::Invalid; }
 
     // Testing support

--- a/Source/WebCore/platform/graphics/NativeImageSource.h
+++ b/Source/WebCore/platform/graphics/NativeImageSource.h
@@ -39,6 +39,7 @@ private:
     IntSize size(ImageOrientation = ImageOrientation::Orientation::FromImage) const final { return m_frame.size(); }
     DestinationColorSpace colorSpace() const final { return m_frame.nativeImage()->colorSpace(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_frame.nativeImage()->singlePixelSolidColor(); }
+    Headroom headroom() const final { return m_frame.nativeImage()->headroom(); }
 
     const ImageFrame& primaryImageFrame(const std::optional<SubsamplingLevel>& = std::nullopt) final { return m_frame; }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -382,7 +382,7 @@ private:
     bool isMainFrameRenderViewLayer() const;
     
     bool paintsBoxDecorations() const;
-    bool paintsContent(RenderLayer::PaintedContentRequest&) const;
+    void determinePaintsContent(RenderLayer::PaintedContentRequest&) const;
 
     void updateDrawsContent(PaintedContentsInfo&);
 
@@ -403,7 +403,7 @@ private:
     void resetContentsRect();
     void updateContentsRects();
 
-    bool isPaintDestinationForDescendantLayers(RenderLayer::PaintedContentRequest&) const;
+    void determineNonCompositedLayerDescendantsPaintedContent(RenderLayer::PaintedContentRequest&) const;
     bool hasVisibleNonCompositedDescendants() const;
 
     bool shouldClipCompositedBounds() const;


### PR DESCRIPTION
#### 0acfecd15ef377be44bb88abd4649cb973a0075f
<pre>
[HDR] Scan the layer backing for HDR contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=287411">https://bugs.webkit.org/show_bug.cgi?id=287411</a>
<a href="https://rdar.apple.com/144534518">rdar://144534518</a>

Reviewed by Simon Fraser.

This work is towards creating HDR layers only when needed. See bug 282298.

When the render sub-tree of a layer is scanned for painted contents, we can check
for the HDR contents also.

PaintedContentRequest will have a new RequestState named `hasPaintedHDRContent`.
PaintedContentsInfo will have a new RequestState named `m_hdrContent`.

PaintedContentsInfo::determinePaintsContent() will determine the paintedContent
and the paintsHDRContent in one traversal by calling
RenderLayerBacking::determinePaintsContent(). When this function returns,
`hasPaintedHDRContent` will be copied to `m_hdrContent`.

determineNonLayerDescendantsPaintedContent() will be changed that such it will
traverse the full render tree until PaintedContentRequest::hasPaintedHDRContent
is satisfied. To optimize the cases where the feature flags are disabled, the
screen is not HDR or the caller does not want to know whether there is HDR content
or not, PaintedContentRequest::hasPaintedHDRContent will be set to DontCare in
these cases.

PaintedContentRequest::isSatisfied() will return true if both hasPaintedContent
and hasPaintedHDRContent are satisfied.

In future patches, a new method RenderLayerBacking::updateDrawsHDRContent() will
be added. It will force calling PaintedContentsInfo::determinePaintsContent() if
it was not called before and it will update the ContentsFormat of its
`m_graphicsLayer`.

* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::drawsHDRContent const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::pixelFormat const):
Make it easy to answer the question: Does this canvas element requrie HDR layer?

* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::headroom const):
* Source/WebCore/loader/cache/CachedImage.h:
Make it easy to answer the question: Does this image element requrie HDR layer?

* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp:
(WebCore::BitmapImageDescriptor::headroom const):
* Source/WebCore/platform/graphics/BitmapImageDescriptor.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::frameHeadroomAtIndex const): Deleted.
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::headroom const):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::frameOrientationAtIndex const):
(WebCore::ImageSource::frameHeadroomAtIndex const): Deleted.
* Source/WebCore/platform/graphics/NativeImageSource.h:
Make the headroom a metadata of the Image. Currently the headroom is a metadata
of NativeImage. This requires decoding the Image before painting it. So it will
eliminate the async image decoding entirely. Ideally, the headroom should be a
metadata of the ImageDecoder. Like ImageDecoder::frameSizeAtIndex(), we should
have something like ImageDecoder::frameHeadroomAtIndex().

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::PaintedContentRequest::PaintedContentRequest):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::paintsBoxDecorations):
(WebCore::PaintedContentsInfo::paintsContent):
(WebCore::PaintedContentsInfo::paintsHDRContent):
(WebCore::PaintedContentsInfo::determinePaintsBoxDecorations):
(WebCore::PaintedContentsInfo::determinePaintsContent):
(WebCore::RenderLayerBacking::determinePaintsContent const):
(WebCore::RenderLayerBacking::determineNonCompositedLayerDescendantsPaintedContent const):
(WebCore::PaintedContentsInfo::paintsBoxDecorationsDetermination): Deleted.
(WebCore::PaintedContentsInfo::paintsContentDetermination): Deleted.
(WebCore::RenderLayerBacking::paintsContent const): Deleted.
(WebCore::RenderLayerBacking::isPaintDestinationForDescendantLayers const): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.h:

Canonical link: <a href="https://commits.webkit.org/290274@main">https://commits.webkit.org/290274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d13d02d2bbb7ea4933527fac83eac68d0d970cd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17325 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68955 "Found 1 new test failure: media/media-fullscreen-inline.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26610 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96339 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16701 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77827 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77143 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19031 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22027 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->