### PR TITLE
Move FullscreenManager ownership from Document to Page

### DIFF
--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -428,7 +428,7 @@ ALWAYS_INLINE bool matchesFullscreenDocumentPseudoClass(const Element& element)
 ALWAYS_INLINE bool matchesInWindowFullscreenPseudoClass(const Element& element)
 {
 #if ENABLE(VIDEO)
-    if (&element != element.document().fullscreenManager().fullscreenElement())
+    if (element.document().fullscreenManager() && &element != element.document().fullscreenManager()->fullscreenElement())
         return false;
 
     auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1010,15 +1010,6 @@ VisitedLinkState& Document::ensureVisitedLinkState()
     return *m_visitedLinkState;
 }
 
-#if ENABLE(FULLSCREEN_API)
-FullscreenManager& Document::ensureFullscreenManager()
-{
-    ASSERT(m_constructionDidFinish);
-    lazyInitialize(m_fullscreenManager, makeUnique<FullscreenManager>(*this));
-    return *m_fullscreenManager;
-}
-#endif
-
 Ref<SecurityOrigin> Document::protectedTopOrigin() const
 {
     return topOrigin();
@@ -8488,26 +8479,44 @@ void Document::addDefaultSpatialTrackingLabelChangedObserver(const DefaultSpatia
 #endif
 
 #if ENABLE(FULLSCREEN_API)
-FullscreenManager& Document::fullscreenManager()
+FullscreenManager* Document::fullscreenManager()
 {
-    if (!m_fullscreenManager)
-        return ensureFullscreenManager();
-    return *m_fullscreenManager;
+    RefPtr page = this->page();
+    if (!page)
+        return nullptr;
+    return &page->fullscreenManager();
 }
 
-const FullscreenManager& Document::fullscreenManager() const
+const FullscreenManager* Document::fullscreenManager() const
 {
-    if (!m_fullscreenManager)
-        return const_cast<Document&>(*this).ensureFullscreenManager();
-    return *m_fullscreenManager;
+    RefPtr page = this->page();
+    if (!page)
+        return nullptr;
+    return &page->fullscreenManager();
 }
 
-CheckedRef<FullscreenManager> Document::checkedFullscreenManager()
+FullscreenManager* Document::fullscreenManagerIfExists()
+{
+    RefPtr page = this->page();
+    if (!page)
+        return nullptr;
+    return page->fullscreenManagerIfExists();
+}
+
+const FullscreenManager* Document::fullscreenManagerIfExists() const
+{
+    RefPtr page = this->page();
+    if (!page)
+        return nullptr;
+    return page->fullscreenManagerIfExists();
+}
+
+CheckedPtr<FullscreenManager> Document::checkedFullscreenManager()
 {
     return fullscreenManager();
 }
 
-CheckedRef<const FullscreenManager> Document::checkedFullscreenManager() const
+CheckedPtr<const FullscreenManager> Document::checkedFullscreenManager() const
 {
     return fullscreenManager();
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1397,12 +1397,12 @@ public:
 #endif
 
 #if ENABLE(FULLSCREEN_API)
-    FullscreenManager* fullscreenManagerIfExists() { return m_fullscreenManager.get(); }
-    const FullscreenManager* fullscreenManagerIfExists() const { return m_fullscreenManager.get(); }
-    WEBCORE_EXPORT FullscreenManager& fullscreenManager();
-    WEBCORE_EXPORT const FullscreenManager& fullscreenManager() const;
-    CheckedRef<FullscreenManager> checkedFullscreenManager(); // Defined in DocumentInlines.h.
-    CheckedRef<const FullscreenManager> checkedFullscreenManager() const; // Defined in DocumentInlines.h.
+    WEBCORE_EXPORT FullscreenManager* fullscreenManagerIfExists();
+    WEBCORE_EXPORT const FullscreenManager* fullscreenManagerIfExists() const;
+    WEBCORE_EXPORT FullscreenManager* fullscreenManager();
+    WEBCORE_EXPORT const FullscreenManager* fullscreenManager() const;
+    CheckedPtr<FullscreenManager> checkedFullscreenManager();
+    CheckedPtr<const FullscreenManager> checkedFullscreenManager() const;
 #endif
 
 #if ENABLE(POINTER_LOCK)
@@ -2005,7 +2005,6 @@ private:
     VisitedLinkState& ensureVisitedLinkState();
     ScriptRunner& ensureScriptRunner();
     ScriptModuleLoader& ensureModuleLoader();
-    WEBCORE_EXPORT FullscreenManager& ensureFullscreenManager();
     inline DocumentFontLoader& fontLoader();
     Ref<DocumentFontLoader> protectedFontLoader();
     DocumentFontLoader& ensureFontLoader();

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -38,48 +38,51 @@ namespace WebCore {
 
 bool DocumentFullscreen::webkitFullscreenEnabled(Document& document)
 {
-    return document.fullscreenManager().isFullscreenEnabled();
+    return document.fullscreenManager()->isFullscreenEnabled(document);
 }
 
 Element* DocumentFullscreen::webkitFullscreenElement(Document& document)
 {
-    return document.ancestorElementInThisScope(document.fullscreenManager().protectedFullscreenElement().get());
+    return document.ancestorElementInThisScope(document.fullscreenManager()->protectedFullscreenElement().get());
 }
 
 bool DocumentFullscreen::webkitIsFullScreen(Document& document)
 {
-    return document.fullscreenManager().isFullscreen();
+    return document.fullscreenManager()->isFullscreen();
 }
 
 bool DocumentFullscreen::webkitFullScreenKeyboardInputAllowed(Document& document)
 {
-    return document.fullscreenManager().isFullscreenKeyboardInputAllowed();
+    return document.fullscreenManager()->isFullscreenKeyboardInputAllowed();
 }
 
 Element* DocumentFullscreen::webkitCurrentFullScreenElement(Document& document)
 {
-    return document.ancestorElementInThisScope(document.fullscreenManager().protectedFullscreenElement().get());
+    return document.ancestorElementInThisScope(document.fullscreenManager()->protectedFullscreenElement().get());
 }
 
 void DocumentFullscreen::webkitCancelFullScreen(Document& document)
 {
-    document.fullscreenManager().cancelFullscreen();
+    document.fullscreenManager()->cancelFullscreen();
 }
 
 // https://fullscreen.spec.whatwg.org/#exit-fullscreen
 void DocumentFullscreen::exitFullscreen(Document& document, RefPtr<DeferredPromise>&& promise)
 {
-    if (!document.isFullyActive() || !document.fullscreenManager().fullscreenElement()) {
+    if (!document.isFullyActive() || !document.fullscreenManager()->fullscreenElement()) {
         promise->reject(Exception { ExceptionCode::TypeError, "Not in fullscreen"_s });
         return;
     }
-    document.checkedFullscreenManager()->exitFullscreen(WTFMove(promise));
+    if (CheckedPtr manager = document.checkedFullscreenManager())
+        manager->exitFullscreen(document, WTFMove(promise));
 }
 
 void DocumentFullscreen::webkitExitFullscreen(Document& document)
 {
-    if (document.fullscreenManager().fullscreenElement())
-        document.checkedFullscreenManager()->exitFullscreen(nullptr);
+    if (document.fullscreenManager()->fullscreenElement()) {
+        if (CheckedPtr manager = document.checkedFullscreenManager())
+            manager->exitFullscreen(document, nullptr);
+    }
 }
 
 // https://fullscreen.spec.whatwg.org/#dom-document-fullscreenenabled
@@ -87,7 +90,9 @@ bool DocumentFullscreen::fullscreenEnabled(Document& document)
 {
     if (!document.isFullyActive())
         return false;
-    return document.checkedFullscreenManager()->isFullscreenEnabled();
+    if (CheckedPtr manager = document.checkedFullscreenManager())
+        return manager->isFullscreenEnabled(document);
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3034,7 +3034,7 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
 
 #if ENABLE(FULLSCREEN_API)
         if (UNLIKELY(hasFullscreenFlag()))
-            oldDocument->fullscreenManager().exitRemovedFullscreenElement(*this);
+            oldDocument->fullscreenManager()->exitRemovedFullscreenElement(*this);
 #endif
 
         if (UNLIKELY(isInTopLayer()))
@@ -4774,7 +4774,7 @@ void Element::webkitRequestFullscreen()
 // FIXME: Options are currently ignored.
 void Element::requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&& promise)
 {
-    protectedDocument()->fullscreenManager().requestFullscreenForElement(*this, WTFMove(promise), FullscreenManager::EnforceIFrameAllowFullscreenRequirement);
+    protectedDocument()->fullscreenManager()->requestFullscreenForElement(*this, WTFMove(promise), FullscreenManager::EnforceIFrameAllowFullscreenRequirement);
 }
 
 void Element::setFullscreenFlag(bool flag)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1363,7 +1363,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
     bool isOutsideOfFullscreen = false;
 #if ENABLE(FULLSCREEN_API)
     if (CheckedPtr fullscreenManager = document->fullscreenManagerIfExists()) {
-        if (RefPtr fullscreenElement = document->fullscreenManager().fullscreenElement())
+        if (RefPtr fullscreenElement = document->fullscreenManager()->fullscreenElement())
             isOutsideOfFullscreen = m_element.isDescendantOf(*fullscreenElement);
     }
 #endif

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -274,7 +274,7 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
         if (event.type() == eventNames().webkitfullscreenchangeEvent || event.type() == eventNames().fullscreenchangeEvent)
-            data->setBoolean("enabled"_s, !!node->document().fullscreenManager().fullscreenElement());
+            data->setBoolean("enabled"_s, !!node->document().fullscreenManager()->fullscreenElement());
 #endif // ENABLE(FULLSCREEN_API)
 
         auto timestamp = m_domAgent.m_environment.executionStopwatch().elapsedTime().seconds();

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3820,7 +3820,7 @@ bool EventHandler::needsKeyboardEventDisambiguationQuirks() const
 bool EventHandler::isKeyEventAllowedInFullScreen(const PlatformKeyboardEvent& keyEvent) const
 {
     RefPtr document = m_frame->document();
-    if (document->fullscreenManager().isFullscreenKeyboardInputAllowed())
+    if (document->fullscreenManager()->isFullscreenKeyboardInputAllowed())
         return true;
 
     if (keyEvent.type() == PlatformKeyboardEvent::Type::Char) {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -123,6 +123,7 @@ class ElementTargetingController;
 class Element;
 class FocusController;
 class FormData;
+class FullscreenManager;
 class HTMLElement;
 class HTMLMediaElement;
 class HistoryItem;
@@ -398,7 +399,6 @@ public:
     void setAutofocusProcessed();
     bool autofocusProcessed() const;
     bool topDocumentHasDocumentClass(DocumentClass) const;
-    void setTopDocumentHasFullscreenElement(bool);
     WEBCORE_EXPORT bool topDocumentHasFullscreenElement();
 
     bool hasInjectedUserScript();
@@ -1304,6 +1304,13 @@ public:
     WEBCORE_EXPORT void setPresentingApplicationBundleIdentifier(String&&);
 #endif
 
+#if ENABLE(FULLSCREEN_API)
+    FullscreenManager* fullscreenManagerIfExists() { return m_fullscreenManager.get(); }
+    const FullscreenManager* fullscreenManagerIfExists() const { return m_fullscreenManager.get(); }
+    WEBCORE_EXPORT FullscreenManager& fullscreenManager();
+    WEBCORE_EXPORT const FullscreenManager& fullscreenManager() const;
+#endif
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1749,6 +1756,9 @@ private:
 
 #if PLATFORM(COCOA)
     String m_presentingApplicationBundleIdentifier;
+#endif
+#if ENABLE(FULLSCREEN_API)
+    mutable std::unique_ptr<FullscreenManager> m_fullscreenManager;
 #endif
 }; // class Page
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -356,7 +356,7 @@ void WebFullScreenManager::willEnterFullScreen(WebCore::HTMLMediaElementEnums::V
 
     m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::Yes);
 
-    if (!m_element->document().fullscreenManager().willEnterFullscreen(*m_element, mode)) {
+    if (!m_element->document().fullscreenManager()->willEnterFullscreen(*m_element, mode)) {
         close();
         return;
     }
@@ -381,7 +381,7 @@ void WebFullScreenManager::didEnterFullScreen()
 
     ALWAYS_LOG(LOGIDENTIFIER, "<", m_element->tagName(), " id=\"", m_element->getIdAttribute(), "\">");
 
-    if (!m_element->document().fullscreenManager().didEnterFullscreen()) {
+    if (!m_element->document().fullscreenManager()->didEnterFullscreen()) {
         close();
         return;
     }
@@ -451,7 +451,7 @@ void WebFullScreenManager::willExitFullScreen()
 #endif
 
     m_finalFrame = screenRectOfContents(m_element.get());
-    if (!m_element->document().fullscreenManager().willExitFullscreen()) {
+    if (!m_element->document().fullscreenManager()->willExitFullscreen()) {
         close();
         return;
     }
@@ -467,10 +467,10 @@ static Vector<Ref<Element>> collectFullscreenElementsFromElement(Element* elemen
 {
     Vector<Ref<Element>> fullscreenElements;
 
-    while (element && element->document().fullscreenManager().fullscreenElement() == element) {
+    while (element && element->document().fullscreenManager()->fullscreenElement() == element) {
         fullscreenElements.append(*element);
         auto parentDocument = element->document().parentDocument();
-        element = parentDocument ? parentDocument->fullscreenManager().fullscreenElement() : nullptr;
+        element = parentDocument ? parentDocument->fullscreenManager()->fullscreenElement() : nullptr;
     }
 
     return fullscreenElements;
@@ -497,7 +497,7 @@ void WebFullScreenManager::didExitFullScreen()
 
     auto fullscreenElements = collectFullscreenElementsFromElement(m_element.get());
 
-    m_element->document().fullscreenManager().didExitFullscreen();
+    m_element->document().fullscreenManager()->didExitFullscreen();
 
     // Ensure the element (and all its parent fullscreen elements) that just exited fullscreen are still in view:
     while (!fullscreenElements.isEmpty()) {
@@ -512,7 +512,7 @@ void WebFullScreenManager::setAnimatingFullScreen(bool animating)
 {
     if (!m_element)
         return;
-    m_element->document().fullscreenManager().setAnimatingFullscreen(animating);
+    m_element->document().fullscreenManager()->setAnimatingFullscreen(animating);
 }
 
 void WebFullScreenManager::requestRestoreFullScreen(CompletionHandler<void(bool)>&& completionHandler)
@@ -529,7 +529,7 @@ void WebFullScreenManager::requestRestoreFullScreen(CompletionHandler<void(bool)
 
     ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
     WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, &element->document());
-    element->document().fullscreenManager().requestFullscreenForElement(*element, nullptr, WebCore::FullscreenManager::ExemptIFrameAllowFullscreenRequirement, WTFMove(completionHandler));
+    element->document().fullscreenManager()->requestFullscreenForElement(*element, nullptr, WebCore::FullscreenManager::ExemptIFrameAllowFullscreenRequirement, WTFMove(completionHandler));
 }
 
 void WebFullScreenManager::requestExitFullScreen()
@@ -554,7 +554,7 @@ void WebFullScreenManager::requestExitFullScreen()
     }
 
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_element->document().fullscreenManager().cancelFullscreen();
+    m_element->document().fullscreenManager()->cancelFullscreen();
 }
 
 void WebFullScreenManager::close()
@@ -600,7 +600,7 @@ void WebFullScreenManager::handleEvent(WebCore::ScriptExecutionContext& context,
         return;
 
     Ref document = m_element->document();
-    if (&context != document.ptr() || !document->fullscreenManager().isFullscreen())
+    if (&context != document.ptr() || !document->fullscreenManager()->isFullscreen())
         return;
 
     if (targetElement == m_element) {
@@ -628,7 +628,7 @@ void WebFullScreenManager::handleEvent(WebCore::ScriptExecutionContext& context,
 #if ENABLE(IMAGE_ANALYSIS)
 void WebFullScreenManager::mainVideoElementTextRecognitionTimerFired()
 {
-    if (!m_element || !m_element->document().fullscreenManager().isFullscreen())
+    if (!m_element || !m_element->document().fullscreenManager()->isFullscreen())
         return;
 
     updateMainVideoElement();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -318,7 +318,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
 {
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = frame.document())
-        document->fullscreenManager().cancelFullscreen();
+        document->fullscreenManager()->cancelFullscreen();
 #endif
 
     auto& webProcess = WebProcess::singleton();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -559,7 +559,7 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 
 #if ENABLE(FULLSCREEN_API)
     auto* document = m_localFrame->document();
-    if (document && document->fullscreenManager().fullscreenElement())
+    if (document && document->fullscreenManager()->fullscreenElement())
         webPage->fullScreenManager().exitFullScreenForElement(webPage->fullScreenManager().element());
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7436,8 +7436,8 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
 #if PLATFORM(IOS_FAMILY)
 
 #if ENABLE(FULLSCREEN_API)
-        if (element.document().fullscreenManager().isFullscreen())
-            element.document().fullscreenManager().cancelFullscreen();
+        if (element.document().fullscreenManager()->isFullscreen())
+            element.document().fullscreenManager()->cancelFullscreen();
 #endif
         if (isChangingFocusedElement && (m_userIsInteracting || m_keyboardIsAttached))
             m_sendAutocorrectionContextAfterFocusingElement = true;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
@@ -48,25 +48,25 @@ using namespace WebCore;
 - (void)webkitWillEnterFullScreen
 {
     if (_element)
-        _element->document().fullscreenManager().willEnterFullscreen(*_element);
+        _element->document().fullscreenManager()->willEnterFullscreen(*_element);
 }
 
 - (void)webkitDidEnterFullScreen
 {
     if (_element)
-        _element->document().fullscreenManager().didEnterFullscreen();
+        _element->document().fullscreenManager()->didEnterFullscreen();
 }
 
 - (void)webkitWillExitFullScreen
 {
     if (_element)
-        _element->document().fullscreenManager().willExitFullscreen();
+        _element->document().fullscreenManager()->willExitFullscreen();
 }
 
 - (void)webkitDidExitFullScreen
 {
     if (_element)
-        _element->document().fullscreenManager().didExitFullscreen();
+        _element->document().fullscreenManager()->didExitFullscreen();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -298,7 +298,7 @@ static void setClipRectForWindow(NSWindow *window, NSRect clipRect)
 {
     if (!_element)
         return;
-    _element->document().fullscreenManager().cancelFullscreen();
+    _element->document().fullscreenManager()->cancelFullscreen();
 }
 
 - (void)exitFullScreen
@@ -441,7 +441,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WebCore::FullscreenManager*)_manager
 {
-    return &_element->document().fullscreenManager();
+    if (!_element->document().page())
+        return nullptr;
+    return &_element->document().page()->fullscreenManager();
 }
 
 - (void)_swapView:(NSView*)view with:(NSView*)otherView


### PR DESCRIPTION
#### 4e408e0224b4efe78facba9df0c849cc279e83ca
<pre>
Move FullscreenManager ownership from Document to Page
<a href="https://bugs.webkit.org/show_bug.cgi?id=287436">https://bugs.webkit.org/show_bug.cgi?id=287436</a>
<a href="https://rdar.apple.com/144562174">rdar://144562174</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesInWindowFullscreenPseudoClass):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::fullscreenManager):
(WebCore::Document::fullscreenManager const):
(WebCore::Document::fullscreenManagerIfExists):
(WebCore::Document::fullscreenManagerIfExists const):
(WebCore::Document::checkedFullscreenManager):
(WebCore::Document::checkedFullscreenManager const):
(WebCore::Document::ensureFullscreenManager): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::fullscreenManagerIfExists): Deleted.
(WebCore::Document::fullscreenManagerIfExists const): Deleted.
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::webkitFullscreenEnabled):
(WebCore::DocumentFullscreen::webkitFullscreenElement):
(WebCore::DocumentFullscreen::webkitIsFullScreen):
(WebCore::DocumentFullscreen::webkitFullScreenKeyboardInputAllowed):
(WebCore::DocumentFullscreen::webkitCurrentFullScreenElement):
(WebCore::DocumentFullscreen::webkitCancelFullScreen):
(WebCore::DocumentFullscreen::exitFullscreen):
(WebCore::DocumentFullscreen::webkitExitFullscreen):
(WebCore::DocumentFullscreen::fullscreenEnabled):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::removedFromAncestor):
(WebCore::Element::requestFullscreen):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::FullscreenManager):
(WebCore::FullscreenManager::fullscreenElement const):
(WebCore::FullscreenManager::mainFrameDocument):
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::cancelFullscreen):
(WebCore::documentsToUnfullscreen):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::finishExitFullscreen):
(WebCore::FullscreenManager::isFullscreenEnabled const):
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::didEnterFullscreen):
(WebCore::FullscreenManager::willExitFullscreen):
(WebCore::FullscreenManager::didExitFullscreen):
(WebCore::FullscreenManager::dispatchPendingEvents):
(WebCore::FullscreenManager::dispatchFullscreenChangeOrErrorEvent):
(WebCore::FullscreenManager::exitRemovedFullscreenElement):
(WebCore::FullscreenManager::setAnimatingFullscreen):
(WebCore::FullscreenManager::clear):
(WebCore::FullscreenManager::queueFullscreenChangeEventForDocument):
(WebCore::FullscreenManager::isSimpleFullscreenDocument const):
(WebCore::FullscreenManager::fullscreenElementIsInTopDocument const):
(WebCore::FullscreenManager::updatePageFullscreenStatusIfTopDocument): Deleted.
(WebCore::FullscreenManager::logChannel const): Deleted.
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::exitFullscreen):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::updateMediaUsageIfChanged):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::isKeyEventAllowedInFullScreen const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::topDocumentHasFullscreenElement):
(WebCore::Page::updateRendering):
(WebCore::Page::outermostFullscreenDocument const):
(WebCore::Page::fullscreenManager):
(WebCore::Page::fullscreenManager const):
(WebCore::Page::setTopDocumentHasFullscreenElement): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::fullscreenManagerIfExists):
(WebCore::Page::fullscreenManagerIfExists const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::didEnterFullScreen):
(WebKit::WebFullScreenManager::willExitFullScreen):
(WebKit::collectFullscreenElementsFromElement):
(WebKit::WebFullScreenManager::didExitFullScreen):
(WebKit::WebFullScreenManager::setAnimatingFullScreen):
(WebKit::WebFullScreenManager::requestRestoreFullScreen):
(WebKit::WebFullScreenManager::requestExitFullScreen):
(WebKit::WebFullScreenManager::handleEvent):
(WebKit::WebFullScreenManager::mainVideoElementTextRecognitionTimerFired):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::elementDidFocus):
* Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm:
(-[WebKitFullScreenListener webkitWillEnterFullScreen]):
(-[WebKitFullScreenListener webkitDidEnterFullScreen]):
(-[WebKitFullScreenListener webkitWillExitFullScreen]):
(-[WebKitFullScreenListener webkitDidExitFullScreen]):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(-[WebFullScreenController requestExitFullScreen]):
(-[WebFullScreenController _manager]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e408e0224b4efe78facba9df0c849cc279e83ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89197 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8721 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44026 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94179 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39958 "Failed to checkout and rebase branch from PR 40372") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91248 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9109 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16913 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/94179 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/39958 "Failed to checkout and rebase branch from PR 40372") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92199 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/9109 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/44026 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/94179 "Failed to checkout and rebase branch from PR 40372") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/9109 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/44026 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39065 "Failed to checkout and rebase branch from PR 40372") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/9109 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/44026 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96012 "Failed to checkout and rebase branch from PR 40372") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16377 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/16913 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/96012 "Failed to checkout and rebase branch from PR 40372") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16633 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/44026 "Failed to checkout and rebase branch from PR 40372") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/96012 "Failed to checkout and rebase branch from PR 40372") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/44026 "Failed to checkout and rebase branch from PR 40372") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9493 "Failed to checkout and rebase branch from PR 40372") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16391 "Failed to checkout and rebase branch from PR 40372") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16132 "Failed to checkout and rebase branch from PR 40372") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19583 "Failed to checkout and rebase branch from PR 40372") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17913 "Failed to checkout and rebase branch from PR 40372") | | | 
<!--EWS-Status-Bubble-End-->