### PR TITLE
REGRESSION(288121@main): [WebAudio] DirectConvolver::process() tries to use use negative indexes on a std::span

### DIFF
--- a/Source/WebCore/platform/audio/DirectConvolver.cpp
+++ b/Source/WebCore/platform/audio/DirectConvolver.cpp
@@ -80,8 +80,8 @@ void DirectConvolver::process(AudioFloatArray* convolutionKernel, std::span<cons
     vDSP_conv(inputBuffer.subspan(inputP.data() - inputBuffer.data() - kernelSize + 1).data(), 1, kernelP.subspan(kernelSize - 1).data(), -1, destination.data(), 1, source.size(), kernelSize);
 #else
     // FIXME: The macro can be further optimized to avoid pipeline stalls. One possibility is to maintain 4 separate sums and change the macro to CONVOLVE_FOUR_SAMPLES.
-#define CONVOLVE_ONE_SAMPLE             \
-    sum += inputP[i - j] * kernelP[j];  \
+#define CONVOLVE_ONE_SAMPLE                                    \
+    sum += inputBuffer[m_inputBlockSize + i - j] * kernelP[j]; \
     j++;
 
     size_t i = 0;


### PR DESCRIPTION
#### 19e127b1e23d0a25485d53ee9d17a4200f83ce8a
<pre>
REGRESSION(288121@main): [WebAudio] DirectConvolver::process() tries to use use negative indexes on a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=287431">https://bugs.webkit.org/show_bug.cgi?id=287431</a>

Reviewed by Chris Dumez.

Before the conversion to std::span in 288121@main (970bbbc53b2d), the
calculation of the buffer indexes in the CONVOLVE_ONE_SAMPLE macro would
fit in the bounds of an &quot;int&quot; and the &quot;float*&quot; would be accessed with a
negative index. This was okay given that the base pointer intentionally
pointed to the middle of the buffer, and the macro would fetch values
from the first half of it.

With the switch to std::span, its array subindex operator would cause a
conversion of the calculated index to size_t, and trying to represent
the negative index as such results in the value wrapping around into
a huge (and invalid) index.

The simplest solution is to always calculate positive index values over
the whole buffer and use the std::span that refers to that, instead of
using the std::span that refers only to the second half of the buffer.

* Source/WebCore/platform/audio/DirectConvolver.cpp:
(WebCore::DirectConvolver::process):

Canonical link: <a href="https://commits.webkit.org/290202@main">https://commits.webkit.org/290202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71ea3b41c31484e5d41dd1c5d81e55fbd2500b58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/89291 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/8815 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/44126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/40052 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/91342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/9203 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/17042 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/94276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/40052 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/92293 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/9203 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/44126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/9203 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/44126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/39159 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/9203 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/44126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/96106 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/16471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/17042 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/96106 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/16727 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/44126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/96106 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/44126 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9597 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13993 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/16485 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19677 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18007 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->