### PR TITLE
[iOS] Prevent navigation transition swipe gestures from taking precedence over scrolling pan gestures

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -326,6 +326,8 @@ public:
     virtual void showBrowsingWarning(const BrowsingWarning&, CompletionHandler<void(std::variant<ContinueUnsafeLoad, URL>&&)>&& completionHandler) { completionHandler(ContinueUnsafeLoad::Yes); }
     virtual void clearBrowsingWarning() { }
     virtual void clearBrowsingWarningIfForMainFrameNavigation() { }
+
+    virtual bool canStartNavigationSwipeAtLastInteractionLocation() const { return true; }
     
 #if ENABLE(DRAG_SUPPORT)
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -176,7 +176,7 @@ void ViewGestureController::setAlternateBackForwardListSourcePage(WebPageProxy* 
     m_alternateBackForwardListSourcePage = page;
 }
 
-bool ViewGestureController::canSwipeInDirection(SwipeDirection direction) const
+bool ViewGestureController::canSwipeInDirection(SwipeDirection direction, DeferToConflictingGestures deferToConflictingGestures) const
 {
     if (!m_swipeGestureEnabled)
         return false;
@@ -190,6 +190,9 @@ bool ViewGestureController::canSwipeInDirection(SwipeDirection direction) const
     if (fullScreenManager && fullScreenManager->isFullScreen())
         return false;
 #endif
+
+    if (deferToConflictingGestures == DeferToConflictingGestures::Yes && !page->canStartNavigationSwipeAtLastInteractionLocation())
+        return false;
 
     RefPtr<WebPageProxy> alternateBackForwardListSourcePage = m_alternateBackForwardListSourcePage.get();
     Ref<WebBackForwardList> backForwardList = alternateBackForwardListSourcePage ? alternateBackForwardListSourcePage->backForwardList() : page->backForwardList();
@@ -482,7 +485,7 @@ bool ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe(Platf
         return false;
 
     potentialSwipeDirection = tryingToSwipeBack ? SwipeDirection::Back : SwipeDirection::Forward;
-    return protectedViewGestureController()->canSwipeInDirection(potentialSwipeDirection);
+    return protectedViewGestureController()->canSwipeInDirection(potentialSwipeDirection, DeferToConflictingGestures::No);
 }
 
 bool ViewGestureController::PendingSwipeTracker::handleEvent(PlatformScrollEvent event)

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -128,10 +128,8 @@ public:
         Swipe
     };
 
-    enum class SwipeDirection {
-        Back,
-        Forward
-    };
+    enum class SwipeDirection : bool { Back, Forward };
+    enum class DeferToConflictingGestures : bool { No, Yes };
 
     typedef uint64_t GestureID;
 
@@ -177,7 +175,7 @@ public:
 
     void setAlternateBackForwardListSourcePage(WebPageProxy*);
 
-    bool canSwipeInDirection(SwipeDirection) const;
+    bool canSwipeInDirection(SwipeDirection, DeferToConflictingGestures) const;
 
     WebCore::Color backgroundColorForCurrentSnapshot() const { return m_backgroundColorForCurrentSnapshot; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16008,6 +16008,12 @@ void WebPageProxy::shouldOffloadIFrameForHost(const String& host, CompletionHand
 }
 #endif
 
+bool WebPageProxy::canStartNavigationSwipeAtLastInteractionLocation() const
+{
+    RefPtr client = pageClient();
+    return !client || client->canStartNavigationSwipeAtLastInteractionLocation();
+}
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2658,6 +2658,8 @@ public:
     RefPtr<ModelPresentationManagerProxy> modelPresentationManagerProxy() const;
 #endif
 
+    bool canStartNavigationSwipeAtLastInteractionLocation() const;
+
 private:
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -655,7 +655,7 @@ void ViewGestureController::removeSwipeSnapshot()
 
 bool ViewGestureController::beginSimulatedSwipeInDirectionForTesting(SwipeDirection direction)
 {
-    if (!canSwipeInDirection(direction))
+    if (!canSwipeInDirection(direction, DeferToConflictingGestures::No))
         return false;
 
     double deltaX = swipeTouchpadBaseWidth / gtkScrollDeltaMultiplier * 0.75;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -206,6 +206,8 @@ private:
     void showPlaybackTargetPicker(bool hasVideo, const WebCore::IntRect& elementRect, WebCore::RouteSharingPolicy, const String&) override;
     void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&) override;
 
+    bool canStartNavigationSwipeAtLastInteractionLocation() const final;
+
     void hardwareKeyboardAvailabilityChanged() override;
 
     bool handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1277,6 +1277,11 @@ bool PageClientImpl::isPotentialTapInProgress() const
     return [m_contentView isPotentialTapInProgress];
 }
 
+bool PageClientImpl::canStartNavigationSwipeAtLastInteractionLocation() const
+{
+    return [m_contentView _canStartNavigationSwipeAtLastInteractionLocation];
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -865,6 +865,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 @property (nonatomic, readonly) BOOL _shouldAvoidScrollingWhenFocusedContentIsVisible;
 @property (nonatomic, readonly) BOOL _shouldUseLegacySelectPopoverDismissalBehavior;
 @property (nonatomic, readonly) BOOL _shouldAvoidSecurityHeuristicScoreUpdates;
+@property (nonatomic, readonly) BOOL _canStartNavigationSwipeAtLastInteractionLocation;
 
 - (void)_didChangeLinkPreviewAvailability;
 - (void)setContinuousSpellCheckingEnabled:(BOOL)enabled;


### PR DESCRIPTION
#### 0fa3ad653470b5fa739117073187ad54d3c974f7
<pre>
[iOS] Prevent navigation transition swipe gestures from taking precedence over scrolling pan gestures
<a href="https://bugs.webkit.org/show_bug.cgi?id=287437">https://bugs.webkit.org/show_bug.cgi?id=287437</a>
<a href="https://rdar.apple.com/115613321">rdar://115613321</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Prevent certain types of horizontal navigation swipe gestures from starting in two scenarios:

- A child scroller underneath the user&apos;s current touch is being scrolled via a pan gesture.
- The page has `touch-action: none;` under the current touch location.

See below for more details.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::canStartNavigationSwipeAtLastInteractionLocation const):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::canSwipeInDirection const):

If the new `DeferToConflictingGestures` flag is set, additionally consult `WebPageProxy` via
`canStartNavigationSwipeAtLastInteractionLocation`, to determine whether the navigation swipe
gesture should commence.

(WebKit::ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::canStartNavigationSwipeAtLastInteractionLocation const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::canStartNavigationSwipeAtLastInteractionLocation const):

Add page -&gt; page client -&gt; content view plumbing, so that we can ask the content view whether or not
we can start a navigation swipe at the last interaction location without running into conflicts with
either the page (via `touch-action`) or subscrollable areas.

* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(-[WKSwipeTransitionController shouldBeginInteractiveTransition:]):

Defer to conflicting pan gestures only if the edge swipe gesture recognizer is in Failed state. This
ensures that the edge swipe gesture continues to take precedence over other types of pan gestures or
`touch-action: none;` in the case where the user is actually swiping from the edge of the screen.

(interactiveTransitionGestureRecognizerClass):
(-[WKSwipeTransitionController gestureRecognizerForInteractiveTransition:WithTarget:action:]):
(-[WKSwipeTransitionController isNavigationSwipeGestureRecognizer:]):
(WebKit::ViewGestureController::beginSimulatedSwipeInDirectionForTesting):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _canStartNavigationSwipeAtLastInteractionLocation]):

Add a helper method that checks:

-   Whether there are any subscrollable areas that are actively being scrolled via pan gesture,
    under the last interaction location.

-   Whether the CSS `touch-actions` under the last interaction location would allow for built-in
    horizontal pan gestures.

Canonical link: <a href="https://commits.webkit.org/290196@main">https://commits.webkit.org/290196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8280cd72135e5f3594509b783ee391d43eca74b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/39982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68740 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26412 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/80970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6751 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96036 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16401 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18974 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9519 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->