### PR TITLE
[WebGPU] Release assertion triggered when offset + size > bufferSize

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287418-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287418-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287418.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287418.html
@@ -1,0 +1,14836 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let promise0 = navigator.gpu.requestAdapter({});
+let adapter0 = await promise0;
+let device0 = await adapter0.requestDevice({});
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.68,
+});
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 35.78,
+  lodMaxClamp: 46.84,
+});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let buffer0 = device0.createBuffer({size: 42, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let buffer1 = device0.createBuffer({size: 442, usage: GPUBufferUsage.COPY_SRC});
+let texture0 = device0.createTexture({
+  size: {width: 124, height: 20, depthOrArrayLayers: 5},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let imageData0 = new ImageData(16, 8);
+let texture1 = device0.createTexture({
+  size: [12, 9, 7],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView0 = texture0.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let sampler2 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'linear'});
+let commandEncoder0 = device0.createCommandEncoder({});
+let texture2 = device0.createTexture({
+  size: {width: 24},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture3 = device0.createTexture({
+  size: {width: 96, height: 72, depthOrArrayLayers: 4},
+  mipLevelCount: 6,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], stencilReadOnly: true});
+let sampler3 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater',
+});
+let buffer2 = device0.createBuffer({size: 78, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder1 = device0.createCommandEncoder({});
+let textureView1 = texture2.createView({});
+try {
+renderBundleEncoder0.setVertexBuffer(6, undefined, 636_719_626);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ, 16, 12);
+} catch {}
+try {
+commandEncoder1.copyBufferToBuffer(buffer1, 148, buffer2, 28, 16);
+} catch {}
+let texture4 = device0.createTexture({
+  size: [12, 9, 30],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture5 = device0.createTexture({
+  size: {width: 31, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView2 = texture4.createView({dimension: '2d', baseArrayLayer: 2});
+let computePassEncoder1 = commandEncoder1.beginComputePass();
+try {
+renderBundleEncoder0.setVertexBuffer(0, undefined, 2_653_006_862);
+} catch {}
+let texture6 = device0.createTexture({
+  size: [62, 10, 21],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let arrayBuffer0 = buffer2.getMappedRange(16, 0);
+try {
+buffer0.unmap();
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpteRp431', transfer: 'hlg'} });
+let buffer3 = device0.createBuffer({size: 5248, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture7 = device0.createTexture({
+  size: [248],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder0.setVertexBuffer(7, buffer3, 700, 175);
+} catch {}
+let texture8 = device0.createTexture({
+  size: [2, 2, 18],
+  sampleCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView3 = texture6.createView({baseArrayLayer: 2, arrayLayerCount: 5});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer3, 'uint32', 444, 39);
+} catch {}
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture9 = device0.createTexture({
+  size: [624],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let commandEncoder2 = device0.createCommandEncoder({});
+let textureView4 = texture4.createView({dimension: '2d', baseArrayLayer: 3});
+let texture10 = device0.createTexture({size: {width: 1248}, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder2 = commandEncoder2.beginComputePass();
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['r16uint']});
+let sampler4 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', mipmapFilter: 'linear', lodMinClamp: 25.77});
+try {
+buffer2.unmap();
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T27 {
+  f0: vec4h,
+}
+
+override override4: u32 = 400212686;
+
+struct T21 {
+  @size(52) f0: T2,
+}
+
+override override5: f32;
+
+@id(2632) override override2: bool;
+
+struct T30 {
+  @size(512) f0: T20,
+  @size(3456) f1: T11,
+}
+
+override override11: i32;
+
+struct T11 {
+  @size(472) f0: T6,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T17 {
+  @size(1792) f0: T1,
+}
+
+@id(54354) override override7: bool;
+
+struct VertexOutput0 {
+  @location(5) @interpolate(flat, centroid) f0: vec4h,
+  @location(0) @interpolate(linear, centroid) f1: f16,
+  @invariant @builtin(position) f2: vec4f,
+  @location(2) f3: vec2f,
+  @location(4) f4: vec2u,
+  @location(12) f5: vec4i,
+}
+
+struct T20 {
+  f0: T18,
+}
+
+@id(4051) override override3: f16;
+
+struct T5 {
+  @size(64) f0: vec4f,
+  @align(16) f1: array<array<array<array<atomic<u32>, 1>, 16>, 1>, 1>,
+  @size(320) f2: array<array<array<array<vec2h, 1>, 1>, 40>>,
+}
+
+struct T2 {
+  @size(8) f0: array<u32>,
+}
+
+struct T6 {
+  @align(8) @size(8) f0: array<u32>,
+}
+
+struct T32 {
+  @align(16) @size(16) f0: atomic<i32>,
+  @size(32) f1: T18,
+}
+
+@id(39941) override override1: u32;
+
+override override10 = true;
+
+struct T10 {
+  @size(32) f0: array<atomic<u32>, 1>,
+  @align(32) @size(32) f1: atomic<i32>,
+  @size(800) f2: array<array<array<array<atomic<u32>, 1>, 1>, 2>>,
+}
+
+/* zero global variables used */
+fn fn1() {
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T25 {
+  @align(32) @size(32) f0: atomic<i32>,
+  @align(32) @size(1152) f1: T12,
+}
+
+struct T1 {
+  @align(16) @size(16) f0: i32,
+  @align(16) @size(448) f1: array<bool, 2>,
+}
+
+struct T7 {
+  @align(16) @size(448) f0: T2,
+}
+
+struct T3 {
+  @align(32) f0: array<atomic<i32>, 64>,
+  @align(64) @size(320) f1: array<u32>,
+}
+
+@id(34596) override override9: f16;
+
+struct T8 {
+  @size(96) f0: array<array<vec4i, 1>>,
+}
+
+/* zero global variables used */
+fn fn0(a0: FragmentOutput0) {
+  let vf0: bool = override10;
+  {
+  let vf1: f16 = override3;
+  var vf2: vec3u = select(vec3u(unpack4xI8(unconst_u32(518924107)).aba.yxx), vec3u(unconst_u32(535099230), unconst_u32(657318706), unconst_u32(265469483)), vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false)));
+  vf2 *= vec3u(atan(vec3h(unconst_f16(2388.6), unconst_f16(946.3), unconst_f16(5152.6))));
+  vf2 ^= vec3u(u32((unconst_bool(false) && bool((vec3i(i32(vf2[unconst_u32(3153258895)])) << vec3u(unconst_u32(40647607), unconst_u32(329993444), unconst_u32(26414518))).b))));
+  vf2 = bitcast<vec3u>(reflect(vec4f(unconst_f32(0.3052e22), unconst_f32(0.02663e-40), unconst_f32(-0.1174e-17), unconst_f32(0.07183e-40)), vec4f(unconst_f32(0.2543), unconst_f32(0.5819e-22), unconst_f32(0.1054), unconst_f32(0.03373))).rrg);
+  _ = override3;
+}
+  var vf3: vec4h = cosh(vec4h(f16(override8)));
+  vf3 *= vec4h(f16(override6));
+  vf3 = vec4h(a0.f0.ggab);
+  let vf4: bool = override10;
+  let vf5: bool = vf0;
+  _ = override8;
+  _ = override10;
+  _ = override6;
+  _ = override3;
+}
+
+@id(54692) override override0 = 0.1456;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  @size(704) f0: vec2i,
+}
+
+struct T18 {
+  @align(16) @size(16) f0: atomic<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T19 {
+  @size(68) f0: array<u32>,
+}
+
+struct T4 {
+  @align(8) @size(608) f0: array<mat3x2h>,
+}
+
+struct T28 {
+  @size(8) f0: atomic<i32>,
+  f1: T21,
+}
+
+struct T22 {
+  @align(8) @size(488) f0: array<atomic<u32>>,
+}
+
+struct T33 {
+  @align(4) @size(8) f0: array<f16>,
+}
+
+struct T23 {
+  @size(64) f0: array<T20>,
+}
+
+struct T9 {
+  @size(128) f0: array<array<array<array<array<vec2h, 1>, 1>, 2>, 4>, 1>,
+  @size(576) f1: array<u32>,
+}
+
+struct T14 {
+  @align(32) @size(1024) f0: T6,
+}
+
+struct T13 {
+  @align(32) @size(2048) f0: array<atomic<i32>>,
+}
+
+struct T15 {
+  @align(8) @size(5248) f0: T12,
+}
+
+struct T12 {
+  @size(32) f0: array<u32>,
+}
+
+struct T16 {
+  @align(32) @size(2944) f0: array<u32>,
+}
+
+struct T29 {
+  f0: array<atomic<i32>, 2>,
+}
+
+override override8: u32;
+
+/* zero global variables used */
+fn fn2() -> vec4i {
+  var out: vec4i;
+  var vf6: vec2f = asin(vec2f(unconst_f32(0.1568), unconst_f32(0.08238e-40)));
+  var vf7: f16 = override9;
+  return out;
+  _ = override9;
+}
+
+override override6: f32;
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4u,
+}
+
+struct T24 {
+  @size(432) f0: array<u32>,
+}
+
+struct T26 {
+  @align(32) @size(160) f0: array<u32>,
+}
+
+struct T31 {
+  @align(8) @size(16) f0: T29,
+  @size(56) f1: array<T29>,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex0(@location(15) @interpolate(flat) a0: i32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out -= vec4f(firstLeadingBit(vec3i(unconst_i32(130672524), unconst_i32(437693306), unconst_i32(1210248481))).yxyz.xzzw);
+  switch bitcast<i32>(override6) { 
+  default {
+  out -= bitcast<vec4f>(countOneBits(vec2i(unconst_i32(758164512), unconst_i32(442098029))).xyxx.rarr.bbbg.zyww);
+  out *= vec4f(override5);
+  out = vec4f(f32(any(unconst_bool(false))));
+  fn0(FragmentOutput0(unpack4xU8(u32(any(unconst_bool(true))))));
+  var vf8 = fn2();
+  for (var it0=pack2x16unorm(tanh(vec2f(unconst_f32(-0.1095), unconst_f32(0.2328e-30)))); it0<(u32(determinant(mat2x2h(f16((bitcast<i32>(select(unconst_f32(0.03908), unconst_f32(0.6529), bool(distance(vec3h(unconst_f16(2628.6), unconst_f16(24748.7), unconst_f16(3266.7)), vec3h(unconst_f16(19792.0), unconst_f16(1305.3), unconst_f16(796.2)))))) << unconst_u32(1242175576))), f16((bitcast<i32>(select(unconst_f32(0.03908), unconst_f32(0.6529), bool(distance(vec3h(unconst_f16(2628.6), unconst_f16(24748.7), unconst_f16(3266.7)), vec3h(unconst_f16(19792.0), unconst_f16(1305.3), unconst_f16(796.2)))))) << unconst_u32(1242175576))), f16((bitcast<i32>(select(unconst_f32(0.03908), unconst_f32(0.6529), bool(distance(vec3h(unconst_f16(2628.6), unconst_f16(24748.7), unconst_f16(3266.7)), vec3h(unconst_f16(19792.0), unconst_f16(1305.3), unconst_f16(796.2)))))) << unconst_u32(1242175576))), f16((bitcast<i32>(select(unconst_f32(0.03908), unconst_f32(0.6529), bool(distance(vec3h(unconst_f16(2628.6), unconst_f16(24748.7), unconst_f16(3266.7)), vec3h(unconst_f16(19792.0), unconst_f16(1305.3), unconst_f16(796.2)))))) << unconst_u32(1242175576)))))) & 0xfff); it0++) {
+  fn0(FragmentOutput0(vec4u(extractBits(unconst_u32(1236739715), u32(override9), unconst_u32(183003720)))));
+  let vf9: mat2x2h = (mat4x2h(unconst_f16(10980.0), unconst_f16(18631.9), unconst_f16(9471.8), unconst_f16(1890.0), unconst_f16(13188.5), unconst_f16(8617.7), unconst_f16(1985.4), unconst_f16(2309.6)) * mat2x4h(unconst_f16(4325.4), unconst_f16(21803.7), unconst_f16(13597.6), unconst_f16(17951.6), unconst_f16(3545.8), unconst_f16(19422.0), unconst_f16(-5570.7), unconst_f16(1537.9)));
+  out = vec4f(override6);
+  var vf10 = fn2();
+  _ = override9;
+  _ = override3;
+  _ = override8;
+  _ = override6;
+  _ = override10;
+}
+  _ = override5;
+  _ = override9;
+  _ = override3;
+  _ = override6;
+  _ = override10;
+  _ = override8;
+}
+  }
+  fn0(FragmentOutput0(vec4u(transpose(mat4x3h(unconst_f16(763.9), unconst_f16(10294.0), unconst_f16(995.5), unconst_f16(-15763.2), unconst_f16(-16918.7), unconst_f16(13584.2), unconst_f16(788.4), unconst_f16(3289.6), unconst_f16(4533.0), unconst_f16(16184.3), unconst_f16(982.3), unconst_f16(20723.9)))[unconst_i32(0)].yxzx)));
+  out *= vec4f(bitcast<f32>(dot4U8Packed(bitcast<u32>(cos(vec2h(unconst_f16(-775.1), unconst_f16(5231.8)))), unconst_u32(186977373))));
+  return out;
+  _ = override10;
+  _ = override5;
+  _ = override6;
+  _ = override3;
+  _ = override9;
+  _ = override8;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex1(@location(14) a0: vec2i, @location(4) a1: u32, @location(7) @interpolate(perspective, first) a2: vec2h, @location(12) @interpolate(linear, center) a3: f32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  let vf11: vec4f = log(vec4f(unconst_f32(0.1169e-19), unconst_f32(0.00233e4), unconst_f32(0.00977), unconst_f32(-0.1599e21)));
+  out.f1 = f16(override6);
+  out.f5 = bitcast<vec4i>(normalize(vec4f(f32(override11))).rrba);
+  var vf12 = fn2();
+  out.f5 = (vec3i(unconst_i32(549192664), unconst_i32(39812641), unconst_i32(408694129)) - vec3i(unconst_i32(297453732), unconst_i32(291188751), unconst_i32(93872686))).bgbb;
+  var vf13: u32 = override1;
+  return out;
+  _ = override1;
+  _ = override9;
+  _ = override11;
+  _ = override6;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 |= vec4u(extractBits(vec3i(unconst_i32(201791967), unconst_i32(-67942035), unconst_i32(199704334)), unconst_u32(47990503), unconst_u32(1265431894)).yzyz);
+  out.f0 = vec4u(u32(override7));
+  var vf14 = fn2();
+  let vf15: vec3f = atan2(vec3f(unconst_f32(0.4929), unconst_f32(-0.1831), unconst_f32(0.04429)), vec3f(unconst_f32(-0.1183), unconst_f32(0.3005e14), unconst_f32(0.2345)));
+  let vf16: bool = override10;
+  out.f0 = unpack4xU8(u32(exp2(unconst_f16(14618.1))));
+  var vf17: u32 = pack4x8unorm(vec4f(unconst_f32(0.2471), unconst_f32(0.00598), unconst_f32(0.07733), unconst_f32(0.4351e-28)));
+  _ = fn2();
+  out.f0 >>= vec4u(sinh(vec4f(countLeadingZeros(vec4i(unconst_i32(-224359343), unconst_i32(502811532), unconst_i32(63576149), unconst_i32(925069168))))).aarg);
+  return out;
+  _ = override9;
+  _ = override10;
+  _ = override7;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(2, 1, 2)
+fn compute0() {
+  var vf18: f16 = override3;
+  vf18 = f16(override5);
+  vf18 -= f16(override1);
+  while bool(length(vec4h(unconst_f16(2774.7), unconst_f16(21329.6), unconst_f16(3293.7), unconst_f16(21807.9)))) {
+  fn1();
+}
+  fn1();
+  fn1();
+  _ = override3;
+  _ = override5;
+  _ = override1;
+}`,
+});
+let textureView5 = texture6.createView({dimension: '2d', baseArrayLayer: 1});
+let textureView6 = texture7.createView({
+  label: '\u2206\u0e98\u7bcd\u86a4\u{1fbe9}\u0c15\ufbf9',
+  dimension: '1d',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(8).fill(195), /* required buffer size: 8 */
+{offset: 8, rowsPerImage: 101}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {4_051: 1, 39_941: 1, override5: 1}},
+});
+let textureView7 = texture4.createView({baseArrayLayer: 3, arrayLayerCount: 4});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+override override14: bool;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T8 {
+  @align(64) @size(192) f0: array<T0>,
+}
+
+override override12 = 0.3099;
+
+struct T4 {
+  @size(8) f0: array<u32>,
+}
+
+struct FragmentOutput1 {
+  @location(6) f0: f32,
+  @location(0) @interpolate(flat) f1: vec2u,
+  @location(7) f2: vec4i,
+  @location(4) f3: f32,
+}
+
+struct T1 {
+  @size(356) f0: array<array<array<atomic<u32>, 1>, 1>>,
+}
+
+struct T0 {
+  @align(8) @size(8) f0: f32,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* zero global variables used */
+fn fn0(a0: FragmentOutput1) -> VertexOutput1 {
+  var out: VertexOutput1;
+  vp0 = FragmentOutput1(f32(degrees(unconst_f16(17104.4))), vec2u(u32(degrees(unconst_f16(17104.4)))), vec4i(i32(degrees(unconst_f16(17104.4)))), f32(degrees(unconst_f16(17104.4))));
+  out.f7 = vec4h((vec2h(f16(override13)) == vec2h(unconst_f16(34078.4), unconst_f16(14230.3))).xyxy);
+  switch i32(vp0.f1[1]) { 
+  default {
+  vp0 = FragmentOutput1(bitcast<vec2f>(a0.f1)[0], a0.f1, vec4i(a0.f1.gggr), f32(a0.f1.y));
+  out.f7 = vec4h(f16(vp0.f3));
+  let vf19: bool = override14;
+  break;
+  _ = override14;
+}
+  }
+  var vf20: FragmentOutput1 = a0;
+  let ptr0: ptr<function, f32> = &vf20.f0;
+  let ptr1: ptr<private, f32> = &vp0.f3;
+  var vf21: f32 = override12;
+  return out;
+  _ = override13;
+  _ = override14;
+  _ = override12;
+}
+
+struct T5 {
+  @align(8) @size(1792) f0: array<atomic<u32>>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T9 {
+  @align(16) @size(448) f0: T6,
+  @align(16) @size(144) f1: atomic<u32>,
+  @size(224) f2: T7,
+}
+
+override override13: bool;
+
+var<private> vp0: FragmentOutput1 = FragmentOutput1(f32(0.00722), vec2u(858178807, 392016851), vec4i(761672309, 1027385644, 389159891, 6829923), f32(0.5302e-11));
+
+struct VertexOutput1 {
+  @invariant @builtin(position) f6: vec4f,
+  @location(4) f7: vec4h,
+}
+
+struct T3 {
+  @align(16) @size(528) f0: array<vec2u>,
+}
+
+struct T6 {
+  @align(8) @size(8) f0: atomic<u32>,
+}
+
+struct T2 {
+  @size(20) f0: array<atomic<u32>>,
+}
+
+struct T10 {
+  f0: T0,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T7 {
+  f0: array<atomic<u32>>,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex2(@location(9) a0: vec4i) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f7 += vec4h(vp0.f2);
+  let vf22: vec4h = exp(vec4h(sign(vec4f(unconst_f32(0.1473e-38), unconst_f32(0.00645), unconst_f32(0.7729), unconst_f32(0.1464))).agga.graa.agrb));
+  vp0.f0 += f32(a0[unconst_u32(180936129)]);
+  var vf23: vec4h = exp(vec4h(unconst_f16(17169.2), unconst_f16(-9610.9), unconst_f16(856.3), unconst_f16(682.7)));
+  out.f7 = vec4h(distance(vec2h(unconst_f16(231.5), unconst_f16(4470.3)), vec2h(unconst_f16(63069.0), unconst_f16(16924.4))));
+  vp0.f0 -= f32(vf22.w);
+  var vf24 = fn0(FragmentOutput1(sign(vec4f(unconst_f32(0.2445e-18), unconst_f32(0.2216), unconst_f32(0.01424e-26), unconst_f32(0.4309))).b, bitcast<vec2u>(sign(vec4f(unconst_f32(0.2445e-18), unconst_f32(0.2216), unconst_f32(0.01424e-26), unconst_f32(0.4309))).gb), bitcast<vec4i>(sign(vec4f(unconst_f32(0.2445e-18), unconst_f32(0.2216), unconst_f32(0.01424e-26), unconst_f32(0.4309)))), sign(vec4f(unconst_f32(0.2445e-18), unconst_f32(0.2216), unconst_f32(0.01424e-26), unconst_f32(0.4309))).r));
+  return out;
+  _ = override12;
+  _ = override14;
+  _ = override13;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let vf25: vec3h = degrees(vec3h(unconst_f16(6469.9), unconst_f16(11046.5), unconst_f16(26963.3)));
+  out.f3 = vp0.f0;
+  return out;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  var vf26 = fn0(FragmentOutput1(f32(vp0.f1[unconst_u32(3332860778)]), vec2u(vp0.f1[unconst_u32(3332860778)]), vec4i(i32(vp0.f1[unconst_u32(3332860778)])), f32(vp0.f1[unconst_u32(3332860778)])));
+  workgroupBarrier();
+  fn0(FragmentOutput1(f32(any((vec4h(unconst_f16(6655.7), unconst_f16(7586.9), unconst_f16(32895.5), unconst_f16(7031.3)) < vec4h(unconst_f16(3076.3), unconst_f16(-32521.1), unconst_f16(2820.4), unconst_f16(8281.9))))), vec2u((vec4h(unconst_f16(6655.7), unconst_f16(7586.9), unconst_f16(32895.5), unconst_f16(7031.3)) < vec4h(unconst_f16(3076.3), unconst_f16(-32521.1), unconst_f16(2820.4), unconst_f16(8281.9))).yy.xx), vec4i((vec4h(unconst_f16(6655.7), unconst_f16(7586.9), unconst_f16(32895.5), unconst_f16(7031.3)) < vec4h(unconst_f16(3076.3), unconst_f16(-32521.1), unconst_f16(2820.4), unconst_f16(8281.9)))), vec4f((vec4h(unconst_f16(6655.7), unconst_f16(7586.9), unconst_f16(32895.5), unconst_f16(7031.3)) < vec4h(unconst_f16(3076.3), unconst_f16(-32521.1), unconst_f16(2820.4), unconst_f16(8281.9))))[3]));
+  let ptr2: ptr<function, vec4f> = &vf26.f6;
+  vp0.f0 = cos(vec4f(unconst_f32(0.06047), unconst_f32(0.2106), unconst_f32(0.1095e-13), unconst_f32(0.2391)))[3];
+  vp0.f0 = bitcast<f32>(vp0.f2[2]);
+  _ = override14;
+  _ = override12;
+  _ = override13;
+}`,
+});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer4 = device0.createBuffer({size: 340, usage: GPUBufferUsage.INDIRECT});
+let textureView8 = texture8.createView({label: '\ubddf\ueed6\u0e50\u0c2c\u7205\u69dc', arrayLayerCount: 1});
+let renderBundle0 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte240m', transfer: 'bt2020_12bit'} });
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder3 = device0.createCommandEncoder({});
+let textureView9 = texture5.createView({});
+let computePassEncoder3 = commandEncoder3.beginComputePass();
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 12, new Uint32Array(1052), 82, 0);
+} catch {}
+let textureView10 = texture9.createView({});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u{1f7c5}');
+} catch {}
+let recycledExplicitBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let texture11 = device0.createTexture({
+  size: {width: 31},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView11 = texture4.createView({dimension: '2d', baseArrayLayer: 2});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 1, depthReadOnly: true});
+let sampler5 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer3, 'uint32', 1_196, 235);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData1 = new ImageData(52, 28);
+let textureView12 = texture6.createView({dimension: '2d', baseArrayLayer: 3, arrayLayerCount: 1});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler6 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 72.16, maxAnisotropy: 9});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer3, 'uint32', 3_468, 515);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+  await promise1;
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder();
+let textureView13 = texture8.createView({baseArrayLayer: 2, arrayLayerCount: 4});
+let computePassEncoder4 = commandEncoder4.beginComputePass();
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ, 0, 12);
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({
+  size: {width: 96, height: 72, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture13 = device0.createTexture({
+  size: {width: 624},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler7 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer3, 'uint32', 816, 853);
+} catch {}
+let pipeline1 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  constants: {54_354: 1, 34_596: 1},
+  targets: [{format: 'r16uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex1',
+    constants: {39_941: 1, override6: 1, 34_596: 1, override11: 1},
+    buffers: [
+      {
+        arrayStride: 120,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x2', offset: 0, shaderLocation: 7},
+          {format: 'sint32', offset: 8, shaderLocation: 14},
+          {format: 'uint32x4', offset: 80, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {},
+});
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 197,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer5 = device0.createBuffer({size: 40, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder6 = device0.createCommandEncoder({});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderBundleEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer3, 0);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(71, 105);
+let commandEncoder7 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer3, 0);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(87).fill(104), /* required buffer size: 87 */
+{offset: 87, bytesPerRow: 253, rowsPerImage: 33}, {width: 18, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder5 = commandEncoder7.beginComputePass();
+let sampler8 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 80.74,
+  compare: 'not-equal',
+});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer3, 'uint32', 412, 549);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 376, new Uint32Array(15459), 1283, 376);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder6.finish();
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer3, 'uint16', 426, 3_182);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'jedecP22Phosphors', transfer: 'iec6196624'} });
+let commandEncoder9 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder5.finish();
+let computePassEncoder6 = commandEncoder9.beginComputePass();
+try {
+renderBundleEncoder3.setIndexBuffer(buffer3, 'uint16', 32, 68);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline1);
+} catch {}
+let buffer6 = device0.createBuffer({size: 104, usage: GPUBufferUsage.COPY_DST});
+let texture14 = device0.createTexture({
+  size: {width: 624, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16uint'],
+});
+let textureView14 = texture2.createView({dimension: '1d'});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler9 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.81,
+});
+try {
+commandEncoder8.copyBufferToTexture({
+  /* bytesInLastRow: 154 widthInBlocks: 77 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 210 */
+  offset: 210,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 13, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 77, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(75); };
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({});
+let textureView15 = texture0.createView({arrayLayerCount: 1});
+let computePassEncoder7 = commandEncoder8.beginComputePass();
+try {
+computePassEncoder2.pushDebugGroup('\u90b3');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let texture15 = device0.createTexture({size: [96], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView16 = texture0.createView({arrayLayerCount: 1});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle4 = renderBundleEncoder4.finish({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 63.68,
+});
+let buffer7 = device0.createBuffer({size: 93, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder11 = device0.createCommandEncoder({});
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 1548, new Uint32Array(37467), 4771, 0);
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  constants: {34_596: 1, 54_354: 1},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {override14: 1, override13: 1},
+    buffers: [
+      {
+        arrayStride: 220,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 6, shaderLocation: 9}],
+      },
+    ],
+  },
+});
+let bindGroup0 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let texture16 = device0.createTexture({
+  label: '\u7bd7\u0fbe\u00d5\u0e92\u7164\u075b\u{1fd49}\udcbc\ud79d',
+  size: [124],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder8 = commandEncoder11.beginComputePass();
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, []);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let shaderModule2 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+struct T3 {
+  @align(32) @size(160) f0: array<u32>,
+}
+
+@group(0) @binding(23) var st2: texture_storage_2d_array<rgba32sint, write>;
+
+struct T2 {
+  @align(8) @size(8) f0: atomic<u32>,
+}
+
+struct T8 {
+  @align(32) @size(3616) f0: array<T2>,
+}
+
+struct T7 {
+  @align(32) @size(128) f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @align(16) @size(1072) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput2 {
+  @builtin(position) f8: vec4f,
+}
+
+struct T9 {
+  f0: atomic<i32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @size(32) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T5 {
+  @align(8) @size(200) f0: array<atomic<u32>>,
+}
+
+struct T4 {
+  @size(48) f0: array<vec4h>,
+}
+
+struct T6 {
+  @size(576) f0: T2,
+}
+
+/* zero global variables used */
+@vertex @must_use
+fn vertex3(@location(7) a0: vec4f) -> VertexOutput2 {
+  var out: VertexOutput2;
+  out.f8 = vec4f((vec2h(unconst_f16(-28718.1), unconst_f16(-2260.4)) < vec2h(unconst_f16(17503.5), unconst_f16(9810.0))).yxxx.ywwz);
+  var vf27: vec2u = (vec2u(unconst_u32(1772702590), unconst_u32(3254380421)) & vec2u(u32(a0[unconst_u32(657753395)])));
+  if bool(length(vec4h(unconst_f16(12054.8), unconst_f16(-5578.2), unconst_f16(7352.5), unconst_f16(17576.0)))) {
+  out = VertexOutput2(vec4f(a0[u32(all( !vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false))))]));
+  var vf28: f32 = a0[unconst_u32(675378484)];
+}
+  return out;
+}
+
+/* used global variables: st2 */
+@fragment
+fn fragment2(@builtin(sample_mask) a0: u32) -> @location(200) vec2u {
+  var out: vec2u;
+  let vf29: vec4f = unpack4x8snorm(unconst_u32(125708794));
+  let vf30: vec3h = cross(vec3h(unconst_f16(6812.9), unconst_f16(12406.3), unconst_f16(-3494.2)), vec3h(unconst_f16(17701.9), unconst_f16(20163.1), unconst_f16(19934.6)));
+  var vf31: vec4f = (vec4f(unconst_f32(0.8588e0), unconst_f32(0.5001e-34), unconst_f32(0.2426), unconst_f32(0.2184e-13)) / unconst_f32(0.2333e-3));
+  vf31 *= round(vec4f(unconst_f32(0.02815), unconst_f32(0.4201), unconst_f32(0.07197), unconst_f32(0.3149)));
+  let vf32: f32 = vf31[unconst_u32(783962821)];
+  let vf33: vec2h = refract(vec2h(unconst_f16(10599.9), unconst_f16(4083.4)), vec2h(unconst_f16(-29095.9), unconst_f16(12215.7)), unconst_f16(4337.2));
+  textureStore(st2, vec2i(unconst_i32(273964185), unconst_i32(342094145)), unconst_i32(333491919), vec4i(unpack4xI8((unconst_u32(109563547) >> unconst_u32(1104585004)))));
+  let vf34: vec3u = (vec3u(unconst_u32(277101574), unconst_u32(480350725), unconst_u32(2360933430)) ^ vec3u(unconst_u32(304735867), unconst_u32(639490862), unconst_u32(753326130)));
+  let vf35: f32 = vf31[vec3u(radians(vec3h(unconst_f16(5489.5), unconst_f16(11158.1), unconst_f16(21771.3))).xzz.rgg.rbb)[0]];
+  out |= vec2u(reverseBits(vec3i(unconst_i32(151723657), unconst_i32(279907732), unconst_i32(645961266))).gb);
+  out >>= vec2u(bitcast<u32>(vf29[unconst_u32(1257229012)]));
+  let vf36: f16 = vf33[unconst_u32(88843033)];
+  return out;
+  _ = st2;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 2, 1)
+fn compute2() {
+  var vf37: vec3i = clamp(vec3i(unconst_i32(340956877), unconst_i32(274730090), unconst_i32(361443073)), vec3i(i32(abs(vec2f((vec2i(unconst_i32(395324945), unconst_i32(665096071)) % vec2i(unconst_i32(324525398), unconst_i32(175851439))))[0]))), vec3i(unconst_i32(258256220), unconst_i32(82904772), unconst_i32(164812977)));
+  vf37 |= clamp(vec3i(unconst_i32(668091319), unconst_i32(709387748), unconst_i32(-468352374)), vec3i(unconst_i32(333489348), unconst_i32(240221468), unconst_i32(31376915)), vec3i(unconst_i32(295855985), unconst_i32(1186680560), unconst_i32(244660872)));
+  vf37 |= vec3i(bitcast<i32>(abs(unconst_f32(0.5433e-40))));
+  for (var it1=bitcast<u32>((f16((vec2i(unconst_i32(276542863), unconst_i32(863873293)) % vec2i(unconst_i32(217060423), unconst_i32(2041685334)))[1]) / vec2h(unconst_f16(28147.8), unconst_f16(3656.7)))); it1<(u32(fract(vec4h(unconst_f16(21946.4), unconst_f16(-11728.0), unconst_f16(6236.6), unconst_f16(4430.3))).y) & 0xfff); it1++) {
+  let vf38: vec4i = firstTrailingBit(vec4i(unconst_i32(360976228), unconst_i32(487422711), unconst_i32(70637722), unconst_i32(2660327)));
+  var vf39: u32 = pack4xU8(vec4u(unconst_u32(469338687), unconst_u32(150709593), unconst_u32(337087072), unconst_u32(963237)));
+  var vf40: vec3h = fma(vec3h((vec2u(unconst_u32(542106376), unconst_u32(330724671)) & vec2u(unconst_u32(284228892), unconst_u32(90831983))).grr), asinh(vec2h(unconst_f16(12907.2), unconst_f16(12871.6))).yyy, vec3h(unconst_f16(6810.6), unconst_f16(6919.3), unconst_f16(7335.7)));
+  vf40 *= vec3h(reflect(vec3f(unconst_f32(0.03946), unconst_f32(0.02681e27), unconst_f32(0.1178)), vec3f(unconst_f32(0.1937), unconst_f32(0.07582e-31), unconst_f32(-0.6833))));
+  let vf41: vec4u = countOneBits(vec4u(unconst_u32(133800419), unconst_u32(766364198), unconst_u32(164349), unconst_u32(390975930)));
+  vf40 *= vec3h(countOneBits(vec4u(fma(vec3h(unconst_f16(3334.4), unconst_f16(4145.1), unconst_f16(17658.2)), vec3h(unconst_f16(-31999.8), unconst_f16(1342.6), unconst_f16(6405.2)), vec3h(unconst_f16(5342.1), unconst_f16(-2027.8), unconst_f16(-17563.9))).grbr)).bbg);
+}
+}`,
+});
+let buffer8 = device0.createBuffer({size: 80, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let sampler11 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 97.07,
+});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let imageData2 = new ImageData(72, 28);
+let buffer9 = device0.createBuffer({
+  size: 76,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture17 = device0.createTexture({
+  size: {width: 12, height: 9, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView17 = texture17.createView({dimension: '2d-array'});
+let computePassEncoder9 = commandEncoder12.beginComputePass();
+let sampler12 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'nearest', minFilter: 'linear'});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup0, new Uint32Array(508), 8, 0);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer9, 20, buffer2, 8, 0);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let bindGroup1 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let buffer10 = device0.createBuffer({
+  size: 220,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture18 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder0 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: 429.7, g: -409.6, b: 711.6, a: -977.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 4108459,
+});
+let sampler13 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.65,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer1]);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct S0 {
+  @location(2) f0: vec4i,
+  @location(1) f1: vec2f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override15: f32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(3584) f0: array<f16>,
+}
+
+struct FragmentOutput2 {
+  @location(0) f0: vec2u,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput3 {
+  @builtin(position) f9: vec4f,
+}
+
+struct T1 {
+  f0: array<u32>,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex4(@location(7) a0: vec4f, @location(8) a1: vec2i, @location(0) @interpolate(flat, first) a2: u32, a3: S0) -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f9 = bitcast<vec4f>(a3.f0);
+  switch i32((unconst_bool(true) && unconst_bool(false))) { 
+  default {
+  out.f9 = vec4f(a3.f0);
+  out.f9 -= vec4f(a1.xxxy);
+  out.f9 = (vec3f(unconst_f32(0.01409e-21), unconst_f32(0.3128), unconst_f32(0.05459)) * a0[vec3u((vec3h(unconst_f16(-4611.0), unconst_f16(368.3), unconst_f16(1390.6)) > vec3h(unconst_f16(-22599.1), unconst_f16(25663.1), unconst_f16(2558.7))).yxy.zzx.yxx.bbr)[2]]).rbrb;
+  out = VertexOutput3(bitcast<vec4f>(a1.rrrg.raaa));
+  out.f9 = vec4f(a1.xyyx);
+  var vf42: vec2<bool> =  !vec2<bool>(unconst_bool(true), unconst_bool(false));
+}
+  }
+  {
+  out.f9 = vec4f(a3.f1[unconst_u32(135432968)]);
+  out.f9 *= unpack4x8snorm(pack2x16snorm(vec2f(unconst_f32(0.00664), unconst_f32(0.1944e11))));
+  var vf43: vec2<bool> = (vec2i(unconst_i32(-482191994), unconst_i32(202930203)) < vec2i(unconst_i32(552298589), unconst_i32(1097165114)));
+  out.f9 = bitcast<vec4f>(a3.f0.abgb);
+  let vf44: S0 = a3;
+}
+  out.f9 = vec4f(bitcast<f32>(firstLeadingBit(unconst_i32(753845841))));
+  let vf45: vec3u = min(bitcast<vec3u>(a3.f1.rrg), vec3u(unconst_u32(913177366), unconst_u32(1503591633), unconst_u32(1171763765)));
+  out.f9 = vec4f(f32(firstLeadingBit(unconst_i32(285904768))));
+  out.f9 = vec4f(bitcast<f32>(a1[unconst_u32(580927629)]));
+  let vf46: u32 = vf45[unconst_u32(128872663)];
+  {
+  out.f9 = vec4f(reflect(vec3h(unconst_f16(3568.2), unconst_f16(3788.7), unconst_f16(587.1)), vec3h(unconst_f16(7209.3), unconst_f16(7049.0), unconst_f16(6659.6))).yyyz.bgra);
+  out.f9 = bitcast<vec4f>(a1.rggr);
+}
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment3(@location(4) a0: vec4h) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let vf47: vec4u = countOneBits(vec4u(unconst_u32(303759894), unconst_u32(318424729), unconst_u32(2495921879), unconst_u32(1781672706)));
+  let vf48: u32 = pack4x8unorm(vec4f(unconst_f32(0.2841e25), unconst_f32(0.2903e29), unconst_f32(0.1264e-22), unconst_f32(0.07674e-15)));
+  return out;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(3, 1, 1)
+fn compute3() {
+  var vf49: vec3u = (vec3u(unconst_u32(878124107), unconst_u32(265455504), unconst_u32(2090802592)) - unconst_u32(1428190591));
+  let vf50: vec3u = min(vec3u(unconst_u32(704408149), unconst_u32(463878427), unconst_u32(1240471495)), vec3u(unconst_u32(744576654), unconst_u32(24159346), unconst_u32(390708548)));
+}`,
+});
+let bindGroup2 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let buffer11 = device0.createBuffer({size: 424, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder13 = device0.createCommandEncoder({});
+let textureView18 = texture4.createView({baseArrayLayer: 11, arrayLayerCount: 3});
+let computePassEncoder10 = commandEncoder13.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline1);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 99},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler14 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 79.52,
+  maxAnisotropy: 20,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer11, 12); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint16', 1_368, 925);
+} catch {}
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 216 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8 */
+  offset: 8,
+  bytesPerRow: 10752,
+  rowsPerImage: 205,
+  buffer: buffer10,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 27, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture20 = device0.createTexture({
+  size: [1248, 120, 24],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder1 = commandEncoder14.beginRenderPass({colorAttachments: [{view: textureView17, loadOp: 'load', storeOp: 'discard'}]});
+let sampler15 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 64.99});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(2444), 110, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4, new Uint32Array(2127), 311, 0);
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpteRp431', transfer: 'linear'} });
+let bindGroup3 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+let commandEncoder15 = device0.createCommandEncoder();
+let textureView19 = texture19.createView({format: 'rgba8sint'});
+let computePassEncoder11 = commandEncoder15.beginComputePass();
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer3, 'uint16', 380, 208);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer3, 1_524, 1_083);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(48); };
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  size: [12, 9, 17],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture22 = device0.createTexture({
+  size: [312, 30, 1],
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder2 = commandEncoder16.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: -70.81, g: -260.4, b: 686.4, a: 976.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(0, bindGroup3, new Uint32Array(1138), 164, 0);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 116, new DataView(new ArrayBuffer(1811)), 870, 20);
+} catch {}
+let buffer12 = device0.createBuffer({size: 7952, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u0f4d\u{1f7ac}'});
+let textureView20 = texture21.createView({format: 'rgba8uint', baseArrayLayer: 0});
+let computePassEncoder12 = commandEncoder3.beginComputePass();
+let sampler16 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.72,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup2, new Uint32Array(478), 203, 0);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint32', 3_480, 15);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, undefined);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer2, 4, 4);
+} catch {}
+let buffer13 = device0.createBuffer({size: 165, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint16', 168, 519);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer3, 1_084, 632);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer14 = device0.createBuffer({
+  size: 940,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let textureView21 = texture7.createView({});
+let computePassEncoder13 = commandEncoder17.beginComputePass();
+try {
+computePassEncoder13.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer14, 'uint32', 148, 169);
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer2, 4, 24);
+} catch {}
+let imageData3 = new ImageData(4, 8);
+let commandEncoder19 = device0.createCommandEncoder({});
+let texture23 = device0.createTexture({
+  size: {width: 12, height: 9, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 1, stencilReadOnly: true});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(919), 23, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(6.883501567805428, 7.831091795169451, 0.12456818442614641, 0.8335722887191522, 0.49832311440793986, 0.6289158499089309);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer14);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 552 */
+  offset: 528,
+  buffer: buffer3,
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let texture24 = device0.createTexture({
+  size: {width: 12},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder14 = commandEncoder18.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(0, bindGroup1, new Uint32Array(660), 333, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint16', 462, 569);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer3);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 400 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 376 */
+  offset: 376,
+  bytesPerRow: 22272,
+  buffer: buffer1,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 214, y: 38, z: 5},
+  aspect: 'all',
+}, {width: 100, height: 5, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup4 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView21}]});
+let buffer15 = device0.createBuffer({size: 40, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let textureView22 = texture19.createView({});
+let textureView23 = texture1.createView({dimension: '2d', baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder19.beginComputePass();
+let sampler17 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup3, new Uint32Array(435), 72, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let texture25 = device0.createTexture({
+  label: '\u{1fad0}\u{1f9d7}\u3d51\ucf34\u2e07\u070b\u{1fcaa}\u56d5\u06b7\u6ad6',
+  size: [12, 9, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer9, 4); };
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(11.441190500712672, 7.805933163767837, 0.2290547386753671, 0.3320266028047251, 0.48752217968601175, 0.6479540472657241);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer14);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(3, bindGroup1, new Uint32Array(713), 72, 0);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup5 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture26 = device0.createTexture({
+  size: [96, 72, 1],
+  mipLevelCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView24 = texture4.createView({dimension: '2d', format: 'rgba32sint', baseArrayLayer: 1});
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.90,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer12, 'uint32', 3_324, 1_164);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer12, 'uint16', 2_316, 60);
+} catch {}
+try {
+renderBundleEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup6 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView6}]});
+let commandEncoder20 = device0.createCommandEncoder({});
+let textureView25 = texture26.createView({dimension: '2d-array', format: 'rgba8uint', baseArrayLayer: 0});
+let computePassEncoder16 = commandEncoder20.beginComputePass();
+let sampler19 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.90,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(5414), 420, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer11, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup3);
+} catch {}
+let pipeline3 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule1, targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL}]},
+  vertex: {
+    module: shaderModule1,
+    constants: {override12: 1, override13: 1, override14: 1},
+    buffers: [
+      {arrayStride: 0, stepMode: 'vertex', attributes: [{format: 'sint32', offset: 116, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+try {
+canvas0.getContext('webgpu');
+} catch {}
+let textureView26 = texture0.createView({arrayLayerCount: 2});
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(1443), 107, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(438);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 12, new Int16Array(31264).fill(3), 3550, 28);
+} catch {}
+let bindGroup7 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView21}]});
+let commandEncoder21 = device0.createCommandEncoder();
+let textureView27 = texture14.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder17 = commandEncoder21.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.draw(0, 219, 0, 394_068_351);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer11, 92);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer3, 36, 1_361);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let textureView28 = texture1.createView({dimension: '2d', baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup7, []);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 8);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture27 = device0.createTexture({
+  size: [1248, 120, 1],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let texture28 = gpuCanvasContext0.getCurrentTexture();
+let textureView29 = texture5.createView({});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup4, new Uint32Array(2392), 194, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle2]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(120); };
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let computePassEncoder18 = commandEncoder22.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer4, 116); };
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup6, new Uint32Array(843), 60, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(69, 0, 348_527_605, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(63, 1, 10, 22_868_871);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 4);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer3, 0, 1_690);
+} catch {}
+let buffer16 = device0.createBuffer({size: 300, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder23 = device0.createCommandEncoder({});
+let renderPassEncoder3 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 694.2, g: 59.04, b: 752.6, a: -517.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 178579669,
+});
+try {
+computePassEncoder7.dispatchWorkgroupsIndirect(buffer9, 4);
+} catch {}
+try {
+renderPassEncoder1.draw(308, 1, 402_539_740);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 204);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer11, 60);
+} catch {}
+let textureView30 = texture4.createView({dimension: '2d', aspect: 'all'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(3, bindGroup6, new Uint32Array(1049), 594, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup3, new Uint32Array(450), 70, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(67, 0, 4, 190_059_196);
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  constants: {54_354: 1, 34_596: 1},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {override8: 1, 4_051: 1, override5: 1, 34_596: 1, override6: 1},
+    buffers: [
+      {
+        arrayStride: 824,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 124, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: false},
+});
+let bindGroup8 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView10}]});
+let texture29 = device0.createTexture({
+  size: {width: 2},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView31 = texture3.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup6, new Uint32Array(1532), 139, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(1104), 252, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(24, 1, 2_013_556_889);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 4);
+} catch {}
+offscreenCanvas0.width = 272;
+let commandEncoder24 = device0.createCommandEncoder();
+let texture30 = device0.createTexture({
+  size: {width: 124, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView32 = texture7.createView({baseMipLevel: 0});
+let computePassEncoder19 = commandEncoder24.beginComputePass();
+try {
+renderPassEncoder1.draw(225, 0, 57_510_654);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer8, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder11.pushDebugGroup('\u{1f8aa}');
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment1',
+  constants: {},
+  targets: [{format: 'r16uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex4',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 148,
+        attributes: [
+          {format: 'uint32', offset: 24, shaderLocation: 0},
+          {format: 'sint32', offset: 8, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 16, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 146, shaderLocation: 7},
+          {format: 'sint32x3', offset: 892, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let buffer17 = device0.createBuffer({size: 192, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let commandEncoder25 = device0.createCommandEncoder({});
+let texture31 = device0.createTexture({
+  size: {width: 156, height: 15, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView33 = texture21.createView({});
+let computePassEncoder20 = commandEncoder25.beginComputePass();
+let sampler21 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.00,
+});
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer14, 'uint16', 114, 454);
+} catch {}
+let buffer18 = device0.createBuffer({
+  size: 316,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(3, bindGroup7, new Uint32Array(1926), 1_261, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer8, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 8);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder();
+let computePassEncoder21 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder19.setBindGroup(0, bindGroup1, new Uint32Array(3065), 124, 0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(201), 4, 0);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 248.3, g: -656.3, b: 221.9, a: 384.9, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(37, 0, 24, -2_027_943_492, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 28);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 20);
+} catch {}
+let bindGroup9 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+let buffer19 = device0.createBuffer({size: 208, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView34 = texture25.createView({dimension: '2d-array'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder1.draw(110, 1, 46_716_762, 1);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 8);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer10);
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'smpte432', transfer: 'bt709'} });
+let buffer20 = device0.createBuffer({size: 111, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let computePassEncoder22 = commandEncoder7.beginComputePass();
+let sampler22 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup2, new Uint32Array(2930), 1_235, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle5, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(911);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer18, 236);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 136);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4, new Int16Array(11100), 1866, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(99).fill(236), /* required buffer size: 99 */
+{offset: 99}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture32 = device0.createTexture({
+  size: {width: 31, height: 5, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], depthReadOnly: true, stencilReadOnly: false});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(1875), 45, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer11, 24);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer12, 'uint32', 380, 310);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup10 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 352});
+let texture33 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(1433), 739, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 28);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 12);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline3);
+} catch {}
+let textureView35 = texture10.createView({baseMipLevel: 0});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup6, new Uint32Array(1003), 37, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 290.5, g: -143.5, b: -758.1, a: -748.3, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(1, 1, 2, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer20, 8);
+} catch {}
+let imageData4 = new ImageData(16, 12);
+let buffer21 = device0.createBuffer({
+  size: 400,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let texture34 = device0.createTexture({
+  size: [156, 15, 1],
+  mipLevelCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], stencilReadOnly: true});
+try {
+computePassEncoder8.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer8, 4);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint16', 164, 1_915);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 24, new Uint32Array(24203), 20797, 0);
+} catch {}
+let bindGroup11 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView32}]});
+let buffer22 = device0.createBuffer({size: 120, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder27 = device0.createCommandEncoder({});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.draw(25, 0, 92_075_224);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer3, 'uint32', 64, 1_237);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup5, new Uint32Array(1090), 955, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer21, 'uint32', 60, 55);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, colorSpace: 'srgb'});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture35 = device0.createTexture({size: [156], dimension: '1d', format: 'r16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder23 = commandEncoder27.beginComputePass();
+let renderBundle7 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup3, new Uint32Array(1148), 123, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.draw(177, 0, 947_921_696);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 20);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer12, 'uint32', 1_080, 194);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 0, new Uint32Array(7604), 1577, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 96, y: 30, z: 8},
+  aspect: 'all',
+}, new Uint8Array(273_637).fill(10), /* required buffer size: 273_637 */
+{offset: 261, bytesPerRow: 2072, rowsPerImage: 15}, {width: 486, height: 12, depthOrArrayLayers: 9});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+let renderPassEncoder4 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: -649.9, g: -286.8, b: -933.5, a: 522.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup8, new Uint32Array(3909), 218, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer9, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 584, new DataView(new ArrayBuffer(1851)), 436, 172);
+} catch {}
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 331});
+try {
+renderPassEncoder1.drawIndexed(68, 0, 15, 399_117_154);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer14, 'uint16', 350, 154);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer10, 0, 20);
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture36 = device0.createTexture({
+  size: {width: 312},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView36 = texture11.createView({dimension: '1d', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder24 = commandEncoder29.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(80, 0, 306, 1_287_370_300);
+} catch {}
+let buffer23 = device0.createBuffer({size: 52, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let textureView37 = texture13.createView({arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer4, 152); };
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer10, 16, 46);
+} catch {}
+try {
+computePassEncoder17.pushDebugGroup('\uff19');
+} catch {}
+try {
+computePassEncoder7.insertDebugMarker('\u{1f67f}');
+} catch {}
+let textureView38 = texture11.createView({});
+let sampler23 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup8, new Uint32Array(4003), 2_191, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(421.616297321881, 37.97539257720716, 34.3997026057515, 5.989343337283525, 0.7678227666569533, 0.831135257658719);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(117, 0, 153, 196_853_885);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer23, 4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+let commandEncoder30 = device0.createCommandEncoder({});
+let renderPassEncoder5 = commandEncoder30.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 43.66, g: 353.1, b: -832.1, a: -256.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 376387330,
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer8, 0);
+} catch {}
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer8, 8); };
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 8);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer23, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 0, new Uint32Array(2636), 72, 0);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+document.body.append(canvas0);
+let texture37 = device0.createTexture({
+  size: [1248, 120, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView39 = texture1.createView({dimension: '2d'});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer23, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer18);
+} catch {}
+document.body.prepend(canvas0);
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 223});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 24);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer21, 'uint32', 60, 39);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer14);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let buffer24 = device0.createBuffer({size: 29136, usage: GPUBufferUsage.VERTEX});
+let sampler24 = device0.createSampler({addressModeU: 'mirror-repeat'});
+try {
+renderPassEncoder1.drawIndexed(19, 0, 24, 656_858_278);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer10, 0, 32);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let bindGroup12 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+let buffer25 = device0.createBuffer({size: 200, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder31 = device0.createCommandEncoder({});
+let computePassEncoder25 = commandEncoder31.beginComputePass();
+try {
+computePassEncoder8.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup11, new Uint32Array(2012), 70, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let textureView40 = texture8.createView({dimension: 'cube', baseArrayLayer: 3});
+try {
+renderPassEncoder1.drawIndirect(buffer23, 8);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline3);
+} catch {}
+let bindGroup13 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let textureView41 = texture0.createView({dimension: '2d', format: 'rgb10a2unorm'});
+let texture38 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 99},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer25, 72);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer21, 'uint32', 12, 196);
+} catch {}
+let computePassEncoder26 = commandEncoder8.beginComputePass();
+let sampler25 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  compare: 'not-equal',
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup11, new Uint32Array(4337), 671, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(70, 0, 44, 1_080_512_975);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData5 = new ImageData(24, 28);
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup9, new Uint32Array(833), 7, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(349, 0, 477_415_551);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(47, 0, 350, 56_839_893);
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame5);
+let textureView42 = texture21.createView({format: 'rgba8uint'});
+let sampler26 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 97.61});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.draw(331, 0, 866_305_482);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(360, 0, 297, 9_584_498);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer14, 'uint32', 12, 509);
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({});
+let textureView43 = texture21.createView({mipLevelCount: 1});
+let renderPassEncoder6 = commandEncoder32.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: -419.6, g: -101.3, b: -142.7, a: 889.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler27 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer9, 0); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup13, new Uint32Array(108), 7, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(94.09333712956274, 8.74533996255559, 137.0299450531573, 11.244882147914886, 0.0922398196356673, 0.4419738257129213);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(35); };
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame4);
+try {
+computePassEncoder26.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer23, 0); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer23, 12);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct T4 {
+  @align(16) @size(512) f0: vec4h,
+  @size(512) f1: array<T0, 1>,
+  @align(256) @size(512) f2: T0,
+}
+
+struct T2 {
+  @size(320) f0: array<vec2f>,
+}
+
+struct T5 {
+  @align(16) @size(64) f0: array<array<i32, 1>>,
+}
+
+var<private> vp1: f32 = f32(0.1652e-36);
+
+struct T1 {
+  @size(36) f0: atomic<u32>,
+}
+
+var<private> vp3: i32 = i32(334592265);
+
+struct T0 {
+  @size(344) f0: array<vec4h, 1>,
+}
+
+/* zero global variables used */
+fn fn0(a0: array<array<array<vec4u, 1>, 10>, 1>) -> vec4<bool> {
+  var out: vec4<bool>;
+  var vf51: vec3h = ceil(vec3h(a0[0][9][0].aag.yzy));
+  var vf52: vec4u = a0[0][unconst_u32(988046674)][unconst_u32(1328517501)];
+  var vf53: u32 = a0[0][9][0][unconst_u32(72662316)];
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T6 {
+  @size(4032) f0: array<array<f32, 4>>,
+}
+
+alias vec3b = vec3<bool>;
+
+var<private> vp2: vec4u = vec4u(268231335, 354027642, 184212139, 785333722);
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw0: array<array<atomic<i32>, 1>, 1>;
+
+/* zero global variables used */
+fn fn2(a0: ptr<private, f32>) -> f16 {
+  var out: f16;
+  let vf57: u32 = pack4xU8(vec4u(unconst_u32(386896246), unconst_u32(1163992446), unconst_u32(2146880388), unconst_u32(490589448)));
+  {
+  vp3 += i32((*a0));
+  var vf58 = fn0(array<array<array<vec4u, 1>, 10>, 1>(array<array<vec4u, 1>, 10>(array<vec4u, 1>(unpack4xU8(u32(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(vec4u(u32(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(unpack4xU8(bitcast<u32>(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(vec4u(bitcast<u32>(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(unpack4xU8(bitcast<u32>(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(vec4u(u32(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(unpack4xU8(u32(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(unpack4xU8(bitcast<u32>(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(vec4u(bitcast<u32>(atomicLoad(&(*&vw0)[0][0])))), array<vec4u, 1>(unpack4xU8(u32(atomicLoad(&(*&vw0)[0][0])))))));
+  let vf59: vec2i = countLeadingZeros(vec2i(unconst_i32(307879998), unconst_i32(74232518)));
+  let vf60: i32 = atomicExchange(&vw0[0][u32(atomicLoad(&vw0[0][unconst_u32(21012103)]))], unconst_i32(400874700));
+  return out;
+}
+  out *= vec3h(acos(vec3f(unconst_f32(0.01842), unconst_f32(0.1981), unconst_f32(0.3710)))).y;
+  let ptr3: ptr<workgroup, atomic<i32>> = &(*&vw0)[0][0];
+  let vf61: i32 = atomicExchange(&vw0[pack4xI8Clamp(clamp(vec4i(atomicLoad(&vw0[0][unconst_u32(472762392)])), vec4i(unconst_i32(332181226), unconst_i32(374905391), unconst_i32(735824289), unconst_i32(118467926)), vec4i(unconst_i32(266964775), unconst_i32(645685058), unconst_i32(234077840), unconst_i32(5029724))))][unconst_u32(306446782)], unconst_i32(-825038362));
+  let vf62: u32 = pack4xI8(vec4i(unconst_i32(-269572352), unconst_i32(32420437), unconst_i32(298891354), unconst_i32(293440429)));
+  (*a0) = f32(atomicLoad(&vw0[unconst_u32(138905294)][0]));
+  var vf63 = fn1();
+  vp3 = i32(vp1);
+  let vf64: i32 = atomicExchange(&vw0[0][unconst_u32(1190469207)], unconst_i32(592582043));
+  let vf65: i32 = atomicExchange(&vw0[unconst_u32(72396968)][0], unconst_i32(1196302173));
+  var vf66 = fn0(array<array<array<vec4u, 1>, 10>, 1>(array<array<vec4u, 1>, 10>(array<vec4u, 1>(unpack4xU8(u32(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(unpack4xU8(bitcast<u32>(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(vec4u(bitcast<u32>(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(unpack4xU8(u32(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(vec4u(bitcast<u32>(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(vec4u(u32(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(vec4u(bitcast<u32>(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(unpack4xU8(u32(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(unpack4xU8(u32(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))), array<vec4u, 1>(vec4u(bitcast<u32>(atomicExchange(&vw0[unconst_u32(48582921)][unconst_u32(1291627092)], unconst_i32(74641570))))))));
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput4 {
+  @location(3) @interpolate(flat, centroid) f10: vec4i,
+  @location(10) f11: vec2f,
+  @location(2) f12: i32,
+  @builtin(position) f13: vec4f,
+  @location(7) f14: f16,
+}
+
+/* zero global variables used */
+fn fn1() -> array<VertexOutput4, 1> {
+  var out: array<VertexOutput4, 1>;
+  var vf54: u32 = vp2[unconst_u32(750496057)];
+  var vf55: vec3f = degrees(vec3f(unconst_f32(0.06151), unconst_f32(0.2782), unconst_f32(0.1861e-14)));
+  vp1 = vf55[unconst_u32(6975654)];
+  vp2 += vec4u(u32(vp3));
+  var vf56: f32 = vf55[unconst_u32(5269986)];
+  return out;
+}
+
+struct T3 {
+  @size(184) f0: array<T1>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex5() -> VertexOutput4 {
+  var out: VertexOutput4;
+  let vf67: vec2h = acos(vec2h(unconst_f16(-13519.7), unconst_f16(37397.4)));
+  out.f13 -= vec4f(acos(vec2h(f16((unconst_bool(true) && unconst_bool(true))))).yyxy.ywww.rgbb);
+  var vf68 = fn1();
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment4() -> @location(200) @interpolate(linear) vec2u {
+  var out: vec2u;
+  let vf69: f16 = exp2(unconst_f16(966.6));
+  let ptr4: ptr<private, vec4u> = &vp2;
+  return out;
+}`,
+});
+let buffer26 = device0.createBuffer({size: 80, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 20);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 92);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer20, 0);
+} catch {}
+try {
+computePassEncoder17.popDebugGroup();
+} catch {}
+let textureView44 = texture37.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup7, new Uint32Array(1603), 487, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(324);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.draw(61, 0, 2_358_339_220);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+} catch {}
+let bindGroup14 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView32}]});
+let commandEncoder33 = device0.createCommandEncoder({});
+let computePassEncoder27 = commandEncoder33.beginComputePass();
+let sampler28 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'equal',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup11, new Uint32Array(196), 19, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer4, 36); };
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle6, renderBundle4, renderBundle0, renderBundle7]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(409).fill(155), /* required buffer size: 409 */
+{offset: 409}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer27 = device0.createBuffer({size: 780, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder34 = device0.createCommandEncoder({});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4, renderBundle1, renderBundle5, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer25, 12);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipeline6 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment2',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 156,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 40, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw'},
+});
+let img0 = await imageWithData(28, 46, '#10101010', '#20202020');
+let computePassEncoder28 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder28.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.draw(73, 0, 943_212_529);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer12, 'uint32', 4_864, 1_305);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer17, 44, 22);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 531});
+let textureView45 = texture14.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5, new Uint32Array(268), 22, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(24, 0, 191_461_245);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(48, 0, 10, 158_841_824);
+} catch {}
+try {
+buffer23.unmap();
+} catch {}
+document.body.prepend(img0);
+let recycledExplicitBindGroupLayout1 = pipeline2.getBindGroupLayout(0);
+let bindGroup15 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout1, entries: [{binding: 23, resource: textureView7}]});
+let buffer28 = device0.createBuffer({size: 316, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder35 = device0.createCommandEncoder();
+let computePassEncoder29 = commandEncoder35.beginComputePass();
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(12, 0, 10, 138_284_001);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer8, 0);
+} catch {}
+let bindGroup16 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+let textureView46 = texture8.createView({dimension: 'cube', aspect: 'all', baseArrayLayer: 2});
+let texture39 = device0.createTexture({
+  size: [24, 18, 1],
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer4, 12);
+} catch {}
+document.body.prepend(canvas0);
+let textureView47 = texture10.createView({aspect: 'all'});
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 99.95,
+});
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup15, new Uint32Array(1542), 19, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle6, renderBundle1, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder0.draw(38, 0, 835_086_258, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer28, 208);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  label: '\ueb68\u07fc\u4598\u6970\ua8e9\u{1fc1c}\u0539',
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 197, resource: textureView21}],
+});
+let buffer29 = device0.createBuffer({
+  size: 32,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+let textureView48 = texture23.createView({label: '\u053a\u16a7\ubd8c\u0b31\u32d6\u99bb\u86cc\uf8b6\uf40f', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder7 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: -933.5, g: 586.6, b: 124.4, a: 221.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 205409615,
+});
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer28, 4);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let textureView49 = texture38.createView({dimension: '3d', mipLevelCount: 1, baseArrayLayer: 0});
+let sampler30 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.21,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer23, 4);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, undefined, 1_759_452_465);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+}, new Uint8Array(354).fill(111), /* required buffer size: 354 */
+{offset: 354}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+globalThis.someLabel = textureView31.label;
+} catch {}
+let bindGroup18 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout1, entries: [{binding: 23, resource: textureView18}]});
+let buffer30 = device0.createBuffer({size: 100, usage: GPUBufferUsage.QUERY_RESOLVE});
+let sampler31 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 64.54,
+});
+try {
+renderPassEncoder3.setStencilReference(310);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(7, 0, 28, -1_422_500_087);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer28, 8);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer20, 'uint32', 28, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer17, 0, 17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(93).fill(252), /* required buffer size: 93 */
+{offset: 93, bytesPerRow: 48}, {width: 23, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture40 = device0.createTexture({
+  size: {width: 624, height: 60, depthOrArrayLayers: 468},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 80);
+} catch {}
+let videoFrame6 = new VideoFrame(videoFrame3, {timestamp: 0});
+let buffer31 = device0.createBuffer({size: 28, usage: GPUBufferUsage.COPY_DST});
+let textureView50 = texture13.createView({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(976), 152, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.draw(200, 0, 1_904_047_421, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(118, 0, 4, 466_423_466);
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup19 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder3.setViewport(192.52866535681332, 32.02826549391619, 413.05790530784515, 11.989148466899904, 0.35885072262283557, 0.8775147114025574);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 696, new Uint32Array(10313), 2299, 52);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 111, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(256).fill(205), /* required buffer size: 256 */
+{offset: 256}, {width: 63, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let bindGroup20 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 384, resource: {buffer: buffer27}}]});
+let buffer32 = device0.createBuffer({
+  size: 176,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder37 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder10.finish();
+let texture41 = device0.createTexture({
+  size: {width: 62, height: 10, depthOrArrayLayers: 24},
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer25, 24);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer12, 'uint16', 2_846, 485);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(40_854).fill(39), /* required buffer size: 40_854 */
+{offset: 86, bytesPerRow: 56, rowsPerImage: 56}, {width: 0, height: 0, depthOrArrayLayers: 14});
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'bt709', transfer: 'log'} });
+let commandEncoder38 = device0.createCommandEncoder({});
+let textureView51 = texture41.createView({mipLevelCount: 1});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 70.44,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(32, 0, 37, 639_712_613);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer32, 20);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer4, 32);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(8_435).fill(221), /* required buffer size: 8_435 */
+{offset: 228, bytesPerRow: 57, rowsPerImage: 35}, {width: 14, height: 4, depthOrArrayLayers: 5});
+} catch {}
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout2 = pipeline2.getBindGroupLayout(0);
+let buffer33 = device0.createBuffer({size: 976, usage: GPUBufferUsage.INDIRECT});
+let computePassEncoder30 = commandEncoder38.beginComputePass();
+let sampler33 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 77.46, compare: 'equal'});
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer11, 4);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 181, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(479).fill(25), /* required buffer size: 479 */
+{offset: 479, bytesPerRow: 219}, {width: 100, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture42 = device0.createTexture({size: [248], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder31 = commandEncoder37.beginComputePass();
+try {
+renderPassEncoder1.draw(56, 0, 1_911_407_118);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(16, 279, 39, 32_539_139, 508_996_750);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer28, 40);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer27, 'uint32', 444, 143);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(0, 0);
+try {
+computePassEncoder23.insertDebugMarker('\u{1fe3c}');
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView52 = texture38.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup18, new Uint32Array(3160), 651, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer9, 4);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer32, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout3 = pipeline6.getBindGroupLayout(0);
+let textureView53 = texture2.createView({});
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup18, new Uint32Array(3070), 133, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle3, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder3.draw(0, 875, 0, 975_590_839);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer9, 12);
+} catch {}
+let arrayBuffer2 = buffer2.getMappedRange(8, 0);
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({});
+let texture43 = device0.createTexture({
+  size: [12],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture44 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder32 = commandEncoder40.beginComputePass();
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer9, 16);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 92, new Uint32Array(24098), 2707, 8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+let recycledExplicitBindGroupLayout4 = pipeline0.getBindGroupLayout(0);
+let buffer34 = device0.createBuffer({size: 104, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder41 = device0.createCommandEncoder();
+let textureView54 = texture41.createView({});
+let texture45 = device0.createTexture({
+  size: {width: 62, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView55 = texture11.createView({});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup19, new Uint32Array(1822), 53, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer28, 88); };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup2, new Uint32Array(443), 15, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(19);
+} catch {}
+try {
+renderPassEncoder3.draw(0, 80, 0, 963_800_353);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(105, 0, 77, 550_597_510);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer4, 60);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer32, 16);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer27, 'uint32', 88, 6);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer29, 0, 10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(56).fill(40), /* required buffer size: 56 */
+{offset: 56}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture46 = device0.createTexture({
+  size: [312],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView56 = texture44.createView({dimension: '2d-array', aspect: 'all', format: 'rgba32uint', mipLevelCount: 1});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(0, bindGroup16, new Uint32Array(2454), 970, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup16, new Uint32Array(167), 0, 0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(34, 0, 95, 239_361_007, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer28, 4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer26, 0, 8);
+} catch {}
+document.body.append(canvas0);
+let commandBuffer3 = commandEncoder23.finish();
+let texture47 = device0.createTexture({
+  size: [48],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture48 = device0.createTexture({
+  size: {width: 156, height: 15, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder8 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  depthSlice: 26,
+  clearValue: { r: 726.3, g: 228.2, b: 628.2, a: -731.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup2, new Uint32Array(568), 205, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.draw(37, 0, 104_002_322);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer33, 248);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer33, 92);
+} catch {}
+let imageData6 = new ImageData(16, 28);
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup21 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 23, resource: textureView18}]});
+let commandEncoder43 = device0.createCommandEncoder();
+let texture49 = device0.createTexture({
+  size: {width: 624},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder33 = commandEncoder43.beginComputePass();
+try {
+computePassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.draw(70, 0, 123_579_711);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(16, 0, 2, 206_234_782);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 200);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+let bindGroup22 = device0.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 23, resource: textureView18}]});
+let textureView57 = texture47.createView({aspect: 'all', arrayLayerCount: 1});
+let textureView58 = texture32.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 58, y: 2, z: 145},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 4, new BigUint64Array(12559), 238, 0);
+} catch {}
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout5 = pipeline6.getBindGroupLayout(0);
+let commandEncoder44 = device0.createCommandEncoder({});
+let textureView59 = texture20.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroupsIndirect(buffer32, 116); };
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -840.6, g: 363.1, b: 981.8, a: -178.2, });
+} catch {}
+try {
+renderPassEncoder1.draw(0, 225, 0, 1_046_676_775);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(42, 19, 2, 64_508_686, 273_508_564);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 24);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer9, 12);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline6);
+} catch {}
+let bindGroup23 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let textureView60 = texture17.createView({dimension: '2d', baseMipLevel: 0});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup0, new Uint32Array(1723), 292, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+requires pointer_composite_access;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput3 {
+  @location(0) @interpolate(flat) f0: vec4u,
+  @location(5) f1: vec4u,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw2: vec4f;
+
+struct VertexOutput5 {
+  @location(9) @interpolate(linear, either) f15: f32,
+  @builtin(position) f16: vec4f,
+}
+
+alias vec3b = vec3<bool>;
+
+var<private> vp5 = array(array(frexp(f16(492.7))));
+
+var<workgroup> vw1: atomic<u32>;
+
+var<private> vp6: VertexOutput5 = VertexOutput5(f32(0.01240), vec4f(0.1291e-10, -0.04352, 0.01047e26, 0.02983));
+
+@id(42686) override override18: bool;
+
+var<private> vp7 = array(modf(f16(11261.7)), modf(f16(6708.6)), modf(f16(843.1)), modf(f16(2432.6)), modf(f16(3075.0)), modf(f16(9424.4)), modf(f16(11959.2)), modf(f16(947.3)), modf(f16(5282.5)), modf(f16(25375.4)), modf(f16(-7419.7)), modf(f16(-8783.8)), modf(f16(-441.4)), modf(f16(-5036.5)), modf(f16(1099.2)), modf(f16(4010.4)), modf(f16(39282.8)), modf(f16(6399.5)));
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(23394) override override17 = 0.1811e28;
+
+override override21: f16 = 585.0;
+
+var<workgroup> vw3: array<FragmentOutput3, 1>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(25487) override override20: f16;
+
+var<private> vp4: vec2u = vec2u(2164376170, 2239725782);
+
+struct T0 {
+  @align(16) @size(16) f0: array<u32>,
+}
+
+override override16: f16 = 12894.9;
+
+override override19: i32 = 193631333;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex6() -> VertexOutput5 {
+  var out: VertexOutput5;
+  let ptr5 = &vp5[unconst_u32(14501686)][unconst_u32(489527647)];
+  let ptr6: ptr<private, f16> = &vp7[17].whole;
+  if bool(vp7[17].whole) {
+  let vf70: f16 = pow(unconst_f16(5736.9), unconst_f16(-7129.4));
+  out.f15 = f32(vp5[0][0].exp);
+  let ptr7 = &vp5[0][unconst_u32(246327945)];
+  out.f15 = bitcast<f32>(vp5[unconst_u32(161891073)][0].exp);
+}
+  let vf71: bool = override18;
+  out.f16 *= vec4f(f32(vp5[0][unconst_u32(583283793)].fract));
+  loop {
+  vp6.f16 *= vec4f(f32(vp7[17].fract));
+  var vf72: u32 = (bitcast<u32>((vec3i(i32(pack4xU8Clamp(vec4u(unconst_u32(111274860), unconst_u32(1072737927), unconst_u32(756707870), unconst_u32(253045433))))) & vec3i(i32(vp7[17].fract))).b) | unconst_u32(57963596));
+  return out;
+  break;
+}
+  out.f16 = vec4f(f32(vp7[unconst_u32(25886421)].whole));
+  let ptr8: ptr<private, f16> = &vp5[unconst_u32(152689927)][unconst_u32(650808472)].fract;
+  let ptr9 = &vp5[unconst_u32(717347026)][0];
+  out.f16 += vec4f(bitcast<f32>((*ptr5).exp));
+  let ptr10 = &vp7[unconst_u32(939339504)];
+  let vf73: u32 = vp4[unconst_u32(426855170)];
+  return out;
+  _ = override18;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment5() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  let vf74: vec3<bool> =  !vec3<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true));
+  vp4 = vec2u(bitcast<u32>(override19));
+  vp5[unconst_u32(258621704)][unconst_u32(1543463385)] = frexp(vp7[unconst_u32(918620150)].fract);
+  return out;
+  _ = override19;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(2, 1, 1)
+fn compute4(@builtin(workgroup_id) a0: vec3u, @builtin(global_invocation_id) a1: vec3u) {
+  vw2 = vec4f((*&vw3)[0].f1.gggb.grra.agrb.rbba);
+  return;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute5() {
+  let ptr11: ptr<workgroup, vec4u> = &(*&vw3)[unconst_u32(607954609)].f1;
+  let ptr12: ptr<workgroup, FragmentOutput3> = &vw3[unconst_u32(2647829064)];
+  let ptr13 = &vp5[unconst_u32(901822781)][unconst_u32(313937553)];
+  vp5[0][unconst_u32(1184885525)].fract = vec4h(workgroupUniformLoad(&vw2).aabg).z;
+  let ptr14: ptr<workgroup, FragmentOutput3> = &vw3[0];
+  atomicCompareExchangeWeak(&vw1, unconst_u32(1015341657), unconst_u32(284668786));
+  let vf75: vec3h = faceForward(vec3h(unconst_f16(2198.7), unconst_f16(10115.6), unconst_f16(16237.6)), vec3h(unconst_f16(6363.9), unconst_f16(3706.6), unconst_f16(5230.6)), vec3h(f16(distance(vec2f(unconst_f32(0.2454), unconst_f32(0.1395)), vec2f(unconst_f32(0.09356), unconst_f32(0.4711e17))))));
+  var vf76: u32 = vw3[unconst_u32(1133551927)].f0[unconst_u32(1028028035)];
+  var vf77: vec3i = sign(vec3i(unconst_i32(996114743), unconst_i32(116636771), unconst_i32(565073814)));
+  if bool(saturate(vec3f(unconst_f32(0.5697e11), unconst_f32(0.1847e22), unconst_f32(0.1858e-25))).r) {
+  vp7[(*&vw3)[0].f0[1]] = modf(vp5[unconst_u32(527529369)][unconst_u32(735962695)].fract);
+  vw3[unconst_u32(384304330)] = FragmentOutput3((*&vw3)[0].f0, (*&vw3)[0].f0);
+}
+  let ptr15: ptr<workgroup, vec4u> = &(*ptr14).f1;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(2, 2, 1)
+fn compute6() {
+  let ptr16: ptr<workgroup, vec4u> = &vw3[0].f1;
+  let ptr17: ptr<workgroup, FragmentOutput3> = &(*&vw3)[unconst_u32(150666123)];
+  vp6.f15 -= bitcast<f32>(vp5[0][unconst_u32(391265402)].exp);
+  let ptr18 = &vp5[u32(vp5[unconst_u32(1129904393)][0].fract)];
+  let vf78: u32 = vw3[0].f1[unconst_u32(308587537)];
+  vp7[unconst_u32(515964872)] = modf(override20);
+  let ptr19: ptr<workgroup, vec4u> = &vw3[unconst_u32(40518616)].f0;
+  vp7[vp4.g] = modf(f16(atomicLoad(&vw1)));
+  let vf79: u32 = vw3[unconst_u32(208347090)].f1[unconst_u32(134779757)];
+  _ = override20;
+}`,
+});
+let bindGroup24 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout5, entries: [{binding: 23, resource: textureView7}]});
+let commandEncoder45 = device0.createCommandEncoder();
+let commandBuffer4 = commandEncoder14.finish();
+let textureView61 = texture40.createView({aspect: 'all'});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer12, 'uint32', 132, 1_308);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer29, 4, 10);
+} catch {}
+document.body.append(canvas0);
+let commandEncoder46 = device0.createCommandEncoder();
+let texture50 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 121},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView62 = texture4.createView({dimension: '2d'});
+let computePassEncoder34 = commandEncoder41.beginComputePass();
+let renderPassEncoder9 = commandEncoder45.beginRenderPass({colorAttachments: [{view: textureView17, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer27, 'uint32', 72, 72);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(229).fill(255), /* required buffer size: 229 */
+{offset: 229, bytesPerRow: 74, rowsPerImage: 6}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView63 = texture32.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder35 = commandEncoder44.beginComputePass();
+let renderPassEncoder10 = commandEncoder42.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: -613.1, g: -540.9, b: -305.3, a: -621.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 19, y: 1, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup25 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 384, resource: {buffer: buffer14}}]});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(10.712735608253606, 1.1245901940850844, 0.3772352897179032, 7.3198155954752595, 0.48246116705393105, 0.998313190696563);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer18);
+} catch {}
+let buffer35 = device0.createBuffer({size: 48, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  size: {width: 156, height: 15, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+let renderPassEncoder11 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  depthSlice: 66,
+  clearValue: { r: 579.0, g: -995.9, b: 143.6, a: 685.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer12, 'uint32', 1_260, 857);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer14, 44, 16);
+} catch {}
+let computePassEncoder36 = commandEncoder47.beginComputePass();
+let sampler35 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 63.21,
+  maxAnisotropy: 6,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1, 1, 2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer35, 0); };
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup4, new Uint32Array(5843), 2_340, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer20, 'uint16', 0, 18);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 4},
+  aspect: 'all',
+}, new Uint8Array(2_067).fill(222), /* required buffer size: 2_067 */
+{offset: 210, bytesPerRow: 59, rowsPerImage: 30}, {width: 7, height: 2, depthOrArrayLayers: 2});
+} catch {}
+let sampler36 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.54,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup19, new Uint32Array(2487), 938, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup9, new Uint32Array(1640), 402, 0);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(1, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer3, 'uint32', 1_560, 342);
+} catch {}
+let imageData7 = new ImageData(48, 8);
+let commandEncoder48 = device0.createCommandEncoder({});
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer26, 4, 9);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer21, 92, buffer12, 1216, 32);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 36, y: 7, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let commandEncoder49 = device0.createCommandEncoder({});
+let textureView64 = texture44.createView({dimension: '2d-array', mipLevelCount: 1});
+let texture52 = device0.createTexture({
+  size: [12, 9, 17],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView65 = texture43.createView({});
+let sampler37 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 50.11,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder10.setIndexBuffer(buffer3, 'uint16', 2_632, 52);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer21, 8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise4;
+} catch {}
+let buffer36 = device0.createBuffer({size: 196, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+try {
+renderPassEncoder7.setIndexBuffer(buffer27, 'uint16', 120, 82);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer29, 0);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+canvas0.height = 1088;
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt470bg', transfer: 'linear'} });
+let buffer37 = device0.createBuffer({size: 183, usage: GPUBufferUsage.STORAGE});
+let textureView66 = texture27.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup6, new Uint32Array(1629), 309, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer32);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 2, y: 10, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer38 = device0.createBuffer({size: 80, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder50 = device0.createCommandEncoder({});
+let textureView67 = texture49.createView({aspect: 'all', baseMipLevel: 0});
+let computePassEncoder37 = commandEncoder49.beginComputePass();
+try {
+computePassEncoder26.setBindGroup(0, bindGroup2, new Uint32Array(572), 17, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup21, new Uint32Array(2952), 104, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer29, 'uint16', 2, 10);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer32, 52, 40);
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\u0bbf');
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment1',
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule4, entryPoint: 'vertex5', constants: {}, buffers: []},
+  primitive: {cullMode: 'front'},
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup21, new Uint32Array(234), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer29, 'uint16', 4, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+await gc();
+let canvas1 = document.createElement('canvas');
+let textureView68 = texture15.createView({baseMipLevel: 0});
+let sampler38 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+renderPassEncoder6.executeBundles([renderBundle7, renderBundle4, renderBundle7, renderBundle4]);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 29, y: 35, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 56 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1804 */
+  offset: 1804,
+  bytesPerRow: 9728,
+  buffer: buffer3,
+}, {width: 56, height: 30, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 20});
+let texture53 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder12 = commandEncoder48.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: 440.2, g: -335.8, b: 53.49, a: 906.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup22, new Uint32Array(1799), 58, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder51.beginComputePass();
+let sampler39 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 97.72,
+});
+try {
+computePassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(1243), 74, 0);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1, renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer21, 180, buffer18, 0, 64);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet4, 0, 5, buffer8, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 40, new BigUint64Array(5967), 274, 4);
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({size: [12], dimension: '1d', format: 'rgba32uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView69 = texture9.createView({baseMipLevel: 0});
+let computePassEncoder39 = commandEncoder50.beginComputePass();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup21, new Uint32Array(1848), 494, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer18, 4);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer33, 28);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer24, 1_164, 9_539);
+} catch {}
+let texture55 = device0.createTexture({
+  size: {width: 48, height: 36, depthOrArrayLayers: 70},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView70 = texture51.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup6, new Uint32Array(2534), 78, 0);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 119, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture56 = device0.createTexture({size: [124, 20, 20], format: 'r16uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let computePassEncoder40 = commandEncoder30.beginComputePass();
+let sampler40 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 90.05,
+  lodMaxClamp: 95.16,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.draw(82, 312, 229_794_520, 59_644_733);
+} catch {}
+try {
+renderPassEncoder6.drawIndexed(3, 274, 4, 129_058_320, 513_266_361);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer28, 56);
+} catch {}
+try {
+commandEncoder52.insertDebugMarker('\u0a25');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas1);
+let bindGroup26 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let commandEncoder53 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer33, 156); };
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer28, 72);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer3, 'uint32', 300, 318);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer26, 0, 9);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let texture57 = device0.createTexture({
+  size: {width: 62, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder13 = commandEncoder52.beginRenderPass({colorAttachments: [{view: textureView17, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler41 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 69.72,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer27, 'uint16', 222, 58);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer18, 4, 30);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 19},
+  aspect: 'all',
+}, new Uint8Array(21).fill(93), /* required buffer size: 21 */
+{offset: 5}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder54 = device0.createCommandEncoder({});
+let sampler42 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(0, bindGroup13, new Uint32Array(993), 164, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer35, 4); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder6.draw(154, 316, 125_991_308, 943_113_238);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer38, 4);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer23, 0);
+} catch {}
+try {
+commandEncoder53.copyBufferToBuffer(buffer21, 68, buffer16, 16, 48);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let recycledExplicitBindGroupLayout6 = pipeline0.getBindGroupLayout(0);
+try {
+computePassEncoder13.setBindGroup(3, bindGroup7, new Uint32Array(1089), 184, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer33, 72);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer10);
+} catch {}
+document.body.append(img0);
+let computePassEncoder41 = commandEncoder54.beginComputePass();
+let sampler43 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.59,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup4, new Uint32Array(1355), 316, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer18, 92);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer4, 20);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer24, 0, 2_627);
+} catch {}
+try {
+commandEncoder53.copyBufferToBuffer(buffer0, 0, buffer3, 1608, 8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 28, new Uint32Array(9976), 3111, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(11_044).fill(125), /* required buffer size: 11_044 */
+{offset: 244, bytesPerRow: 40, rowsPerImage: 54}, {width: 5, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let textureView71 = texture49.createView({});
+let computePassEncoder42 = commandEncoder53.beginComputePass();
+try {
+computePassEncoder6.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(2, bindGroup17, new Uint32Array(46), 11, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder21.pushDebugGroup('\u07a0');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(128).fill(137), /* required buffer size: 128 */
+{offset: 128, bytesPerRow: 488}, {width: 30, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout7 = pipeline3.getBindGroupLayout(0);
+let texture58 = device0.createTexture({
+  size: [62, 10, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture59 = device0.createTexture({
+  size: {width: 1248, height: 120, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView72 = texture26.createView({dimension: '2d-array'});
+let computePassEncoder43 = commandEncoder32.beginComputePass();
+let externalTexture2 = device0.importExternalTexture({source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, undefined, 1_115_635_593, 599_498_332);
+} catch {}
+let canvas2 = document.createElement('canvas');
+try {
+computePassEncoder9.setBindGroup(0, bindGroup24, new Uint32Array(1122), 77, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup12, new Uint32Array(3853), 254, 0);
+} catch {}
+let bindGroup27 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout5, entries: [{binding: 23, resource: textureView18}]});
+let commandEncoder55 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({
+  size: {width: 624, height: 60, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder44 = commandEncoder55.beginComputePass();
+try {
+computePassEncoder42.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer25, 0); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup17, new Uint32Array(10000), 310, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer27, 'uint32', 96, 234);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4, new Uint32Array(2825), 365, 0);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let textureView73 = texture4.createView({baseMipLevel: 0, baseArrayLayer: 14, arrayLayerCount: 8});
+let texture61 = gpuCanvasContext1.getCurrentTexture();
+let sampler44 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 99.61});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup27, new Uint32Array(1541), 59, 0);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder8.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(0, bindGroup19, new Uint32Array(4315), 2_132, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer27, 'uint32', 52, 156);
+} catch {}
+try {
+renderPassEncoder12.insertDebugMarker('\u0831');
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'iec61966-2-1'} });
+try {
+computePassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup1, new Uint32Array(745), 123, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer12, 'uint16', 200, 2_405);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer24, 0, 5_599);
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let buffer39 = device0.createBuffer({size: 140, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let sampler45 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 98.69,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup3, new Uint32Array(2109), 505, 0);
+} catch {}
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer20, 'uint16', 4, 43);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer24, 5_268);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(9); };
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let computePassEncoder45 = commandEncoder56.beginComputePass();
+try {
+computePassEncoder36.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(0, bindGroup16, new Uint32Array(295), 19, 0);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup11, new Uint32Array(3104), 48, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7, renderBundle0, renderBundle3, renderBundle4, renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer34, 4, 5);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 226, y: 17, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({});
+let commandBuffer5 = commandEncoder24.finish();
+let computePassEncoder46 = commandEncoder57.beginComputePass();
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 20.31,
+  compare: 'less-equal',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+let buffer40 = device0.createBuffer({size: 116, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture62 = device0.createTexture({size: [2], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder47 = commandEncoder58.beginComputePass();
+try {
+computePassEncoder26.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup27, new Uint32Array(2145), 57, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(538.5099165927539, 21.124711304654504, 35.07034709107897, 16.629143023770638, 0.33592582415228966, 0.6861918546186325);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture63 = device0.createTexture({
+  size: [1248, 120, 1],
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder14 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{view: textureView70, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 58770516,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder21.popDebugGroup();
+} catch {}
+try {
+computePassEncoder21.insertDebugMarker('\u1c69');
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  label: '\u8420\u0861',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule2,
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 300,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 68, shaderLocation: 7},
+          {format: 'uint8x2', offset: 24, shaderLocation: 0},
+          {format: 'sint32', offset: 72, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 112, shaderLocation: 1},
+          {format: 'sint32x3', offset: 56, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder60 = device0.createCommandEncoder();
+let textureView74 = texture34.createView({dimension: '2d-array'});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+commandEncoder60.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 96 */
+  offset: 96,
+  bytesPerRow: 39680,
+  rowsPerImage: 861,
+  buffer: buffer21,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer41 = device0.createBuffer({size: 272, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder61 = device0.createCommandEncoder({});
+let textureView75 = texture22.createView({baseArrayLayer: 0});
+let computePassEncoder48 = commandEncoder60.beginComputePass();
+let renderPassEncoder15 = commandEncoder61.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: -993.3, g: 525.2, b: 983.9, a: 650.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler47 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.42,
+  lodMaxClamp: 92.10,
+  compare: 'equal',
+});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup20, new Uint32Array(7774), 172, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer14);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'unspecified', transfer: 'gamma22curve'} });
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer8, 0); };
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer29, 'uint16', 8, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer10, 0);
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({});
+let sampler48 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 99.68});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer14, 0, 170);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer31, 4);
+} catch {}
+let buffer42 = device0.createBuffer({size: 11380, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture64 = device0.createTexture({
+  size: {width: 624, height: 60, depthOrArrayLayers: 62},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder49 = commandEncoder62.beginComputePass();
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup5, new Uint32Array(819), 114, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer18, 4);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer8, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer3, 'uint32', 804, 21);
+} catch {}
+let pipeline9 = device0.createComputePipeline({
+  label: '\ufd4b\uab53',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, constants: {39_941: 1, override5: 1, 4_051: 1}},
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+try {
+computePassEncoder49.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(2);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle3, renderBundle7, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(9, 0, 1, 676_527_247);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 744 widthInBlocks: 93 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1656 */
+  offset: 1656,
+  rowsPerImage: 238,
+  buffer: buffer42,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 117, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 93, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas0);
+let recycledExplicitBindGroupLayout8 = pipeline5.getBindGroupLayout(0);
+let bindGroup28 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 384, resource: {buffer: buffer27, offset: 0}}],
+});
+let renderPassEncoder16 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView70,
+  clearValue: { r: 401.7, g: -199.6, b: -17.81, a: 649.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 66101763,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup4, new Uint32Array(2345), 407, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(8, 0, 3, 117_066_768);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer18, 76);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 68, y: 11, z: 0},
+  aspect: 'all',
+}, new Uint8Array(126).fill(56), /* required buffer size: 126 */
+{offset: 126, bytesPerRow: 236, rowsPerImage: 94}, {width: 43, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule5, entryPoint: 'compute5'}});
+await gc();
+let textureView76 = texture62.createView({baseMipLevel: 0});
+let computePassEncoder50 = commandEncoder63.beginComputePass();
+try {
+renderPassEncoder2.draw(0, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(1, 0, 1, -337_789_856);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer36, 52);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer33, 96);
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let texture65 = device0.createTexture({size: [624, 60, 1], format: 'rgba32uint', usage: GPUTextureUsage.STORAGE_BINDING});
+let texture66 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder51 = commandEncoder65.beginComputePass();
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint'], sampleCount: 1, depthReadOnly: true});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(0, bindGroup24, new Uint32Array(3095), 1_171, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer9, 0); };
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup1, new Uint32Array(1756), 188, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: 927.0, g: 557.3, b: 755.7, a: -612.9, });
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer12, 'uint16', 512, 7_280);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer34);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer23, 8, buffer6, 0, 8);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1086 */
+  offset: 1086,
+  bytesPerRow: 512,
+  buffer: buffer12,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer9, 0, new Uint32Array(2155), 59, 4);
+} catch {}
+let textureView77 = texture64.createView({});
+let computePassEncoder52 = commandEncoder16.beginComputePass();
+let renderBundle8 = renderBundleEncoder8.finish({});
+let sampler49 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 97.08});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup21, new Uint32Array(170), 49, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(43); };
+} catch {}
+let imageData8 = new ImageData(8, 68);
+let commandEncoder66 = device0.createCommandEncoder({});
+try {
+computePassEncoder50.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer29, 'uint32', 0, 15);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline4);
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 78, resource: textureView54}]});
+let commandEncoder67 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup12, new Uint32Array(1624), 79, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(2, 2, 1); };
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder16.setViewport(30.30089018607235, 13.139439156875921, 120.87491646146759, 0.1846432885282474, 0.39262347016125587, 0.790957140234775);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer18, 16);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer32, 0);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 168 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56 */
+  offset: 56,
+  bytesPerRow: 9472,
+  buffer: buffer32,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 42, height: 10, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 20, new Uint32Array(20163), 1738, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 126, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(225).fill(228), /* required buffer size: 225 */
+{offset: 225, bytesPerRow: 802}, {width: 185, height: 29, depthOrArrayLayers: 0});
+} catch {}
+canvas1.height = 217;
+let buffer43 = device0.createBuffer({size: 56, usage: GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let textureView78 = texture26.createView({format: 'rgba8uint', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder53 = commandEncoder15.beginComputePass();
+let sampler50 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.04,
+  lodMaxClamp: 95.63,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder28); computePassEncoder28.dispatchWorkgroupsIndirect(buffer23, 0); };
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup25, new Uint32Array(1088), 57, 0);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder48.insertDebugMarker('\u4a27');
+} catch {}
+let pipeline11 = device0.createComputePipeline({
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, constants: {4_051: 1, override5: 1, 39_941: 1}},
+});
+let renderPassEncoder17 = commandEncoder48.beginRenderPass({
+  colorAttachments: [{view: textureView52, depthSlice: 49, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 39452427,
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint'], stencilReadOnly: true});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder53.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4370 */
+  offset: 4370,
+  buffer: buffer3,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 0, new Uint32Array(4076), 774, 0);
+} catch {}
+let bindGroup30 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout7, entries: [{binding: 23, resource: textureView18}]});
+let buffer44 = device0.createBuffer({size: 200, usage: GPUBufferUsage.VERTEX});
+let textureView79 = texture34.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder54 = commandEncoder67.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder23); computePassEncoder23.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle2, renderBundle0]);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer15, 0, buffer31, 0, 4);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 140 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 916 */
+  offset: 916,
+  bytesPerRow: 30464,
+  rowsPerImage: 53,
+  buffer: buffer42,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 22, y: 6, z: 1},
+  aspect: 'all',
+}, {width: 35, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise5;
+} catch {}
+let recycledExplicitBindGroupLayout9 = pipeline8.getBindGroupLayout(0);
+let textureView80 = texture25.createView({});
+let texture67 = device0.createTexture({size: [312, 30, 1], format: 'r16uint', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let computePassEncoder55 = commandEncoder66.beginComputePass();
+try {
+computePassEncoder50.setBindGroup(3, bindGroup7, new Uint32Array(1107), 290, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup5, new Uint32Array(6088), 355, 0);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(234);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer3, 'uint16', 36, 1_087);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 200, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(449).fill(73), /* required buffer size: 449 */
+{offset: 449, bytesPerRow: 727, rowsPerImage: 65}, {width: 169, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline10);
+} catch {}
+let pipeline12 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0x5ad7da7},
+  fragment: {module: shaderModule5, targets: [{format: 'rgba32uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule2,
+    constants: {},
+    buffers: [{arrayStride: 40, attributes: [{format: 'unorm8x2', offset: 12, shaderLocation: 7}]}],
+  },
+});
+let bindGroup31 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout3, entries: [{binding: 23, resource: textureView18}]});
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let texture68 = device0.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler51 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 63.48,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup10, []);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(0, bindGroup2, new Uint32Array(976), 18, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup21, new Uint32Array(1541), 22, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({});
+let texture69 = device0.createTexture({
+  size: [156, 15, 651],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 212.7, g: 797.1, b: -699.2, a: -193.8, });
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer14, 'uint32', 112, 72);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer14, 0);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer21, 16, buffer9, 20, 4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture70 = device0.createTexture({
+  size: [156, 15, 1],
+  dimension: '2d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder18 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  clearValue: { r: 285.8, g: -916.3, b: -619.7, a: -906.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroupsIndirect(buffer32, 0); };
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle3, renderBundle7, renderBundle1, renderBundle3]);
+} catch {}
+try {
+commandEncoder37.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3550 */
+  offset: 3550,
+  buffer: buffer12,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 0, new Int16Array(4458), 110, 28);
+} catch {}
+document.body.append(canvas2);
+let textureView81 = texture69.createView({aspect: 'all', format: 'r32float', mipLevelCount: 1});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer38, 4); };
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup28, new Uint32Array(931), 496, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer28, 0, 229);
+} catch {}
+let bindGroup32 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 23, resource: textureView18}]});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let buffer45 = device0.createBuffer({size: 57, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture71 = device0.createTexture({
+  size: {width: 124, height: 20, depthOrArrayLayers: 45},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup21, new Uint32Array(2792), 298, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, undefined, 178_314_806, 918_995_362);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(canvas0);
+let textureView82 = texture71.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 1});
+let textureView83 = texture12.createView({dimension: '2d-array'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup22, new Uint32Array(3499), 888, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(2); };
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 36, y: 10, z: 16},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({});
+let textureView84 = texture69.createView({});
+let computePassEncoder56 = commandEncoder37.beginComputePass();
+try {
+computePassEncoder56.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle3, renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, undefined);
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u255b');
+} catch {}
+let bindGroup33 = device0.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 23, resource: textureView73}]});
+let buffer46 = device0.createBuffer({size: 20, usage: GPUBufferUsage.COPY_DST});
+let texture72 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 72},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture73 = device0.createTexture({
+  size: [96, 72, 140],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView85 = texture0.createView({format: 'rgb10a2unorm', baseMipLevel: 0, arrayLayerCount: 2});
+try {
+renderPassEncoder16.executeBundles([renderBundle7]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(185).fill(199), /* required buffer size: 185 */
+{offset: 185, bytesPerRow: 237}, {width: 74, height: 13, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder71 = device0.createCommandEncoder();
+let textureView86 = texture72.createView({baseArrayLayer: 5, arrayLayerCount: 2});
+let textureView87 = texture59.createView({dimension: '2d-array'});
+let computePassEncoder57 = commandEncoder69.beginComputePass();
+let renderPassEncoder19 = commandEncoder71.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  depthSlice: 40,
+  clearValue: { r: -86.03, g: -772.8, b: 845.8, a: -936.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder15.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer27, 'uint32', 196, 83);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline4);
+} catch {}
+let textureView88 = texture67.createView({});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup10, new Uint32Array(3490), 247, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(32, 8, 99, 7);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer12, 'uint32', 2_576, 3_550);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(querySet2, 45, 1, buffer7, 0);
+} catch {}
+try {
+globalThis.someLabel = computePassEncoder21.label;
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder();
+let texture74 = device0.createTexture({
+  size: {width: 48, height: 36, depthOrArrayLayers: 34},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView89 = texture58.createView({});
+let sampler52 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.12,
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup0, new Uint32Array(1666), 150, 0);
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3360 */
+  offset: 3360,
+  bytesPerRow: 13568,
+  buffer: buffer42,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder58 = commandEncoder70.beginComputePass();
+let sampler53 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 35.63,
+  lodMaxClamp: 66.16,
+  compare: 'never',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup11, new Uint32Array(1360), 78, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer34, 0, 45);
+} catch {}
+let textureView90 = texture12.createView({dimension: '2d-array'});
+let renderPassEncoder20 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{
+  view: textureView49,
+  depthSlice: 8,
+  clearValue: { r: -574.4, g: 138.9, b: -248.1, a: -281.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler54 = device0.createSampler({
+  label: '\u{1f67a}\u0a78',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.00,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer10);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer13, 12, buffer7, 16, 4);
+} catch {}
+let bindGroup34 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout3, entries: [{binding: 23, resource: textureView7}]});
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView91 = texture71.createView({format: 'r32uint', baseArrayLayer: 4, arrayLayerCount: 5});
+let texture75 = device0.createTexture({
+  size: [248, 40, 51],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder17.executeBundles([renderBundle3, renderBundle0, renderBundle4, renderBundle7, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer44, 0, 3);
+} catch {}
+let buffer47 = device0.createBuffer({size: 248, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder74 = device0.createCommandEncoder({});
+let texture76 = device0.createTexture({
+  size: {width: 312, height: 30, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView92 = texture3.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder59 = commandEncoder74.beginComputePass();
+let sampler55 = device0.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 97.11});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(57);
+} catch {}
+try {
+renderPassEncoder13.setViewport(0.5200615749065229, 8.828823033229963, 5.54539891860299, 0.05568434569253341, 0.8584730753720808, 0.9943638505190437);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 129, 2, 231_688_889, 1_057_114_904);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer9, 8);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(209); };
+} catch {}
+let textureView93 = texture21.createView({dimension: '3d'});
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.draw(147, 63, 110_951_656, 3_699_265_944);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer47, 4);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer12, 'uint32', 292, 4_093);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer44, 8);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(39).fill(204), /* required buffer size: 39 */
+{offset: 39}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView94 = texture52.createView({aspect: 'all', format: 'r16uint'});
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder10.draw(137, 0, 1_031_295_546);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer35, 4);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer9, 20);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 44, new Uint32Array(5598), 449, 8);
+} catch {}
+let buffer48 = device0.createBuffer({size: 502, usage: GPUBufferUsage.STORAGE});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup4, new Uint32Array(868), 276, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(90, 0, 1_008_708_129);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer36, 20);
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder();
+let texture77 = device0.createTexture({
+  size: {width: 312, height: 30, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView95 = texture59.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder60 = commandEncoder75.beginComputePass();
+try {
+computePassEncoder58.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(600, 0, 1_003, 165_339_777);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer4, 12);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer14, 'uint16', 134, 125);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, undefined);
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 146, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(100).fill(58), /* required buffer size: 100 */
+{offset: 100, bytesPerRow: 336}, {width: 35, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup35 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 78, resource: textureView51}]});
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture78 = device0.createTexture({
+  size: [62, 10, 20],
+  mipLevelCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture79 = device0.createTexture({
+  size: [96],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder61 = commandEncoder8.beginComputePass();
+let sampler56 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 45.46,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder10.beginOcclusionQuery(202);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer25, 32);
+} catch {}
+let promise7 = shaderModule5.getCompilationInfo();
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 328 */
+  offset: 328,
+  bytesPerRow: 7424,
+  buffer: buffer42,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 12, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = device0.createComputePipeline({
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, constants: {override12: 1, override13: 1, override14: 1}},
+});
+try {
+globalThis.someLabel = renderPassEncoder7.label;
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({});
+let textureView96 = texture72.createView({baseArrayLayer: 11, arrayLayerCount: 22});
+let textureView97 = texture3.createView({dimension: '2d', baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder62 = commandEncoder39.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer23, 0); };
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(433, 0, 16, 333_646_203);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet2, 18, 0, buffer0, 0);
+} catch {}
+try {
+computePassEncoder42.pushDebugGroup('\u9eb0');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(12); };
+} catch {}
+let bindGroup36 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 23, resource: textureView73}]});
+let buffer49 = device0.createBuffer({size: 388, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture80 = device0.createTexture({
+  size: {width: 96, height: 72, depthOrArrayLayers: 20},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView98 = texture26.createView({});
+let computePassEncoder63 = commandEncoder76.beginComputePass();
+try {
+computePassEncoder17.setPipeline(pipeline13);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer11, 4);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer29, 'uint16', 2, 6);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder42.popDebugGroup();
+} catch {}
+try {
+  await promise7;
+} catch {}
+let computePassEncoder64 = commandEncoder77.beginComputePass();
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup21, new Uint32Array(2480), 651, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer23, 0);
+} catch {}
+let commandBuffer6 = commandEncoder73.finish();
+let texture81 = device0.createTexture({
+  size: [248, 40, 5],
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder64.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder10.draw(369, 0, 932_038_508);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(1_637, 0, 103, 147_595_673);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer38, 16);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer25, 40);
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3184 */
+  offset: 3184,
+  bytesPerRow: 4096,
+  rowsPerImage: 1065,
+  buffer: buffer42,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(310).fill(125), /* required buffer size: 310 */
+{offset: 310}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  label: '\ub878\u{1f864}\u7c6b\u4814\u74ca\u05ea\u8882\u048f\uce47',
+  layout: veryExplicitBindGroupLayout7,
+  entries: [{binding: 78, resource: textureView51}],
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroupsIndirect(buffer25, 4); };
+} catch {}
+try {
+renderPassEncoder10.draw(353, 0, 1_545_324_657);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(139, 0, 425, 691_195_133);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4_004).fill(112), /* required buffer size: 4_004 */
+{offset: 94, bytesPerRow: 62, rowsPerImage: 58}, {width: 1, height: 6, depthOrArrayLayers: 2});
+} catch {}
+let bindGroup38 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout7, entries: [{binding: 23, resource: textureView7}]});
+let buffer50 = device0.createBuffer({size: 112, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture82 = device0.createTexture({
+  size: {width: 156, height: 15, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup13, new Uint32Array(2396), 155, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle7]);
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 424 widthInBlocks: 53 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3904 */
+  offset: 3904,
+  buffer: buffer42,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 112, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 53, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 0 */
+  offset: 0,
+  bytesPerRow: 27136,
+  rowsPerImage: 2168,
+  buffer: buffer23,
+}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u8281');
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let renderPassEncoder21 = commandEncoder42.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: -286.1, g: 47.56, b: 651.1, a: -954.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint'], stencilReadOnly: true});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer45);
+} catch {}
+try {
+commandEncoder78.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer51 = device0.createBuffer({size: 132, usage: GPUBufferUsage.INDEX});
+let computePassEncoder65 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder14.setBindGroup(0, bindGroup31, []);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 288 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1920 */
+  offset: 1632,
+  rowsPerImage: 53,
+  buffer: buffer42,
+}, {
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 15, y: 7, z: 28},
+  aspect: 'all',
+}, {width: 18, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder23.insertDebugMarker('\u07b2');
+} catch {}
+let recycledExplicitBindGroupLayout10 = pipeline8.getBindGroupLayout(0);
+let computePassEncoder66 = commandEncoder78.beginComputePass();
+try {
+computePassEncoder29.setBindGroup(1, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(50);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\uf798');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0); };
+} catch {}
+let sampler57 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 66.26, compare: 'less'});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer51, 'uint32', 52, 12);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let promise8 = device0.createComputePipelineAsync({
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, constants: {override5: 1, 4_051: 1, 39_941: 1}},
+});
+let buffer52 = device0.createBuffer({
+  label: '\u0666\u0e50\u1c61\u{1ff51}\u8710\u283b\u02f9\u08d8',
+  size: 32,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder79 = device0.createCommandEncoder({});
+let texture83 = device0.createTexture({size: {width: 1248}, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_DST});
+let textureView99 = texture44.createView({dimension: '2d-array', format: 'rgba32uint', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle10 = renderBundleEncoder10.finish();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup39 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let buffer53 = device0.createBuffer({
+  size: 124,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+let computePassEncoder67 = commandEncoder79.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroupsIndirect(buffer35, 0); };
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer45, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(155).fill(11), /* required buffer size: 155 */
+{offset: 155}, {width: 5, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 212,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let buffer54 = device0.createBuffer({size: 292, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder81 = device0.createCommandEncoder({label: '\u8ac6\u0ef5\u4f0e\u48ca\u{1fe6b}\u0c76'});
+let texture84 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder68 = commandEncoder80.beginComputePass();
+let sampler58 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 73.42,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup27, new Uint32Array(2346), 1_215, 0);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer15, 0, buffer32, 12, 4);
+} catch {}
+let texture85 = device0.createTexture({
+  size: {width: 624, height: 60, depthOrArrayLayers: 131},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer20, 'uint16', 16, 18);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder1.copyBufferToTexture({
+  /* bytesInLastRow: 168 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3392 */
+  offset: 3392,
+  buffer: buffer42,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 33, y: 28, z: 3},
+  aspect: 'all',
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder81.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 13, y: 9, z: 1},
+  aspect: 'all',
+},
+{width: 3, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder81.resolveQuerySet(querySet0, 14, 2, buffer36, 0);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(19); };
+} catch {}
+let texture86 = device0.createTexture({
+  size: [312, 30, 1],
+  dimension: '2d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder69 = commandEncoder1.beginComputePass();
+let sampler59 = device0.createSampler({addressModeV: 'clamp-to-edge', magFilter: 'linear', lodMaxClamp: 75.11});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer51, 'uint32', 0, 24);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer49);
+} catch {}
+try {
+commandEncoder27.copyTextureToTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 36, y: 15, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 23, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer55 = device0.createBuffer({size: 56, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder82 = device0.createCommandEncoder();
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 870});
+let commandBuffer7 = commandEncoder27.finish();
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer53, 76); };
+} catch {}
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup14, new Uint32Array(1649), 242, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(106, 404, 865_476_444, 1_791_625_116);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer25, 8);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer36, 8);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder81.copyBufferToBuffer(buffer28, 28, buffer10, 0, 72);
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {module: shaderModule5, constants: {}, targets: [{format: 'rgba32uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex4',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 64,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32', offset: 4, shaderLocation: 0},
+          {format: 'sint8x4', offset: 8, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 4, shaderLocation: 7},
+          {format: 'float32x3', offset: 20, shaderLocation: 1},
+          {format: 'sint32x2', offset: 8, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let recycledExplicitBindGroupLayout11 = pipeline8.getBindGroupLayout(0);
+let buffer56 = device0.createBuffer({size: 56, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+computePassEncoder68.setBindGroup(1, bindGroup1, new Uint32Array(445), 11, 0);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder7.draw(39, 210, 82_753_803, 447_811_113);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 515, 3, 53_948_495, 2_357_190_906);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer18, 116);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer53, 'uint16', 68, 13);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer18, 0);
+} catch {}
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 700 */
+  offset: 700,
+  bytesPerRow: 38656,
+  rowsPerImage: 811,
+  buffer: buffer12,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer46);
+} catch {}
+let commandBuffer8 = commandEncoder70.finish();
+let textureView100 = texture58.createView({dimension: '2d-array'});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle6]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8, commandBuffer7]);
+} catch {}
+let texture87 = device0.createTexture({
+  size: {width: 1248, height: 120, depthOrArrayLayers: 4},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder70 = commandEncoder81.beginComputePass();
+try {
+computePassEncoder68.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup0, new Uint32Array(1011), 218, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer32, 28);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer41, 60);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+commandEncoder82.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 75, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder50.pushDebugGroup('\u02a0');
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+let imageData9 = new ImageData(40, 8);
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 10,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {
+      binding: 283,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup40 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let texture88 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 35},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView101 = texture7.createView({});
+let computePassEncoder71 = commandEncoder2.beginComputePass();
+try {
+computePassEncoder38.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup37, new Uint32Array(232), 25, 0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup30, new Uint32Array(612), 90, 0);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer28, 12);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer8, 8);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, undefined);
+} catch {}
+try {
+computePassEncoder50.popDebugGroup();
+} catch {}
+let buffer57 = device0.createBuffer({size: 31552, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder83 = device0.createCommandEncoder({});
+let commandBuffer9 = commandEncoder4.finish();
+let texture89 = device0.createTexture({size: [31], dimension: '1d', format: 'rgba32uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView102 = texture30.createView({});
+let computePassEncoder72 = commandEncoder83.beginComputePass();
+let renderPassEncoder22 = commandEncoder82.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 584.4, g: -552.2, b: -807.5, a: -276.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder70.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup40, new Uint32Array(2680), 605, 0);
+} catch {}
+try {
+renderPassEncoder20.draw(38, 5, 69_083_151, 408_691_206);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(0, 10, 0, 286_015_027, 194_337_375);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer25, 32);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer32, 40);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let textureView103 = texture83.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder56.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.draw(103, 3, 42_807_688, 238_246_543);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(0, 5, 0, 136_286_384, 1_444_776_808);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer42, 'uint32', 1_116, 2_284);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer17, 4, 117);
+} catch {}
+let buffer58 = device0.createBuffer({size: 237, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let texture90 = device0.createTexture({
+  size: {width: 624, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture91 = gpuCanvasContext2.getCurrentTexture();
+let sampler60 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'nearest'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData8,
+  origin: { x: 0, y: 7 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 608, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 24, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder84 = device0.createCommandEncoder({});
+let computePassEncoder73 = commandEncoder84.beginComputePass();
+try {
+renderPassEncoder7.drawIndirect(buffer18, 4);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer51, 'uint32', 0, 49);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(7, buffer24, 0);
+} catch {}
+let bindGroup41 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 0, resource: textureView95}]});
+let commandEncoder85 = device0.createCommandEncoder({});
+let renderPassEncoder23 = commandEncoder85.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  clearValue: { r: -461.8, g: -523.7, b: 724.0, a: 818.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder73.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(65);
+} catch {}
+try {
+renderPassEncoder20.draw(239, 290, 475_523_064, 443_302_984);
+} catch {}
+try {
+commandEncoder36.insertDebugMarker('\u{1feff}');
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 784});
+let sampler61 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 96.67});
+try {
+renderPassEncoder20.draw(539, 105, 1_538_219_886, 697_924_019);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(0, 191, 0, 672_713_790, 56_454_925);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4144 */
+  offset: 4144,
+  bytesPerRow: 50688,
+  buffer: buffer42,
+}, {
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 3},
+  aspect: 'all',
+}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture92 = device0.createTexture({
+  size: [248, 40, 99],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder20.draw(75, 22, 130_211_676, 449_705_694);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(0, 524, 0, -1_310_024_497, 827_755_445);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer20, 'uint32', 28, 16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 23, y: 1 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 134, y: 35, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 20, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer59 = device0.createBuffer({size: 220, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView104 = texture36.createView({aspect: 'all'});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame5});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup21);
+} catch {}
+document.body.append(canvas0);
+let buffer60 = device0.createBuffer({
+  size: 92,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture93 = gpuCanvasContext0.getCurrentTexture();
+let renderPassEncoder24 = commandEncoder86.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 79,
+  clearValue: { r: 444.1, g: 919.6, b: -560.3, a: -199.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder9.copyBufferToTexture({
+  /* bytesInLastRow: 190 widthInBlocks: 95 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1162 */
+  offset: 1162,
+  bytesPerRow: 1024,
+  buffer: buffer42,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 311, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 95, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(77); };
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout7]});
+let renderPassEncoder25 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{view: textureView52, depthSlice: 42, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 11728074,
+});
+let sampler62 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup33, new Uint32Array(2888), 526, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder20.draw(182, 257, 20_769_921, 1_141_714_521);
+} catch {}
+try {
+renderPassEncoder20.drawIndexed(0, 415, 0, 211_867_655, 2_180_946_015);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6118 */
+  offset: 6118,
+  bytesPerRow: 20992,
+  rowsPerImage: 160,
+  buffer: buffer42,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 122, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup42 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView101}]});
+let computePassEncoder74 = commandEncoder29.beginComputePass();
+try {
+computePassEncoder68.setBindGroup(0, bindGroup10, new Uint32Array(6467), 877, 0);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup27, new Uint32Array(247), 22, 0);
+} catch {}
+try {
+renderPassEncoder20.draw(242, 78, 80_770_089, 97_605_757);
+} catch {}
+try {
+renderPassEncoder20.drawIndirect(buffer9, 4);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer57, 'uint32', 3_572, 6_771);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer26, 0, 6);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let pipeline15 = device0.createRenderPipeline({
+  layout: pipelineLayout7,
+  fragment: {module: shaderModule5, entryPoint: 'fragment5', targets: [{format: 'rgba32uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule3,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 352, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 64, shaderLocation: 7},
+          {format: 'sint8x2', offset: 130, shaderLocation: 8},
+          {format: 'sint32x2', offset: 472, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 92, attributes: [{format: 'snorm8x4', offset: 16, shaderLocation: 1}]},
+    ],
+  },
+});
+document.body.prepend(canvas1);
+let img1 = await imageWithData(88, 41, '#10101010', '#20202020');
+let bindGroup43 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 384, resource: {buffer: buffer14}}]});
+let commandEncoder88 = device0.createCommandEncoder({});
+let texture94 = device0.createTexture({
+  size: {width: 1248, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 97.28,
+});
+try {
+renderPassEncoder20.drawIndexed(1, 82, 0, -1_907_668_254, 1_645_137_837);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(1, buffer29, 0, 0);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout12 = pipeline13.getBindGroupLayout(0);
+let buffer61 = device0.createBuffer({
+  size: 180,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 1049});
+let textureView105 = texture65.createView({});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup9, new Uint32Array(554), 187, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle2, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder20.draw(132, 45, 512_192_514, 52_970_896);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer29, 'uint32', 4, 10);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1920 */
+  offset: 1920,
+  rowsPerImage: 525,
+  buffer: buffer42,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView106 = texture75.createView({dimension: '2d', baseArrayLayer: 9});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup22, new Uint32Array(1506), 155, 0);
+} catch {}
+try {
+renderPassEncoder20.draw(6, 488, 25_089_968, 216_105_385);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer29, 0, 9);
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 26808 */
+  offset: 1192,
+  bytesPerRow: 5120,
+  buffer: buffer57,
+}, {width: 2, height: 6, depthOrArrayLayers: 1});
+} catch {}
+await gc();
+let commandEncoder90 = device0.createCommandEncoder({});
+try {
+computePassEncoder57.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder89.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 368 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 768 */
+  offset: 768,
+  buffer: buffer12,
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'film', transfer: 'smpte170m'} });
+try {
+globalThis.someLabel = texture81.label;
+} catch {}
+let texture95 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder75 = commandEncoder9.beginComputePass();
+let sampler64 = device0.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 94.20});
+try {
+{ clearResourceUsages(device0, computePassEncoder52); computePassEncoder52.dispatchWorkgroupsIndirect(buffer32, 52); };
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder20.drawIndexedIndirect(buffer47, 12);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 26, y: 14, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 0, new Int16Array(15730), 5952, 4);
+} catch {}
+let computePassEncoder76 = commandEncoder90.beginComputePass();
+let sampler65 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup17, new Uint32Array(3248), 1_819, 0);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture94,
+  mipLevel: 3,
+  origin: {x: 28, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 162, y: 51, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap2 = await createImageBitmap(videoFrame2);
+let bindGroup44 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout11, entries: [{binding: 23, resource: textureView7}]});
+let commandEncoder91 = device0.createCommandEncoder({});
+let texture96 = device0.createTexture({
+  size: {width: 96, height: 72, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView107 = texture9.createView({baseArrayLayer: 0});
+let renderPassEncoder26 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 406,
+  clearValue: { r: -77.24, g: 239.5, b: 644.2, a: 70.86, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+let sampler66 = device0.createSampler({addressModeU: 'repeat', magFilter: 'linear', lodMaxClamp: 94.98});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 544 */
+  offset: 544,
+  bytesPerRow: 22784,
+  buffer: buffer42,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder77 = commandEncoder89.beginComputePass();
+try {
+renderPassEncoder16.insertDebugMarker('\u0829');
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 176,
+        attributes: [{format: 'snorm8x4', offset: 0, shaderLocation: 7}, {format: 'uint8x4', offset: 8, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 16,
+        attributes: [
+          {format: 'sint8x2', offset: 0, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 1},
+          {format: 'sint8x4', offset: 0, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+document.body.prepend(img1);
+let externalTexture9 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'srgb'});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup22, new Uint32Array(2387), 356, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer36, 36); };
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await promise9;
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({});
+let commandBuffer10 = commandEncoder72.finish();
+let textureView108 = texture35.createView({dimension: '1d', aspect: 'all'});
+let computePassEncoder78 = commandEncoder87.beginComputePass();
+let sampler67 = device0.createSampler({addressModeW: 'repeat', lodMinClamp: 80.11, lodMaxClamp: 97.91});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup1, new Uint32Array(2431), 156, 0);
+} catch {}
+let recycledExplicitBindGroupLayout13 = pipeline9.getBindGroupLayout(0);
+let commandEncoder94 = device0.createCommandEncoder();
+let renderPassEncoder27 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 842.1, g: -892.4, b: 841.1, a: -803.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 22225481,
+});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup36, new Uint32Array(1558), 74, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 304 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 0 */
+  offset: 0,
+  rowsPerImage: 457,
+  buffer: buffer56,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(147).fill(52), /* required buffer size: 147 */
+{offset: 147, bytesPerRow: 988, rowsPerImage: 68}, {width: 59, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let buffer62 = device0.createBuffer({
+  size: 92,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder79 = commandEncoder92.beginComputePass();
+try {
+computePassEncoder59.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(3, bindGroup11, new Uint32Array(24), 6, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder19.draw(354, 91, 662_797_437, 3_664_593_348);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer42, 'uint16', 380, 1_034);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, undefined, 0, 405_748_402);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup45 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout8, entries: [{binding: 23, resource: textureView7}]});
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder80 = commandEncoder95.beginComputePass();
+let sampler68 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 48.31, compare: 'never'});
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder19.draw(143, 1, 1_525_099_227, 611_532_896);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(337).fill(44), /* required buffer size: 337 */
+{offset: 337}, {width: 64, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture97 = device0.createTexture({
+  size: {width: 24, height: 18, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture98 = gpuCanvasContext2.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder19.draw(333, 79, 888_824_828, 2_830_763_834);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer36, 24);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder88.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 81, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 336 widthInBlocks: 21 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1296 */
+  offset: 1296,
+  bytesPerRow: 12288,
+  buffer: buffer57,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData6,
+  origin: { x: 3, y: 5 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 183, y: 38, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let imageData10 = new ImageData(20, 116);
+let bindGroup46 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 78, resource: textureView51}]});
+let commandEncoder96 = device0.createCommandEncoder({});
+let textureView109 = texture10.createView({aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, undefined, 0, 419_309_815);
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 176 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 160 */
+  offset: 160,
+  buffer: buffer42,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(23); };
+} catch {}
+let bindGroup47 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 0, resource: textureView95}]});
+let textureView110 = texture27.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder81 = commandEncoder96.beginComputePass();
+let sampler69 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 98.83});
+try {
+computePassEncoder78.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer53, 'uint32', 24, 24);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer56, 16, buffer18, 72, 0);
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  label: '\u0f08\ueafa\u07fe\u3561\ueb67\udb8b\uf314\u{1fc69}\u{1f65a}\u052b',
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 384, resource: {buffer: buffer14}}],
+});
+let buffer63 = device0.createBuffer({size: 560, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let computePassEncoder82 = commandEncoder88.beginComputePass();
+let renderPassEncoder28 = commandEncoder44.beginRenderPass({
+  colorAttachments: [{
+  view: textureView52,
+  depthSlice: 31,
+  clearValue: { r: -82.35, g: -513.7, b: 176.8, a: -727.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+let sampler70 = device0.createSampler({
+  label: '\uff44\u{1f7aa}\u63a1\u5f9c\u4599\u00f3\u003e\uf89c\ua63f\u0bbf',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.44,
+  compare: 'less',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup26, new Uint32Array(3173), 59, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder19.draw(3, 1, 821_619_512, 140_523_176);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer45, 0, 9);
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let buffer64 = device0.createBuffer({size: 40, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder97 = device0.createCommandEncoder({});
+let computePassEncoder83 = commandEncoder94.beginComputePass();
+try {
+computePassEncoder47.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(215);
+} catch {}
+try {
+renderPassEncoder19.drawIndirect(buffer36, 24);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer6);
+} catch {}
+let buffer65 = device0.createBuffer({size: 28, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder98 = device0.createCommandEncoder({});
+let texture99 = device0.createTexture({
+  size: [48, 36, 1],
+  mipLevelCount: 4,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder29 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 294.0, g: -693.4, b: 253.9, a: 196.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder19.draw(83, 0, 666_126_648, 246_656_665);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer57, 'uint32', 1_676, 2_376);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 12, new Uint8Array(new ArrayBuffer(4974)).fill(3), 73, 8);
+} catch {}
+let textureView111 = texture60.createView({baseMipLevel: 0});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup43, []);
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle1, renderBundle7, renderBundle3, renderBundle2, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder28.setViewport(107.99113213782294, 35.39379143353895, 27.598863901274775, 3.336501160790236, 0.5375381233280923, 0.8419272024073834);
+} catch {}
+let videoFrame12 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let bindGroup49 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 384, resource: {buffer: buffer14}}]});
+let commandEncoder99 = device0.createCommandEncoder({label: '\u0196\ue724\u2598\u{1f9a4}\u{1fb69}\u0945\u0a7e'});
+let textureView112 = texture12.createView({dimension: '2d-array'});
+let computePassEncoder84 = commandEncoder97.beginComputePass();
+let renderPassEncoder30 = commandEncoder26.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 391,
+  clearValue: { r: -824.2, g: 986.3, b: 959.4, a: 863.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup23, new Uint32Array(1105), 128, 0);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle6, renderBundle5, renderBundle5, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline5);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+commandEncoder71.copyTextureToBuffer({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 50 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 354 */
+  offset: 354,
+  buffer: buffer57,
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = sampler58.label;
+} catch {}
+let bindGroup50 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout11, entries: [{binding: 23, resource: textureView18}]});
+let buffer66 = device0.createBuffer({
+  size: 4,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandBuffer11 = commandEncoder71.finish();
+let texture100 = device0.createTexture({
+  size: [2, 2, 29],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder85 = commandEncoder99.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 178, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder();
+let texture101 = device0.createTexture({
+  size: {width: 624},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let texture102 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder77.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup18, new Uint32Array(537), 25, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer12, 'uint32', 756, 6);
+} catch {}
+try {
+commandEncoder100.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 1,
+  origin: {x: 4, y: 5, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(151).fill(70), /* required buffer size: 151 */
+{offset: 151}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture8.label;
+} catch {}
+let bindGroup51 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout12, entries: [{binding: 23, resource: textureView73}]});
+let commandEncoder101 = device0.createCommandEncoder({});
+let computePassEncoder86 = commandEncoder100.beginComputePass();
+try {
+computePassEncoder82.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(57);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder101.copyBufferToTexture({
+  /* bytesInLastRow: 230 widthInBlocks: 115 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1112 */
+  offset: 1112,
+  bytesPerRow: 6144,
+  buffer: buffer42,
+}, {
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 127, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 115, height: 31, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+let pipeline17 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule3, constants: {}}});
+let commandEncoder102 = device0.createCommandEncoder({});
+let sampler71 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 51.98, maxAnisotropy: 1});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup8, new Uint32Array(3467), 732, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 27, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(82).fill(205), /* required buffer size: 82 */
+{offset: 82, bytesPerRow: 77}, {width: 19, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup52 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 23, resource: textureView18}]});
+let texture103 = device0.createTexture({
+  size: {width: 156},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+let bindGroup53 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 23, resource: textureView73}]});
+let computePassEncoder87 = commandEncoder11.beginComputePass();
+try {
+computePassEncoder78.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle6, renderBundle7, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder18.setViewport(1.8625688457303653, 3.5790335386799805, 9.133140027912333, 1.6322518280065927, 0.7926523912389799, 0.8827015354171582);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer61);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder102.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 288 */
+  offset: 288,
+  bytesPerRow: 13312,
+  buffer: buffer28,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 16, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup54 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout3, entries: [{binding: 23, resource: textureView18}]});
+let buffer67 = device0.createBuffer({
+  size: 72,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder103 = device0.createCommandEncoder();
+let computePassEncoder88 = commandEncoder103.beginComputePass();
+try {
+computePassEncoder88.setBindGroup(3, bindGroup11, new Uint32Array(1600), 5, 0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder17.setViewport(177.50808378200537, 21.879667085809142, 70.08362967770108, 17.22266770049389, 0.7882222624028191, 0.8651439534843407);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 22, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(432).fill(243), /* required buffer size: 432 */
+{offset: 432, rowsPerImage: 12}, {width: 100, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder104 = device0.createCommandEncoder({});
+let sampler72 = device0.createSampler({magFilter: 'linear', lodMinClamp: 95.52, lodMaxClamp: 98.82, compare: 'never'});
+try {
+computePassEncoder85.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+computePassEncoder37.setBindGroup(0, bindGroup31, new Uint32Array(486), 18, 0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(5, buffer29);
+} catch {}
+try {
+commandEncoder102.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1888 */
+  offset: 1888,
+  bytesPerRow: 22016,
+  buffer: buffer42,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder101.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 256 widthInBlocks: 128 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1910 */
+  offset: 1910,
+  bytesPerRow: 18176,
+  buffer: buffer57,
+}, {width: 128, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer68 = device0.createBuffer({size: 224, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX, mappedAtCreation: false});
+let textureView113 = texture8.createView({dimension: '2d'});
+let textureView114 = texture8.createView({arrayLayerCount: 1});
+let computePassEncoder89 = commandEncoder101.beginComputePass();
+try {
+computePassEncoder83.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+commandEncoder102.copyBufferToBuffer(buffer28, 12, buffer7, 64, 4);
+} catch {}
+try {
+computePassEncoder54.insertDebugMarker('\u8afe');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(83).fill(240), /* required buffer size: 83 */
+{offset: 83, bytesPerRow: 55}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+let texture104 = device0.createTexture({
+  size: {width: 96, height: 72, depthOrArrayLayers: 140},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView115 = texture86.createView({dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder90 = commandEncoder102.beginComputePass();
+try {
+computePassEncoder45.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder78); computePassEncoder78.dispatchWorkgroupsIndirect(buffer23, 0); };
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder104.copyBufferToBuffer(buffer66, 0, buffer3, 352, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(523).fill(30), /* required buffer size: 523 */
+{offset: 235, bytesPerRow: 12, rowsPerImage: 24}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout11, recycledExplicitBindGroupLayout12]});
+let buffer69 = device0.createBuffer({size: 52, usage: GPUBufferUsage.INDEX, mappedAtCreation: false});
+let textureView116 = texture83.createView({format: 'r16uint'});
+let sampler73 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder16.setViewport(57.42038313929562, 8.259084051597629, 50.1665242821044, 3.7403412172700494, 0.8563385659857933, 0.9521321040977431);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline5);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let bindGroup55 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout3, entries: [{binding: 23, resource: textureView18}]});
+let buffer70 = device0.createBuffer({size: 44, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup47, new Uint32Array(4597), 2_650, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroupsIndirect(buffer23, 12); };
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 562 */
+  offset: 562,
+  bytesPerRow: 7168,
+  buffer: buffer42,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 8, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let bindGroup56 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout9, entries: [{binding: 23, resource: textureView7}]});
+let buffer71 = device0.createBuffer({size: 32, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder105 = device0.createCommandEncoder();
+let texture105 = device0.createTexture({
+  size: {width: 156, height: 15, depthOrArrayLayers: 1},
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder91 = commandEncoder104.beginComputePass();
+try {
+computePassEncoder22.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(182);
+} catch {}
+try {
+commandEncoder105.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 126, y: 29, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 387, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 353, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(210).fill(120), /* required buffer size: 210 */
+{offset: 210, bytesPerRow: 245}, {width: 112, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({});
+let texture106 = device0.createTexture({
+  label: '\u0659\u0f3a\ub625\ue2fe\u7147\u9372\u7da2\u{1fb47}\u07fc\u{1f754}\ue6db',
+  size: {width: 62, height: 10, depthOrArrayLayers: 24},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder92 = commandEncoder106.beginComputePass();
+try {
+computePassEncoder57.setBindGroup(0, bindGroup39, new Uint32Array(476), 7, 0);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer70, 'uint16', 10, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let computePassEncoder93 = commandEncoder105.beginComputePass();
+let sampler74 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 96.21});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup37, new Uint32Array(1699), 328, 0);
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup5, new Uint32Array(3729), 1_555, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer51, 'uint32', 0, 75);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3252 */
+  offset: 3252,
+  bytesPerRow: 19200,
+  buffer: buffer42,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let recycledExplicitBindGroupLayout14 = pipeline10.getBindGroupLayout(0);
+let bindGroup57 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView21}]});
+let texture107 = device0.createTexture({
+  size: [312, 30, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView117 = texture47.createView({});
+let computePassEncoder94 = commandEncoder18.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer61, 40); };
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer44);
+} catch {}
+let textureView118 = texture34.createView({dimension: '2d-array', format: 'r16uint'});
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer12, 'uint16', 418, 2_933);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer17, 40, 27);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 0, new BigUint64Array(7998), 1705, 8);
+} catch {}
+let img2 = await imageWithData(112, 63, '#10101010', '#20202020');
+let commandEncoder107 = device0.createCommandEncoder({});
+let textureView119 = texture51.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder95 = commandEncoder107.beginComputePass();
+try {
+computePassEncoder29.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup26, new Uint32Array(3834), 807, 0);
+} catch {}
+try {
+computePassEncoder36.end();
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer51, 'uint16', 16, 0);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 736 */
+  offset: 736,
+  buffer: buffer42,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 48, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+try {
+globalThis.someLabel = buffer30.label;
+} catch {}
+try {
+computePassEncoder73.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer44);
+} catch {}
+let pipeline18 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {}}});
+try {
+  await promise11;
+} catch {}
+let textureView120 = texture107.createView({dimension: '2d', format: 'rgba32uint'});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer32, 0, 107);
+} catch {}
+let pipeline19 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, entryPoint: 'compute2'}});
+let adapter1 = await navigator.gpu.requestAdapter();
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder108 = device0.createCommandEncoder();
+let texture108 = device0.createTexture({
+  size: {width: 24, height: 18, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder54.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup31, new Uint32Array(53), 9, 0);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 208 */
+  offset: 208,
+  bytesPerRow: 1024,
+  buffer: buffer10,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 253, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(69).fill(28), /* required buffer size: 69 */
+{offset: 69, bytesPerRow: 388}, {width: 180, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let buffer72 = device0.createBuffer({size: 192, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let texture109 = device0.createTexture({
+  size: {width: 31, height: 5, depthOrArrayLayers: 9},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder31 = commandEncoder47.beginRenderPass({
+  label: '\u4dc7\u837a\u{1f944}',
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: -327.4, g: 763.9, b: 728.1, a: -936.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler75 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup39, new Uint32Array(1002), 27, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup2, new Uint32Array(1033), 437, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer62, 0);
+} catch {}
+try {
+commandEncoder108.clearBuffer(buffer59);
+} catch {}
+try {
+commandEncoder108.resolveQuerySet(querySet2, 47, 0, buffer7, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(176).fill(5), /* required buffer size: 176 */
+{offset: 176, bytesPerRow: 41}, {width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpte170m', transfer: 'pq'} });
+let buffer73 = device0.createBuffer({size: 112, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture110 = device0.createTexture({
+  size: {width: 156, height: 15, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView121 = texture5.createView({format: 'r16uint'});
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup21, new Uint32Array(81), 13, 0);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder108.copyBufferToTexture({
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 252 */
+  offset: 252,
+  buffer: buffer42,
+}, {
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 40, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 46, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder108.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 13, y: 36, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let bindGroup58 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 384, resource: {buffer: buffer14}}]});
+let buffer74 = device0.createBuffer({size: 40, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandBuffer12 = commandEncoder35.finish();
+let textureView122 = texture34.createView({dimension: '2d-array'});
+let computePassEncoder96 = commandEncoder108.beginComputePass();
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(4, buffer45, 0);
+} catch {}
+let recycledExplicitBindGroupLayout15 = pipeline8.getBindGroupLayout(0);
+try {
+computePassEncoder22.setBindGroup(3, bindGroup58, new Uint32Array(360), 205, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder57); computePassEncoder57.dispatchWorkgroupsIndirect(buffer35, 0); };
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder30.setViewport(466.31379653905185, 43.96632181379713, 52.35911182322383, 8.790326562719624, 0.23870743518269488, 0.8558591106055026);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer69, 'uint32', 0, 0);
+} catch {}
+let buffer75 = device0.createBuffer({size: 76, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+computePassEncoder74.setBindGroup(0, bindGroup32, new Uint32Array(372), 160, 0);
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle3, renderBundle4, renderBundle2, renderBundle2, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer67, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 24, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData11 = new ImageData(36, 4);
+let bindGroup59 = device0.createBindGroup({layout: veryExplicitBindGroupLayout1, entries: [{binding: 197, resource: textureView10}]});
+let buffer76 = device0.createBuffer({size: 96, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer0, 4, buffer46, 4, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 12, new Uint32Array(16103), 2934, 8);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(img1);
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte432', transfer: 'iec61966-2-1'} });
+let renderPassEncoder32 = commandEncoder16.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 532.2, g: 343.4, b: 552.8, a: 577.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup35, new Uint32Array(3648), 1_044, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer53, 'uint32', 4, 42);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 9, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(324).fill(224), /* required buffer size: 324 */
+{offset: 324, bytesPerRow: 497, rowsPerImage: 22}, {width: 28, height: 11, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer13 = commandEncoder30.finish();
+let texture111 = device0.createTexture({
+  size: [48, 36, 22],
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder88.setBindGroup(2, bindGroup46, new Uint32Array(222), 101, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup60 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout11, entries: [{binding: 23, resource: textureView73}]});
+let sampler76 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 51.38,
+  lodMaxClamp: 70.92,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+computePassEncoder70.setBindGroup(0, bindGroup24, new Uint32Array(956), 100, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer53, 'uint16', 24, 10);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, buffer28);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 4, new DataView(new ArrayBuffer(10300)), 338, 4);
+} catch {}
+let bindGroup61 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout13, entries: [{binding: 23, resource: textureView73}]});
+try {
+computePassEncoder76.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 19, y: 20, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(28, 20);
+let videoFrame15 = new VideoFrame(videoFrame12, {timestamp: 0});
+let commandEncoder109 = device0.createCommandEncoder({});
+let textureView123 = texture78.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+let texture112 = device0.createTexture({
+  size: [312],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder97 = commandEncoder109.beginComputePass();
+let sampler77 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 61.74});
+try {
+computePassEncoder88.setPipeline(pipeline10);
+} catch {}
+let texture113 = device0.createTexture({
+  size: [48, 36, 30],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder85.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline2);
+} catch {}
+let bindGroup62 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout12, entries: [{binding: 23, resource: textureView7}]});
+let buffer77 = device0.createBuffer({
+  size: 120,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let sampler78 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', magFilter: 'nearest', lodMaxClamp: 63.91});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'display-p3'});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup53, new Uint32Array(266), 37, 0);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+buffer67.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 68, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(38).fill(102), /* required buffer size: 38 */
+{offset: 38}, {width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup24, new Uint32Array(82), 11, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer77, 'uint16', 4, 41);
+} catch {}
+let sampler79 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  compare: 'less-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder95.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup5, new Uint32Array(4583), 16, 0);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer17, 0, 33);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(72).fill(163), /* required buffer size: 72 */
+{offset: 72}, {width: 145, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas1.width = 52;
+let sampler80 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'linear'});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer69, 'uint16', 4, 8);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline2);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let device1 = await adapter1.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'float32-blendable',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxVertexBuffers: 8,
+    maxUniformBufferBindingSize: 30042126,
+    maxStorageBufferBindingSize: 146390710,
+    maxSampledTexturesPerShaderStage: 16,
+  },
+});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 1066});
+let texture114 = device0.createTexture({
+  size: [31, 5, 1],
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler81 = device0.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'linear', compare: 'less'});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup21, new Uint32Array(475), 115, 0);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer29, 'uint32', 24, 2);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u88a6');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 73, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(242).fill(136), /* required buffer size: 242 */
+{offset: 242}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas1);
+let imageData13 = new ImageData(16, 28);
+let buffer78 = device1.createBuffer({
+  size: 60,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture115 = device1.createTexture({size: [780, 10, 1], mipLevelCount: 3, format: 'astc-10x10-unorm-srgb', usage: GPUTextureUsage.COPY_SRC});
+let textureView124 = texture115.createView({mipLevelCount: 1});
+let bindGroup63 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [{binding: 2, resource: {buffer: buffer48, size: 480}}],
+});
+let commandEncoder110 = device0.createCommandEncoder({label: '\u{1fc03}\u767a\ubd61\u{1fec6}\u{1fe54}'});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 79});
+let computePassEncoder98 = commandEncoder110.beginComputePass();
+let sampler82 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.22,
+  compare: 'less',
+});
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup49, new Uint32Array(189), 3, 0);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline12);
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let texture116 = gpuCanvasContext2.getCurrentTexture();
+let computePassEncoder99 = commandEncoder111.beginComputePass();
+let sampler83 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.45,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder65.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(1, buffer75, 0);
+} catch {}
+let veryExplicitBindGroupLayout12 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 446,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let sampler84 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.57,
+  compare: 'equal',
+  maxAnisotropy: 9,
+});
+let commandEncoder112 = device0.createCommandEncoder({});
+let texture117 = device0.createTexture({
+  size: {width: 124, height: 20, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder33 = commandEncoder112.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 204.6, g: 382.4, b: 51.21, a: -172.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 70886671,
+});
+try {
+renderPassEncoder23.beginOcclusionQuery(184);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline16);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer32, 12, 14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 36, y: 7, z: 1},
+  aspect: 'all',
+}, new Uint8Array(7).fill(164), /* required buffer size: 7 */
+{offset: 7, bytesPerRow: 571, rowsPerImage: 28}, {width: 34, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 405, y: 14, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData14 = new ImageData(112, 56);
+let buffer79 = device0.createBuffer({
+  size: 24,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint'], depthReadOnly: true});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder73.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer77, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup38, new Uint32Array(711), 191, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData9,
+  origin: { x: 5, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 730, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder113 = device0.createCommandEncoder({});
+let texture118 = device0.createTexture({
+  size: [248],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder100 = commandEncoder113.beginComputePass();
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+computePassEncoder78.end();
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder17.setViewport(54.094247217498975, 10.979538268508694, 116.08196790690225, 17.84037004284686, 0.934330449874734, 0.9732182318131668);
+} catch {}
+let veryExplicitBindGroupLayout13 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 446,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture119 = device1.createTexture({
+  size: [195, 2, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let bindGroup64 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout7, entries: [{binding: 23, resource: textureView7}]});
+let computePassEncoder101 = commandEncoder87.beginComputePass();
+try {
+computePassEncoder96.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup43, new Uint32Array(884), 40, 0);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(362);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData15 = new ImageData(8, 32);
+let veryExplicitBindGroupLayout14 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 446,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout10 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout13]});
+let buffer80 = device1.createBuffer({size: 668, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder114 = device1.createCommandEncoder({});
+let texture120 = device1.createTexture({
+  size: {width: 2688, height: 12, depthOrArrayLayers: 19},
+  format: 'astc-6x6-unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler85 = device1.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 92.63});
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(204); };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder41.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline14);
+} catch {}
+try {
+texture38.destroy();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 222, y: 53, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder115 = device1.createCommandEncoder({});
+document.body.append(canvas0);
+let imageData16 = new ImageData(84, 16);
+let pipelineLayout11 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout12]});
+let commandEncoder116 = device1.createCommandEncoder({});
+let computePassEncoder102 = commandEncoder114.beginComputePass();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout12 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout13]});
+let commandEncoder117 = device1.createCommandEncoder({});
+let texture121 = device1.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 22},
+  dimension: '2d',
+  format: 'astc-8x8-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture122 = device1.createTexture({size: [20, 1, 1], sampleCount: 1, format: 'rgb10a2unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+buffer78.unmap();
+} catch {}
+let commandEncoder118 = device1.createCommandEncoder({});
+let textureView125 = texture121.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+device1.queue.submit([]);
+} catch {}
+let commandEncoder119 = device1.createCommandEncoder({});
+let texture123 = device1.createTexture({
+  size: [1560, 20, 14],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder103 = commandEncoder117.beginComputePass();
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder115.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 336 */
+  offset: 336,
+  buffer: buffer80,
+}, {
+  texture: texture119,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpteRp431', transfer: 'smpteSt4281'} });
+let textureView126 = texture121.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let sampler86 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 14,
+});
+let buffer81 = device0.createBuffer({size: 161, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder120 = device0.createCommandEncoder({});
+let textureView127 = texture45.createView({mipLevelCount: 1});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup32, new Uint32Array(2147), 539, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup36, new Uint32Array(432), 12, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 64, new DataView(new ArrayBuffer(7365)), 34, 4);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(16); };
+} catch {}
+await gc();
+try {
+globalThis.someLabel = device1.queue.label;
+} catch {}
+let texture124 = device1.createTexture({
+  size: [1896, 1, 1],
+  mipLevelCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView128 = texture119.createView({dimension: '2d', format: 'rgba8sint', mipLevelCount: 1});
+let commandEncoder121 = device1.createCommandEncoder({});
+let texture125 = device1.createTexture({
+  size: {width: 1560, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture12 = device1.importExternalTexture({source: videoFrame6});
+let commandEncoder122 = device1.createCommandEncoder({});
+let textureView129 = texture125.createView({mipLevelCount: 2});
+let textureView130 = texture120.createView({dimension: '2d'});
+let computePassEncoder104 = commandEncoder122.beginComputePass();
+let sampler87 = device1.createSampler({addressModeW: 'mirror-repeat', magFilter: 'linear'});
+try {
+device1.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 1584, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1_217).fill(53), /* required buffer size: 1_217 */
+{offset: 7, bytesPerRow: 242, rowsPerImage: 5}, {width: 84, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(2); };
+} catch {}
+canvas1.width = 591;
+let commandEncoder123 = device0.createCommandEncoder({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup28, new Uint32Array(93), 3, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup10, new Uint32Array(6123), 1_380, 0);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer81, 0, 35);
+} catch {}
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4940 */
+  offset: 4940,
+  bytesPerRow: 2816,
+  buffer: buffer42,
+}, {
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder124 = device1.createCommandEncoder();
+let texture126 = device1.createTexture({
+  size: [195, 2, 1],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView131 = texture119.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder105 = commandEncoder118.beginComputePass();
+let renderBundleEncoder12 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder12.finish({});
+let promise13 = device1.queue.onSubmittedWorkDone();
+let img3 = await imageWithData(12, 3, '#10101010', '#20202020');
+let buffer82 = device0.createBuffer({size: 247, usage: GPUBufferUsage.COPY_SRC});
+let texture127 = gpuCanvasContext2.getCurrentTexture();
+let textureView132 = texture68.createView({});
+let computePassEncoder106 = commandEncoder123.beginComputePass();
+let renderPassEncoder34 = commandEncoder120.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 419.4, g: 755.7, b: -693.8, a: 160.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 25415004,
+});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+computePassEncoder97.setBindGroup(3, bindGroup0, new Uint32Array(2952), 127, 0);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+globalThis.someLabel = externalTexture12.label;
+} catch {}
+let texture128 = device1.createTexture({
+  size: [40, 1, 15],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView133 = texture124.createView({dimension: '2d', aspect: 'depth-only'});
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1896, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise13;
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 384, resource: {buffer: buffer14, offset: 0}}],
+});
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+computePassEncoder47.pushDebugGroup('\u2ef6');
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder125 = device0.createCommandEncoder();
+try {
+computePassEncoder13.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup25, new Uint32Array(3087), 1_012, 0);
+} catch {}
+let promise14 = shaderModule3.getCompilationInfo();
+canvas3.height = 909;
+let buffer83 = device0.createBuffer({size: 2120, usage: GPUBufferUsage.VERTEX});
+let texture129 = device0.createTexture({
+  size: [62, 10, 16],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView134 = texture92.createView({dimension: '3d', mipLevelCount: 1});
+let computePassEncoder107 = commandEncoder125.beginComputePass();
+try {
+computePassEncoder60.setBindGroup(0, bindGroup44);
+} catch {}
+try {
+computePassEncoder86.setBindGroup(0, bindGroup44, new Uint32Array(297), 135, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer66, 0);
+} catch {}
+try {
+computePassEncoder47.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: img3,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 16, y: 17, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(21); };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture130 = device1.createTexture({
+  size: {width: 80, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({});
+let texture131 = device0.createTexture({
+  size: [96, 72, 140],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView135 = texture51.createView({mipLevelCount: 1});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup5, new Uint32Array(5751), 43, 0);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer20, 'uint32', 4, 1);
+} catch {}
+let pipeline20 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {override5: 1, 4_051: 1, 39_941: 1}}});
+await gc();
+let computePassEncoder108 = commandEncoder126.beginComputePass();
+try {
+computePassEncoder37.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup2, new Uint32Array(1382), 854, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer26, 12, 4);
+} catch {}
+let commandEncoder127 = device0.createCommandEncoder({});
+let textureView136 = texture35.createView({});
+let computePassEncoder109 = commandEncoder127.beginComputePass();
+try {
+computePassEncoder89.setBindGroup(0, bindGroup1, new Uint32Array(1879), 688, 0);
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer57, 'uint16', 5_704, 1_651);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline2);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 37, y: 4, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 47, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout14]});
+let buffer84 = device0.createBuffer({size: 155, usage: GPUBufferUsage.COPY_DST});
+let textureView137 = texture70.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder110 = commandEncoder25.beginComputePass();
+let sampler88 = device0.createSampler({addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 59.26});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup37, new Uint32Array(774), 295, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer3, 'uint32', 484, 453);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.insertDebugMarker('\u017c');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 30 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 202, y: 13, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 8, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  label: '\u{1fc9e}\ubaa0\uf596\u0b8c\u4fa4\u{1fbb3}\u32f6\u65ab',
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [{binding: 23, resource: textureView18}],
+});
+let buffer85 = device0.createBuffer({size: 32, usage: GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+try {
+computePassEncoder96.setBindGroup(0, bindGroup61, new Uint32Array(1418), 151, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder27); computePassEncoder27.dispatchWorkgroupsIndirect(buffer25, 4); };
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle11, renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer53, 'uint32', 0, 6);
+} catch {}
+try {
+renderPassEncoder31.insertDebugMarker('\u{1fee2}');
+} catch {}
+try {
+  await promise14;
+} catch {}
+let bindGroup67 = device0.createBindGroup({
+  label: '\u0f1b\u58a0\u{1fee3}\u4b35\ud0e8\u26c0\u{1ffc8}\u4714\u{1fc21}\u7201',
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 197, resource: textureView101}],
+});
+let buffer86 = device0.createBuffer({size: 556, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder128 = device0.createCommandEncoder({});
+let computePassEncoder111 = commandEncoder128.beginComputePass();
+try {
+computePassEncoder25.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(3, bindGroup42, new Uint32Array(1160), 61, 0);
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup64);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline2);
+} catch {}
+let texture132 = device1.createTexture({
+  size: {width: 237, height: 1, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture133 = device1.createTexture({
+  size: [10, 1, 1],
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder112 = commandEncoder119.beginComputePass();
+let sampler89 = device1.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', minFilter: 'nearest'});
+let buffer87 = device1.createBuffer({size: 117, usage: GPUBufferUsage.QUERY_RESOLVE});
+let textureView138 = texture121.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let texture134 = device1.createTexture({
+  size: {width: 20, height: 1, depthOrArrayLayers: 10},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder113 = commandEncoder116.beginComputePass();
+try {
+device1.queue.submit([]);
+} catch {}
+let pipelineLayout14 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout12]});
+let texture135 = device1.createTexture({
+  size: {width: 195, height: 2, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder112.insertDebugMarker('\u{1fd8f}');
+} catch {}
+let recycledExplicitBindGroupLayout16 = pipeline8.getBindGroupLayout(0);
+let bindGroup68 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout12, entries: [{binding: 23, resource: textureView7}]});
+let buffer88 = device0.createBuffer({size: 19, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder21.setStencilReference(3037);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(1, buffer34, 0);
+} catch {}
+let shaderModule6 = device1.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+diagnostic(info, xyz);
+
+enable f16;
+
+requires pointer_composite_access;
+
+var<private> vp8: VertexOutput6 = VertexOutput6();
+
+var<private> vp17: array<VertexOutput6, 1> = array(VertexOutput6(vec2h(2036.1, -8408.0), vec4h(4565.9, 1580.5, 31002.3, 40317.1), vec4f(-0.01209, 0.06224, -0.1302, 0.2308e26), vec4f(0.2325, 0.1760e-40, 0.02361, 0.3669e17), vec4h(23066.7, 1691.5, 10922.3, 197.2), vec4u(1016115423, 389278554, 611554287, 470501698), f16(2354.8)));
+
+var<private> vp11: array<FragmentOutput4, 1> = array(FragmentOutput4());
+
+var<private> vp10: bool = bool(true);
+
+@id(19443) override override22: bool;
+
+var<private> vp16: VertexOutput6 = VertexOutput6();
+
+/* zero global variables used */
+fn fn3(a0: bool, a1: ptr<private, vec4f>) {
+  let ptr26: ptr<private, vec2h> = &vp8.f17;
+  let ptr27: ptr<private, array<FragmentOutput4, 1>> = &vp11;
+  var vf87: u32 = vp8.f22[unconst_u32(77886515)];
+  vp16.f22 |= vp17[0].f22;
+  vp8 = VertexOutput6(bitcast<vec2h>(dot4I8Packed(unconst_u32(480202252), unconst_u32(735833559))), vec4h(f16(dot4I8Packed(unconst_u32(480202252), unconst_u32(735833559)))), vec4f(bitcast<f32>(dot4I8Packed(unconst_u32(480202252), unconst_u32(735833559)))), vec4f(f32(dot4I8Packed(unconst_u32(480202252), unconst_u32(735833559)))), vec4h(f16(dot4I8Packed(unconst_u32(480202252), unconst_u32(735833559)))), vec4u(bitcast<u32>(dot4I8Packed(unconst_u32(480202252), unconst_u32(735833559)))), f16(dot4I8Packed(unconst_u32(480202252), unconst_u32(735833559))));
+  let ptr28: ptr<private, vec4u> = &vp16.f22;
+  for (var jj61=0u; jj61<3; jj61++) { vp12[jj61].fract *= vec3h(vp17[0].f18[unconst_u32(38537403)]); }
+}
+
+var<private> vp9: VertexOutput6 = VertexOutput6();
+
+/* zero global variables used */
+@must_use 
+fn fn2(a0: ptr<private, vec4f>) -> f32 {
+  var out: f32;
+  vp17[unconst_u32(56585422)].f19 = vec4f(vp16.f17.xyxx.abgr);
+  out += f32(vp9.f17[unconst_u32(499598879)]);
+  return out;
+}
+
+/* zero global variables used */
+@must_use 
+fn fn1() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  var vf83: u32 = vp8.f22[unconst_u32(153332089)];
+  vp8.f18 = vp17[0].f18;
+  while bool(pack4xU8(vp8.f22)) {
+  if bool(vp17[unconst_u32(178132967)].f20[2]) {
+  out.f0 = vp11[0].f2.r;
+  loop {
+  vp14[unconst_u32(60915010)] = vec2<bool>(vp11[unconst_u32(1790370268)].f1.gr.rr.rr);
+  break;
+}
+  vp16.f21 = vec4h( !vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true)).zyxx);
+}
+  for (var jj5=0u; jj5<3; jj5++) { vp14[jj5] = vec2<bool>(bool(vp16.f23)); }
+  while bool(vp11[0].f0) {
+  vp10 = bool(dot4I8Packed(unconst_u32(808861724), bitcast<u32>(inverseSqrt(vec3f(unconst_f32(0.1609e33), unconst_f32(0.4492), unconst_f32(0.01718)))[1])));
+  var vf84: f32 = vp17[0].f19[unconst_u32(1091747115)];
+  var vf85: vec2h = step(vec2h(unconst_f16(2904.5), unconst_f16(-11649.1)), vec2h(unconst_f16(25127.6), unconst_f16(-11484.8)));
+}
+}
+  vp14[bitcast<vec4u>(vp11[0].f2)[1]] = vec2<bool>(vp17[0].f21.rb);
+  if bool(vp9.f22[bitcast<u32>(vp11[0].f2[unconst_u32(1334022991)])]) {
+  var vf86: u32 = vp8.f22[unconst_u32(1461165284)];
+}
+  let ptr23: ptr<private, vec4h> = &vp8.f18;
+  let ptr24: ptr<private, vec4f> = &vp9.f20;
+  {
+  out.f0 += vp17[0].f20.x;
+  out.f1 = vec2f(f32(vp17[0].f18[unconst_u32(1445370420)]));
+}
+  let ptr25: ptr<private, vec4h> = &vp16.f18;
+  return out;
+}
+
+@group(0) @binding(153) var<storage, read_write> buffer89: array<vec2u>;
+
+@group(1) @binding(1) var tex0: texture_cube_array<f32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* used global variables: tex0 */
+@must_use 
+fn fn0() -> VertexOutput6 {
+  var out: VertexOutput6;
+  switch bitcast<i32>(vp9.f19[unconst_u32(156570186)]) { 
+  default {
+  vp9.f21 = vec4h(vp8.f19);
+  vp11[unconst_u32(2534510786)] = FragmentOutput4(vp9.f20[2], vp9.f20.bg, vp9.f20, bitcast<i32>(vp9.f20.r));
+  out.f20 *= bitcast<vec4f>(textureDimensions(tex0, unconst_i32(367228902)).rrrg);
+  out.f23 = f16(vp12[0].exp.g);
+  break;
+  _ = tex0;
+}
+  }
+  vp13 = modf(vp16.f20.xz);
+  vp17[unconst_u32(297359685)].f23 = vp17[0].f18[2];
+  out.f18 = vec4h(vp8.f18[u32(vp9.f18[unconst_u32(216626280)])]);
+  let vf80: u32 = vp8.f22[unconst_u32(385142880)];
+  let ptr20: ptr<private, i32> = &vp11[unconst_u32(355951641)].f3;
+  out.f19 = unpack4x8snorm(vp17[unconst_u32(572222028)].f22[unconst_u32(253186156)]);
+  for (var it2=pack4x8unorm(vp17[0].f20); it2<(pack4x8unorm(vp17[0].f20) & 0xfff); it2++) {
+  let ptr21: ptr<private, vec2h> = &vp17[unconst_u32(1377717664)].f17;
+  let vf81: f32 = vp17[0].f19[unconst_u32(628246016)];
+  vp13.whole = vp17[0].f20.ga;
+  let ptr22: ptr<private, vec2f> = &vp11[0].f1;
+  var vf82: f32 = vp9.f20[u32(vp10)];
+}
+  return out;
+  _ = tex0;
+}
+
+struct T0 {
+  @align(8) @size(8) f0: array<atomic<i32>>,
+}
+
+var<private> vp14: array<vec2<bool>, 1> = array<vec2<bool>, 1>();
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @align(16) @size(384) f0: array<vec2<bool>, 5>,
+  @align(16) @size(64) f1: u32,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp15: bool = bool(false);
+
+struct VertexOutput6 {
+  @location(14) @interpolate(perspective, centroid) f17: vec2h,
+  @location(1) @interpolate(perspective, first) f18: vec4h,
+  @location(9) @interpolate(linear, sample) f19: vec4f,
+  @builtin(position) f20: vec4f,
+  @location(7) @interpolate(linear, center) f21: vec4h,
+  @location(15) f22: vec4u,
+  @location(11) @interpolate(linear, sample) f23: f16,
+}
+
+var<private> vp13 = modf(vec2f(-0.00164, 0.7733e-1));
+
+var<private> vp12 = array(frexp(vec3h(17932.7, 7892.3, 2566.0)));
+
+@group(0) @binding(446) var<storage, read_write> buffer90: array<array<array<atomic<i32>, 20>, 2>>;
+
+struct FragmentOutput4 {
+  @builtin(frag_depth) f0: f32,
+  @location(7) @interpolate(perspective) f1: vec2f,
+  @location(0) @interpolate(perspective) f2: vec4f,
+  @location(3) f3: i32,
+}
+
+/* used global variables: tex0 */
+@vertex
+fn vertex7(@location(12) @interpolate(flat, centroid) a0: vec2u) -> VertexOutput6 {
+  var out: VertexOutput6;
+  vp16.f20 = vp8.f20;
+  vp10 = vp15;
+  var vf88: u32 = vp17[0].f22[unconst_u32(488655987)];
+  vp16 = VertexOutput6(vec2h(vp17[0].f20.gb), vec4h(vp17[0].f20.wzxy), vp17[0].f20, vp17[0].f20, vec4h(vp17[0].f20), vec4u(vp17[0].f20.wwyy), f16(vp17[0].f20.x));
+  var vf89: f32 = vp11[0].f1[unconst_u32(411795227)];
+  vp14[0] = vec2<bool>(vp17[unconst_u32(171089249)].f20.ba);
+  loop {
+  _ = fn0();
+  break;
+  _ = tex0;
+}
+  fn3(bool(ceil(vec2f(unconst_f32(0.1065e-7), unconst_f32(0.06101e36))).g), &vp17[0].f19);
+  let ptr29: ptr<private, vec4f> = &vp17[0].f19;
+  let ptr30: ptr<private, vec4f> = &vp11[unconst_u32(4294967295)].f2;
+  return out;
+  _ = tex0;
+}
+
+/* used global variables: buffer89, buffer90 */
+@fragment
+fn fragment6() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  let ptr31: ptr<storage, array<vec2u>, read_write> = &buffer89;
+  let ptr32: ptr<private, i32> = &vp11[0].f3;
+  let ptr33: ptr<storage, array<array<atomic<i32>, 20>, 2>, read_write> = &buffer90[arrayLength(&buffer90)];
+  vp13 = modf(vec2f(f32(atomicExchange(&buffer90[unconst_u32(1602282281)][unconst_u32(830052248)][19], unconst_i32(174165956)))));
+  out.f2 = pow(vec2f(unconst_f32(0.2110e23), unconst_f32(-0.2262)), vec2f(unconst_f32(0.01649), unconst_f32(0.00558e-2))).rggg;
+  vp10 = bool(atomicLoad(&(*&buffer90)[unconst_u32(1554999649)][1][19]));
+  var vf90: vec3<bool> = (vec3h(unconst_f16(10710.6), unconst_f16(18352.9), unconst_f16(5305.2)) == vec3h(f16(atomicLoad(&(*&buffer90)[arrayLength(&(*&buffer90))][unconst_u32(972306628)][19]))));
+  let vf91: i32 = atomicLoad(&buffer90[arrayLength(&buffer90)][unconst_u32(346428304)][unconst_u32(1011053945)]);
+  vp11[unconst_u32(15953243)].f1 = bitcast<vec2f>(vp17[0].f22.gb);
+  let vf92: vec2f = tan(vec2f((vec2<bool>(unconst_bool(true), unconst_bool(false)) | vec2<bool>(unconst_bool(true), unconst_bool(false))).rr.yx.gr));
+  return out;
+  _ = buffer90;
+  _ = buffer89;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(8, 2, 1)
+fn compute7() {
+  _ = fn2(&vp17[0].f20);
+  vp11[unconst_u32(827161645)].f0 += f32(vp16.f17[unconst_u32(182067628)]);
+  vp8.f23 = f16(unpack2x16unorm(unconst_u32(52976007))[0]);
+  let ptr34: ptr<private, vec4h> = &vp17[0].f18;
+  vp13.fract = vp17[0].f19.ra;
+  vp10 = bool(vp11[bitcast<u32>(vp9.f20[unconst_u32(9385712)])].f1[0]);
+  let vf93: f16 = vp9.f18[unconst_u32(137387246)];
+  vp15 = bool(vp9.f17[0]);
+  let ptr35: ptr<private, vec4h> = &vp16.f18;
+}`,
+});
+let texture136 = device1.createTexture({
+  size: {width: 20, height: 1, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView139 = texture125.createView({dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler90 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 8,
+});
+await gc();
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: true }},
+  ],
+});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 1707});
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer67);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let pipeline21 = await promise8;
+let buffer91 = device1.createBuffer({size: 112, usage: GPUBufferUsage.COPY_DST});
+let texture137 = device1.createTexture({
+  size: [390, 5, 1],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture138 = device1.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 22},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView140 = texture136.createView({label: '\u080a\u0a6a\ub82a\u{1fbc5}\uc2b4\u03db\ucde0\uabc7', aspect: 'depth-only'});
+try {
+buffer91.unmap();
+} catch {}
+let texture139 = device1.createTexture({
+  size: {width: 948, height: 1, depthOrArrayLayers: 30},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView141 = texture123.createView({format: 'rgb10a2unorm', mipLevelCount: 1});
+let buffer92 = device1.createBuffer({size: 80, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder129 = device1.createCommandEncoder();
+let commandBuffer14 = commandEncoder115.finish();
+let texture140 = device1.createTexture({
+  size: {width: 20, height: 1, depthOrArrayLayers: 106},
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture141 = device1.createTexture({
+  size: [474, 1, 36],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder114 = commandEncoder121.beginComputePass();
+let sampler91 = device1.createSampler({mipmapFilter: 'nearest', lodMaxClamp: 71.31});
+try {
+commandEncoder129.copyBufferToBuffer(buffer80, 4, buffer92, 8, 0);
+} catch {}
+let pipeline22 = await device1.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 290076803,
+    depthBiasSlopeScale: 709.0017719670749,
+    depthBiasClamp: 218.90334172994494,
+  },
+  vertex: {
+    module: shaderModule6,
+    constants: {},
+    buffers: [{arrayStride: 40, attributes: [{format: 'uint32', offset: 0, shaderLocation: 12}]}],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back'},
+});
+let textureView142 = texture138.createView({
+  label: '\u03dd\u19ef\ud80e\u05e7\u0f10\u05cc\u1b91\u2c61\u2f8e\u0291\u1ec9',
+  dimension: 'cube-array',
+  baseArrayLayer: 2,
+  arrayLayerCount: 6,
+});
+let texture142 = device1.createTexture({
+  size: [948, 1, 4],
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView143 = texture139.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 3});
+let computePassEncoder115 = commandEncoder124.beginComputePass();
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({});
+let renderPassEncoder35 = commandEncoder130.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: -737.9, g: -444.4, b: -181.2, a: -530.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 304804098,
+});
+let sampler92 = device0.createSampler({addressModeU: 'repeat'});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder99.setBindGroup(3, bindGroup65, new Uint32Array(1064), 89, 0);
+} catch {}
+try {
+computePassEncoder97.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup2);
+} catch {}
+await gc();
+let commandEncoder131 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 818});
+let texture143 = device0.createTexture({
+  size: [1248, 120, 1],
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder4.setIndexBuffer(buffer61, 'uint32', 36, 36);
+} catch {}
+try {
+commandEncoder131.clearBuffer(buffer35);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 40, new Int16Array(5335), 825, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 342, y: 30, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 212,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let buffer93 = device0.createBuffer({size: 56, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let sampler93 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.24,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder101.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline15);
+} catch {}
+try {
+commandEncoder131.copyBufferToTexture({
+  /* bytesInLastRow: 26 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1430 */
+  offset: 1430,
+  bytesPerRow: 2048,
+  buffer: buffer42,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: img2,
+  origin: { x: 11, y: 4 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 236, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 8, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder132 = device1.createCommandEncoder({});
+let textureView144 = texture142.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder116 = commandEncoder132.beginComputePass();
+let sampler94 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 97.96,
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder129.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 188 */
+  offset: 188,
+  buffer: buffer80,
+}, {
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(13).fill(142), /* required buffer size: 13 */
+{offset: 13, rowsPerImage: 32}, {width: 1896, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas3);
+let textureView145 = texture125.createView({aspect: 'depth-only', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder117 = commandEncoder129.beginComputePass();
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+let canvas4 = document.createElement('canvas');
+let buffer94 = device1.createBuffer({
+  size: 12,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let querySet12 = device1.createQuerySet({type: 'occlusion', count: 77});
+let texture144 = device1.createTexture({
+  size: [20, 1, 1],
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let commandEncoder133 = device0.createCommandEncoder({});
+let textureView146 = texture30.createView({});
+let computePassEncoder118 = commandEncoder131.beginComputePass();
+try {
+computePassEncoder76.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+computePassEncoder107.setBindGroup(0, bindGroup36, new Uint32Array(451), 61, 0);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView147 = texture121.createView({dimension: '2d', baseArrayLayer: 6});
+let gpuCanvasContext4 = canvas4.getContext('webgpu');
+document.body.append(canvas2);
+await gc();
+let commandEncoder134 = device0.createCommandEncoder({});
+let renderPassEncoder36 = commandEncoder134.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: -341.4, g: 949.5, b: -215.2, a: 257.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+});
+try {
+computePassEncoder88.setBindGroup(0, bindGroup58, new Uint32Array(2137), 44, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup61, new Uint32Array(2360), 548, 0);
+} catch {}
+let veryExplicitBindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 163,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout17 = pipeline11.getBindGroupLayout(0);
+let bindGroup69 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout11, entries: [{binding: 23, resource: textureView73}]});
+let commandEncoder135 = device0.createCommandEncoder({});
+let computePassEncoder119 = commandEncoder133.beginComputePass();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup56);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder84); computePassEncoder84.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: -348.6, g: 267.5, b: -143.7, a: -47.40, });
+} catch {}
+try {
+renderPassEncoder36.setViewport(125.76220942822647, 13.093480796805473, 84.50835489453128, 3.6322603218077694, 0.42566106691389904, 0.5539812407988343);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline15);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+let pipeline23 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule5, constants: {42_686: 1}, buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let buffer95 = device0.createBuffer({size: 52, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder136 = device0.createCommandEncoder({});
+let computePassEncoder120 = commandEncoder135.beginComputePass();
+let renderPassEncoder37 = commandEncoder136.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: -253.7, g: 507.6, b: -421.6, a: 112.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 255333775,
+});
+try {
+computePassEncoder108.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1158 */
+  offset: 1158,
+  bytesPerRow: 64256,
+  rowsPerImage: 1052,
+  buffer: buffer42,
+}, {
+  texture: texture14,
+  mipLevel: 1,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let renderPassEncoder38 = commandEncoder43.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 260.3, g: 76.13, b: 122.9, a: 469.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler95 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.93,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(4, 0, 12, 9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData13,
+  origin: { x: 2, y: 3 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 41, y: 73, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let pipeline24 = await device0.createComputePipelineAsync({
+  layout: pipelineLayout5,
+  compute: {module: shaderModule0, constants: {override5: 1, 4_051: 1, 39_941: 1}},
+});
+await gc();
+let sampler96 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 58.22,
+  lodMaxClamp: 77.41,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder110.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer42, 'uint32', 2_412, 2);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline1);
+} catch {}
+let veryExplicitBindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 1068});
+let textureView148 = texture4.createView({dimension: '2d', baseArrayLayer: 1});
+let sampler97 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 93.30,
+});
+try {
+renderPassEncoder4.setIndexBuffer(buffer29, 'uint32', 0, 1);
+} catch {}
+let promise15 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x1f23410b},
+  fragment: {
+  module: shaderModule1,
+  targets: [{
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex1',
+    constants: {override11: 1, 34_596: 1, override6: 1, 39_941: 1},
+    buffers: [
+      {
+        arrayStride: 328,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 28, shaderLocation: 14},
+          {format: 'uint32x3', offset: 92, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 36, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: false},
+});
+let textureView149 = texture27.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer53, 'uint32', 12, 29);
+} catch {}
+let buffer96 = device0.createBuffer({size: 200, usage: GPUBufferUsage.STORAGE});
+let commandEncoder137 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(1, buffer45, 0, 0);
+} catch {}
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 12, y: 4, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 16, y: 21, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 24, new Uint32Array(4835), 264, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 15, y: 7, z: 0},
+  aspect: 'all',
+}, new Uint8Array(341).fill(2), /* required buffer size: 341 */
+{offset: 341, bytesPerRow: 38, rowsPerImage: 17}, {width: 11, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(48); };
+} catch {}
+let veryExplicitBindGroupLayout19 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 153,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 446,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder138 = device1.createCommandEncoder({});
+let texture145 = device1.createTexture({
+  size: [20, 1, 19],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device1.queue.writeBuffer(buffer91, 8, new Uint32Array(3562), 629, 0);
+} catch {}
+let imageData17 = new ImageData(8, 44);
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 23});
+let texture146 = device0.createTexture({
+  size: [12, 9, 17],
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView150 = texture96.createView({});
+let renderPassEncoder39 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView45,
+  clearValue: { r: 257.5, g: -694.3, b: -188.5, a: 782.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+try {
+computePassEncoder89.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(3105), 319, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer62, 'uint16', 30, 2);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise16;
+} catch {}
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup70 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+let buffer97 = device0.createBuffer({size: 255, usage: GPUBufferUsage.VERTEX});
+let commandEncoder139 = device0.createCommandEncoder({});
+let renderPassEncoder40 = commandEncoder139.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: 84.97, g: 681.6, b: 334.4, a: 275.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+computePassEncoder100.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer98 = device1.createBuffer({size: 184, usage: GPUBufferUsage.INDEX, mappedAtCreation: false});
+let commandEncoder140 = device1.createCommandEncoder({});
+let texture147 = device1.createTexture({
+  size: [40, 1, 1],
+  mipLevelCount: 4,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let commandEncoder141 = device1.createCommandEncoder({});
+let computePassEncoder121 = commandEncoder140.beginComputePass();
+let computePassEncoder122 = commandEncoder138.beginComputePass();
+let sampler98 = device1.createSampler({label: '\u0427\u6920\u{1f859}\u2f3c\u{1fc65}', addressModeV: 'mirror-repeat', lodMaxClamp: 83.25});
+document.body.append(canvas0);
+let commandEncoder142 = device0.createCommandEncoder();
+let renderPassEncoder41 = commandEncoder142.beginRenderPass({
+  colorAttachments: [{view: textureView60, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet14,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer47, 68); };
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer67, 'uint32', 16, 19);
+} catch {}
+try {
+computePassEncoder49.insertDebugMarker('\u451f');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(1); };
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470bg', transfer: 'bt2020_12bit'} });
+let autogeneratedBindGroupLayout0 = pipeline22.getBindGroupLayout(0);
+let querySet15 = device1.createQuerySet({type: 'occlusion', count: 686});
+let externalTexture14 = device1.importExternalTexture({source: videoFrame12, colorSpace: 'display-p3'});
+try {
+commandEncoder141.resolveQuerySet(querySet12, 5, 0, buffer92, 0);
+} catch {}
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba8sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder143 = device0.createCommandEncoder({});
+let texture148 = device0.createTexture({
+  size: [24, 18, 35],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler99 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 93.14});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame12});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup3, new Uint32Array(5297), 1_050, 0);
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline13);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder({});
+let computePassEncoder123 = commandEncoder144.beginComputePass();
+try {
+computePassEncoder84.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+computePassEncoder123.setBindGroup(0, bindGroup33, new Uint32Array(14), 4, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer21, 'uint16', 50, 247);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(6, buffer18, 0, 28);
+} catch {}
+let pipeline25 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, constants: {}}});
+let bindGroup71 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout8, entries: [{binding: 23, resource: textureView7}]});
+let commandEncoder145 = device0.createCommandEncoder({});
+let commandBuffer15 = commandEncoder17.finish();
+let renderPassEncoder42 = commandEncoder143.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  clearValue: { r: -57.55, g: -680.9, b: 406.8, a: -56.73, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder107); computePassEncoder107.dispatchWorkgroupsIndirect(buffer28, 8); };
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder145.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3574 */
+  offset: 3574,
+  rowsPerImage: 74,
+  buffer: buffer42,
+}, {
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder145.resolveQuerySet(querySet8, 197, 0, buffer66, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(810).fill(0), /* required buffer size: 810 */
+{offset: 189, bytesPerRow: 381, rowsPerImage: 11}, {width: 15, height: 2, depthOrArrayLayers: 1});
+} catch {}
+let texture149 = device1.createTexture({
+  size: [474, 1, 1],
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder124 = commandEncoder141.beginComputePass();
+let veryExplicitBindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView151 = texture77.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder32.executeBundles([renderBundle11, renderBundle10]);
+} catch {}
+try {
+commandEncoder145.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16 */
+  offset: 16,
+  bytesPerRow: 2816,
+  rowsPerImage: 1065,
+  buffer: buffer10,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer99 = device0.createBuffer({size: 69, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder146 = device0.createCommandEncoder({});
+let textureView152 = texture8.createView({dimension: 'cube', baseArrayLayer: 1});
+let textureView153 = texture71.createView({dimension: '2d', baseArrayLayer: 3});
+let computePassEncoder125 = commandEncoder145.beginComputePass();
+let sampler100 = device0.createSampler({
+  label: '\u0202\u54c7\u4002\uc5f8\u01ae\u036d\u{1fa1a}\u{1f6a6}\u0681',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.13,
+  compare: 'less',
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder110.setBindGroup(2, bindGroup63);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(3, bindGroup4, new Uint32Array(411), 166, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder60); computePassEncoder60.dispatchWorkgroupsIndirect(buffer77, 32); };
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer68, 'uint32', 52, 31);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer72, 0);
+} catch {}
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'jedecP22Phosphors', transfer: 'linear'} });
+let computePassEncoder126 = commandEncoder146.beginComputePass();
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r16uint']});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder126.setPipeline(pipeline13);
+} catch {}
+let buffer100 = device1.createBuffer({
+  size: 162,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture150 = device1.createTexture({size: [474], dimension: '1d', format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(65); };
+} catch {}
+let imageBitmap3 = await createImageBitmap(imageBitmap0);
+let buffer101 = device0.createBuffer({size: 100, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let texture151 = device0.createTexture({
+  size: {width: 1248, height: 120, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder90.setBindGroup(0, bindGroup44, []);
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline25);
+} catch {}
+let buffer102 = device0.createBuffer({size: 96, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler101 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest'});
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroupsIndirect(buffer38, 20); };
+} catch {}
+try {
+renderPassEncoder40.beginOcclusionQuery(19);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer51, 'uint16', 8, 6);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(0, buffer83, 76);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout9, entries: [{binding: 23, resource: textureView7}]});
+let buffer103 = device0.createBuffer({size: 60, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder147 = device0.createCommandEncoder({});
+let computePassEncoder127 = commandEncoder147.beginComputePass();
+try {
+computePassEncoder34.setBindGroup(0, bindGroup56, new Uint32Array(3063), 22, 0);
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let textureView154 = texture92.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let sampler102 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.84,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder38.insertDebugMarker('\ub5f1');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData9,
+  origin: { x: 4, y: 2 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 45, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup73 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout3, entries: [{binding: 23, resource: textureView7}]});
+let buffer104 = device0.createBuffer({size: 124, usage: GPUBufferUsage.QUERY_RESOLVE});
+let computePassEncoder128 = commandEncoder148.beginComputePass();
+try {
+computePassEncoder87.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+computePassEncoder127.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+buffer95.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 233, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(65).fill(240), /* required buffer size: 65 */
+{offset: 65, bytesPerRow: 788}, {width: 197, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup74 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 446, resource: {buffer: buffer100, size: 160}},
+    {binding: 153, resource: {buffer: buffer100, offset: 0, size: 116}},
+  ],
+});
+let texture152 = device1.createTexture({
+  size: {width: 390},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture153 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder121.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+buffer92.unmap();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(121); };
+} catch {}
+let buffer105 = device1.createBuffer({
+  label: '\u0609\u0e9d\u{1fa12}\udc02\u2c03\u0a0f\ub504',
+  size: 44,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder149 = device1.createCommandEncoder({});
+let texture154 = device1.createTexture({
+  size: {width: 948, height: 1, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth32float-stencil8', 'depth32float-stencil8', 'depth32float-stencil8'],
+});
+let computePassEncoder129 = commandEncoder149.beginComputePass();
+let pipeline26 = device1.createComputePipeline({layout: pipelineLayout14, compute: {module: shaderModule6, constants: {}}});
+document.body.append(canvas0);
+let sampler103 = device1.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 70.24});
+try {
+computePassEncoder104.setPipeline(pipeline26);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(212).fill(238), /* required buffer size: 212 */
+{offset: 2, bytesPerRow: 35, rowsPerImage: 6}, {width: 6, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let canvas5 = document.createElement('canvas');
+let texture155 = device1.createTexture({
+  size: [10, 1, 39],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let sampler104 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 78.26,
+});
+let commandEncoder150 = device0.createCommandEncoder();
+let computePassEncoder130 = commandEncoder150.beginComputePass();
+let sampler105 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 85.66,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder130.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer9, 4);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer67, 0);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer51, 'uint32', 28, 1);
+} catch {}
+try {
+buffer103.unmap();
+} catch {}
+try {
+renderPassEncoder34.insertDebugMarker('\u{1f6e1}');
+} catch {}
+let gpuCanvasContext5 = canvas5.getContext('webgpu');
+let buffer106 = device0.createBuffer({size: 448, usage: GPUBufferUsage.STORAGE});
+let textureView155 = texture95.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup14, new Uint32Array(126), 49, 0);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle7, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer77, 4);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(2, buffer34);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'jedecP22Phosphors', transfer: 'log'} });
+let bindGroup75 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 446, resource: {buffer: buffer100, size: 160}}, {binding: 153, resource: {buffer: buffer78}}],
+});
+let buffer107 = device1.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView156 = texture115.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder103.setPipeline(pipeline26);
+} catch {}
+let bindGroup76 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout9, entries: [{binding: 23, resource: textureView18}]});
+let externalTexture16 = device0.importExternalTexture({
+  label: '\u3a5b\u5ec4\u{1fe78}\u{1f8fe}\ufe6c\u{1ffab}\uf91b\u3d8a',
+  source: videoFrame17,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder128.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder40.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.draw(0, 318, 0, 663_085_909);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(0, 384, 0, 20_103_201, 228_192_766);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline12);
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'film', transfer: 'bt2020_10bit'} });
+let texture156 = device0.createTexture({
+  size: [1248, 120, 1],
+  mipLevelCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame12, colorSpace: 'srgb'});
+try {
+computePassEncoder55.end();
+} catch {}
+try {
+renderPassEncoder33.draw(0, 160, 0, 135_234_372);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(0, 29, 0, 86_394_191, 220_167_864);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 86 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1432 */
+  offset: 1432,
+  bytesPerRow: 33024,
+  buffer: buffer42,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 43, height: 26, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData1,
+  origin: { x: 24, y: 7 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 47, y: 20, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule7 = device1.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct T1 {
+  @align(8) @size(160) f0: array<atomic<u32>, 1>,
+}
+
+var<private> vp20: FragmentOutput5 = FragmentOutput5(vec4f(0.1066e-14, 0.1177, 0.03603e-24, 0.2032), f32(0.2619e-29));
+
+var<private> vp19: vec2<bool> = vec2<bool>(true, false);
+
+/* zero global variables used */
+fn fn0(a0: array<array<vec4h, 1>, 1>, a1: ptr<private, vec4f>) -> vec2f {
+  var out: vec2f;
+  vp20.f1 = tan(vec4f(unconst_f32(0.00995), unconst_f32(0.01755e3), unconst_f32(0.2236), unconst_f32(0.2578))).z;
+  out = bitcast<vec2f>(a0[0][unconst_u32(677853562)]);
+  vp21.exp = vp22[0][0].exp.grb;
+  let ptr36: ptr<private, vec4f> = &vp22[0][0].fract;
+  let ptr37 = &vp22[unconst_u32(356861970)][unconst_u32(435372263)];
+  loop {
+  var vf94: u32 = pack4x8unorm(vec4f(unconst_f32(0.1985), unconst_f32(0.4000e19), unconst_f32(0.1089), unconst_f32(0.05110)));
+  (*a1) += unpack4x8unorm(pack4xU8(vec4u(unconst_u32(312630372), unconst_u32(2003810538), unconst_u32(160493678), unconst_u32(326467275))));
+  let ptr38 = &vp22[0][unconst_u32(561599017)];
+  let ptr39 = &vp21;
+  let ptr40: ptr<private, vec3i> = &(*ptr39).exp;
+  let ptr41: ptr<private, vec4f> = &vp22[0][unconst_u32(603819790)].fract;
+  break;
+}
+  let ptr42 = &vp22[0][0];
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp18: T0 = T0(array(vec2<bool>(false, false)));
+
+@group(0) @binding(153) var<storage, read_write> buffer108: array<vec4h>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(446) var<storage, read_write> buffer109: array<array<array<vec2h, 5>, 8>>;
+
+struct T0 {
+  @size(192) f0: array<vec2<bool>, 1>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp22 = array(array(frexp(vec4f(0.1686, 0.02217e-6, 0.09307, 0.02297e-21))));
+
+override override23: f16;
+
+override override24: u32;
+
+alias vec3b = vec3<bool>;
+
+var<private> vp21 = frexp(vec3h(3580.4, -5874.3, 5287.4));
+
+struct FragmentOutput5 {
+  @location(0) f0: vec4f,
+  @builtin(frag_depth) f1: f32,
+}
+
+/* used global variables: buffer108, buffer109 */
+@fragment
+fn fragment7(@location(7) a0: vec4h) -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  while bool(buffer109[arrayLength(&buffer109)][unconst_u32(874249763)][unconst_u32(1486431310)].g) {
+  while bool(trunc(vec2h(unconst_f16(8402.8), unconst_f16(10382.0))).x) {
+  let ptr43: ptr<storage, vec4h, read_write> = &buffer108[unconst_u32(1339201280)];
+  var vf95: vec2h = refract(vec2h(unconst_f16(4417.1), unconst_f16(13104.5)), vec2h(vp22[0][0].exp.yx), buffer108[arrayLength(&buffer108)][unconst_u32(1199372988)]);
+  let vf96: vec3h = inverseSqrt(vec3h(unconst_f16(13113.6), unconst_f16(3483.4), unconst_f16(4972.6)));
+  _ = buffer108;
+}
+  vp22[unconst_u32(550238946)][unconst_u32(64360684)] = frexp(vec4f(buffer109[unconst_u32(267610919)][7][4].xxyy.ywyy.rbag));
+  break;
+  _ = buffer109;
+  _ = buffer108;
+}
+  return out;
+  _ = buffer108;
+  _ = buffer109;
+}`,
+});
+let buffer110 = device1.createBuffer({size: 100, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture157 = device1.createTexture({size: [10, 1, 1], format: 'depth32float-stencil8', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView157 = texture147.createView({dimension: '2d-array', aspect: 'stencil-only', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder113.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline26);
+} catch {}
+let textureView158 = texture86.createView({dimension: '2d-array'});
+let computePassEncoder131 = commandEncoder66.beginComputePass();
+try {
+computePassEncoder88.setBindGroup(0, bindGroup72, new Uint32Array(1610), 522, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup48, new Uint32Array(2251), 362, 0);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(0, 25, 0, 355_409_488, 311_614_335);
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer41, 164);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer53, 8);
+} catch {}
+try {
+renderPassEncoder16.insertDebugMarker('\u093f');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer101, 32, new BigUint64Array(4936), 160, 0);
+} catch {}
+let veryExplicitBindGroupLayout23 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup77 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 446, resource: {buffer: buffer100, offset: 0, size: 160}},
+    {binding: 153, resource: {buffer: buffer78}},
+  ],
+});
+let texture158 = gpuCanvasContext5.getCurrentTexture();
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+try {
+renderBundleEncoder14.setVertexBuffer(4, buffer100);
+} catch {}
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 210,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup78 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 78, resource: textureView54}]});
+let commandEncoder151 = device0.createCommandEncoder({});
+let texture159 = device0.createTexture({
+  size: [312],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView159 = texture16.createView({});
+let computePassEncoder132 = commandEncoder151.beginComputePass();
+let sampler106 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 93.19});
+try {
+computePassEncoder131.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(2, buffer61, 64, 14);
+} catch {}
+try {
+  await shaderModule3.getCompilationInfo();
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer99, 68, buffer16, 0, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: canvas4,
+  origin: { x: 5, y: 6 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 61, y: 17, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 212, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let texture160 = device1.createTexture({
+  size: {width: 390},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture18 = device1.importExternalTexture({source: videoFrame13});
+try {
+renderBundleEncoder14.setIndexBuffer(buffer78, 'uint16', 2, 2);
+} catch {}
+let buffer111 = device0.createBuffer({size: 294, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder152 = device0.createCommandEncoder({});
+let computePassEncoder133 = commandEncoder152.beginComputePass();
+try {
+computePassEncoder60.end();
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer62, 'uint16', 2, 24);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(2, buffer88, 0, 3);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 828 widthInBlocks: 207 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3020 */
+  offset: 3020,
+  bytesPerRow: 14080,
+  buffer: buffer42,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 660, y: 1, z: 4},
+  aspect: 'all',
+}, {width: 207, height: 13, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+try {
+globalThis.someLabel = textureView133.label;
+} catch {}
+let buffer112 = device1.createBuffer({size: 216, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder153 = device1.createCommandEncoder({});
+let texture161 = device1.createTexture({
+  label: '\u{1fe30}\u0d9d\u41c5\u031f\u00ff',
+  size: {width: 80, height: 1, depthOrArrayLayers: 20},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder134 = commandEncoder153.beginComputePass();
+try {
+computePassEncoder113.setBindGroup(0, bindGroup77, new Uint32Array(3), 0, 0);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer110, 'uint16', 42, 6);
+} catch {}
+try {
+device1.queue.submit([commandBuffer14]);
+} catch {}
+document.body.prepend(canvas0);
+let canvas6 = document.createElement('canvas');
+let computePassEncoder135 = commandEncoder75.beginComputePass();
+let sampler107 = device0.createSampler({addressModeW: 'repeat', magFilter: 'linear', mipmapFilter: 'linear'});
+try {
+renderPassEncoder40.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder112.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 109, y: 0, z: 63},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView160 = texture10.createView({});
+let computePassEncoder136 = commandEncoder112.beginComputePass();
+let sampler108 = device0.createSampler({addressModeV: 'mirror-repeat', magFilter: 'linear', mipmapFilter: 'linear'});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup32, new Uint32Array(1095), 275, 0);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(506);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: canvas3,
+  origin: { x: 28, y: 30 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 943, y: 98, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 48, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout25 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup79 = device1.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 446, resource: {buffer: buffer112}}, {binding: 153, resource: {buffer: buffer100, size: 12}}],
+});
+let buffer113 = device1.createBuffer({size: 976, usage: GPUBufferUsage.STORAGE});
+let commandEncoder154 = device1.createCommandEncoder({});
+let sampler109 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 81.41, compare: 'less'});
+let computePassEncoder137 = commandEncoder154.beginComputePass();
+try {
+renderBundleEncoder14.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(6, buffer100, 0, 0);
+} catch {}
+try {
+device1.lost.then(({reason, message}) => { console.log('device1 lost!'); console.log(message, reason); });
+} catch {}
+let promise17 = device1.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0x16d184eb},
+  fragment: {
+  module: shaderModule6,
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'never', failOp: 'keep', depthFailOp: 'replace', passOp: 'replace'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'keep'},
+    stencilReadMask: 616301384,
+    stencilWriteMask: 598782763,
+    depthBias: -1820726643,
+    depthBiasClamp: 989.1930882713352,
+  },
+  vertex: {
+    module: shaderModule6,
+    buffers: [
+      {
+        arrayStride: 760,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 12, shaderLocation: 12}],
+      },
+    ],
+  },
+});
+let texture162 = device1.createTexture({
+  size: [948],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView161 = texture130.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup79);
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(6, buffer100);
+} catch {}
+let gpuCanvasContext6 = canvas6.getContext('webgpu');
+let pipelineLayout15 = device1.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout23, veryExplicitBindGroupLayout13]});
+let sampler110 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 99.95,
+  compare: 'not-equal',
+});
+try {
+device1.lost.then(({reason, message}) => { console.log('device1 lost!'); console.log(message, reason); });
+} catch {}
+try {
+computePassEncoder129.insertDebugMarker('\u{1fa21}');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture163 = device0.createTexture({
+  size: [1248],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder77.setBindGroup(2, bindGroup58, new Uint32Array(2665), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroups(1); };
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+let texture164 = device1.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 3},
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView162 = texture149.createView({dimension: '2d-array', aspect: 'all', baseMipLevel: 0, baseArrayLayer: 0});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder112.setBindGroup(1, bindGroup77, new Uint32Array(487), 22, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline26);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+let texture165 = device0.createTexture({
+  size: [248, 40, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler111 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 99.50});
+try {
+renderPassEncoder38.setIndexBuffer(buffer69, 'uint32', 0, 8);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 130, y: 22, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup80 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout15, entries: [{binding: 23, resource: textureView7}]});
+let buffer114 = device0.createBuffer({size: 124, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder26.executeBundles([renderBundle0]);
+} catch {}
+let imageData18 = new ImageData(8, 20);
+let bindGroup81 = device0.createBindGroup({layout: veryExplicitBindGroupLayout9, entries: [{binding: 212, resource: sampler79}]});
+let texture166 = device0.createTexture({
+  size: [312, 30, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView163 = texture148.createView({});
+let sampler112 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 34.82,
+  lodMaxClamp: 44.67,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup57, new Uint32Array(544), 38, 0);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer20, 'uint16', 6, 52);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 54 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2236 */
+  offset: 2236,
+  bytesPerRow: 14080,
+  buffer: buffer42,
+}, {
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder155 = device1.createCommandEncoder({});
+let textureView164 = texture147.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder138 = commandEncoder155.beginComputePass();
+let sampler113 = device1.createSampler({addressModeU: 'repeat'});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup75, new Uint32Array(1638), 392, 0);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline26);
+} catch {}
+let commandBuffer16 = commandEncoder0.finish();
+let externalTexture19 = device0.importExternalTexture({source: videoFrame15});
+try {
+computePassEncoder125.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 65, y: 29, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer115 = device1.createBuffer({size: 72, usage: GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder122.setBindGroup(2, bindGroup75);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(202, 559);
+try {
+offscreenCanvas1.getContext('webgpu');
+} catch {}
+let bindGroup82 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout15, entries: [{binding: 23, resource: textureView7}]});
+let buffer116 = device0.createBuffer({size: 208, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let textureView165 = texture12.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+let texture167 = device0.createTexture({
+  size: {width: 124, height: 20, depthOrArrayLayers: 5},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView166 = texture8.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+computePassEncoder136.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup44, new Uint32Array(53), 12, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer86, 'uint32', 252, 19);
+} catch {}
+let pipeline27 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {4_051: 1, override5: 1, 39_941: 1}}});
+let commandEncoder156 = device1.createCommandEncoder({});
+let texture168 = device1.createTexture({
+  size: [474, 1, 59],
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder139 = commandEncoder156.beginComputePass();
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm'],
+  depthStencilFormat: 'depth32float-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder114.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer105, 'uint32', 24, 1);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 474, height: 1, depthOrArrayLayers: 59}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 150, y: 0, z: 25},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img2);
+let commandEncoder157 = device0.createCommandEncoder();
+let texture169 = device0.createTexture({
+  size: [96, 72, 40],
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder140 = commandEncoder157.beginComputePass();
+let sampler114 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 98.72});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup4, new Uint32Array(417), 11, 0);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer51, 'uint32', 4, 31);
+} catch {}
+let imageData19 = new ImageData(128, 36);
+let commandEncoder158 = device0.createCommandEncoder({});
+let texture170 = device0.createTexture({
+  size: {width: 2, height: 2, depthOrArrayLayers: 18},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView167 = texture45.createView({mipLevelCount: 1});
+let computePassEncoder141 = commandEncoder158.beginComputePass();
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+await gc();
+let querySet16 = device1.createQuerySet({type: 'timestamp', count: 472});
+let renderBundle15 = renderBundleEncoder15.finish();
+let sampler115 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 61.27,
+  compare: 'equal',
+});
+try {
+computePassEncoder115.setPipeline(pipeline26);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 16, new Int16Array(12436), 6548, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture161,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(71_541).fill(239), /* required buffer size: 71_541 */
+{offset: 309, bytesPerRow: 106, rowsPerImage: 48}, {width: 29, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let bindGroup83 = device0.createBindGroup({layout: veryExplicitBindGroupLayout20, entries: [{binding: 23, resource: textureView7}]});
+let sampler116 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.95,
+  lodMaxClamp: 92.62,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder38.setPipeline(pipeline15);
+} catch {}
+try {
+device0.queue.submit([commandBuffer16]);
+} catch {}
+let promise18 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule4,
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule4, constants: {}, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+let buffer117 = device1.createBuffer({size: 42, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+try {
+{ clearResourceUsages(device1, computePassEncoder103); computePassEncoder103.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+let buffer118 = device0.createBuffer({size: 500, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder159 = device0.createCommandEncoder({});
+let textureView168 = texture85.createView({mipLevelCount: 1});
+try {
+computePassEncoder133.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder159.copyTextureToTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 34, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img2);
+let bindGroup84 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout12, entries: [{binding: 23, resource: textureView7}]});
+let buffer119 = device0.createBuffer({size: 80, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder142 = commandEncoder159.beginComputePass();
+let sampler117 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 92.47});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup62, new Uint32Array(1358), 140, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup45, new Uint32Array(2109), 95, 0);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer62, 'uint32', 32, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipeline28 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  constants: {34_596: 1, 54_354: 1, override10: 1},
+  targets: [{format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    constants: {},
+    buffers: [{arrayStride: 576, attributes: [{format: 'snorm8x2', offset: 82, shaderLocation: 7}]}],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let buffer120 = device1.createBuffer({size: 252, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder160 = device1.createCommandEncoder({});
+let computePassEncoder143 = commandEncoder160.beginComputePass();
+try {
+{ clearResourceUsages(device1, computePassEncoder113); computePassEncoder113.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(188).fill(109), /* required buffer size: 188 */
+{offset: 188}, {width: 107, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup85 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 384, resource: {buffer: buffer27}}]});
+let buffer121 = device0.createBuffer({size: 72, usage: GPUBufferUsage.QUERY_RESOLVE});
+let texture171 = device0.createTexture({
+  size: {width: 1248, height: 120, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler118 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.591,
+});
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle3, renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder39.draw(49, 207, 403_346_406, 480_120_637);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder161 = device0.createCommandEncoder();
+let texture172 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder43 = commandEncoder161.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 986.4, g: 843.7, b: -334.2, a: 755.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler119 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 80.28});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup0, new Uint32Array(498), 13, 0);
+} catch {}
+try {
+renderPassEncoder39.draw(98, 204, 102_268_646, 371_988_343);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer29, 'uint32', 0, 9);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer10);
+} catch {}
+let canvas7 = document.createElement('canvas');
+let autogeneratedBindGroupLayout1 = pipeline22.getBindGroupLayout(0);
+let buffer122 = device1.createBuffer({size: 17452, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder162 = device1.createCommandEncoder({});
+let textureView169 = texture149.createView({dimension: '2d-array', format: 'rgb10a2unorm'});
+let computePassEncoder144 = commandEncoder162.beginComputePass();
+let sampler120 = device1.createSampler({label: '\ue3d8\u77de\u6649\u6664\u019e\u29c0', addressModeW: 'mirror-repeat', lodMaxClamp: 91.86});
+try {
+computePassEncoder122.setBindGroup(1, bindGroup79);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline26);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 474, height: 1, depthOrArrayLayers: 59}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas3.height = 224;
+let videoFrame21 = new VideoFrame(videoFrame10, {timestamp: 0});
+try {
+canvas7.getContext('2d');
+} catch {}
+let buffer123 = device1.createBuffer({size: 60, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder163 = device1.createCommandEncoder({});
+let textureView170 = texture150.createView({});
+let canvas8 = document.createElement('canvas');
+let textureView171 = texture2.createView({baseArrayLayer: 0});
+let sampler121 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 33.11,
+  lodMaxClamp: 62.38,
+});
+try {
+computePassEncoder140.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder39.draw(359, 95, 83_585_226, 76_064_764);
+} catch {}
+try {
+renderPassEncoder39.drawIndirect(buffer25, 84);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer67, 'uint16', 2, 20);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(5, buffer32);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: img3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 22, y: 97, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup86 = device1.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 446, resource: {buffer: buffer113}}, {binding: 153, resource: {buffer: buffer122}}],
+});
+let textureView172 = texture130.createView({label: '\u33c1\uf8f3\u8ede\u{1fd16}', dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let texture173 = device1.createTexture({
+  size: {width: 10},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder145 = commandEncoder163.beginComputePass();
+try {
+buffer94.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(409).fill(231), /* required buffer size: 409 */
+{offset: 409, bytesPerRow: 325}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder64.setBindGroup(1, bindGroup63);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder128); computePassEncoder128.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(217);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(73); };
+} catch {}
+let buffer124 = device1.createBuffer({size: 267, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let commandEncoder164 = device1.createCommandEncoder();
+try {
+device1.queue.writeBuffer(buffer117, 0, new BigUint64Array(8330), 2347, 0);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(293, 19);
+let commandEncoder165 = device0.createCommandEncoder({});
+let texture174 = device0.createTexture({
+  size: {width: 31, height: 5, depthOrArrayLayers: 12},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder146 = commandEncoder165.beginComputePass();
+try {
+computePassEncoder32.setPipeline(pipeline19);
+} catch {}
+try {
+computePassEncoder142.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup21, new Uint32Array(583), 20, 0);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(4, 241, 3, 145_198_421, 67_417_777);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer68, 'uint32', 36, 36);
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\ue6b8');
+} catch {}
+let gpuCanvasContext7 = canvas8.getContext('webgpu');
+try {
+computePassEncoder146.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle3, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder39.draw(105, 210, 1_263_158_858, 415_849_349);
+} catch {}
+try {
+renderPassEncoder39.drawIndexedIndirect(buffer18, 12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt470m', transfer: 'pq'} });
+let texture175 = device0.createTexture({
+  size: [624, 60, 1],
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder30.executeBundles([renderBundle13, renderBundle3, renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(4, 12, 1, 23_478_465, 239_783_654);
+} catch {}
+try {
+renderPassEncoder39.drawIndirect(buffer93, 24);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline12);
+} catch {}
+try {
+  await shaderModule5.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer60, 28, new Uint32Array(11945), 736, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(158).fill(201), /* required buffer size: 158 */
+{offset: 158, bytesPerRow: 1416}, {width: 86, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder();
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 464});
+let computePassEncoder147 = commandEncoder166.beginComputePass();
+let sampler122 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 44.23,
+  maxAnisotropy: 2,
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let computePassEncoder148 = commandEncoder164.beginComputePass();
+try {
+computePassEncoder114.setBindGroup(0, bindGroup74, new Uint32Array(1765), 68, 0);
+} catch {}
+try {
+computePassEncoder103.end();
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder167 = device1.createCommandEncoder({});
+let querySet18 = device1.createQuerySet({type: 'occlusion', count: 494});
+let texture176 = device1.createTexture({size: [256, 256, 22], mipLevelCount: 2, format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder149 = commandEncoder167.beginComputePass({timestampWrites: {querySet: querySet16}});
+try {
+computePassEncoder148.setBindGroup(0, bindGroup79);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline26);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+  await buffer80.mapAsync(GPUMapMode.WRITE, 56, 112);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer124, 20, buffer117, 0, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData20 = new ImageData(20, 4);
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'unspecified', transfer: 'smpteSt4281'} });
+let texture177 = device1.createTexture({
+  size: {width: 10, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder150 = commandEncoder117.beginComputePass();
+let renderBundleEncoder16 = device1.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthStencilFormat: 'depth32float-stencil8', stencilReadOnly: true});
+let sampler123 = device1.createSampler({addressModeW: 'repeat', magFilter: 'linear', lodMaxClamp: 90.14});
+try {
+computePassEncoder143.setBindGroup(1, bindGroup77, new Uint32Array(640), 14, 0);
+} catch {}
+try {
+computePassEncoder113.end();
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer78, 'uint16', 2, 4);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer92, 0, new BigUint64Array(2971), 243, 0);
+} catch {}
+let recycledExplicitBindGroupLayout18 = pipeline26.getBindGroupLayout(0);
+let buffer125 = device1.createBuffer({size: 424, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder168 = device1.createCommandEncoder({});
+let textureView173 = texture177.createView({format: 'rgba8uint'});
+let texture178 = device1.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 4, stencilReadOnly: true});
+try {
+computePassEncoder134.setBindGroup(3, bindGroup79, []);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+commandEncoder168.copyTextureToTexture({
+  texture: texture137,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = await device1.createComputePipelineAsync({layout: pipelineLayout11, compute: {module: shaderModule6}});
+let buffer126 = device1.createBuffer({
+  size: 316,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let computePassEncoder151 = commandEncoder168.beginComputePass();
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle16 = renderBundleEncoder17.finish({});
+try {
+{ clearResourceUsages(device1, computePassEncoder114); computePassEncoder114.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer78, 'uint32', 12, 13);
+} catch {}
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 5.183,
+});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup14, new Uint32Array(80), 3, 0);
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup51, new Uint32Array(1192), 486, 0);
+} catch {}
+try {
+renderPassEncoder39.draw(34, 307, 720_125_261, 37_325_480);
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(4, 142, 0, -1_749_017_656, 2_005_973_119);
+} catch {}
+try {
+renderPassEncoder39.drawIndexedIndirect(buffer8, 4);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer86, 'uint16', 82, 31);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 80, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(390).fill(69), /* required buffer size: 390 */
+{offset: 390, bytesPerRow: 258}, {width: 106, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let buffer127 = device0.createBuffer({size: 40, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder169 = device0.createCommandEncoder({label: '\u{1fe31}\u0acc\u{1fbf0}\u0888\u{1fb1e}\u0df0\u016b\u2c22\u03d7\u03c2\u0f77'});
+let texture179 = gpuCanvasContext3.getCurrentTexture();
+let textureView174 = texture10.createView({});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder147.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup65, new Uint32Array(420), 188, 0);
+} catch {}
+try {
+renderPassEncoder39.draw(248, 200, 4_294_967_047, 868_058_298);
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(1, 46, 2, 68_955_947, 1_189_242_417);
+} catch {}
+try {
+renderPassEncoder39.drawIndexedIndirect(buffer9, 16);
+} catch {}
+try {
+renderPassEncoder39.drawIndirect(buffer47, 60);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer53, 'uint32', 8, 5);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer101, 'uint32', 12, 10);
+} catch {}
+try {
+commandEncoder169.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2512 */
+  offset: 2512,
+  bytesPerRow: 33536,
+  buffer: buffer42,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 13, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder169.copyTextureToTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 11, y: 9, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 167, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: canvas3,
+  origin: { x: 250, y: 1 },
+  flipY: false,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 627, y: 9, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 50, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let textureView175 = texture177.createView({arrayLayerCount: 1});
+let texture180 = device1.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 22},
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView176 = texture122.createView({dimension: '2d-array', format: 'rgb10a2unorm'});
+try {
+computePassEncoder151.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer110, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer105, 8, new DataView(new ArrayBuffer(54767)), 5306, 0);
+} catch {}
+let textureView177 = texture140.createView({aspect: 'all', arrayLayerCount: 22});
+let textureView178 = texture133.createView({});
+let computePassEncoder152 = commandEncoder116.beginComputePass();
+let sampler125 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+let externalTexture20 = device1.importExternalTexture({source: videoFrame11});
+try {
+{ clearResourceUsages(device1, computePassEncoder114); computePassEncoder114.dispatchWorkgroupsIndirect(buffer92, 8); };
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(7, buffer120, 24, 1);
+} catch {}
+let pipeline30 = device1.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule7, constants: {}, targets: [{format: 'rgb10a2unorm', writeMask: 0}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 67631514,
+    stencilWriteMask: 381074210,
+    depthBiasSlopeScale: 544.32492370549,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex7',
+    buffers: [{arrayStride: 16, attributes: [{format: 'uint32', offset: 0, shaderLocation: 12}]}],
+  },
+  primitive: {},
+});
+let buffer128 = device1.createBuffer({
+  size: 256,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView179 = texture119.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let texture181 = device1.createTexture({
+  size: [40],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView180 = texture157.createView({dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1});
+let sampler126 = device1.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 98.56});
+try {
+computePassEncoder148.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(3, bindGroup86);
+} catch {}
+let commandEncoder170 = device1.createCommandEncoder();
+let computePassEncoder153 = commandEncoder170.beginComputePass({timestampWrites: {querySet: querySet16, beginningOfPassWriteIndex: 403}});
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+try {
+computePassEncoder151.setBindGroup(2, bindGroup86);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline26);
+} catch {}
+document.body.append(img1);
+let commandEncoder171 = device1.createCommandEncoder();
+let computePassEncoder154 = commandEncoder171.beginComputePass({timestampWrites: {querySet: querySet16}});
+try {
+computePassEncoder105.setBindGroup(0, bindGroup79, []);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup74, new Uint32Array(7173), 68, 0);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer110);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer92, 16, new Uint32Array(21009), 10221, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 474, height: 1, depthOrArrayLayers: 59}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas9 = document.createElement('canvas');
+let buffer129 = device1.createBuffer({size: 260, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let sampler127 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 35.23,
+  compare: 'always',
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder20.setVertexBuffer(3, buffer110, 0, 10);
+} catch {}
+let texture182 = device1.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+try {
+{ clearResourceUsages(device1, computePassEncoder114); computePassEncoder114.dispatchWorkgroups(4); };
+} catch {}
+try {
+computePassEncoder114.end();
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer129, 'uint16', 24, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer110);
+} catch {}
+try {
+buffer92.unmap();
+} catch {}
+try {
+commandEncoder121.copyTextureToTexture({
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture135,
+  mipLevel: 0,
+  origin: {x: 23, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 71, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 432, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(161_295).fill(225), /* required buffer size: 161_295 */
+{offset: 35, bytesPerRow: 1466, rowsPerImage: 22}, {width: 534, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let buffer130 = device1.createBuffer({size: 40, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder172 = device1.createCommandEncoder({});
+let texture183 = device1.createTexture({
+  size: {width: 390, height: 5, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder155 = commandEncoder121.beginComputePass({timestampWrites: {querySet: querySet16, endOfPassWriteIndex: 289}});
+try {
+computePassEncoder138.setBindGroup(0, bindGroup79, new Uint32Array(800), 397, 0);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline22);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(253).fill(194), /* required buffer size: 253 */
+{offset: 253, bytesPerRow: 24}, {width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap4 = await createImageBitmap(canvas6);
+let commandEncoder173 = device0.createCommandEncoder({});
+let textureView181 = texture77.createView({dimension: '2d-array'});
+let computePassEncoder156 = commandEncoder173.beginComputePass();
+let sampler128 = device0.createSampler({
+  label: '\u0a1f\u8dfc\u0b21\u0499\ud042\u286c\u7620',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.35,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder107); computePassEncoder107.dispatchWorkgroupsIndirect(buffer33, 356); };
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle2, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder39.draw(98, 285, 664_908_879, 662_225_875);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup47, new Uint32Array(3385), 390, 0);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline28);
+} catch {}
+try {
+  await buffer73.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder169.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2380 */
+  offset: 2380,
+  buffer: buffer42,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData21 = new ImageData(136, 44);
+let commandEncoder174 = device1.createCommandEncoder({});
+let texture184 = device1.createTexture({
+  size: {width: 1560, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder157 = commandEncoder172.beginComputePass();
+let sampler129 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.98,
+  maxAnisotropy: 4,
+});
+let externalTexture21 = device1.importExternalTexture({source: videoFrame17});
+try {
+computePassEncoder134.setBindGroup(0, bindGroup77, new Uint32Array(3336), 139, 0);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(5, buffer110, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer128, 16, new DataView(new ArrayBuffer(3421)), 150, 60);
+} catch {}
+let buffer131 = device0.createBuffer({
+  size: 48,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderBundle17 = renderBundleEncoder19.finish({});
+let sampler130 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 81.79, compare: 'less'});
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder156.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup50, new Uint32Array(330), 59, 0);
+} catch {}
+try {
+renderPassEncoder39.draw(323, 42, 2_619_475_144, 154_556_855);
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(0, 7, 1, -2_010_406_041, 163_769_474);
+} catch {}
+try {
+renderPassEncoder39.drawIndexedIndirect(buffer47, 4);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline31 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule5, entryPoint: 'compute5', constants: {}}});
+document.body.append(img1);
+let imageData22 = new ImageData(28, 8);
+let recycledExplicitBindGroupLayout19 = pipeline29.getBindGroupLayout(0);
+let bindGroup87 = device1.createBindGroup({
+  layout: recycledExplicitBindGroupLayout18,
+  entries: [{binding: 153, resource: {buffer: buffer113}}, {binding: 446, resource: {buffer: buffer122}}],
+});
+let commandEncoder175 = device1.createCommandEncoder({});
+let textureView182 = texture138.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let textureView183 = texture130.createView({mipLevelCount: 1});
+let renderBundleEncoder22 = device1.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm'], depthStencilFormat: 'depth32float-stencil8', depthReadOnly: true});
+try {
+computePassEncoder157.setBindGroup(3, bindGroup87, new Uint32Array(2664), 244, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 474, height: 1, depthOrArrayLayers: 59}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup88 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout16, entries: [{binding: 23, resource: textureView73}]});
+let buffer132 = device0.createBuffer({size: 72, usage: GPUBufferUsage.STORAGE});
+let texture185 = device0.createTexture({
+  size: [62, 10, 1],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView184 = texture105.createView({dimension: '2d-array'});
+let computePassEncoder158 = commandEncoder169.beginComputePass();
+let sampler131 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.32,
+  maxAnisotropy: 19,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder89); computePassEncoder89.dispatchWorkgroupsIndirect(buffer33, 64); };
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(60, 0, 1, 6);
+} catch {}
+try {
+renderPassEncoder39.drawIndirect(buffer41, 4);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0); };
+} catch {}
+try {
+computePassEncoder57.setBindGroup(2, bindGroup46, new Uint32Array(698), 25, 0);
+} catch {}
+try {
+renderPassEncoder39.draw(11, 250, 638_462_049, 1_618_168_709);
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(1, 97, 2, -1_726_824_749, 77_693_809);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer12, 'uint32', 148, 1_861);
+} catch {}
+document.body.prepend(img3);
+let imageBitmap5 = await createImageBitmap(videoFrame16);
+let veryExplicitBindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 8,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder176 = device0.createCommandEncoder();
+let computePassEncoder159 = commandEncoder176.beginComputePass();
+try {
+computePassEncoder119.setBindGroup(0, bindGroup42, new Uint32Array(1751), 9, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup0, new Uint32Array(1730), 104, 0);
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(0, 12, 5, 169_422_812, 1_269_126_863);
+} catch {}
+try {
+renderPassEncoder39.drawIndirect(buffer28, 32);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer51, 'uint32', 28, 49);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 4, new BigUint64Array(2941), 1405, 0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.append(img3);
+let texture186 = device1.createTexture({
+  size: {width: 20, height: 1, depthOrArrayLayers: 80},
+  mipLevelCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView185 = texture152.createView({dimension: '1d', baseMipLevel: 0});
+let renderBundle18 = renderBundleEncoder16.finish({});
+let sampler132 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+let promise19 = shaderModule7.getCompilationInfo();
+try {
+buffer126.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer105, 0, new Uint32Array(4403), 2003, 0);
+} catch {}
+await gc();
+let imageData23 = new ImageData(48, 4);
+let bindGroup89 = device1.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 153, resource: {buffer: buffer112}}, {binding: 446, resource: {buffer: buffer112}}],
+});
+let texture187 = device1.createTexture({size: [1560, 20, 1], mipLevelCount: 3, format: 'eac-r11snorm', usage: GPUTextureUsage.COPY_DST});
+let textureView186 = texture119.createView({mipLevelCount: 1});
+try {
+computePassEncoder129.setPipeline(pipeline26);
+} catch {}
+try {
+computePassEncoder153.insertDebugMarker('\u878b');
+} catch {}
+await gc();
+let buffer133 = device0.createBuffer({
+  size: 311,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder39.drawIndexedIndirect(buffer23, 8);
+} catch {}
+try {
+renderPassEncoder39.drawIndirect(buffer53, 4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 84, new Uint32Array(27634), 2831, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(76).fill(231), /* required buffer size: 76 */
+{offset: 76, bytesPerRow: 52}, {width: 10, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let externalTexture22 = device0.importExternalTexture({source: videoFrame13});
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder39.drawIndexed(4, 190, 1, 328_296_466, 329_987_900);
+} catch {}
+try {
+renderPassEncoder39.drawIndexedIndirect(buffer53, 4);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer77, 'uint16', 22, 26);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer20, 0, 2);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+let buffer134 = device1.createBuffer({size: 184, usage: GPUBufferUsage.INDEX});
+let commandEncoder177 = device1.createCommandEncoder();
+let texture188 = device1.createTexture({
+  size: {width: 195, height: 2, depthOrArrayLayers: 1},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler133 = device1.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 2.705});
+try {
+computePassEncoder138.setBindGroup(3, bindGroup89, new Uint32Array(1), 0, 0);
+} catch {}
+try {
+computePassEncoder153.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup79, new Uint32Array(1060), 93, 0);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer98, 'uint32', 112, 0);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer105, 0, new Uint32Array(11335), 1236, 0);
+} catch {}
+let commandEncoder178 = device1.createCommandEncoder({label: '\u409c\ua4be\u06cc\u0011\u0722\u9243\u{1fc9c}\u{1f7d9}\u0b66\uc6aa\u{1fb53}'});
+let texture189 = device1.createTexture({size: [256], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let sampler134 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 98.81,
+});
+try {
+computePassEncoder143.setBindGroup(1, bindGroup79, new Uint32Array(667), 28, 0);
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder22.insertDebugMarker('\u9aed');
+} catch {}
+let commandEncoder179 = device1.createCommandEncoder();
+let computePassEncoder160 = commandEncoder178.beginComputePass({timestampWrites: {querySet: querySet16, beginningOfPassWriteIndex: 412, endOfPassWriteIndex: 460}});
+let renderBundle19 = renderBundleEncoder21.finish();
+let textureView187 = texture88.createView({dimension: '3d', mipLevelCount: 1});
+try {
+computePassEncoder159.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+renderPassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(272);
+} catch {}
+try {
+commandEncoder137.copyBufferToTexture({
+  /* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4448 */
+  offset: 4448,
+  bytesPerRow: 11008,
+  rowsPerImage: 619,
+  buffer: buffer42,
+}, {
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 53, y: 24, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 18, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder137.clearBuffer(buffer3);
+} catch {}
+try {
+renderPassEncoder42.pushDebugGroup('\u59c9');
+} catch {}
+let bindGroup90 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [{binding: 153, resource: {buffer: buffer113}}, {binding: 446, resource: {buffer: buffer125}}],
+});
+let commandEncoder180 = device1.createCommandEncoder({});
+let texture190 = device1.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 68},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture191 = device1.createTexture({
+  size: {width: 1896, height: 1, depthOrArrayLayers: 1},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle20 = renderBundleEncoder20.finish();
+try {
+computePassEncoder160.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup79, new Uint32Array(1317), 49, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer130, 0, 10);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let veryExplicitBindGroupLayout27 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView188 = texture152.createView({});
+let texture192 = device1.createTexture({
+  size: [10, 1, 311],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder161 = commandEncoder180.beginComputePass({timestampWrites: {querySet: querySet16, beginningOfPassWriteIndex: 103, endOfPassWriteIndex: 263}});
+let sampler135 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 20.97,
+});
+try {
+computePassEncoder105.setBindGroup(0, bindGroup77);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline26);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture192,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 25},
+  aspect: 'all',
+}, new Uint8Array(17_761).fill(231), /* required buffer size: 17_761 */
+{offset: 667, bytesPerRow: 37, rowsPerImage: 14}, {width: 0, height: 0, depthOrArrayLayers: 34});
+} catch {}
+let texture193 = device0.createTexture({
+  size: {width: 624, height: 60, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture194 = gpuCanvasContext4.getCurrentTexture();
+let textureView189 = texture172.createView({});
+let computePassEncoder162 = commandEncoder137.beginComputePass();
+let sampler136 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 69.48,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(3, undefined, 404_815_634);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer61, 'uint32', 0, 27);
+} catch {}
+canvas8.height = 78;
+let buffer135 = device1.createBuffer({size: 212, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let texture195 = device1.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 87},
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle21 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder157.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer125, 'uint16', 74, 21);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(1, buffer120);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 474, height: 1, depthOrArrayLayers: 59}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 121, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext8 = canvas9.getContext('webgpu');
+try {
+offscreenCanvas2.getContext('webgpu');
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder();
+let computePassEncoder163 = commandEncoder181.beginComputePass();
+let externalTexture23 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup65, new Uint32Array(2613), 14, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder49); computePassEncoder49.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup0, new Uint32Array(3550), 345, 0);
+} catch {}
+try {
+  await promise19;
+} catch {}
+let texture196 = device0.createTexture({
+  size: [1248, 120, 1],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder59.setBindGroup(0, bindGroup0, new Uint32Array(2484), 179, 0);
+} catch {}
+try {
+computePassEncoder108.end();
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(7, buffer32);
+} catch {}
+try {
+commandEncoder126.copyBufferToBuffer(buffer28, 52, buffer57, 1256, 92);
+} catch {}
+try {
+commandEncoder126.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 76 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1586 */
+  offset: 1586,
+  bytesPerRow: 6912,
+  buffer: buffer42,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 13, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 76, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder126.clearBuffer(buffer114);
+} catch {}
+let renderPassEncoder44 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView155,
+  clearValue: { r: -17.16, g: 865.3, b: 512.0, a: 177.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup70, new Uint32Array(2588), 250, 0);
+} catch {}
+let bindGroup91 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView7}]});
+let textureView190 = texture41.createView({});
+try {
+renderPassEncoder4.setIndexBuffer(buffer68, 'uint16', 16, 6);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer26);
+} catch {}
+let commandEncoder182 = device1.createCommandEncoder({});
+let texture197 = device1.createTexture({
+  size: {width: 237, height: 1, depthOrArrayLayers: 11},
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder164 = commandEncoder177.beginComputePass();
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup87, new Uint32Array(439), 15, 0);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer105, 'uint32', 4, 5);
+} catch {}
+let promise20 = device1.queue.onSubmittedWorkDone();
+let bindGroup92 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout14, entries: [{binding: 23, resource: textureView18}]});
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout15]});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 734});
+try {
+computePassEncoder120.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+document.body.prepend(canvas3);
+let bindGroup93 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 23, resource: textureView7}]});
+let textureView191 = texture99.createView({format: 'rgba32uint', mipLevelCount: 1});
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer12, 'uint32', 1_072, 100);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6844 */
+  offset: 6844,
+  bytesPerRow: 11520,
+  buffer: buffer42,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 20, y: 22, z: 1},
+  aspect: 'all',
+}, {width: 1, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder50.insertDebugMarker('\u0a9a');
+} catch {}
+let buffer136 = device0.createBuffer({size: 138, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder183 = device0.createCommandEncoder({});
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup83);
+} catch {}
+try {
+renderPassEncoder35.setStencilReference(1580);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let buffer137 = device0.createBuffer({
+  size: 16,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder10.insertDebugMarker('\u0fae');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture146,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+}, new Uint8Array(274).fill(246), /* required buffer size: 274 */
+{offset: 274}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView192 = texture118.createView({});
+let computePassEncoder165 = commandEncoder33.beginComputePass();
+let sampler137 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup64);
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup62, new Uint32Array(1293), 106, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer86, 'uint16', 30, 4);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline2);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let bindGroup94 = device1.createBindGroup({layout: veryExplicitBindGroupLayout23, entries: [{binding: 1, resource: {buffer: buffer122}}]});
+let pipelineLayout17 = device1.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout18]});
+let computePassEncoder166 = commandEncoder175.beginComputePass();
+let sampler138 = device1.createSampler({addressModeU: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 86.80});
+try {
+computePassEncoder104.setBindGroup(3, bindGroup94, new Uint32Array(3473), 2_050, 0);
+} catch {}
+try {
+{ clearResourceUsages(device1, computePassEncoder105); computePassEncoder105.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline29);
+} catch {}
+try {
+computePassEncoder154.insertDebugMarker('\u1c41');
+} catch {}
+let buffer138 = device1.createBuffer({
+  size: 24,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder184 = device1.createCommandEncoder({});
+let texture198 = device1.createTexture({
+  size: {width: 10, height: 1, depthOrArrayLayers: 5},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder167 = commandEncoder184.beginComputePass({timestampWrites: {querySet: querySet16, endOfPassWriteIndex: 447}});
+try {
+computePassEncoder152.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder179.copyBufferToBuffer(buffer80, 120, buffer117, 4, 0);
+} catch {}
+try {
+  await promise20;
+} catch {}
+let computePassEncoder168 = commandEncoder182.beginComputePass();
+try {
+{ clearResourceUsages(device1, computePassEncoder105); computePassEncoder105.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline22);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let computePassEncoder169 = commandEncoder179.beginComputePass({timestampWrites: {querySet: querySet16}});
+let renderBundle22 = renderBundleEncoder22.finish();
+try {
+computePassEncoder143.setBindGroup(2, bindGroup89, new Uint32Array(437), 61, 0);
+} catch {}
+try {
+{ clearResourceUsages(device1, computePassEncoder105); computePassEncoder105.dispatchWorkgroups(1); };
+} catch {}
+let computePassEncoder170 = commandEncoder183.beginComputePass();
+try {
+computePassEncoder61.setBindGroup(0, bindGroup92, new Uint32Array(2584), 45, 0);
+} catch {}
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer57, 'uint32', 2_416, 10_585);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline3);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer86.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 0, new BigUint64Array(26641), 1554, 0);
+} catch {}
+let imageBitmap6 = await createImageBitmap(imageData14);
+let veryExplicitBindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let computePassEncoder171 = commandEncoder13.beginComputePass();
+try {
+computePassEncoder165.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer127, 0, new Uint32Array(37579), 898, 0);
+} catch {}
+document.body.append(canvas4);
+let bindGroup95 = device0.createBindGroup({layout: veryExplicitBindGroupLayout28, entries: [{binding: 3, resource: sampler55}]});
+let textureView193 = texture19.createView({format: 'rgba8sint'});
+let texture199 = device0.createTexture({
+  size: {width: 96, height: 72, depthOrArrayLayers: 140},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder88.setBindGroup(2, bindGroup6, new Uint32Array(696), 165, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer53, 'uint16', 0, 7);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(3, buffer133, 0, 20);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(4).fill(83), /* required buffer size: 4 */
+{offset: 4, bytesPerRow: 343}, {width: 14, height: 23, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas6);
+let texture200 = device1.createTexture({size: [237, 1, 9], format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let textureView194 = texture197.createView({format: 'rgb10a2unorm', baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder172 = commandEncoder174.beginComputePass();
+try {
+{ clearResourceUsages(device1, computePassEncoder105); computePassEncoder105.dispatchWorkgroupsIndirect(buffer138, 0); };
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup96 = device1.createBindGroup({
+  layout: recycledExplicitBindGroupLayout18,
+  entries: [{binding: 446, resource: {buffer: buffer135}}, {binding: 153, resource: {buffer: buffer138}}],
+});
+try {
+{ clearResourceUsages(device1, computePassEncoder105); computePassEncoder105.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder105.end();
+} catch {}
+try {
+computePassEncoder164.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder118.resolveQuerySet(querySet18, 3, 1, buffer92, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(58).fill(189), /* required buffer size: 58 */
+{offset: 58}, {width: 82, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup97 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [{binding: 446, resource: {buffer: buffer112}}, {binding: 153, resource: {buffer: buffer125}}],
+});
+let textureView195 = texture141.createView({aspect: 'depth-only', format: 'depth32float', arrayLayerCount: 2});
+try {
+computePassEncoder154.setBindGroup(0, bindGroup75, new Uint32Array(263), 12, 0);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(482).fill(31), /* required buffer size: 482 */
+{offset: 74, bytesPerRow: 24, rowsPerImage: 17}, {width: 2, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 87}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture195,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline32 = device1.createComputePipeline({layout: pipelineLayout14, compute: {module: shaderModule6}});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+computePassEncoder22.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer53, 'uint16', 4, 17);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer99, 0, new Int16Array(6900), 170, 0);
+} catch {}
+let textureView196 = texture173.createView({});
+try {
+computePassEncoder169.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder118.copyBufferToBuffer(buffer129, 40, buffer92, 36, 0);
+} catch {}
+try {
+  await promise21;
+} catch {}
+try {
+computePassEncoder43.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+computePassEncoder171.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline12);
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder();
+let textureView197 = texture71.createView({dimension: '2d', aspect: 'all'});
+let computePassEncoder173 = commandEncoder185.beginComputePass();
+try {
+computePassEncoder22.setBindGroup(2, bindGroup59, new Uint32Array(913), 74, 0);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup37, new Uint32Array(2973), 233, 0);
+} catch {}
+try {
+computePassEncoder100.insertDebugMarker('\u50c2');
+} catch {}
+document.body.append(img1);
+try {
+globalThis.someLabel = buffer107.label;
+} catch {}
+let computePassEncoder174 = commandEncoder118.beginComputePass({timestampWrites: {querySet: querySet16, beginningOfPassWriteIndex: 4294967295}});
+try {
+computePassEncoder121.setBindGroup(0, bindGroup96, new Uint32Array(953), 229, 0);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline26);
+} catch {}
+let commandEncoder186 = device0.createCommandEncoder({});
+let textureView198 = texture199.createView({});
+let textureView199 = texture96.createView({mipLevelCount: 1});
+let computePassEncoder175 = commandEncoder186.beginComputePass();
+let sampler139 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 92.04,
+});
+try {
+computePassEncoder156.setBindGroup(2, bindGroup61);
+} catch {}
+try {
+computePassEncoder142.setBindGroup(1, bindGroup71, new Uint32Array(779), 185, 0);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer21, 'uint16', 76, 0);
+} catch {}
+let buffer139 = device1.createBuffer({size: 48, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder187 = device1.createCommandEncoder({});
+let computePassEncoder176 = commandEncoder187.beginComputePass();
+try {
+computePassEncoder151.setBindGroup(0, bindGroup96);
+} catch {}
+try {
+{ clearResourceUsages(device1, computePassEncoder154); computePassEncoder154.dispatchWorkgroupsIndirect(buffer78, 4); };
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline32);
+} catch {}
+let pipeline33 = device1.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x2baa82ac},
+  fragment: {
+  module: shaderModule7,
+  constants: {},
+  targets: [{format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'invert'},
+    stencilReadMask: 210821837,
+    stencilWriteMask: 182965286,
+    depthBiasSlopeScale: -78.25192326350738,
+    depthBiasClamp: -90.94891457967266,
+  },
+  vertex: {
+    module: shaderModule6,
+    constants: {},
+    buffers: [{arrayStride: 4, attributes: [{format: 'uint8x2', offset: 0, shaderLocation: 12}]}],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+adapter0.label = '\uc163\u02bb\uc453\u0de4';
+} catch {}
+let bindGroup98 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 384, resource: {buffer: buffer14}}]});
+let commandEncoder188 = device0.createCommandEncoder();
+let texture201 = device0.createTexture({
+  size: [96, 72, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder45 = commandEncoder188.beginRenderPass({colorAttachments: [{view: textureView120, loadOp: 'load', storeOp: 'store'}]});
+let sampler140 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder175.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer29, 'uint16', 2, 5);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(1, buffer29, 4);
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise22;
+} catch {}
+let bindGroup99 = device1.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [{binding: 153, resource: {buffer: buffer78}}, {binding: 446, resource: {buffer: buffer135}}],
+});
+let buffer140 = device1.createBuffer({size: 88, usage: GPUBufferUsage.COPY_SRC});
+let textureView200 = texture145.createView({dimension: '2d', baseArrayLayer: 1});
+let sampler141 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup99, new Uint32Array(2584), 475, 0);
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline32);
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout16, entries: [{binding: 23, resource: textureView7}]});
+let texture202 = device0.createTexture({
+  size: [24, 18, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder38.setIndexBuffer(buffer70, 'uint16', 10, 5);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder42.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup101 = device1.createBindGroup({layout: veryExplicitBindGroupLayout27, entries: [{binding: 1, resource: {buffer: buffer122}}]});
+let texture203 = device1.createTexture({
+  size: [40, 1, 3],
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture204 = device1.createTexture({
+  size: [10, 1, 81],
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView201 = texture123.createView({mipLevelCount: 1});
+try {
+computePassEncoder144.setPipeline(pipeline29);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer123.unmap();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer126, 88, new Uint32Array(42871), 5452, 12);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let buffer141 = device1.createBuffer({size: 8, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder189 = device1.createCommandEncoder({});
+let texture205 = device1.createTexture({
+  size: {width: 195, height: 2, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device1, computePassEncoder151); computePassEncoder151.dispatchWorkgroupsIndirect(buffer138, 0); };
+} catch {}
+try {
+  await shaderModule7.getCompilationInfo();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(2); };
+} catch {}
+let videoFrame24 = new VideoFrame(videoFrame6, {timestamp: 0});
+let sampler142 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.14,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder44.setBindGroup(2, bindGroup7, new Uint32Array(914), 28, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup48, new Uint32Array(1100), 33, 0);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: -828.1, g: -193.1, b: -945.1, a: 132.6, });
+} catch {}
+let texture206 = device1.createTexture({
+  size: [10, 1, 5],
+  mipLevelCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView202 = texture145.createView({baseArrayLayer: 3, arrayLayerCount: 6});
+try {
+computePassEncoder151.setBindGroup(0, bindGroup77, new Uint32Array(544), 200, 0);
+} catch {}
+try {
+computePassEncoder168.setPipeline(pipeline32);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(218).fill(237), /* required buffer size: 218 */
+{offset: 218}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas6);
+let texture207 = device0.createTexture({
+  size: {width: 24, height: 18, depthOrArrayLayers: 18},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder84.setBindGroup(0, bindGroup55);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(5, buffer26);
+} catch {}
+let texture208 = device1.createTexture({size: [780], dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder177 = commandEncoder189.beginComputePass();
+let sampler143 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 59.28,
+  lodMaxClamp: 77.22,
+});
+try {
+computePassEncoder176.setBindGroup(1, bindGroup89);
+} catch {}
+try {
+computePassEncoder168.end();
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder182.copyBufferToTexture({
+  /* bytesInLastRow: 896 widthInBlocks: 224 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 108 */
+  offset: 108,
+  bytesPerRow: 5120,
+  buffer: buffer135,
+}, {
+  texture: texture183,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 224, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder190 = device1.createCommandEncoder({});
+let textureView203 = texture140.createView({format: 'r32sint', baseArrayLayer: 14, arrayLayerCount: 18});
+let computePassEncoder178 = commandEncoder182.beginComputePass({timestampWrites: {querySet: querySet16}});
+try {
+computePassEncoder139.setPipeline(pipeline29);
+} catch {}
+let videoFrame25 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let bindGroup102 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout22,
+  entries: [{binding: 384, resource: {buffer: buffer14, offset: 0}}],
+});
+let commandEncoder191 = device0.createCommandEncoder({});
+let texture209 = device0.createTexture({size: {width: 248}, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder46 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView191,
+  clearValue: { r: 266.9, g: 326.8, b: 133.9, a: 200.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder90.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(0, bindGroup22, new Uint32Array(1668), 301, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup81);
+} catch {}
+document.body.append(canvas5);
+await gc();
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 1883});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(3, bindGroup95, new Uint32Array(301), 4, 0);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(0, buffer97);
+} catch {}
+try {
+computePassEncoder164.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline32);
+} catch {}
+let buffer142 = device1.createBuffer({
+  size: 108,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView204 = texture125.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder179 = commandEncoder190.beginComputePass();
+try {
+{ clearResourceUsages(device1, computePassEncoder154); computePassEncoder154.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder129.end();
+} catch {}
+try {
+device1.lost.then(({reason, message}) => { console.log('device1 lost!'); console.log(message, reason); });
+} catch {}
+document.body.prepend(canvas2);
+let commandEncoder192 = device1.createCommandEncoder();
+let textureView205 = texture149.createView({format: 'rgb10a2unorm'});
+let computePassEncoder180 = commandEncoder192.beginComputePass();
+try {
+computePassEncoder149.setPipeline(pipeline32);
+} catch {}
+try {
+device1.queue.submit([]);
+} catch {}
+await gc();
+let shaderModule8 = device1.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+struct T2 {
+  @size(120) f0: f32,
+}
+
+@id(19059) override override26: u32;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+override override31: f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override25: bool;
+
+var<workgroup> vw5: array<atomic<u32>, 1>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T3 {
+  @align(8) @size(160) f0: array<f32>,
+}
+
+struct T5 {
+  @align(16) @size(16) f0: array<atomic<u32>>,
+}
+
+@group(0) @binding(446) var<storage, read_write> buffer144: array<array<vec4h, 4>, 5>;
+
+@group(1) @binding(1) var tex2: texture_cube_array<f32>;
+
+struct FragmentOutput6 {
+  @location(0) f0: u32,
+}
+
+var<workgroup> vw7: f32;
+
+struct T1 {
+  @align(8) @size(8) f0: atomic<i32>,
+}
+
+override override28 = 0.06111;
+
+override override30: i32;
+
+var<workgroup> vw4: atomic<i32>;
+
+@id(11588) override override29: u32 = 538002359;
+
+struct T0 {
+  @align(32) @size(160) f0: array<atomic<i32>>,
+}
+
+@id(14774) override override27: f16 = 4569.1;
+
+@group(0) @binding(153) var<storage, read_write> buffer143: vec2u;
+
+struct T4 {
+  @align(8) @size(8) f0: array<u32>,
+}
+
+struct VertexOutput7 {
+  @location(10) @interpolate(flat, centroid) f24: vec2i,
+  @builtin(position) f25: vec4f,
+  @location(9) @interpolate(linear, either) f26: f16,
+}
+
+var<workgroup> vw6: T1;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* used global variables: tex2 */
+@vertex
+fn vertex8(@location(2) a0: vec4u, @location(10) @interpolate(flat) a1: i32) -> VertexOutput7 {
+  var out: VertexOutput7;
+  let vf97: vec2u = textureDimensions(tex2);
+  return out;
+  _ = tex2;
+}
+
+/* used global variables: buffer143, buffer144 */
+@fragment
+fn fragment8(@location(11) @interpolate(perspective) a0: f16, @location(15) @interpolate(flat) a1: vec4u, @builtin(sample_mask) a2: u32) -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  if bool(buffer144[unconst_u32(104277779)][unconst_u32(605818110)][2]) {
+  while bool((*&buffer144)[4][3].x) {
+  buffer144[unconst_u32(971695123)][unconst_u32(394976519)] = vec4h(f16(a2));
+  return out;
+  _ = buffer144;
+}
+  return out;
+  _ = buffer144;
+}
+  for (var it3=bitcast<u32>(unpack4xI8(unconst_u32(514806215)).w); it3<(bitcast<u32>(dot4I8Packed(unconst_u32(75365200), unconst_u32(292084299))) & 0xfff); it3++) {
+  let vf98: f16 = buffer144[4][unconst_u32(2226516170)][unconst_u32(844038575)];
+  switch bitcast<vec2i>(tanh(vec2f(unconst_f32(0.04499e24), unconst_f32(0.1344))).gg)[0] { 
+  default {
+  buffer143 *= vec2u(u32((*&buffer144)[unconst_u32(181939748)][3][unconst_u32(718798265)]));
+  let vf99: f16 = buffer144[unconst_u32(982397243)][unconst_u32(1057898016)][unconst_u32(100328687)];
+  out.f0 |= u32(buffer144[unconst_u32(129072705)][unconst_u32(3264879754)].b);
+  var vf100: f16 = buffer144[unconst_u32(156210226)][3][unconst_u32(382581221)];
+  _ = buffer144;
+  _ = buffer143;
+}
+  }
+  _ = buffer144;
+  _ = buffer143;
+}
+  out.f0 = a1[unconst_u32(29697424)];
+  out.f0 = bitcast<u32>(quantizeToF16(vec4f(unconst_f32(0.2720), unconst_f32(0.2165), unconst_f32(0.1332e-19), unconst_f32(0.2440))).w);
+  buffer144[unconst_u32(480946545)][3] = buffer144[4][3];
+  out = FragmentOutput6(bitcast<vec3u>(tanh(vec3f(unconst_f32(0.07916e24), unconst_f32(-0.01680e-21), unconst_f32(0.6533))).rbb.zzz.grb.xxy).r);
+  {
+  let vf101: f16 = override31;
+  if bool(buffer144[4][3][1]) {
+  let vf102: u32 = override29;
+  let ptr44: ptr<storage, vec2u, read_write> = &buffer143;
+  let ptr45: ptr<storage, vec2u, read_write> = &(*ptr44);
+  _ = override29;
+  _ = buffer143;
+}
+  let ptr46: ptr<storage, vec4h, read_write> = &(*&buffer144)[4][unconst_u32(765680367)];
+  let ptr47: ptr<storage, array<vec4h, 4>, read_write> = &buffer144[unconst_u32(1235232976)];
+  return out;
+  _ = override29;
+  _ = override31;
+  _ = buffer144;
+  _ = buffer143;
+}
+  for (var jj81=0u; jj81<6; jj81++) { buffer144[unconst_u32(23413149)][jj81] = bitcast<vec4h>(firstTrailingBit(vec2i(unconst_i32(953921020), unconst_i32(18881250)))); }
+  var vf103: vec3<bool> = (vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true)) == vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false)));
+  while (f32(buffer144[unconst_u32(889146024)][3][unconst_u32(193847662)]) > unconst_f32(0.02634e29)) {
+  buffer144[unconst_u32(457970267)][unconst_u32(15049863)] -= vec4h(ldexp(vec3f(unconst_f32(0.3297e10), unconst_f32(0.02712e19), unconst_f32(0.3622)), vec3i(unconst_i32(376807051), unconst_i32(-168358184), unconst_i32(433560876))).yxxy.ragr.wxwx);
+  _ = buffer144;
+}
+  return out;
+  _ = override29;
+  _ = override31;
+  _ = buffer143;
+  _ = buffer144;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute8(@builtin(workgroup_id) a0: vec3u) {
+  atomicStore(&vw5[unconst_u32(218147237)], unconst_u32(1473313687));
+  atomicStore(&vw5[unconst_u32(3767838189)], unconst_u32(232389702));
+  var vf104: u32 = atomicLoad(&vw5[0]);
+  loop {
+  atomicXor(&vw6.f0, atomicExchange(&(*&vw6).f0, unconst_i32(917499128)));
+  atomicStore(&vw5[unconst_u32(63456442)], unconst_u32(1408750492));
+  break;
+}
+  vw7 = bitcast<f32>(atomicLoad(&vw5[unconst_u32(51147829)]));
+  vw7 -= bitcast<f32>(atomicLoad(&(*&vw4)));
+  let ptr48: ptr<workgroup, f32> = &(*&vw7);
+  loop {
+  var vf105: u32 = atomicLoad(&vw5[unconst_u32(608152086)]);
+  while bool(atomicLoad(&vw6.f0)) {
+  var vf106: vec3f = quantizeToF16(vec3f(vw7));
+  var vf107: i32 = atomicLoad(&(*&vw4));
+  atomicExchange(&vw4, unconst_i32(602778196));
+  atomicAdd(&vw6.f0, unconst_i32(53130678));
+  break;
+}
+  let ptr49: ptr<workgroup, atomic<u32>> = &(*&vw5)[unconst_u32(254373508)];
+  let ptr50: ptr<workgroup, atomic<u32>> = &(*&vw5)[unconst_u32(392797368)];
+  break;
+}
+}`,
+});
+let commandEncoder193 = device1.createCommandEncoder({label: '\u027e\u0e6c\u30ea\u0814\u46a1\u0f78\u05c2'});
+try {
+computePassEncoder122.setPipeline(pipeline29);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+  await shaderModule6.getCompilationInfo();
+} catch {}
+let commandEncoder194 = device0.createCommandEncoder({});
+let computePassEncoder181 = commandEncoder194.beginComputePass();
+try {
+computePassEncoder181.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder41.draw(53, 0, 1_618_206_242, 0);
+} catch {}
+try {
+renderPassEncoder41.drawIndexed(0, 0, 1, 303_432_145);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer53, 'uint16', 36, 7);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+externalTexture20.label = '\ua134\u{1f621}\u{1f6ac}\u928b\u{1fe79}';
+} catch {}
+let querySet21 = device1.createQuerySet({type: 'occlusion', count: 212});
+let computePassEncoder182 = commandEncoder193.beginComputePass();
+try {
+computePassEncoder154.setBindGroup(1, bindGroup79, new Uint32Array(4135), 869, 0);
+} catch {}
+try {
+commandEncoder149.copyBufferToTexture({
+  /* bytesInLastRow: 832 widthInBlocks: 208 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 120 */
+  offset: 120,
+  bytesPerRow: 25856,
+  buffer: buffer129,
+}, {
+  texture: texture183,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 208, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer145 = device1.createBuffer({size: 304, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture210 = device1.createTexture({
+  size: [948, 1, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView206 = texture139.createView({aspect: 'depth-only', baseArrayLayer: 1, arrayLayerCount: 3});
+try {
+computePassEncoder154.setBindGroup(0, bindGroup99, new Uint32Array(4017), 837, 0);
+} catch {}
+try {
+buffer123.unmap();
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 40, height: 1, depthOrArrayLayers: 87}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture195,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture7.label;
+} catch {}
+let buffer146 = device0.createBuffer({
+  size: 112,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let sampler144 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer61, 104);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer67, 4);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer68, 'uint32', 16, 44);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 40, new Uint32Array(15759), 10476, 0);
+} catch {}
+let commandEncoder195 = device1.createCommandEncoder({});
+let textureView207 = texture164.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder183 = commandEncoder149.beginComputePass();
+let sampler145 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.34,
+  compare: 'greater-equal',
+});
+try {
+{ clearResourceUsages(device1, computePassEncoder115); computePassEncoder115.dispatchWorkgroupsIndirect(buffer92, 0); };
+} catch {}
+try {
+computePassEncoder151.end();
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline32);
+} catch {}
+try {
+computePassEncoder145.setPipeline(pipeline32);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup103 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout24,
+  entries: [{binding: 0, resource: textureView117}, {binding: 210, resource: textureView31}],
+});
+let commandEncoder196 = device0.createCommandEncoder({});
+let texture211 = device0.createTexture({
+  size: [12, 9, 1],
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture212 = device0.createTexture({
+  size: {width: 12, height: 9, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder47 = commandEncoder196.beginRenderPass({colorAttachments: [{view: textureView70, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder111.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder41.draw(299, 0, 58_271_909);
+} catch {}
+try {
+renderPassEncoder41.drawIndexed(0, 0, 1, 115_079_383);
+} catch {}
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer79, 0);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(1, buffer26, 0);
+} catch {}
+try {
+buffer96.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture170,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(71).fill(66), /* required buffer size: 71 */
+{offset: 71}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1248, height: 120, depthOrArrayLayers: 4}
+*/
+{
+  source: imageData7,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 37, y: 35, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer147 = device1.createBuffer({size: 68, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder184 = commandEncoder168.beginComputePass({timestampWrites: {querySet: querySet16, endOfPassWriteIndex: 389}});
+try {
+computePassEncoder174.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+computePassEncoder184.setPipeline(pipeline26);
+} catch {}
+let texture213 = device0.createTexture({
+  size: [1248, 120, 1],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler146 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.65,
+  compare: 'equal',
+});
+try {
+renderPassEncoder41.drawIndexed(0, 0, 1, 852_261_559);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer70, 'uint32', 4, 0);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline8);
+} catch {}
+let buffer148 = device1.createBuffer({size: 116, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder197 = device1.createCommandEncoder();
+let computePassEncoder185 = commandEncoder195.beginComputePass();
+try {
+computePassEncoder179.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder197.clearBuffer(buffer105);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer91, 4, new Uint32Array(12206), 1934, 0);
+} catch {}
+let imageData24 = new ImageData(16, 28);
+let textureView208 = texture208.createView({aspect: 'all'});
+let sampler147 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 88.30,
+  lodMaxClamp: 99.25,
+});
+try {
+computePassEncoder167.setBindGroup(0, bindGroup99);
+} catch {}
+try {
+computePassEncoder102.setBindGroup(0, bindGroup96, new Uint32Array(5588), 2_138, 0);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { console.log('device1.uncapturederror'); console.log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 32, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6_786).fill(16), /* required buffer size: 6_786 */
+{offset: 18, bytesPerRow: 124, rowsPerImage: 48}, {width: 36, height: 28, depthOrArrayLayers: 2});
+} catch {}
+let texture214 = device1.createTexture({
+  size: [948, 1, 17],
+  format: 'r16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'iec6196624'} });
+let sampler148 = device1.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less-equal',
+});
+try {
+{ clearResourceUsages(device1, computePassEncoder154); computePassEncoder154.dispatchWorkgroupsIndirect(buffer124, 8); };
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let computePassEncoder186 = commandEncoder197.beginComputePass({timestampWrites: {querySet: querySet16, beginningOfPassWriteIndex: 41, endOfPassWriteIndex: 227}});
+try {
+computePassEncoder185.setPipeline(pipeline26);
+} catch {}
+let promise23 = device1.queue.onSubmittedWorkDone();
+await gc();
+let commandEncoder198 = device1.createCommandEncoder();
+let texture215 = gpuCanvasContext3.getCurrentTexture();
+let computePassEncoder187 = commandEncoder198.beginComputePass();
+let sampler149 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.50,
+});
+try {
+computePassEncoder180.setPipeline(pipeline29);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 145, y: 0, z: 18},
+  aspect: 'all',
+}, new Uint8Array(58).fill(199), /* required buffer size: 58 */
+{offset: 58, bytesPerRow: 28}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture216 = device0.createTexture({
+  size: [31, 5, 12],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture217 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView209 = texture172.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let sampler150 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.87,
+  compare: 'greater',
+});
+try {
+renderPassEncoder16.executeBundles([renderBundle13, renderBundle1, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder41.draw(1, 0, 35_745_220);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer61, 36);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer81, 16, 24);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView210 = texture211.createView({});
+let texture218 = device0.createTexture({
+  size: {width: 48, height: 36, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder119.setBindGroup(0, bindGroup18, new Uint32Array(929), 27, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -556.1, g: -999.3, b: -392.1, a: 229.2, });
+} catch {}
+try {
+renderPassEncoder41.draw(677, 0, 500_990_424);
+} catch {}
+let buffer149 = device1.createBuffer({size: 176, usage: GPUBufferUsage.COPY_SRC});
+let textureView211 = texture206.createView({dimension: '2d-array', aspect: 'stencil-only', arrayLayerCount: 1});
+let sampler151 = device1.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 60.57});
+try {
+computePassEncoder172.setBindGroup(3, bindGroup101);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline29);
+} catch {}
+let pipeline34 = await device1.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule8, constants: {}}});
+let pipeline35 = device1.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule6,
+  constants: {},
+  targets: [{
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'not-equal', depthFailOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'zero'},
+    stencilReadMask: 380013801,
+    stencilWriteMask: 1345857749,
+  },
+  vertex: {
+    module: shaderModule8,
+    buffers: [
+      {
+        arrayStride: 252,
+        attributes: [
+          {format: 'sint32x4', offset: 20, shaderLocation: 10},
+          {format: 'uint32', offset: 12, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+document.body.append(img2);
+let commandEncoder199 = device1.createCommandEncoder({});
+try {
+computePassEncoder176.setBindGroup(2, bindGroup96, new Uint32Array(324), 31, 0);
+} catch {}
+try {
+commandEncoder199.copyBufferToBuffer(buffer107, 4, buffer126, 0, 0);
+} catch {}
+let imageData25 = new ImageData(88, 8);
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'smpteSt4281'} });
+let recycledExplicitBindGroupLayout20 = pipeline7.getBindGroupLayout(0);
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1464});
+let textureView212 = texture216.createView({format: 'rg32float'});
+let texture219 = device0.createTexture({
+  size: [31, 5, 8],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler152 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 82.22, compare: 'not-equal'});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle8, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder41.draw(180, 0, 345_067_231);
+} catch {}
+try {
+renderPassEncoder41.drawIndexed(2, 0, 0, -2_029_536_777);
+} catch {}
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer79, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer137, 'uint32', 0, 3);
+} catch {}
+let promise24 = device0.createComputePipelineAsync({
+  layout: pipelineLayout4,
+  compute: {module: shaderModule1, constants: {override14: 1, override13: 1, override12: 1}},
+});
+let commandEncoder200 = device1.createCommandEncoder({});
+let computePassEncoder188 = commandEncoder199.beginComputePass();
+try {
+computePassEncoder177.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder200.clearBuffer(buffer91);
+} catch {}
+try {
+  await promise23;
+} catch {}
+let veryExplicitBindGroupLayout29 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let texture220 = device1.createTexture({
+  size: [40, 1, 1],
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder154.setBindGroup(2, bindGroup101);
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline29);
+} catch {}
+let arrayBuffer3 = buffer80.getMappedRange(56, 16);
+try {
+buffer139.unmap();
+} catch {}
+try {
+commandEncoder200.copyTextureToTexture({
+  texture: texture149,
+  mipLevel: 0,
+  origin: {x: 131, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture200,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder201 = device1.createCommandEncoder({});
+let texture221 = device1.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView213 = texture197.createView({baseArrayLayer: 3, arrayLayerCount: 1});
+let computePassEncoder189 = commandEncoder201.beginComputePass();
+let buffer150 = device1.createBuffer({size: 44, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView214 = texture220.createView({format: 'depth24plus'});
+let computePassEncoder190 = commandEncoder200.beginComputePass({timestampWrites: {querySet: querySet16}});
+let sampler153 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+});
+try {
+{ clearResourceUsages(device1, computePassEncoder102); computePassEncoder102.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline29);
+} catch {}
+try {
+buffer87.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture173,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(37).fill(143), /* required buffer size: 37 */
+{offset: 37}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture222 = device0.createTexture({
+  size: {width: 31, height: 5, depthOrArrayLayers: 12},
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder101.setBindGroup(2, bindGroup78, new Uint32Array(789), 2, 0);
+} catch {}
+try {
+computePassEncoder57.end();
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup80, new Uint32Array(389), 6, 0);
+} catch {}
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer79, 0);
+} catch {}
+let texture223 = device0.createTexture({
+  size: {width: 12},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView215 = texture81.createView({dimension: '2d', baseArrayLayer: 0});
+let computePassEncoder191 = commandEncoder69.beginComputePass();
+let sampler154 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 90.89});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(0, bindGroup62, new Uint32Array(959), 40, 0);
+} catch {}
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer67, 'uint16', 2, 4);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline8);
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+let pipeline36 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {module: shaderModule5, constants: {}, targets: [{format: 'rgba32uint', writeMask: 0}]},
+  vertex: {module: shaderModule5, constants: {42_686: 1}, buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpteRp431', transfer: 'hlg'} });
+let buffer151 = device0.createBuffer({
+  size: 196,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture224 = device0.createTexture({
+  size: [12],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture225 = device0.createTexture({
+  size: {width: 31, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let texture226 = gpuCanvasContext5.getCurrentTexture();
+let computePassEncoder192 = commandEncoder54.beginComputePass();
+let renderPassEncoder48 = commandEncoder142.beginRenderPass({
+  colorAttachments: [{
+  view: textureView215,
+  clearValue: { r: -471.3, g: -879.0, b: 177.3, a: 262.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 125875801,
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['r16uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup54, new Uint32Array(1883), 30, 0);
+} catch {}
+let commandEncoder202 = device0.createCommandEncoder({});
+let texture227 = device0.createTexture({
+  size: {width: 156, height: 15, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle23 = renderBundleEncoder23.finish({});
+let sampler155 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.09,
+  compare: 'less',
+});
+try {
+computePassEncoder192.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder202.copyTextureToBuffer({
+  texture: texture156,
+  mipLevel: 0,
+  origin: {x: 124, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2112 */
+  offset: 2112,
+  bytesPerRow: 14336,
+  buffer: buffer3,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer35, 4, new Uint32Array(2486), 423, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(340).fill(108), /* required buffer size: 340 */
+{offset: 340}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData26 = new ImageData(8, 48);
+let textureView216 = texture222.createView({});
+let texture228 = device0.createTexture({size: {width: 48}, dimension: '1d', format: 'r16uint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder140.setBindGroup(0, bindGroup40, []);
+} catch {}
+try {
+computePassEncoder123.setBindGroup(0, bindGroup3, new Uint32Array(1592), 67, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup69, new Uint32Array(6), 0, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer86, 'uint32', 16, 91);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder202.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1648 */
+  offset: 1648,
+  bytesPerRow: 9984,
+  rowsPerImage: 228,
+  buffer: buffer42,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup104 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout0, entries: [{binding: 23, resource: textureView18}]});
+let textureView217 = texture223.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder65); computePassEncoder65.dispatchWorkgroups(1, 4); };
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup12, new Uint32Array(881), 123, 0);
+} catch {}
+try {
+renderPassEncoder29.setViewport(95.63770107266963, 12.99762565764502, 194.19795542853214, 8.148317797183257, 0.941365246847668, 0.9618353237289753);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 28, new BigUint64Array(13276), 706, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 31, height: 5, depthOrArrayLayers: 12}
+*/
+{
+  source: imageData2,
+  origin: { x: 9, y: 4 },
+  flipY: true,
+}, {
+  texture: texture222,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let texture229 = device0.createTexture({
+  size: [24, 18, 7],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder193 = commandEncoder202.beginComputePass();
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u0914\u00a9\u08ea\u0514\uf887\u9ade\u8868\uab7c\u0d8c',
+  colorFormats: ['rgba32uint'],
+  depthReadOnly: true,
+});
+let renderBundle24 = renderBundleEncoder24.finish({});
+try {
+computePassEncoder120.setBindGroup(3, bindGroup6, new Uint32Array(950), 34, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup38, new Uint32Array(2244), 202, 0);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer76, 'uint16', 28, 3);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline4);
+} catch {}
+let texture230 = device1.createTexture({
+  size: {width: 20},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView218 = texture152.createView({});
+try {
+computePassEncoder121.setBindGroup(2, bindGroup89, new Uint32Array(156), 48, 0);
+} catch {}
+let commandEncoder203 = device1.createCommandEncoder({});
+let textureView219 = texture221.createView({format: 'rgba32uint'});
+let textureView220 = texture208.createView({arrayLayerCount: 1});
+let computePassEncoder194 = commandEncoder203.beginComputePass();
+try {
+computePassEncoder187.setBindGroup(2, bindGroup90);
+} catch {}
+try {
+computePassEncoder138.setBindGroup(0, bindGroup75, new Uint32Array(521), 111, 0);
+} catch {}
+let buffer152 = device0.createBuffer({
+  size: 76,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+let texture231 = device0.createTexture({
+  size: [62, 10, 136],
+  mipLevelCount: 2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture232 = device0.createTexture({
+  size: {width: 48},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder76.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup91);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup42, new Uint32Array(2041), 263, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer70, 'uint32', 8, 2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder143.setBindGroup(3, bindGroup86, new Uint32Array(3490), 681, 0);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline29);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 474, height: 1, depthOrArrayLayers: 59}
+*/
+{
+  source: img1,
+  origin: { x: 2, y: 7 },
+  flipY: false,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 261, y: 0, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView221 = texture188.createView({dimension: '2d-array', baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({colorFormats: ['r16uint'], sampleCount: 4, stencilReadOnly: true});
+let sampler156 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 81.83,
+  compare: 'never',
+});
+try {
+computePassEncoder102.setBindGroup(3, bindGroup79, new Uint32Array(568), 8, 0);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup96, new Uint32Array(243), 17, 0);
+} catch {}
+let arrayBuffer4 = buffer80.getMappedRange(88, 8);
+try {
+buffer130.unmap();
+} catch {}
+let buffer153 = device0.createBuffer({size: 208, usage: GPUBufferUsage.VERTEX});
+let texture233 = device0.createTexture({
+  size: {width: 248, height: 40, depthOrArrayLayers: 1},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler157 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.81,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup80);
+} catch {}
+try {
+computePassEncoder173.setBindGroup(3, bindGroup11, new Uint32Array(1207), 43, 0);
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(3, buffer24);
+} catch {}
+try {
+commandEncoder204.copyBufferToBuffer(buffer1, 124, buffer152, 0, 0);
+} catch {}
+try {
+commandEncoder204.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1664 widthInBlocks: 104 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5040 */
+  offset: 5040,
+  bytesPerRow: 2048,
+  buffer: buffer57,
+}, {width: 104, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder100.pushDebugGroup('\u0385');
+} catch {}
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout16]});
+let texture234 = device0.createTexture({
+  size: [2, 2, 18],
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler158 = device0.createSampler({
+  label: '\uc4b6\u{1fd86}\u06ab\u{1fdb2}\u41dd\u{1fd22}\u3a5b\u9ed4\u01a8\u0f8c\u{1fd6f}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.96,
+});
+try {
+renderPassEncoder38.setIndexBuffer(buffer68, 'uint16', 28, 13);
+} catch {}
+let commandEncoder205 = device0.createCommandEncoder({});
+let textureView222 = texture234.createView({dimension: 'cube'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder206 = device0.createCommandEncoder();
+let texture235 = device0.createTexture({
+  size: {width: 312, height: 30, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({colorFormats: ['rgba32uint'], depthReadOnly: false});
+try {
+computePassEncoder142.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 503.9, g: -533.3, b: 998.1, a: 198.7, });
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer14, 'uint32', 44, 5);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline36);
+} catch {}
+document.body.append(img2);
+let commandEncoder207 = device1.createCommandEncoder({});
+let texture236 = device1.createTexture({
+  size: [195, 2, 1],
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder195 = commandEncoder207.beginComputePass({timestampWrites: {querySet: querySet16, beginningOfPassWriteIndex: 235}});
+try {
+computePassEncoder160.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+  await buffer147.mapAsync(GPUMapMode.WRITE, 0, 0);
+} catch {}
+videoFrame3.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame27.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -536,6 +536,8 @@ void Buffer::takeSlowIndirectIndexValidationPath(CommandBuffer& commandBuffer, B
     auto queue = protectedDevice()->protectedQueue();
     queue->waitForAllCommitedWorkToComplete();
     queue->synchronizeResourceAndWait(m_buffer);
+    if (m_buffer.length < indexBufferOffsetInBytes + sizeof(MTLDrawIndexedPrimitivesIndirectArguments))
+        return;
     auto bufferSubData = span<MTLDrawIndexedPrimitivesIndirectArguments>(m_buffer, indexBufferOffsetInBytes);
     if (!bufferSubData.data() || !bufferSubData.size())
         return;


### PR DESCRIPTION
#### 06f75863a83f7072c92d04fde7daba7201894a73
<pre>
[WebGPU] Release assertion triggered when offset + size &gt; bufferSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=287418">https://bugs.webkit.org/show_bug.cgi?id=287418</a>
<a href="https://rdar.apple.com/144542281">rdar://144542281</a>

Reviewed by Tadeu Zagallo.

We triggered a release assertion created the span when the buffer offset
plus the size of the type exceeded the buffer&apos;s length.

Check for this and early return. It is an error for the website to do this,
but we don&apos;t want to crash the GPU process.

* LayoutTests/fast/webgpu/nocrash/fuzz-287418-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-287418.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::takeSlowIndirectIndexValidationPath):

Canonical link: <a href="https://commits.webkit.org/290195@main">https://commits.webkit.org/290195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef46aa6bb26e31c112fbd43eb4ece5da3bbd4728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94156 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39936 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68712 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26381 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49074 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95989 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77603 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76881 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18973 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9470 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21680 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->