### PR TITLE
[GStreamer] Remove usage of unsafe-buffer in RTCRtpSFrameTransformerOpenSSL

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerOpenSSL.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerOpenSSL.cpp
@@ -136,10 +136,8 @@ static std::optional<Vector<uint8_t>> crypt(int operation, const Vector<uint8_t>
             return std::nullopt;
 
         // Finalize the encryption(decryption)
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.data() + len, &len))
+        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.subvector(len).mutableSpan().data() , &len))
             return std::nullopt;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     // Second part
@@ -157,14 +155,12 @@ static std::optional<Vector<uint8_t>> crypt(int operation, const Vector<uint8_t>
             return std::nullopt;
 
         // Provide the message to be encrypted(decrypted), and obtain the encrypted(decrypted) output
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib
-        if (1 != EVP_CipherUpdate(ctx.get(), outputText.data() + headSize, &len, inputText.data() + headSize, tailSize))
+        if (1 != EVP_CipherUpdate(ctx.get(), outputText.subvector(headSize).mutableSpan().data(), &len, inputText.subspan(headSize).data(), tailSize))
             return std::nullopt;
 
         // Finalize the encryption(decryption)
-        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.data() + headSize + len, &len))
+        if (1 != EVP_CipherFinal_ex(ctx.get(), outputText.subvector(headSize + len).mutableSpan().data(), &len))
             return std::nullopt;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     return outputText;


### PR DESCRIPTION
#### 0454a02757a2f281a752d4bd9c6f9f1ccc5059cd
<pre>
[GStreamer] Remove usage of unsafe-buffer in RTCRtpSFrameTransformerOpenSSL
<a href="https://bugs.webkit.org/show_bug.cgi?id=287428">https://bugs.webkit.org/show_bug.cgi?id=287428</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerOpenSSL.cpp:
(WebCore::crypt):

Canonical link: <a href="https://commits.webkit.org/290392@main">https://commits.webkit.org/290392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8627dd861da1e7e479524f4c41acf4019cae665

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68940 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96321 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77128 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19107 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21553 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9840 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22008 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->