### PR TITLE
AX: [AX Thread Text APIs] CurrentLine is sometimes missing the first character of a line

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/line-range-at-soft-breaks-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/line-range-at-soft-breaks-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that all characters in each line are included in the line range when at soft line breaks.
+
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'WebKit is the web browser engine used by Safari, Mail, App Store, and many'
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'other apps on macOS, iOS, and Linux. Get started contributing code, or'
+PASS: paragraph.stringForTextMarkerRange(lineRange) === 'reporting bugs.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+WebKit is the web browser engine used by Safari, Mail, App Store, and many other apps on macOS, iOS, and Linux. Get started contributing code, or reporting bugs.

--- a/LayoutTests/accessibility/ax-thread-text-apis/line-range-at-soft-breaks.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/line-range-at-soft-breaks.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="paragraph" style="width: 500px">
+WebKit is the web browser engine used by Safari, Mail, App Store, and many other apps on macOS, iOS, and Linux. Get started contributing code, or reporting bugs.
+</p>
+
+<script>
+if (window.accessibilityController) {
+    var output = "This test verifies that all characters in each line are included in the line range when at soft line breaks.\n\n";
+
+    var paragraph = accessibilityController.accessibleElementById("paragraph");
+    var textMarkerRange = paragraph.textMarkerRangeForElement(paragraph)
+    var currentMarker = paragraph.startTextMarkerForTextMarkerRange(textMarkerRange);
+    
+    var lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'WebKit is the web browser engine used by Safari, Mail, App Store, and many'");
+    
+    currentMarker = paragraph.nextLineEndTextMarkerForTextMarker(currentMarker);
+    currentMarker = paragraph.nextTextMarker(currentMarker);
+
+    lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'other apps on macOS, iOS, and Linux. Get started contributing code, or'");
+    
+    currentMarker = paragraph.nextLineEndTextMarkerForTextMarker(currentMarker);
+    currentMarker = paragraph.nextTextMarker(currentMarker);
+    
+    lineRange = paragraph.lineTextMarkerRangeForTextMarker(currentMarker);
+    output += expect("paragraph.stringForTextMarkerRange(lineRange)", "'reporting bugs.'");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -73,6 +73,7 @@ class Scrollbar;
 class ScrollView;
 class VisiblePosition;
 class Widget;
+enum class AXStreamOptions : uint8_t;
 
 struct CharacterOffset {
     RefPtr<Node> node;
@@ -471,8 +472,8 @@ public:
 #endif
 
     // Text marker utilities.
-    std::optional<TextMarkerData> textMarkerDataForVisiblePosition(const VisiblePosition&);
-    TextMarkerData textMarkerDataForCharacterOffset(const CharacterOffset&);
+    std::optional<TextMarkerData> textMarkerDataForVisiblePosition(const VisiblePosition&, TextMarkerOrigin = TextMarkerOrigin::Unknown);
+    TextMarkerData textMarkerDataForCharacterOffset(const CharacterOffset&, TextMarkerOrigin = TextMarkerOrigin::Unknown);
     TextMarkerData textMarkerDataForNextCharacterOffset(const CharacterOffset&);
     AXTextMarker nextTextMarker(const AXTextMarker&);
     TextMarkerData textMarkerDataForPreviousCharacterOffset(const CharacterOffset&);
@@ -590,7 +591,7 @@ public:
 
     static ASCIILiteral notificationPlatformName(AXNotification);
 
-    AXTreeData treeData();
+    AXTreeData treeData(std::optional<OptionSet<AXStreamOptions>> = std::nullopt);
 
     enum class UpdateRelations : bool { No, Yes };
     // Returns the IDs of the objects that relate to the given object with the specified relationship.

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -840,14 +840,14 @@ VisiblePositionRange visiblePositionRangeForTextMarkerRange(AXObjectCache* cache
 
 // TextMarker <-> CharacterOffset conversion.
 
-AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache* cache, const CharacterOffset& characterOffset)
+AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache* cache, const CharacterOffset& characterOffset, TextMarkerOrigin origin)
 {
     ASSERT(isMainThread());
 
     if (!cache)
         return nil;
 
-    auto textMarkerData = cache->textMarkerDataForCharacterOffset(characterOffset);
+    auto textMarkerData = cache->textMarkerDataForCharacterOffset(characterOffset, origin);
     if (!textMarkerData.objectID || textMarkerData.ignored)
         return nil;
     return adoptCF(AXTextMarkerCreate(kCFAllocatorDefault, (const UInt8*)&textMarkerData, sizeof(textMarkerData))).autorelease();

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
@@ -26,6 +26,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "AXTextMarker.h"
 #import "WebAccessibilityObjectWrapperBase.h"
 
 #if PLATFORM(MAC)
@@ -84,7 +85,7 @@ AXTextMarkerRangeRef textMarkerRangeFromVisiblePositions(AXObjectCache*, const V
 VisiblePositionRange visiblePositionRangeForTextMarkerRange(AXObjectCache*, AXTextMarkerRangeRef);
 
 // TextMarker <-> CharacterOffset conversion.
-AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache*, const CharacterOffset&);
+AXTextMarkerRef textMarkerForCharacterOffset(AXObjectCache*, const CharacterOffset&, TextMarkerOrigin = TextMarkerOrigin::Unknown);
 CharacterOffset characterOffsetForTextMarker(AXObjectCache*, AXTextMarkerRef);
 
 // TextMarkerRange <-> SimpleRange conversion.

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -211,6 +211,10 @@ namespace ax = WebCore::Accessibility;
 
 - (WebCore::LocalFrame *)focusedLocalFrame
 {
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainRunLoop())
+        return nullptr;
+#endif
     if (!m_page)
         return nullptr;
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
@@ -87,6 +87,11 @@ public:
     void logValueChangeEvents() { }
     void logScrollingStartEvents() { }
     void logAccessibilityEvents() { };
+#if PLATFORM(MAC)
+    void printTrees(JSContextRef);
+#else
+    void printTrees(JSContextRef) { }
+#endif
 
     void resetToConsistentState();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityController.idl
@@ -48,6 +48,8 @@ interface AccessibilityController {
     undefined logScrollingStartEvents();
     undefined logAccessibilityEvents();
     undefined resetToConsistentState();
+    
+    undefined printTrees();
 
     undefined overrideClient(DOMString clientType);
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -168,6 +168,12 @@ void AccessibilityController::overrideClient(JSStringRef clientType)
         _AXSetClientIdentificationOverride(kAXClientTypeNoActiveRequestFound);
 }
 
+void AccessibilityController::printTrees(JSContextRef context)
+{
+    PlatformUIElement root = static_cast<PlatformUIElement>(WKAccessibilityRootObject(WKBundleFrameForJavaScriptContext(context)));
+    [root accessibilityPerformAction:@"AXLogTrees"];
+}
+
 // AXThread implementation
 
 void AXThread::initializeRunLoop()


### PR DESCRIPTION
#### e67fcd568d5f0ea91b202f58514c73549dbe5ce2
<pre>
AX: [AX Thread Text APIs] CurrentLine is sometimes missing the first character of a line
<a href="https://bugs.webkit.org/show_bug.cgi?id=287438">https://bugs.webkit.org/show_bug.cgi?id=287438</a>
<a href="https://rdar.apple.com/143915387">rdar://143915387</a>

Reviewed by Tyler Wilcock.

Due to some bugs in `findLine`, the current line range would sometimes miss the first character
in a line. This is because `atLineBoundaryForDirection` didn&apos;t handle text affinity, so if we
have the following text, with a soft line break after hello:

Hello
world

A text marker after the &apos;w&apos; in world would be considered at a line break with our old implementation,
which would just check the previous text marker&apos;s line (which could be on the previous line). This PR
re-writes `atLineBoundaryForDirection` to use line offsets instead, which should be more robust
against these affinity cases.

This PR also includes some text marker enhancements:
- Iterating in `findLine` now follows the direction of the search, which is more accurate and
aligned with our other `find` methods.
- A new debug method `printTrees` was added to the WKTR accessibility controller to more easily
log the AX trees to standard error when debugging.
    - This change includes added a new optional paramater to treeData for streaming options.
- More TextMarkerOrigin fields were added, with new parameters where necessary to pipe them
through.
- An update to `focusedLocalFrame`, co-authored by Alex Christensen, to fix a memory-safety
issue with accessing m_page.

* LayoutTests/accessibility/ax-thread-text-apis/line-range-at-soft-breaks-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/line-range-at-soft-breaks.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::textMarkerDataForCharacterOffset):
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
(WebCore::AXObjectCache::treeData):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::atLineBoundaryForDirection const):
(WebCore::AXTextMarker::findLine const):
(WebCore::AXTextMarker::lineRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::originToString):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::textMarkerForCharacterOffset):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityPerformAction:]):
(-[WebAccessibilityObjectWrapper _accessibilityPrintTrees]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase focusedLocalFrame]):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h:
(WTR::AccessibilityController::printTrees):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityController.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::printTrees):

Canonical link: <a href="https://commits.webkit.org/290212@main">https://commits.webkit.org/290212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5a9da33ff398d1d45f4cb3ecb12c392ee4d83e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96070 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16435 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77643 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76938 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21352 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9555 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16449 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21760 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16190 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->