### PR TITLE
REGRESSION(290132@main): [iOS] TestWebKitAPI.iOSStylusSupport.StylusLaterDisconnected (api-tests) are crashing.

### DIFF
--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1702,7 +1702,6 @@ void WebPageProxy::statusBarWasTapped()
 
 double WebPageProxy::displayedContentScale() const
 {
-    ASSERT(internals().lastVisibleContentRectUpdate);
     if (internals().lastVisibleContentRectUpdate)
         return internals().lastVisibleContentRectUpdate->scale();
     return 1;
@@ -1710,7 +1709,6 @@ double WebPageProxy::displayedContentScale() const
 
 FloatRect WebPageProxy::exposedContentRect() const
 {
-    ASSERT(internals().lastVisibleContentRectUpdate);
     if (internals().lastVisibleContentRectUpdate)
         return internals().lastVisibleContentRectUpdate->exposedContentRect();
     return { };
@@ -1718,7 +1716,6 @@ FloatRect WebPageProxy::exposedContentRect() const
 
 FloatRect WebPageProxy::unobscuredContentRect() const
 {
-    ASSERT(internals().lastVisibleContentRectUpdate);
     if (internals().lastVisibleContentRectUpdate)
         return internals().lastVisibleContentRectUpdate->unobscuredContentRect();
     return { };
@@ -1726,7 +1723,6 @@ FloatRect WebPageProxy::unobscuredContentRect() const
 
 bool WebPageProxy::inStableState() const
 {
-    ASSERT(internals().lastVisibleContentRectUpdate);
     if (internals().lastVisibleContentRectUpdate)
         return internals().lastVisibleContentRectUpdate->inStableState();
     return false;
@@ -1734,7 +1730,6 @@ bool WebPageProxy::inStableState() const
 
 FloatRect WebPageProxy::unobscuredContentRectRespectingInputViewBounds() const
 {
-    ASSERT(internals().lastVisibleContentRectUpdate);
     if (internals().lastVisibleContentRectUpdate)
         return internals().lastVisibleContentRectUpdate->unobscuredContentRectRespectingInputViewBounds();
     return { };
@@ -1742,7 +1737,6 @@ FloatRect WebPageProxy::unobscuredContentRectRespectingInputViewBounds() const
 
 FloatRect WebPageProxy::layoutViewportRect() const
 {
-    ASSERT(internals().lastVisibleContentRectUpdate);
     if (internals().lastVisibleContentRectUpdate)
         return internals().lastVisibleContentRectUpdate->layoutViewportRect();
     return { };


### PR DESCRIPTION
#### e240c702bc2d00fc8ed641aed8bad4de33419ebf
<pre>
REGRESSION(290132@main): [iOS] TestWebKitAPI.iOSStylusSupport.StylusLaterDisconnected (api-tests) are crashing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287414">https://bugs.webkit.org/show_bug.cgi?id=287414</a>
&lt;<a href="https://rdar.apple.com/144538441">rdar://144538441</a>&gt;

Reviewed by Jonathan Bedard.

These assertions were invalid, so removing them.

The old code didn&apos;t have an optional for lastVisibleContentRectUpdate, so just
returned the default initializations of the members if read before we actually
got a rect update.

I added the assertions when moving the struct into an optional, expecting this
not to happen, but it clearly does (without any known broken behaviour).
Removing the assertions to explictly return default values restores the old
behaviour.

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::displayedContentScale const):
(WebKit::WebPageProxy::exposedContentRect const):
(WebKit::WebPageProxy::unobscuredContentRect const):
(WebKit::WebPageProxy::inStableState const):
(WebKit::WebPageProxy::unobscuredContentRectRespectingInputViewBounds const):
(WebKit::WebPageProxy::layoutViewportRect const):

Canonical link: <a href="https://commits.webkit.org/290175@main">https://commits.webkit.org/290175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d419fb841ae691748c056ea8fa1d32cf89566b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39939 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16891 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80941 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/49077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39046 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/95992 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16358 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76727 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21294 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9473 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13977 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16372 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->