### PR TITLE
PublicKeyCredential.prototype.toJSON() does not Base64url Encode buffers, violating the spec and causing site breakage

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -30,14 +30,16 @@
     const expected = {
         "authenticatorAttachment" : "cross-platform",
         "clientExtensionResults" : { "credProps" : { "rk" : false } },
-        "id" : "KAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A==",
-        "rawId" : "KAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A==",
-        "response" : {"attestationObject" : "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjERsx/uWedVbLbkJLhyNnl4dArdYDwtIEsdwli4eSPWthBAAAATgAAAAAAAAAAAAAAAAAAAAAAQCgIrc7o/k7Jc3pX9/72cCBrQ0DYKCnhXeaBInmM4cswOubGn9LStsP5qKGu7ULRoA3cGSIzoY3LmdKUNWo6BOClAQIDJiABIVggQVuF7dGQ253qyDKtoEaOWHWnNOUJl6FCUv9vXwdnpYYiWCAmB9R396f2nkAioxBtSeKcR5d0UuS9bT/NXkGkSOM3EA==",
-        "authenticatorData" : "Rsx/uWedVbLbkJLhyNnl4dArdYDwtIEsdwli4eSPWthBAAAATgAAAAAAAAAAAAAAAAAAAAAAQCgIrc7o/k7Jc3pX9/72cCBrQ0DYKCnhXeaBInmM4cswOubGn9LStsP5qKGu7ULRoA3cGSIzoY3LmdKUNWo6BOClAQIDJiABIVggQVuF7dGQ253qyDKtoEaOWHWnNOUJl6FCUv9vXwdnpYYiWCAmB9R396f2nkAioxBtSeKcR5d0UuS9bT/NXkGkSOM3EA==",
-        "clientDataJSON" : "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiTVRJek5EVTIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDo5NDQzIn0=",
-        "publicKey" : "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQVuF7dGQ253qyDKtoEaOWHWnNOUJl6FCUv9vXwdnpYYmB9R396f2nkAioxBtSeKcR5d0UuS9bT/NXkGkSOM3EA==",
-        "publicKeyAlgorithm" : -7,
-        "transports" : [ "usb" ]},
+        "id" : "KAitzuj-Tslzelf3_vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w_mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A",
+        "rawId" : "KAitzuj-Tslzelf3_vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w_mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A",
+        "response" : { 
+            "attestationObject" : "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjERsx_uWedVbLbkJLhyNnl4dArdYDwtIEsdwli4eSPWthBAAAATgAAAAAAAAAAAAAAAAAAAAAAQCgIrc7o_k7Jc3pX9_72cCBrQ0DYKCnhXeaBInmM4cswOubGn9LStsP5qKGu7ULRoA3cGSIzoY3LmdKUNWo6BOClAQIDJiABIVggQVuF7dGQ253qyDKtoEaOWHWnNOUJl6FCUv9vXwdnpYYiWCAmB9R396f2nkAioxBtSeKcR5d0UuS9bT_NXkGkSOM3EA",
+            "authenticatorData" : "Rsx_uWedVbLbkJLhyNnl4dArdYDwtIEsdwli4eSPWthBAAAATgAAAAAAAAAAAAAAAAAAAAAAQCgIrc7o_k7Jc3pX9_72cCBrQ0DYKCnhXeaBInmM4cswOubGn9LStsP5qKGu7ULRoA3cGSIzoY3LmdKUNWo6BOClAQIDJiABIVggQVuF7dGQ253qyDKtoEaOWHWnNOUJl6FCUv9vXwdnpYYiWCAmB9R396f2nkAioxBtSeKcR5d0UuS9bT_NXkGkSOM3EA",
+            "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiTVRJek5EVTIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDo5NDQzIn0",
+            "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQVuF7dGQ253qyDKtoEaOWHWnNOUJl6FCUv9vXwdnpYYmB9R396f2nkAioxBtSeKcR5d0UuS9bT_NXkGkSOM3EA",
+            "publicKeyAlgorithm" : -7,
+            "transports" : [ "usb" ]
+        },
         "type" : "public-key"
     };
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -19,12 +19,12 @@
         let expected = {
             "authenticatorAttachment" : "cross-platform",
             "clientExtensionResults":{},
-            "id":"KAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A==",
-            "rawId":"KAitzuj+Tslzelf3/vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w/mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A==",
+            "id":"KAitzuj-Tslzelf3_vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w_mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A",
+            "rawId":"KAitzuj-Tslzelf3_vZwIGtDQNgoKeFd5oEieYzhyzA65saf0tK2w_mooa7tQtGgDdwZIjOhjcuZ0pQ1ajoE4A",
             "response" : {
-                "authenticatorData":"Rsx/uWedVbLbkJLhyNnl4dArdYDwtIEsdwli4eSPWtgBAAAAUA==",
-                "clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTVRJek5EVTIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDo5NDQzIn0=",
-                "signature":"MEUCIQCSFTuuBWgB4/F0VB7DlUVM09IHPmxe1MzHUwRoCRZbCAIgGKov6xoAx2MEf6/6qNs8OutzhP2CQoJ1L7Fe64G9uBc="
+                "authenticatorData":"Rsx_uWedVbLbkJLhyNnl4dArdYDwtIEsdwli4eSPWtgBAAAAUA",
+                "clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTVRJek5EVTIiLCJvcmlnaW4iOiJodHRwczovL2xvY2FsaG9zdDo5NDQzIn0",
+                "signature":"MEUCIQCSFTuuBWgB4_F0VB7DlUVM09IHPmxe1MzHUwRoCRZbCAIgGKov6xoAx2MEf6_6qNs8OutzhP2CQoJ1L7Fe64G9uBc"
             },
             "type":"public-key"
         };

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp
@@ -89,13 +89,13 @@ AuthenticationResponseJSON::AuthenticatorAssertionResponseJSON AuthenticatorAsse
 {
     AuthenticationResponseJSON::AuthenticatorAssertionResponseJSON value;
     if (auto authData = authenticatorData())
-        value.authenticatorData = base64EncodeToString(authData->span());
+        value.authenticatorData = base64URLEncodeToString(authData->span());
     if (auto sig = signature())
-        value.signature = base64EncodeToString(sig->span());
+        value.signature = base64URLEncodeToString(sig->span());
     if (auto handle = userHandle())
-        value.userHandle = base64EncodeToString(handle->span());
+        value.userHandle = base64URLEncodeToString(handle->span());
     if (auto clientData = clientDataJSON())
-        value.clientDataJSON = base64EncodeToString(clientData->span());
+        value.clientDataJSON = base64URLEncodeToString(clientData->span());
     return value;
 }
 

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -188,14 +188,14 @@ RegistrationResponseJSON::AuthenticatorAttestationResponseJSON AuthenticatorAtte
         transports.append(toString(transport));
     RegistrationResponseJSON::AuthenticatorAttestationResponseJSON value;
     if (auto clientData = clientDataJSON())
-        value.clientDataJSON = base64EncodeToString(clientData->span());
+        value.clientDataJSON = base64URLEncodeToString(clientData->span());
     value.transports = transports;
     if (auto authData = getAuthenticatorData())
-        value.authenticatorData = base64EncodeToString(authData->span());
+        value.authenticatorData = base64URLEncodeToString(authData->span());
     if (auto publicKey = getPublicKey())
-        value.publicKey = base64EncodeToString(publicKey->span());
+        value.publicKey = base64URLEncodeToString(publicKey->span());
     if (auto attestationObj = attestationObject())
-        value.attestationObject = base64EncodeToString(attestationObj->span());
+        value.attestationObject = base64URLEncodeToString(attestationObj->span());
     value.publicKeyAlgorithm = getPublicKeyAlgorithm();
 
     return value;

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -92,8 +92,9 @@ PublicKeyCredentialJSON PublicKeyCredential::toJSON()
     if (is<AuthenticatorAttestationResponse>(m_response)) {
         RegistrationResponseJSON response;
         if (auto id = rawId()) {
-            response.id = base64EncodeToString(id->span());
-            response.rawId = base64EncodeToString(id->span());
+            auto encodedString = base64URLEncodeToString(id->span());
+            response.id = encodedString;
+            response.rawId = encodedString;
         }
 
         response.response = downcast<AuthenticatorAttestationResponse>(m_response)->toJSON();
@@ -106,8 +107,9 @@ PublicKeyCredentialJSON PublicKeyCredential::toJSON()
     if (is<AuthenticatorAssertionResponse>(m_response)) {
         AuthenticationResponseJSON response;
         if (auto id = rawId()) {
-            response.id = base64EncodeToString(id->span());
-            response.rawId = base64EncodeToString(id->span());
+            auto encodedString = base64URLEncodeToString(id->span());
+            response.id = encodedString;
+            response.rawId = encodedString;
         }
         response.response = downcast<AuthenticatorAssertionResponse>(m_response)->toJSON();
         response.authenticatorAttachment = convertEnumerationToString(authenticatorAttachment());


### PR DESCRIPTION
#### 18830d681125e1ea202a3aedbf28c740f4c95637
<pre>
PublicKeyCredential.prototype.toJSON() does not Base64url Encode buffers, violating the spec and causing site breakage
<a href="https://rdar.apple.com/144537421">rdar://144537421</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287378">https://bugs.webkit.org/show_bug.cgi?id=287378</a>

Reviewed by Charlie Wolfe and Pascoe.

URL encode id field as per
<a href="https://w3c.github.io/webauthn/#dom-publickeycredential-tojson%5C.">https://w3c.github.io/webauthn/#dom-publickeycredential-tojson%5C.</a>

Also changing other fields in Attestation/Assertion that are
ArrayBuffers but not URL safe encoded.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html:
* Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.cpp:
(WebCore::AuthenticatorAssertionResponse::toJSON):
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
(WebCore::AuthenticatorAttestationResponse::toJSON):
* Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp:
(WebCore::PublicKeyCredential::toJSON):

Canonical link: <a href="https://commits.webkit.org/290187@main">https://commits.webkit.org/290187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b075d4e676b6948c2ba4c606b0b972b6b098fd93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39946 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16899 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35326 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96000 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16365 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19910 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9481 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21690 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19571 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->